### PR TITLE
Add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,12 @@
+This PR fixes the leaking coffee machine.
+
+How to test:
+0. install on stage
+
+1. go to the coffee machine
+1. add cup in dispenser
+1. press coffee or tea
+1. wait 2 minutes
+
+Expected outcome:
+Chck the right hand side of the machine. That side should now stay dry.

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,12 +1,12 @@
 This PR fixes the leaking coffee machine.
 
 How to test:
-0. install on stage
+0. install on stage (add instructions on how to as needed)
 
 1. go to the coffee machine
 1. add cup in dispenser
-1. press coffee or tea
+1. order any liquid beverage
 1. wait 2 minutes
 
 Expected outcome:
-Chck the right hand side of the machine. That side should now stay dry.
+Check the right hand side of the machine. That side should now stay dry.


### PR DESCRIPTION
I would like to play around with pull request templates as a way to save our test results with PRs. This template would be prefilled in the description of the pull request at the time of opening. The template is based on what Patrik has been using so far.

Now that I write it like that, it seems that my suggested template only handles the 'how to test' and not 'how to document'.