### PR TITLE
adds 1508:16 as valid orderform

### DIFF
--- a/cg/apps/lims/orderform.py
+++ b/cg/apps/lims/orderform.py
@@ -12,6 +12,7 @@ CONTAINER_TYPES = ['Tube', '96 well plate']
 SOURCE_TYPES = set().union(METAGENOME_SOURCES, ANALYSIS_SOURCES)
 VALID_ORDERFORMS=[
     '1508:15',      # Orderform MIP, Balsamic, sequencing only
+    '1508:16',      # Orderform MIP, Balsamic, sequencing only. same as 1508:15 with new date
     '1541:6',       # Orderform Externally sequenced samples
     '1603:7',       # Microbial WGS
     '1604:8',       # Orderform Ready made libraries (RML)


### PR DESCRIPTION
adds since it is the same document as 1508:15 but with newer approval date

How to test:
1. install on stage (add instructions on how to as needed)
1. us
1. test upload with the new orderform in AM at least one sample row is needed

Expected outcome:
Sample is loaded in the Orderportal
