### PR TITLE
Adds upload delivery-reports command

### DIFF
--- a/cg/cli/upload.py
+++ b/cg/cli/upload.py
@@ -188,7 +188,9 @@ def delivery_reports(context, print_console):
     for analysis_obj in context.obj['status'].analyses_to_delivery_report():
         LOG.info("uploading delivery report for family: %s", analysis_obj.family.internal_id)
         try:
-            context.invoke(delivery_report, family_id=analysis_obj.family.internal_id, print_console=print_console)
+            context.invoke(delivery_report,
+                           family_id=analysis_obj.family.internal_id,
+                           print_console=print_console)
         except Exception:
             LOG.error("uploading delivery report failed for family: %s",
                       analysis_obj.family.internal_id)

--- a/cg/cli/upload.py
+++ b/cg/cli/upload.py
@@ -141,12 +141,15 @@ def delivery_report(context, family_id, print_console):
         click.echo(delivery_report_html)
     else:
         tb_api = context.obj['tb_api']
+        status_api = context.obj['status']
         delivery_report_file = report_api.create_delivery_report_file(family_id,
                                                                       file_path=
                                                                       tb_api.get_family_root_dir(
                                                                         family_id))
         hk_api = context.obj['housekeeper_api']
-        _add_delivery_report_to_hk(delivery_report_file, hk_api, family_id)
+        result = _add_delivery_report_to_hk(delivery_report_file, hk_api, family_id)
+        if result:
+            _update_delivery_report_date(status_api, family_id)
 
 
 def _add_delivery_report_to_hk(delivery_report_file, hk_api: hk.HousekeeperAPI, family_id):
@@ -162,6 +165,33 @@ def _add_delivery_report_to_hk(delivery_report_file, hk_api: hk.HousekeeperAPI, 
         file_obj = hk_api.add_file(delivery_report_file.name, version_obj, delivery_report_tag_name)
         hk_api.include_file(file_obj, version_obj)
         hk_api.add_commit(file_obj)
+        return True
+
+    return False
+
+
+def _update_delivery_report_date(status_api, family_id):
+    family_obj = status_api.family(family_id)
+    analysis_obj = family_obj.analyses[0]
+    analysis_obj.delivery_report_created_at = dt.datetime.now()
+    status_api.commit()
+
+
+@upload.command('delivery-reports')
+@click.option('-p', '--print', 'print_console', is_flag=True, help='print list to console')
+@click.pass_context
+def delivery_reports(context, print_console):
+    """Generate a delivery reports for all cases that need one"""
+
+    click.echo(click.style('----------------- DELIVERY REPORTS ------------------------'))
+
+    for analysis_obj in context.obj['status'].analyses_to_delivery_report():
+        LOG.info("uploading delivery report for family: %s", analysis_obj.family.internal_id)
+        try:
+            context.invoke(delivery_report, family_id=analysis_obj.family.internal_id, print_console=print_console)
+        except Exception:
+            LOG.error("uploading delivery report failed for family: %s",
+                      analysis_obj.family.internal_id)
 
 
 @upload.command()

--- a/cg/store/api/status.py
+++ b/cg/store/api/status.py
@@ -408,9 +408,30 @@ class StatusHandler:
         """Fetch analyses that have been uploaded but not delivered."""
         records = (
             self.Analysis.query
+            .join(models.Family, models.Family.links, models.FamilySample.sample)
             .filter(
-                models.Analysis.uploaded_at != None,
-                models.Analysis.delivered_at == None
+                models.Analysis.uploaded_at.isnot(None),
+                models.Sample.delivered_at.is_(None)
+            )
+            .order_by(models.Analysis.uploaded_at.desc())
+        )
+
+        return records
+
+    def analyses_to_delivery_report(self):
+        """Fetch analyses that needs the delivery report to be regenerated."""
+        records = (
+            self.Analysis.query
+            .join(models.Family, models.Family.links, models.FamilySample.sample)
+            .filter(
+                models.Sample.delivered_at.isnot(None),
+                or_(
+                    models.Analysis.delivery_report_created_at.is_(None),
+                    and_(
+                        models.Analysis.delivery_report_created_at.isnot(None),
+                        models.Analysis.delivery_report_created_at < models.Sample.delivered_at
+                    )
+                )
             )
             .order_by(models.Analysis.uploaded_at.desc())
         )

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -424,11 +424,10 @@ class Analysis(Model):
     pipeline_version = Column(types.String(32))
     started_at = Column(types.DateTime)
     completed_at = Column(types.DateTime)
+    delivery_report_created_at = Column(types.DateTime)
     uploaded_at = Column(types.DateTime)
-    delivered_at = Column(types.DateTime)
     # primary analysis is the one originally delivered to the customer
     is_primary = Column(types.Boolean, default=False)
-    housekeeper_id = Column(types.Integer)
 
     created_at = Column(types.DateTime, default=dt.datetime.now, nullable=False)
     family_id = Column(ForeignKey('family.id', ondelete='CASCADE'), nullable=False)

--- a/scripts/add-delivery_report_created_at-to-analysis.sql
+++ b/scripts/add-delivery_report_created_at-to-analysis.sql
@@ -1,0 +1,8 @@
+ALTER TABLE `analysis`
+ADD COLUMN `delivery_report_created_at` datetime DEFAULT NULL;
+
+Update `analysis` SET delivery_report_created_at = uploaded_at;
+
+ALTER TABLE `analysis` DROP COLUMN `delivered_at`;
+
+ALTER TABLE `analysis` DROP COLUMN `housekeeper_id`;

--- a/tests/store/api/test_store_api_status_analyses_to_delivery_report.py
+++ b/tests/store/api/test_store_api_status_analyses_to_delivery_report.py
@@ -1,0 +1,127 @@
+"""This file tests the analyses_to_delivery_report part of the status api"""
+from datetime import datetime, timedelta
+
+from cg.store import Store
+
+
+def test_analyses_to_delivery_report_missing(analysis_store: Store):
+    """Tests that analyses that are completed but lacks delivery report are returned"""
+
+    # GIVEN an analysis that is delivered but has no delivery report
+    analysis = add_analysis(analysis_store)
+    sample = add_sample(analysis_store, delivered=True)
+    analysis_store.relate_sample(family=analysis.family, sample=sample, status='unknown')
+    assert sample.delivered_at is not None
+    assert analysis.delivery_report_created_at is None
+
+    # WHEN calling the analyses_to_delivery_report
+    analyses = analysis_store.analyses_to_delivery_report().all()
+
+    # THEN this analyse should be returned
+    assert analysis in analyses
+
+
+def test_analyses_to_delivery_report_outdated(analysis_store):
+    """Tests that analyses that have a delivery report but is older than the delivery are
+    returned"""
+
+    # GIVEN an analysis that is delivered but has an outdated delivery report
+    analysis = add_analysis(analysis_store, old_delivery_report=True)
+    sample = add_sample(analysis_store, delivered=True)
+    analysis_store.relate_sample(family=analysis.family, sample=sample, status='unknown')
+    # WHEN calling the analyses_to_delivery_report
+    analyses = analysis_store.analyses_to_delivery_report().all()
+
+    # THEN this analyse should be returned
+    assert analysis in analyses
+
+
+def ensure_application_version(disk_store, application_tag='dummy_tag'):
+    """utility function to return existing or create application version for tests"""
+    application = disk_store.application(tag=application_tag)
+    if not application:
+        application = disk_store.add_application(tag=application_tag, category='wgs',
+                                                 description='dummy_description')
+        disk_store.add_commit(application)
+
+    prices = {'standard': 10, 'priority': 20, 'express': 30, 'research': 5}
+    version = disk_store.application_version(application, 1)
+    if not version:
+        version = disk_store.add_version(application, 1, valid_from=datetime.now(),
+                                         prices=prices)
+
+        disk_store.add_commit(version)
+    return version
+
+
+def ensure_customer(disk_store, customer_id='cust_test'):
+    """utility function to return existing or create customer for tests"""
+    customer_group = disk_store.customer_group('dummy_group')
+    if not customer_group:
+        customer_group = disk_store.add_customer_group('dummy_group', 'dummy group')
+
+        customer = disk_store.add_customer(internal_id=customer_id, name="Test Customer",
+                                           scout_access=False, customer_group=customer_group,
+                                           invoice_address='dummy_address',
+                                           invoice_reference='dummy_reference')
+        disk_store.add_commit(customer)
+    customer = disk_store.customer(customer_id)
+    return customer
+
+
+def ensure_panel(disk_store, panel_id='panel_test', customer_id='cust_test'):
+    """utility function to add a panel to use in tests"""
+    customer = ensure_customer(disk_store, customer_id)
+    panel = disk_store.panel(panel_id)
+    if not panel:
+        panel = disk_store.add_panel(customer=customer, name=panel_id, abbrev=panel_id,
+                                     version=1.0,
+                                     date=datetime.now(), genes=1)
+        disk_store.add_commit(panel)
+    return panel
+
+
+def add_sample(store, sample_name='sample_test', delivered=False, date=datetime.now()):
+    """utility function to add a sample to use in tests"""
+    customer = ensure_customer(store)
+    application_version_id = ensure_application_version(store).id
+    sample = store.add_sample(name=sample_name, sex='unknown')
+    sample.application_version_id = application_version_id
+    sample.customer = customer
+    if delivered:
+        sample.delivered_at = date
+    store.add_commit(sample)
+    return sample
+
+
+def add_family(disk_store, family_id='family_test', customer_id='cust_test', ordered_days_ago=0,
+               action=None, priority=None):
+    """utility function to add a family to use in tests"""
+    panel = ensure_panel(disk_store)
+    customer = ensure_customer(disk_store, customer_id)
+    family = disk_store.add_family(name=family_id, panels=panel.name)
+    family.customer = customer
+    family.ordered_at = datetime.now() - timedelta(days=ordered_days_ago)
+    if action:
+        family.action = action
+    if priority:
+        family.priority = priority
+    disk_store.add_commit(family)
+    return family
+
+
+def add_analysis(store, completed=False, delivered=False, old_delivery_report=False):
+    """Utility function to add an analysis for tests"""
+    family = add_family(store)
+    analysis = store.add_analysis(pipeline='', version='')
+    if completed:
+        analysis.completed_at = datetime.now()
+    if delivered:
+        analysis.delivered_at = datetime.now()
+    if old_delivery_report:
+        analysis.delivery_report_created_at = datetime.now() - timedelta(days=1)
+        analysis.delivered_at = datetime.now()
+
+    family.analyses.append(analysis)
+    store.add_commit(analysis)
+    return analysis

--- a/tests/store/conftest.py
+++ b/tests/store/conftest.py
@@ -99,3 +99,76 @@ def microbial_store(base_store, microbial_submitted_order):
 
     base_store.commit()
     yield base_store
+
+
+def _analysis_family():
+    """Build an example family."""
+    family = {
+        'name': 'family',
+        'internal_id': 'yellowhog',
+        'panels': ['IEM', 'EP'],
+        'samples': [{
+            'name': 'son',
+            'sex': 'male',
+            'internal_id': 'ADM1',
+            'father': 'ADM2',
+            'mother': 'ADM3',
+            'status': 'affected',
+            'ticket_number': 123456,
+            'reads': 5000000,
+        }, {
+            'name': 'father',
+            'sex': 'male',
+            'internal_id': 'ADM2',
+            'status': 'unaffected',
+            'ticket_number': 123456,
+            'reads': 6000000,
+        }, {
+            'name': 'mother',
+            'sex': 'female',
+            'internal_id': 'ADM3',
+            'status': 'unaffected',
+            'ticket_number': 123456,
+            'reads': 7000000,
+        }]
+    }
+    return family
+
+
+@pytest.yield_fixture(scope='function')
+def analysis_store(base_store):
+    """Setup a store instance for testing analysis API."""
+    analysis_family = _analysis_family()
+    customer = base_store.customer('cust000')
+    family = base_store.Family(name=analysis_family['name'], panels=analysis_family[
+        'panels'], internal_id=analysis_family['internal_id'], priority='standard')
+    family.customer = customer
+    base_store.add(family)
+    application_version = base_store.application('WGTPCFC030').versions[0]
+    for sample_data in analysis_family['samples']:
+        sample = base_store.add_sample(name=sample_data['name'], sex=sample_data['sex'],
+                                       internal_id=sample_data['internal_id'],
+                                       ticket=sample_data['ticket_number'],
+                                       reads=sample_data['reads'], )
+        sample.family = family
+        sample.application_version = application_version
+        sample.customer = customer
+        base_store.add(sample)
+    base_store.commit()
+    for sample_data in analysis_family['samples']:
+        sample_obj = base_store.sample(sample_data['internal_id'])
+        link = base_store.relate_sample(
+            family=family,
+            sample=sample_obj,
+            status=sample_data['status'],
+            father=base_store.sample(sample_data['father']) if sample_data.get('father') else None,
+            mother=base_store.sample(sample_data['mother']) if sample_data.get('mother') else None,
+        )
+        base_store.add(link)
+
+    _analysis = base_store.add_analysis(pipeline='pipeline', version='version')
+    _analysis.family = family
+    _analysis.config_path = 'dummy_path'
+
+    base_store.commit()
+    yield base_store


### PR DESCRIPTION
This PR adds the CLI command to upload several delivery-reports at once

How to test:
0. install on stage 
1. run add-delivery_report_created_at-to-analysis.sql
1. us
1. cg upload delivery-reports

Expected outcome:
The command should create a delivery-report for each analysis that doesn't already have one
