### PR TITLE
Skip deleting mip analysis when missing sample_info

### DIFF
--- a/cg/cli/clean.py
+++ b/cg/cli/clean.py
@@ -147,5 +147,5 @@ def mipauto(context: click.Context, before_str: str, yes: bool=False):
             LOG.info(f"{family_id}: cleaning MIP output")
             context.invoke(mip, yes=yes, sample_info=sampleinfo_path)
         except FileNotFoundError as err:
-            LOG.error(f"{family_id}: sample_info file not found")
+            LOG.error(f"{family_id}: sample_info file not found, please mark the analysis as deleted in the analysis table in trailblazer.")
             

--- a/cg/cli/clean.py
+++ b/cg/cli/clean.py
@@ -142,6 +142,10 @@ def mipauto(context: click.Context, before_str: str, yes: bool=False):
             LOG.warning(f"{family_id}: family already re-started")
             continue
 
-        LOG.info(f"{family_id}: cleaning MIP output")
-        sampleinfo_path = context.obj['tb'].get_sampleinfo(tb_analysis)
-        context.invoke(mip, yes=yes, sample_info=open(sampleinfo_path, 'r'))
+        try:
+            sampleinfo_path = context.obj['tb'].get_sampleinfo(tb_analysis)
+            LOG.info(f"{family_id}: cleaning MIP output")
+            context.invoke(mip, yes=yes, sample_info=sampleinfo_path)
+        except FileNotFoundError as err:
+            LOG.error(f"{family_id}: sample_info file not found")
+            


### PR DESCRIPTION
We automatically delete finished analysis after 21 days. CG now fails when the sample_info.yaml file is missing (e.g. when the analysis was deleted manually). Got tired of setting already deleted analysis to 'deleted' in TB. So here we go: we skip them for now.