### PR TITLE
adds date when sample connected to family

### DIFF
--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -106,6 +106,10 @@ class FamilySample(Model):
     sample_id = Column(ForeignKey('sample.id', ondelete='CASCADE'), nullable=False)
     status = Column(types.Enum('affected', 'unaffected', 'unknown'), default='unknown',
                     nullable=False)
+
+    created_at = Column(types.DateTime, default=dt.datetime.now)
+    updated_at = Column(types.DateTime, onupdate=dt.datetime.now)
+
     mother_id = Column(ForeignKey('sample.id'))
     father_id = Column(ForeignKey('sample.id'))
 

--- a/scripts/add-created_at-updated_at-to-family_sample.sql
+++ b/scripts/add-created_at-updated_at-to-family_sample.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `family_sample`
+ADD COLUMN `created_at` datetime DEFAULT NULL;
+
+ALTER TABLE `family_sample`
+ADD COLUMN `updated_at` datetime DEFAULT NULL;


### PR DESCRIPTION
This PR stores when we connect a sample to a family so we can we have that information when we try to understand when/why we have the data that we have

**How to test:**
1. install clinical-api on clinical-db stage (add instructions on how to as needed)
1. run the script _cg/scripts/add-created_at-updated_at-to-family_sample.sql_ 
1. open clinical-api
1. login
1. open the view Family Sample
1. create a Family Sample 
1. save the Family Sample
1. change the status on the newly created Family Sample
1. view (open/edit) the newly created Family Sample

**Expected outcome:**
The created_at field should have a datetime-value reflecting when the Family Sample was created
The updated_at field should have another datetime-value reflecting when the Family Sample was updated
