### PR TITLE
check dependencies after pip install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,13 @@ language: python
 python:
     - '3.6'
 
-before_install:
-    - pip install git-lint pylint pycodestyle yamllint docutils html-linter
-    - git reset --soft ${TRAVIS_COMMIT_RANGE%...*} && git lint
-
 install:
     - pip install cython
-    - pip install -q -r requirements-dev.txt .
+    - pip install -r requirements.txt -r requirements-dev.txt .
+    - pip check
 
 script:
+    - git reset --soft ${TRAVIS_COMMIT_RANGE%...*} && git lint
     - coverage run --source "$(basename "$PWD")" setup.py test
 
 after_success: coveralls

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-pytest
+pytest>=3.6     # due to pytest-flask, pytest-cov
 mock
 ipdb
 pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,9 @@ Flask-Dance
 google-auth
 werkzeug
 requests[security]
+requests-oauthlib<1.2.0     # due to scout-browser Flask-OAuthlib
+oauthlib<3.0.0              # due to scout-browser Flask-OAuthlib
+requests_cache
 
 # utils
 ruamel.yaml
@@ -37,6 +40,6 @@ trailblazer>=3.1.1
 housekeeper>=2.0.0b2
 chanjo>=4.2.0
 genotype>=2.2.0
-scout-browser>=3.3.0
+scout-browser>=4.3.0
 cgstats>=1.1.2
 cgbeacon


### PR DESCRIPTION
This PR adds a dependency check to the travis build

How to test:
1. Open this PR
1. Open "Details" on continuous-integration/travis-ci

Expected outcome:
After pip install there should be a line:
`pip check`
And then the result of the pip check, it should fail if the dependencies are not satisfied
`No broken requirements found.`
or 
`The command "pip check" failed and exited with 1 during .`