### PR TITLE
Fix errr when passing sampleinfo_path to `clean mip`

### DIFF
--- a/cg/cli/clean.py
+++ b/cg/cli/clean.py
@@ -145,7 +145,8 @@ def mipauto(context: click.Context, before_str: str, yes: bool=False):
         try:
             sampleinfo_path = context.obj['tb'].get_sampleinfo(tb_analysis)
             LOG.info(f"{family_id}: cleaning MIP output")
-            context.invoke(mip, yes=yes, sample_info=open(sampleinfo_path, 'r'))
+            with open(sampleinfo_path, 'r') as sampleinfo_file:
+                context.invoke(mip, yes=yes, sample_info=sampleinfo_file)
         except FileNotFoundError as err:
             LOG.error(f"{family_id}: sample_info file not found, please mark the analysis as deleted in the analysis table in trailblazer.")
             

--- a/cg/cli/clean.py
+++ b/cg/cli/clean.py
@@ -145,7 +145,7 @@ def mipauto(context: click.Context, before_str: str, yes: bool=False):
         try:
             sampleinfo_path = context.obj['tb'].get_sampleinfo(tb_analysis)
             LOG.info(f"{family_id}: cleaning MIP output")
-            context.invoke(mip, yes=yes, sample_info=sampleinfo_path)
+            context.invoke(mip, yes=yes, sample_info=open(sampleinfo_path, 'r'))
         except FileNotFoundError as err:
             LOG.error(f"{family_id}: sample_info file not found, please mark the analysis as deleted in the analysis table in trailblazer.")
             


### PR DESCRIPTION
Seems like you need to open the file and pass the file obj to a click method.