### PR TITLE
removed explicit install of standard requirements and dev build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
 
 install:
     - pip install cython
-    - pip install -r requirements.txt -r requirements-dev.txt -e .
+    - pip install -q -r requirements-dev.txt .
 
 script:
     - coverage run --source "$(basename "$PWD")" setup.py test


### PR DESCRIPTION
This PR removes the explicit install of standard requirements and dev build in the automatic travis builds on github. I.e. removal of -r requirements.txt and -e flag in the explicit pip install command

How to test:

1. open PR

Expected outcome:
Travis build succeeds