### PR TITLE
Add FQN for nas-9

### DIFF
--- a/cg/apps/pdc.py
+++ b/cg/apps/pdc.py
@@ -19,6 +19,6 @@ class PdcApi():
             raise ValueError(f"{sequencer_type}: invalid sequencer type")
 
         bash_command = f"bash SCRIPTS/retrieve_run_nas.bash {flowcell_id} {dest_server}"
-        command = ['ssh', 'nas-9', bash_command]
+        command = ['ssh', 'nas-9.scilifelab.se', bash_command]
         LOG.info(' '.join(command))
         subprocess.check_call(command)


### PR DESCRIPTION
Fixes #313



```
[0|0|4] [hiseq.clinical@hasta:~] [S_main] $ cg backup fetch-flowcell -f HKY5HCCXY
HKY5HCCXY: retreiving from PDC
ssh nas-9.scilifelab.se bash SCRIPTS/retrieve_run_nas.bash HKY5HCCXY rasta
Password updated.

[20190322133512] bash SCRIPTS/retrieve_decrypt.bash /home/hiseq.clinical/ENCRYPT/180417_ST-E00214_0216_BHKY5HCCXY.tar.gz.gpg localhost /home/hiseq.clinical/oldRuns/
[20190322133513] dsmc retrieve '/home/hiseq.clinical/ENCRYPT/180417_ST-E00214_0216_BHKY5HCCXY.key.gpg' /tmp/tmp.XLWpaM8oey
IBM Tivoli Storage Manager
Command Line Backup-Archive Client Interface
  Client Version 7, Release 1, Level 4.0 
  Client date/time: 03/22/19   13:35:13
(c) Copyright by IBM Corporation and other(s) 1990, 2015. All Rights Reserved.

Retrieve function invoked.
...
```