### PR TITLE
Removed gene panels from master list

### DIFF
--- a/cg/meta/analysis.py
+++ b/cg/meta/analysis.py
@@ -14,7 +14,7 @@ from cg.meta.deliver.api import DeliverAPI
 
 COLLABORATORS = ('cust000', 'cust002', 'cust003', 'cust004', 'cust042')
 MASTER_LIST = ('ENDO', 'EP', 'IEM', 'IBMFS', 'mtDNA', 'MIT', 'PEDHEP', 'OMIM-AUTO',
-               'PIDCAD', 'PID', 'SKD', 'NMD', 'ATX', 'CTD', 'SPG', 'Ataxi', 'AD-HSP', 'IF')
+               'PIDCAD', 'PID', 'SKD', 'NMD', 'CTD', 'IF')
 COMBOS = {
     'DSD': ('DSD', 'HYP', 'SEXDIF', 'SEXDET'),
     'CM': ('CNM', 'CM'),


### PR DESCRIPTION
As requested in SuSy ticket 563304

This PR removes some obsolete gene panels from the master list by request from customers.

How to test:
0. install on stage on rasta (update-cg-stage.sh edit_masterlist) 

1. us
2. cg analysis panel -p wiredbass 

Expected outcome:
The top part of the output printed to screen beginning with "Fetching gene panels" should not contain the panels ATX, SPG, Ataxi, AD-HSP.
It should however contain 'ENDO', 'EP', 'IEM', 'IBMFS', 'mtDNA', 'MIT', 'PEDHEP', 'OMIM-AUTO', 'PIDCAD', 'PID', 'SKD', 'NMD', 'CTD', 'IF'.
