### PR TITLE
Add CLI command to set the status of a FC

### DIFF
--- a/cg/cli/set.py
+++ b/cg/cli/set.py
@@ -66,3 +66,20 @@ def sample(context, sex, sample_id):
 
         print(click.style('update LIMS/Gender', fg='blue'))
         lims_api.update_sample(sample_id, sex=sex)
+
+@set_cmd.command()
+@click.option('-s', '--status', type=click.Choice(['ondisk', 'removed', 'requested', 'processing']))
+@click.argument('flowcell_name')
+@click.pass_context
+def flowcell(context, flowcell_name, status):
+    """Update information about a flowcell"""
+    flowcell_obj = context.obj['status'].flowcell(flowcell_name)
+
+    if flowcell_obj is None:
+        print(click.style(f"flowcell not found: {flowcell_name}", fg='yellow'))
+        context.abort()
+    prev_status = flowcell_obj.status
+    flowcell_obj.status = status
+
+    context.obj['status'].commit()
+    print(click.style(f"{flowcell_name} set: {prev_status} -> {status}", fg='green'))


### PR DESCRIPTION
This is a first part of making fastq management easier. This adds a command to set the status of a FC so we can use it in the FC removal script.

Once this is approved we can then go ahead and:
1. import fastq's to HK
2. manage the removal of fastq files through HK