### PR TITLE
accepts empty string as none

### DIFF
--- a/cg/meta/orders/schema.py
+++ b/cg/meta/orders/schema.py
@@ -45,7 +45,7 @@ class TypeValidatorNone(validators.TypeValidator):
 
     def validate(self, value):
         """Validate the type of the value, accept None"""
-        if value is None:
+        if value in (None, ''):
             return value
         return super().validate(value)
 
@@ -55,7 +55,7 @@ class RegexValidatorNone(validators.RegexValidator):
 
     def validate(self, value):
         """Validate the the value against an regular expression, accept None"""
-        if value is None:
+        if value in (None, ''):
             return value
         return super().validate(value)
 
@@ -72,7 +72,7 @@ class OptionalNone(validators.Optional):
         if value:
             val = value[0]
 
-            if val is None:
+            if val in (None, ''):
                 return val
 
             return super().validate(val)


### PR DESCRIPTION
This PR fixes the submission problem of RML samples with empty capture-kit.

How to test:
1. install on clinical-api-stage on clinical-db 
1. install on cgweb-stage on clinical-db
1. go to OP-stage
1. create an RML test order (e.g. name #123456)
1. fill in valid sample data but leave the capture-kit empty
1. save
1. submit

Expected outcome:
The sample should have been submitted without complaints on missing capture-kit