### PR TITLE
Store which sample is tumour for mip and balsamic

### DIFF
--- a/cg/meta/orders/status.py
+++ b/cg/meta/orders/status.py
@@ -202,6 +202,7 @@ class StatusHandler:
                         comment=sample['comment'],
                         capture_kit=sample['capture_kit'],
                         data_analysis=sample['data_analysis'],
+                        tumour=sample['tumour'],
                     )
                     new_sample.customer = customer_obj
                     with self.status.session.no_autoflush:

--- a/tests/meta/orders/test_meta_orders_status.py
+++ b/tests/meta/orders/test_meta_orders_status.py
@@ -316,6 +316,7 @@ def test_store_mip(orders_api, base_store, mip_status_data):
     assert new_link.sample.sex == 'female'
     assert new_link.sample.application_version.application.tag == 'WGTPCFC030'
     assert new_link.sample.data_analysis == 'MIP'
+    assert new_link.sample.is_tumour
     assert isinstance(new_family.links[1].sample.comment, str)
 
     assert base_store.deliveries().count() == base_store.samples().count()
@@ -490,6 +491,7 @@ def test_store_cancer_samples(orders_api, base_store, balsamic_status_data):
     assert new_link.sample.application_version.application.tag == 'WGTPCFC030'
     assert new_link.sample.data_analysis == 'Balsamic'
     assert new_link.sample.comment == 'comment'
+    assert new_link.sample.is_tumour
 
     assert base_store.deliveries().count() == base_store.samples().count()
     for link in new_family.links:


### PR DESCRIPTION
This PR fixes problem saving which sample is tumour in status db for mip and balsamic samples

How to test:
0. install on clinical-api on clinical-db stage 
1. create and submit mip order with tumour sample
1. create and submit balsamic order with tumour sample
1. create and submit mip+balsamic order with tumour sample

Expected outcome:
The tumour samples should be marked as tumour in status-db