### PR TITLE
make optional sample attributes non-mandatory

### DIFF
--- a/cg/apps/lims/limsjson.py
+++ b/cg/apps/lims/limsjson.py
@@ -1,4 +1,4 @@
-OPTIONAL_KEYS = ('container_name', 'quantity', 'status',
+OPTIONAL_KEYS = ('container_name', 'quantity', 'volume', 'concentration', 'status',
                  'comment', 'capture_kit', 'mother', 'father')
 
 def parse_json(indata: dict) -> dict:
@@ -42,9 +42,6 @@ def parse_json(indata: dict) -> dict:
                 'application': sample['application'],
                 'source': sample['source'],
                 'container': sample['container'],
-                'comment': sample['comment'],
-                'volume': sample.get('volume'),
-                'concentration': sample.get('concentration'),
             }
             well_position_raw = sample.get('well_position')
             if well_position_raw:


### PR DESCRIPTION
Order portal crashed when comment was missing, probably when supplying an order as an excel file 
Now is volume, concentration and comment handled as optionals