### PR TITLE
make requirement less stringent

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ openpyxl
 tabulate
 lxml
 python-dateutil
-cyvcf2==0.9.0
+cyvcf2<0.10.0
 pymongo
 
 # apps


### PR DESCRIPTION
Production cg on clinical fail since cyvcf2 is of version 0.8.1, this version should be allowed since we only have had problem with 0.10.0 as far as I know