### PR TITLE
fix: change master step name 'CG002 - Delivery' -> 'Delivery v1' to follow changes in LIMS

### DIFF
--- a/cg/apps/lims/api.py
+++ b/cg/apps/lims/api.py
@@ -101,7 +101,7 @@ class LimsAPI(Lims, OrderHandler):
 
     def get_delivery_date(self, lims_id: str) -> dt.date:
         """Get delivery date for a sample."""
-        artifacts = self.get_artifacts(samplelimsid=lims_id, process_type='CG002 - Delivery',
+        artifacts = self.get_artifacts(samplelimsid=lims_id, process_type='Delivery v1',
                                        type='Analyte')
         if len(artifacts) == 1:
             return artifacts[0].parent_process.udf.get('Date delivered')


### PR DESCRIPTION
This PR fixes a defect where `cg transfer lims -s delivered` returned no dates. This was due to a change in LIMS where the master step name `CG002 - Delivery` was changed to `Delivery v1`.

How to test:
1. install on stage
2. optional: run `/home/hiseq.clinical/servers/resources/clinical-db.scilifelab.se/dbcopy-prod-to-stage.sh` on clinical-db.
3. run `cg transfer lims -s delivered` on hasta

Expected outcome:
the program should now retrieve delivery dates form LIMS, showing the following messages: 
`Found new delivered date for <SAMPLE_ID>: <DELIVERY_DATE>, old value: None `
