### PR TITLE
Get current apptag version

### DIFF
--- a/cg/cli/add.py
+++ b/cg/cli/add.py
@@ -81,7 +81,7 @@ def sample(context, lims_id, downsampled, sex, order, application, priority, cus
         downsampled_to=downsampled,
         priority=priority,
     )
-    new_record.application_version = application_obj.versions[-1]
+    new_record.application_version = status.current_version(application)
     new_record.customer = customer_obj
     status.add_commit(new_record)
     LOG.info(f"{new_record.internal_id}: new sample added")

--- a/cg/cli/set.py
+++ b/cg/cli/set.py
@@ -52,8 +52,7 @@ def family(context, action, priority, panels, family_id):
 @click.option('-s', '--sex', type=click.Choice(['male', 'female', 'unknown']))
 @click.option('-c', '--customer', help='updates customer, input format custXXX.')
 @click.option('-C', '--add-comment', 'comment', type=str, help='adds a note/comment to a sample, '
-                                                         'put text \
-              between quotation marks! This will not overwrite the current comment.')
+              'put text between quotation marks! This will not overwrite the current comment.')
 @click.option('-d', '--downsampled-to', type=int, help='sets number of downsampled \
               total reads. Enter 0 to reset.')
 @click.option('-a', '--application-tag', 'apptag', help='sets application tag.')
@@ -124,8 +123,12 @@ def sample(context, sex, customer, comment, downsampled_to, apptag, capture_kit,
             click.echo(click.style(f"Application tag {apptag} does not exist.", fg='red'))
             context.abort()
 
-        application_version = context.obj['status'].latest_version(apptag)
-        application_version_id = context.obj['status'].latest_version(apptag).id
+        application_version = context.obj['status'].current_version(apptag)
+        if application_version is None:
+            click.echo(click.style(f"No valid current application version found!", fg='red'))
+            context.abort()
+
+        application_version_id = application_version.id
 
         if sample_obj.application_version_id == application_version_id:
             click.echo(click.style(f"Sample {sample_obj.internal_id} already has the application "

--- a/cg/meta/orders/api.py
+++ b/cg/meta/orders/api.py
@@ -71,7 +71,7 @@ class OrdersAPI(LimsHandler, StatusHandler):
 
                     if ticket.get('name'):
                         message += f"<br />{ticket.get('name')}"
-                        
+
                     data['ticket'] = self.osticket.open_ticket(
                         name=ticket['name'],
                         email=ticket['email'],
@@ -176,8 +176,8 @@ class OrdersAPI(LimsHandler, StatusHandler):
 
     def update_application(self, ticket_number: int, families: List[models.Family]):
         """Update application for trios if relevant."""
-        reduced_map  = {'EXOSXTR100': 'EXTSXTR100', 'WGSPCFC030': 'WGTPCFC030',
-                        'WGSPCFC060': 'WGTPCFC060'}
+        reduced_map = {'EXOSXTR100': 'EXTSXTR100', 'WGSPCFC030': 'WGTPCFC030',
+                       'WGSPCFC060': 'WGTPCFC060'}
         for family_obj in families:
             LOG.debug(f"{family_obj.name}: update application for trios")
             order_samples = [link_obj.sample for link_obj in family_obj.links if
@@ -194,7 +194,7 @@ class OrdersAPI(LimsHandler, StatusHandler):
                                 reduced_tag = reduced_map[application_tag]
                                 LOG.info(f"{sample_obj.internal_id}: update application tag - "
                                          f"{reduced_tag}")
-                                reduced_version = self.status.latest_version(reduced_tag)
+                                reduced_version = self.status.current_version(reduced_tag)
                                 sample_obj.application_version = reduced_version
 
     def add_missing_reads(self, samples: List[models.Sample]):

--- a/cg/meta/orders/status.py
+++ b/cg/meta/orders/status.py
@@ -199,7 +199,7 @@ class StatusHandler:
                     new_sample.customer = customer_obj
                     with self.status.session.no_autoflush:
                         application_tag = sample['application']
-                        new_sample.application_version = self.status.latest_version(application_tag)
+                        new_sample.application_version = self.status.current_version(application_tag)
                     if new_sample.application_version is None:
                         raise OrderError(f"unknown application tag: {sample['application']}")
                     family_samples[new_sample.name] = new_sample
@@ -252,7 +252,7 @@ class StatusHandler:
                 )
             new_sample.customer = customer_obj
             with self.status.session.no_autoflush:
-                new_sample.application_version = self.status.latest_version(sample['application'])
+                new_sample.application_version = self.status.current_version(sample['application'])
             new_samples.append(new_sample)
 
             if not new_sample.is_tumour:
@@ -293,7 +293,7 @@ class StatusHandler:
             )
             for sample_data in samples:
                 application_tag = sample_data['application']
-                application_version = self.status.latest_version(application_tag)
+                application_version = self.status.current_version(application_tag)
                 if application_version is None:
                     raise OrderError(f"unknown application tag: {sample_data['application']}")
 
@@ -321,7 +321,7 @@ class StatusHandler:
         new_pools = []
         for pool in pools:
             with self.status.session.no_autoflush:
-                application_version = self.status.latest_version(pool['application'])
+                application_version = self.status.current_version(pool['application'])
                 if application_version is None:
                     raise OrderError(f"unknown application: {pool['application']}")
             new_pool = self.status.add_pool(

--- a/cg/store/api/find.py
+++ b/cg/store/api/find.py
@@ -2,7 +2,7 @@
 import datetime as dt
 from typing import List
 
-from sqlalchemy import or_, and_, func
+from sqlalchemy import or_, and_, func, desc
 from sqlalchemy.orm import Query
 
 from cg.store import models
@@ -101,6 +101,17 @@ class FindHandler:
         """Fetch the latest application version for an application tag."""
         application_obj = self.Application.query.filter_by(tag=tag).first()
         return application_obj.versions[-1] if application_obj else None
+
+    def current_version(self, tag: str) -> models.ApplicationVersion:
+        """Fetch the current application version for an application tag."""
+        application_obj = self.Application.query.filter_by(tag=tag).first()
+        application_id = application_obj.id
+        records = self.ApplicationVersion.query
+        records = records.filter_by(application_id=application_id)
+        records = records.filter(self.ApplicationVersion.valid_from < dt.datetime.now())
+        records = records.order_by(desc(self.ApplicationVersion.valid_from))
+
+        return records.first()
 
     def panel(self, abbrev):
         """Find a panel by abbreviation."""

--- a/cg/store/api/find.py
+++ b/cg/store/api/find.py
@@ -106,6 +106,8 @@ class FindHandler:
     def current_version(self, tag: str) -> models.ApplicationVersion:
         """Fetch the current application version for an application tag."""
         application_obj = self.Application.query.filter_by(tag=tag).first()
+        if not application_obj:
+            return None
         application_id = application_obj.id
         records = self.ApplicationVersion.query.filter_by(application_id=application_id)
         records = records.filter(self.ApplicationVersion.valid_from < dt.datetime.now())

--- a/cg/store/api/find.py
+++ b/cg/store/api/find.py
@@ -106,8 +106,7 @@ class FindHandler:
         """Fetch the current application version for an application tag."""
         application_obj = self.Application.query.filter_by(tag=tag).first()
         application_id = application_obj.id
-        records = self.ApplicationVersion.query
-        records = records.filter_by(application_id=application_id)
+        records = self.ApplicationVersion.query.filter_by(application_id=application_id)
         records = records.filter(self.ApplicationVersion.valid_from < dt.datetime.now())
         records = records.order_by(desc(self.ApplicationVersion.valid_from))
 


### PR DESCRIPTION
Currently, when a new sample is created or an application is added to a sample, the latest application version is used. This is incorrect in case the valid_from date of that version is in the future. Solution: added a method to the FindHandler class in cg/store/api/find.py that finds the current version instead of the latest one:

1) Find all application versions of a given application id
2) Filter out all versions with a valid_from date > datetime.datetime.now()
3) Sort in descending order
4) Return first result

new method is used in cg set sample and cg add sample
