### PR TITLE
cg transfer pool: update pools in status-db with received_at or delivered_at dates form LIMS

### DIFF
--- a/cg/cli/transfer.py
+++ b/cg/cli/transfer.py
@@ -39,3 +39,17 @@ def lims(context, status):
     lims_api = lims_app.LimsAPI(context.obj)
     transfer_api = transfer_app.TransferLims(context.obj['db'], lims_api)
     transfer_api.transfer_samples(transfer_app.SampleState[status.upper()])
+
+
+@transfer.command()
+@click.option('-s', '--status', type=click.Choice(['received', 'delivered']),
+              default='delivered')
+@click.pass_context
+def pools(context, status):
+    """
+    Update pools with received_at or delivered_at dates from LIMS. Defaults to delivered is no
+    option is provided.
+    """
+    lims_api = lims_app.LimsAPI(context.obj)
+    transfer_api = transfer_app.TransferLims(context.obj['db'], lims_api)
+    transfer_api.transfer_pools(transfer_app.PoolState[status.upper()])

--- a/cg/meta/transfer/__init__.py
+++ b/cg/meta/transfer/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 from .flowcell import TransferFlowcell
-from .lims import TransferLims, SampleState
+from .lims import TransferLims, SampleState, PoolState

--- a/cg/meta/transfer/lims.py
+++ b/cg/meta/transfer/lims.py
@@ -14,6 +14,11 @@ class SampleState(Enum):
     DELIVERED = 'delivered'
 
 
+class PoolState(Enum):
+    RECEIVED = 'received'
+    DELIVERED = 'delivered'
+
+
 class TransferLims(object):
 
     def __init__(self, status: Store, lims: LimsAPI):
@@ -25,10 +30,16 @@ class TransferLims(object):
             SampleState.PREPARED: self.status.samples_to_prepare,
             SampleState.DELIVERED: self.status.samples_to_deliver,
         }
+        self._pool_functions = {
+            PoolState.RECEIVED: self.status.pools_to_receive,
+            PoolState.DELIVERED: self.status.pools_to_deliver,
+        }
         self._date_functions = {
             SampleState.RECEIVED: self.lims.get_received_date,
             SampleState.PREPARED: self.lims.get_prepared_date,
             SampleState.DELIVERED: self.lims.get_delivery_date,
+            PoolState.RECEIVED: self.lims.get_received_date,
+            PoolState.DELIVERED: self.lims.get_delivery_date,
         }
 
     def transfer_samples(self, status_type: SampleState):
@@ -42,3 +53,27 @@ class TransferLims(object):
                 LOG.info(f"found {status_type.value} date for {sample_obj.internal_id}: {status_date}")
                 setattr(sample_obj, f"{status_type.value}_at", status_date)
                 self.status.commit()
+
+    def transfer_pools(self, status_type: PoolState):
+        """Transfer information about pools."""
+        pools = self._pool_functions[status_type]()
+
+        for pool_obj in pools:
+            ticket_number = pool_obj.ticket_number
+            number_of_samples = self.lims.get_sample_number(projectname=ticket_number)
+
+            if ticket_number is None:
+                LOG.warning(f"No ticket number found for pool with order number {pool_obj.order}.")
+            elif number_of_samples == 0:
+                LOG.warning(f"No samples found for pool with ticket number {ticket_number}.")
+            else:
+                samples_in_pool = self.lims.get_samples(projectname=ticket_number)
+                for sample_obj in samples_in_pool:
+                    status_date = self._date_functions[status_type](sample_obj.id)
+                    if sample_obj.udf['pool name'] == pool_obj.name and status_date is not None:
+                        LOG.info(f"Found {status_type.value} date for pool id {pool_obj.id}: {status_date}.")
+                        setattr(pool_obj, f"{status_type.value}_at", status_date)
+                        self.status.commit()
+                        break
+                    else:
+                        continue

--- a/cg/store/api/status.py
+++ b/cg/store/api/status.py
@@ -138,20 +138,36 @@ class StatusHandler:
         return records, customers_to_invoice
 
     def pools_to_invoice(self, customer: models.Customer=None):
-        """Fetch pools that should be invoiced.
-        
-        Return pools have been delivered but not invoiced, excluding those that
-        have been marked to skip invoicing.
         """
-        records = ( self.Pool.query.filter(
+        Fetch pools that should be invoiced.
+        """
+        records = (
+            self.Pool.query.filter(
                 models.Pool.invoice_id == None,
-           # #    models.Pool.no_invoice != True,
                 models.Pool.delivered_at != None
-           ##     models.Pool.received_at != None
-           # #    models.Pool.downsampled_to == None
             )
         )
         customers_to_invoice = [record.customer for record in records.all() if not record.customer.internal_id=='cust000']
-        customers_to_invoice=list(set(customers_to_invoice))
+        customers_to_invoice = list(set(customers_to_invoice))
         records = records.filter(models.Pool.customer_id == customer.id) if customer else records
         return records, customers_to_invoice
+
+    def pools_to_receive(self):
+        """Fetch pools that have been not yet been received."""
+        records = (
+            self.Pool.query
+            .filter(
+                models.Pool.received_at == None
+            )
+        )
+        return records
+
+    def pools_to_deliver(self):
+        """Fetch pools that have been not yet been delivered."""
+        records = (
+            self.Pool.query
+            .filter(
+                models.Pool.delivered_at == None
+            )
+        )
+        return records


### PR DESCRIPTION
Resolves issue #133.

Added command ```pools``` to ```cg transfer```: fetch all pools with no received_at date or delivered_at date from status-db. Finds those dates in LIMS by finding samples belonging to those pools and transferring the relevant dates to the pools in status-db.
