### PR TITLE
adds pip cache to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: python
 python:
     - '3.6'
 
+cache: pip
+
 install:
     - pip install cython
     - pip install -r requirements.txt -r requirements-dev.txt .


### PR DESCRIPTION
This PR speeds up the travis build process by keeping pip packages cached between builds.

How to test:
1. open the build details
1. choose restart build
1. wait for the build to finish

Expected outcome:
Every pip install line says something along the lines: `Using cached https://files.pythonhosted.org/packages/da/27`
The build succeeds.