### PR TITLE
List all panels for all customers

### DIFF
--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -332,7 +332,7 @@ def options():
             'value': customer.internal_id,
         } for customer in customer_objs],
         applications=apptag_groups,
-        panels=[panel.abbrev for panel in db.Panel.query if panel.customer in customer_objs],
+        panels=[panel.abbrev for panel in db.Panel.query],
         organisms=[{
             'name': organism.name,
             'reference_genome': organism.reference_genome,

--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -332,7 +332,7 @@ def options():
             'value': customer.internal_id,
         } for customer in customer_objs],
         applications=apptag_groups,
-        panels=[panel.abbrev for panel in db.Panel.query],
+        panels=[panel.abbrev for panel in db.panels()],
         organisms=[{
             'name': organism.name,
             'reference_genome': organism.reference_genome,

--- a/cg/store/api/find.py
+++ b/cg/store/api/find.py
@@ -172,6 +172,10 @@ class FindHandler:
         """Find a panel by abbreviation."""
         return self.Panel.query.filter_by(abbrev=abbrev).first()
 
+    def panels(self):
+        """Returns all panels."""
+        return self.Panel.query.order_by(models.Panel.abbrev)
+
     def analyses(self, *, family: models.Family = None, before: dt.datetime = None) -> Query:
         """Fetch multiple analyses."""
         records = self.Analysis.query


### PR DESCRIPTION
This PR lets the user select all panels in the Orderportal

How to test:
1. install clinical-api and cgweb on stage (add instructions on how to as needed) on clinical-db
1. login to OP stage
1. create an MIP order
1. add family
1. open panel list

Expected outcome:
All the panels in statusDB should be selectable