### PR TITLE
Adds delivery report step dates 

### DIFF
--- a/cg/meta/report/api.py
+++ b/cg/meta/report/api.py
@@ -61,7 +61,7 @@ class ReportAPI:
         report_data['panels'] = ReportAPI._present_list(panels)
         self._incorporate_lims_data(report_data)
         self._incorporate_lims_methods(report_samples)
-        self._incorporate_delivery_date_from_lims(report_samples)
+        self._incorporate_dates_from_lims(report_samples)
         self._incorporate_processing_time_from_lims(report_samples)
         self._incorporate_coverage_data(report_samples, panels)
         self._incorporate_trending_data(report_data, family_id)
@@ -86,11 +86,15 @@ class ReportAPI:
                 method_name = get_method(lims_id)
                 sample[method_type] = ReportAPI._present_string(method_name)
 
-    def _incorporate_delivery_date_from_lims(self, samples: list):
+    def _incorporate_dates_from_lims(self, samples: list):
         """Fetch and add the delivery date from LIMS for each sample."""
 
         for sample in samples:
             lims_id = sample['id']
+            prep_date = self.lims.get_prepared_date(lims_id)
+            sample['prep_date'] = ReportAPI._present_date(prep_date)
+            sequencing_date = self.lims.get_sequenced_date(lims_id)
+            sample['sequencing_date'] = ReportAPI._present_date(sequencing_date)
             delivery_date = self.lims.get_delivery_date(lims_id)
             sample['delivery_date'] = ReportAPI._present_date(delivery_date)
 
@@ -238,6 +242,7 @@ class ReportAPI:
             delivery_data_sample['id'] = sample.internal_id
             delivery_data_sample['ticket'] = ReportAPI._present_int(sample.ticket_number)
             delivery_data_sample['status'] = ReportAPI._present_string(family_sample.status)
+            delivery_data_sample['order_date'] = ReportAPI._present_date(sample.ordered_at)
 
             if sample.reads:
                 delivery_data_sample['million_read_pairs'] = round(sample.reads / 2000000, 1)

--- a/cg/meta/report/api.py
+++ b/cg/meta/report/api.py
@@ -92,7 +92,7 @@ class ReportAPI:
         for sample in samples:
             lims_id = sample['id']
             prep_date = self.lims.get_prepared_date(lims_id)
-            sample['prep_date'] = ReportAPI._present_date(prep_date)
+            sample['prep_date'] = ReportAPI._present_datetime(prep_date)
             sequencing_date = self.lims.get_sequenced_date(lims_id)
             sample['sequencing_date'] = ReportAPI._present_date(sequencing_date)
             delivery_date = self.lims.get_delivery_date(lims_id)
@@ -172,8 +172,20 @@ class ReportAPI:
         return presentable_value
 
     @staticmethod
+    def _present_datetime(a_date: datetime) -> str:
+        """Make an date value presentable for the delivery report."""
+
+        if a_date:
+            presentable_value = str(a_date.date())
+        else:
+            presentable_value = 'N/A'
+
+        return presentable_value
+
+    @staticmethod
     def _present_date(a_date: datetime.date) -> str:
         """Make an date value presentable for the delivery report."""
+
         if a_date:
             presentable_value = str(a_date)
         else:
@@ -242,7 +254,7 @@ class ReportAPI:
             delivery_data_sample['id'] = sample.internal_id
             delivery_data_sample['ticket'] = ReportAPI._present_int(sample.ticket_number)
             delivery_data_sample['status'] = ReportAPI._present_string(family_sample.status)
-            delivery_data_sample['order_date'] = ReportAPI._present_date(sample.ordered_at)
+            delivery_data_sample['order_date'] = ReportAPI._present_datetime(sample.ordered_at)
 
             if sample.reads:
                 delivery_data_sample['million_read_pairs'] = round(sample.reads / 2000000, 1)

--- a/cg/meta/report/templates/report.html
+++ b/cg/meta/report/templates/report.html
@@ -69,7 +69,7 @@
               {% for sample in samples %}
                 <tr>
                 <td>{{ sample.name }}* ({{ sample.id }})</td>
-                  <td>{{ sample.order_date }})</td>
+                  <td>{{ sample.order_date }}</td>
                   <td>{{ family }}*</td>
                   <td>
                     {{ sample.sex }}*

--- a/cg/meta/report/templates/report.html
+++ b/cg/meta/report/templates/report.html
@@ -95,7 +95,7 @@
             <thead>
               <tr>
                 <th>Prov</th>
-                <th>Ankomstdatum</th>
+                <th>Ankom</th>
                 <th>Biblioteksberedning</th>
                 <th>Beredd</th>
                 <th>Sekvensering</th>

--- a/cg/meta/report/templates/report.html
+++ b/cg/meta/report/templates/report.html
@@ -56,6 +56,7 @@
             <thead>
               <tr>
                 <th>Prov</th>
+                <th>Beställt</th>
                 <th>Familj</th>
                 <th>Kön</th>
                 <th>Status</th>
@@ -68,6 +69,7 @@
               {% for sample in samples %}
                 <tr>
                 <td>{{ sample.name }}* ({{ sample.id }})</td>
+                  <td>{{ sample.order_date }})</td>
                   <td>{{ family }}*</td>
                   <td>
                     {{ sample.sex }}*
@@ -106,7 +108,9 @@
                   <td>{{ sample.name }}*</td>
                   <td>{{ sample.received }}</td>
                   <td>{{ sample.prep_method }}</td>
+                  <td>{{ sample.prep_date }}</td>
                   <td>{{ sample.sequencing_method }}</td>
+                  <td>{{ sample.sequencing_date }}</td>
                   <td>{{ sample.delivery_method }}</td>
                   <td>
                     {{ sample.delivery_date }}

--- a/cg/meta/report/templates/report.html
+++ b/cg/meta/report/templates/report.html
@@ -97,7 +97,9 @@
                 <th>Prov</th>
                 <th>Ankomstdatum</th>
                 <th>Biblioteksberedning</th>
+                <th>Beredd</th>
                 <th>Sekvensering</th>
+                <th>Sekvenserad</th>
                 <th>Analys</th>
                 <th>Svarsdatum</th>
               </tr>

--- a/cg/store/api/find.py
+++ b/cg/store/api/find.py
@@ -121,16 +121,6 @@ class FindHandler:
         """Fetch a microbial sample by lims id."""
         return self.MicrobialSample.query.filter_by(internal_id=internal_id).first()
 
-    def find_sample(self, customer: models.Customer, name: str) -> List[models.Sample]:
-        """Find samples within a customer."""
-        return self.Sample.query.filter_by(customer=customer, name=name)
-
-    def find_sample_in_customer_group(self, customer: models.Customer, name: str) -> List[
-        models.Sample]:
-        """Find samples within the customer group."""
-        return self.Sample.query.filter(
-            models.Sample.customer.customer_group == customer.customer_group, name == name)
-
     def application(self, tag: str) -> models.Application:
         """Fetch an application from the store."""
         return self.Application.query.filter_by(tag=tag).first()

--- a/tests/meta/report/conftest.py
+++ b/tests/meta/report/conftest.py
@@ -38,6 +38,12 @@ class MockLims(LimsAPI):
     def get_processing_time(self, lims_id: str) -> str:
         return datetime.datetime.today() - datetime.datetime.today()
 
+    def get_prepared_date(self, lims_id: str) -> str:
+        return datetime.datetime.today()
+
+    def get_sequenced_date(self, lims_id: str) -> str:
+        return datetime.datetime.today()
+
     def get_delivery_date(self, lims_id: str) -> str:
         return datetime.datetime.today()
 

--- a/tests/meta/report/test_meta_report.py
+++ b/tests/meta/report/test_meta_report.py
@@ -42,11 +42,14 @@ def test_collect_delivery_data(report_api):
         assert sample['application']
         assert sample['received']
 
+        assert sample['order_date']
         assert sample['prep_method']
+        assert sample['prep_date']
         assert sample['sequencing_method']
+        assert sample['sequencing_date']
         assert sample['delivery_method']
-
         assert sample['delivery_date']
+
         assert sample['million_read_pairs']
         assert sample['mapped_reads']
         assert sample['target_coverage']
@@ -64,12 +67,14 @@ def test_incorporate_delivery_date_from_lims(lims_samples, report_api):
 
     # WHEN fetch_and_add_delivery_date_from_lims
     samples = lims_samples
-    report_api._incorporate_delivery_date_from_lims(samples)
+    report_api._incorporate_dates_from_lims(samples)
 
     # THEN
     # each sample has a property processing_time with a value of the days between received_at and
     #   delivery_date
     for sample in samples:
+        assert sample['prep_date']
+        assert sample['sequencing_date']
         assert sample['delivery_date']
 
 

--- a/tests/meta/report/test_meta_report.py
+++ b/tests/meta/report/test_meta_report.py
@@ -65,7 +65,7 @@ def test_collect_delivery_data(report_api):
 def test_incorporate_delivery_date_from_lims(lims_samples, report_api):
     # GIVEN data from an analysed case and an initialised report_api
 
-    # WHEN fetch_and_add_delivery_date_from_lims
+    # WHEN _incorporate_dates_from_lims
     samples = lims_samples
     report_api._incorporate_dates_from_lims(samples)
 

--- a/tests/meta/report/test_meta_report.py
+++ b/tests/meta/report/test_meta_report.py
@@ -70,8 +70,7 @@ def test_incorporate_delivery_date_from_lims(lims_samples, report_api):
     report_api._incorporate_dates_from_lims(samples)
 
     # THEN
-    # each sample has a property processing_time with a value of the days between received_at and
-    #   delivery_date
+    # each sample has step dates from different steps registered in LIMS
     for sample in samples:
         assert sample['prep_date']
         assert sample['sequencing_date']


### PR DESCRIPTION
This PR adds order/prep and sequencing dates for the samples in the delivery report

How to test:
0. install on stage on rasta 
1. us
1. cg upload delivery-report -p CUST-ID FAMILY-ID

Expected outcome:
order/prep and sequencing dates are present for the samples
