### PR TITLE
fix: fix defect in cg upload

### DIFF
--- a/cg/meta/analysis.py
+++ b/cg/meta/analysis.py
@@ -35,7 +35,7 @@ class AnalysisAPI:
 
     def __init__(self, db: Store, hk_api: hk.HousekeeperAPI, scout_api: scoutapi.ScoutAPI,
                  tb_api: tb.TrailblazerAPI, lims_api: lims.LimsAPI, deliver_api: DeliverAPI,
-                 fastq_handler: fastq.FastqHandler, yaml_loader=safe_load, path_api=Path,
+                 fastq_handler=fastq.FastqHandler, yaml_loader=safe_load, path_api=Path,
                  logger=logging.getLogger(
                      __name__)):
         self.db = db


### PR DESCRIPTION
This PR the defect occurring in ```cg upload``` in cg version 2.24.0
How to test:

0. install on stage (add instructions on how to as needed)

1. run ```cg upload auto```

Expected outcome:

Following error message should **not** appear:
```
File "/mnt/hds/proj/bioinfo/SERVER/miniconda/envs/prod170926/lib/python3.6/site-packages/cg/cli/upload.py", line 46, in upload
    deliver_api=context.obj['deliver_api'])
TypeError: __init__() missing 1 required positional argument: 'fastq_handler'
```

note that when running ```cg upload auto``` another, unrelated, error occurs involving housekeeper...