### PR TITLE
Other elution buffer

### DIFF
--- a/cg/apps/lims/orderform.py
+++ b/cg/apps/lims/orderform.py
@@ -192,6 +192,7 @@ def parse_sample(raw_sample):
         'tumour': True if raw_sample.get('UDF/tumor') == 'yes' else False,
         'custom_index': raw_sample.get('UDF/Custom index'),
         'elution_buffer': raw_sample.get('UDF/Sample Buffer'),
+        'elution_buffer_other': raw_sample.get('UDF/Other Elution Buffer'),
         'strain': raw_sample.get('UDF/Strain'),
         'strain_other': raw_sample.get('UDF/Other species'),
         'reference_genome': raw_sample.get('UDF/Reference Genome Microbial'),


### PR DESCRIPTION
How to test:

0. Install on OP-stage and clinical-api-stage
1. Create microbial order file with the new UDF/Other Elution Buffer' filled for atleast one sample
2. Go to OP-stage
3. Add microbial order file
4. Open the sample(s) 

Expected outcome: 
The Other Buffer value should be seen in the Other elution buffer field