### PR TITLE
Uploads delivery report separate from scout upload

### DIFF
--- a/cg/apps/scoutapi.py
+++ b/cg/apps/scoutapi.py
@@ -52,10 +52,11 @@ class ScoutAPI(MongoAdapter):
             panel genes: panel genes list
         """
         gene_panel = self.gene_panel(panel_id=panel_id, version=version)
+
         if gene_panel:
             return gene_panel.get('genes')
-        else:
-            return None
+
+        return None
 
     def get_cases(self, case_id=None, institute=None, reruns=None, finished=None,
                   causatives=None, research_requested=None, is_research=None, status=None):
@@ -76,9 +77,9 @@ class ScoutAPI(MongoAdapter):
         return models
 
     def upload_delivery_report(self,
-                             report_path: str,
-                             case_id: str,
-                             update: bool = False):
+                               report_path: str,
+                               case_id: str,
+                               update: bool = False):
         """ Load a delivery report into a case in the database
 
         If the report already exists the function will exit.

--- a/cg/apps/scoutapi.py
+++ b/cg/apps/scoutapi.py
@@ -88,7 +88,7 @@ class ScoutAPI(MongoAdapter):
 
         Args:
             report_path (string):       Path to delivery report
-            case_id     (string):       Optional case identifier
+            case_id     (string):       Case identifier
             update      (bool):         If an existing report should be replaced
 
         Returns:

--- a/cg/apps/scoutapi.py
+++ b/cg/apps/scoutapi.py
@@ -4,7 +4,7 @@ from typing import List
 
 from pymongo import MongoClient
 from scout.adapter.mongo import MongoAdapter
-from scout.adapter.mongo.panel import PanelHandler
+from scout.load.report import load_delivery_report
 from scout.export.panel import export_panels as scout_export_panels
 from scout.load import load_scout
 from scout.parse.case import parse_case_data
@@ -52,10 +52,13 @@ class ScoutAPI(MongoAdapter):
             panel genes: panel genes list
         """
         gene_panel = self.gene_panel(panel_id=panel_id, version=version)
-        return gene_panel.get('genes')
+        if gene_panel:
+            return gene_panel.get('genes')
+        else:
+            return None
 
-    def get_cases(self, case_id=None, institute=None, reruns=None, finished=None, causatives=None, research_requested=None,
-          is_research=None, status=None):
+    def get_cases(self, case_id=None, institute=None, reruns=None, finished=None,
+                  causatives=None, research_requested=None, is_research=None, status=None):
         """Interact with cases existing in the database."""
 
         models = []
@@ -66,8 +69,31 @@ class ScoutAPI(MongoAdapter):
 
         else:
             models = self.cases(collaborator=institute, reruns=reruns,
-                               finished=finished, has_causatives=causatives,
-                               research_requested=research_requested,
-                               is_research=is_research, status=status)
+                                finished=finished, has_causatives=causatives,
+                                research_requested=research_requested,
+                                is_research=is_research, status=status)
 
         return models
+
+    def upload_delivery_report(self,
+                             report_path: str,
+                             case_id: str,
+                             update: bool = False):
+        """ Load a delivery report into a case in the database
+
+        If the report already exists the function will exit.
+        If the user want to load a report that is already in the database
+        'update' has to be 'True'
+
+        Args:
+            report_path (string):       Path to delivery report
+            case_id     (string):       Optional case identifier
+            update      (bool):         If an existing report should be replaced
+
+        Returns:
+            updated_case(dict)
+
+        """
+
+        return load_delivery_report(adapter=self, case_id=case_id, report_path=report_path,
+                                    update=update)

--- a/cg/apps/scoutapi.py
+++ b/cg/apps/scoutapi.py
@@ -51,12 +51,7 @@ class ScoutAPI(MongoAdapter):
         Returns:
             panel genes: panel genes list
         """
-        gene_panel = self.gene_panel(panel_id=panel_id, version=version)
-
-        if gene_panel:
-            return gene_panel.get('genes')
-
-        return None
+        return self.gene_panel(panel_id=panel_id, version=version)
 
     def get_cases(self, case_id=None, institute=None, reruns=None, finished=None,
                   causatives=None, research_requested=None, is_research=None, status=None):

--- a/cg/cli/upload.py
+++ b/cg/cli/upload.py
@@ -154,7 +154,7 @@ def delivery_report(context, family_id, print_console):
         if added_file:
             click.echo(click.style('uploaded to housekeeper', fg='green'))
             _add_delivery_report_to_scout(context, added_file.path, family_id)
-            click.echo(click.style('uploaded to scout'), fg='green')
+            click.echo(click.style('uploaded to scout', fg='green'))
             _update_delivery_report_date(status_api, family_id)
         else:
             click.echo(click.style('already uploaded to housekeeper, skipping'))

--- a/cg/cli/upload.py
+++ b/cg/cli/upload.py
@@ -153,16 +153,18 @@ def delivery_report(context, family_id, print_console):
 
         if added_file:
             click.echo(click.style('uploaded to housekeeper', fg='green'))
-            _add_delivery_report_to_scout(context, added_file.full_path, family_id)
-            click.echo(click.style('uploaded to scout', fg='green'))
-            _update_delivery_report_date(status_api, family_id)
+            if _add_delivery_report_to_scout(context, added_file.full_path, family_id):
+                click.echo(click.style('uploaded to scout', fg='green'))
+                _update_delivery_report_date(status_api, family_id)
+            else:
+                click.echo(click.style('Failed to upload to scout', fg='red'))
         else:
             click.echo(click.style('already uploaded to housekeeper, skipping'))
 
 
 def _add_delivery_report_to_scout(context, path, case_id):
     scout_api = scoutapi.ScoutAPI(context.obj)
-    scout_api.upload_delivery_report(path, case_id, update=True)
+    return scout_api.upload_delivery_report(path, case_id, update=True)
 
 
 def _add_delivery_report_to_hk(delivery_report_file, hk_api: hk.HousekeeperAPI, family_id):

--- a/cg/cli/upload.py
+++ b/cg/cli/upload.py
@@ -153,18 +153,16 @@ def delivery_report(context, family_id, print_console):
 
         if added_file:
             click.echo(click.style('uploaded to housekeeper', fg='green'))
-            if _add_delivery_report_to_scout(context, added_file.full_path, family_id):
-                click.echo(click.style('uploaded to scout', fg='green'))
-                _update_delivery_report_date(status_api, family_id)
-            else:
-                click.echo(click.style('Failed to upload to scout', fg='red'))
+            _add_delivery_report_to_scout(context, added_file.full_path, family_id)
+            click.echo(click.style('uploaded to scout', fg='green'))
+            _update_delivery_report_date(status_api, family_id)
         else:
             click.echo(click.style('already uploaded to housekeeper, skipping'))
 
 
 def _add_delivery_report_to_scout(context, path, case_id):
     scout_api = scoutapi.ScoutAPI(context.obj)
-    return scout_api.upload_delivery_report(path, case_id, update=True)
+    scout_api.upload_delivery_report(path, case_id, update=True)
 
 
 def _add_delivery_report_to_hk(delivery_report_file, hk_api: hk.HousekeeperAPI, family_id):

--- a/cg/cli/upload.py
+++ b/cg/cli/upload.py
@@ -153,7 +153,7 @@ def delivery_report(context, family_id, print_console):
 
         if added_file:
             click.echo(click.style('uploaded to housekeeper', fg='green'))
-            _add_delivery_report_to_scout(context, added_file.path, family_id)
+            _add_delivery_report_to_scout(context, added_file.full_path, family_id)
             click.echo(click.style('uploaded to scout', fg='green'))
             _update_delivery_report_date(status_api, family_id)
         else:

--- a/cg/cli/upload.py
+++ b/cg/cli/upload.py
@@ -162,7 +162,7 @@ def delivery_report(context, family_id, print_console):
 
 def _add_delivery_report_to_scout(context, path, case_id):
     scout_api = scoutapi.ScoutAPI(context.obj)
-    scout_api.upload_delivery_report(path, case_id, upload=True)
+    scout_api.upload_delivery_report(path, case_id, update=True)
 
 
 def _add_delivery_report_to_hk(delivery_report_file, hk_api: hk.HousekeeperAPI, family_id):

--- a/cg/cli/upload.py
+++ b/cg/cli/upload.py
@@ -83,7 +83,7 @@ def upload(context, family_id):
 @click.option('-p', '--print', 'print_console', is_flag=True, help='print report to console')
 @click.pass_context
 def delivery_report(context, family_id, print_console):
-    """Generate a delivery report for a case.
+    """Generates a delivery report for a case and uploads it to housekeeper and scout
 
     The report contains data from several sources:
 

--- a/cg/cli/upload.py
+++ b/cg/cli/upload.py
@@ -149,11 +149,11 @@ def delivery_report(context, family_id, print_console):
                                                                       tb_api.get_family_root_dir(
                                                                         family_id))
         hk_api = context.obj['housekeeper_api']
-        result = _add_delivery_report_to_hk(delivery_report_file, hk_api, family_id)
+        added_file = _add_delivery_report_to_hk(delivery_report_file, hk_api, family_id)
 
-        if result:
+        if added_file:
             click.echo(click.style('uploaded to housekeeper', fg='green'))
-            _add_delivery_report_to_scout(context, delivery_report_file, family_id)
+            _add_delivery_report_to_scout(context, added_file.path, family_id)
             click.echo(click.style('uploaded to scout'), fg='green')
             _update_delivery_report_date(status_api, family_id)
         else:
@@ -162,7 +162,7 @@ def delivery_report(context, family_id, print_console):
 
 def _add_delivery_report_to_scout(context, delivery_report_file, family_id):
     scout_api = scoutapi.ScoutAPI(context.obj)
-    scout_api.upload_delivery_report(delivery_report_file, family_id)
+    scout_api.upload_delivery_report(delivery_report_file.name, family_id)
 
 
 def _add_delivery_report_to_hk(delivery_report_file, hk_api: hk.HousekeeperAPI, family_id):
@@ -178,9 +178,9 @@ def _add_delivery_report_to_hk(delivery_report_file, hk_api: hk.HousekeeperAPI, 
         file_obj = hk_api.add_file(delivery_report_file.name, version_obj, delivery_report_tag_name)
         hk_api.include_file(file_obj, version_obj)
         hk_api.add_commit(file_obj)
-        return True
+        return file_obj
 
-    return False
+    return None
 
 
 def _update_delivery_report_date(status_api, family_id):

--- a/cg/cli/upload.py
+++ b/cg/cli/upload.py
@@ -160,9 +160,9 @@ def delivery_report(context, family_id, print_console):
             click.echo(click.style('already uploaded to housekeeper, skipping'))
 
 
-def _add_delivery_report_to_scout(context, delivery_report_file, family_id):
+def _add_delivery_report_to_scout(context, path, case_id):
     scout_api = scoutapi.ScoutAPI(context.obj)
-    scout_api.upload_delivery_report(delivery_report_file.name, family_id)
+    scout_api.upload_delivery_report(path, case_id)
 
 
 def _add_delivery_report_to_hk(delivery_report_file, hk_api: hk.HousekeeperAPI, family_id):

--- a/cg/cli/upload.py
+++ b/cg/cli/upload.py
@@ -162,7 +162,7 @@ def delivery_report(context, family_id, print_console):
 
 def _add_delivery_report_to_scout(context, path, case_id):
     scout_api = scoutapi.ScoutAPI(context.obj)
-    scout_api.upload_delivery_report(path, case_id)
+    scout_api.upload_delivery_report(path, case_id, upload=True)
 
 
 def _add_delivery_report_to_hk(delivery_report_file, hk_api: hk.HousekeeperAPI, family_id):

--- a/cg/meta/report/api.py
+++ b/cg/meta/report/api.py
@@ -242,7 +242,9 @@ class ReportAPI:
         panel_genes = list()
 
         for panel in panels:
-            panel_genes.extend(self.scout.get_genes(panel))
+            genes = self.scout.get_genes(panel)
+            if genes:
+                panel_genes.extend(genes)
 
         panel_gene_ids = [gene.get('hgnc_id') for gene in panel_genes]
 

--- a/cg/meta/report/api.py
+++ b/cg/meta/report/api.py
@@ -242,9 +242,7 @@ class ReportAPI:
         panel_genes = list()
 
         for panel in panels:
-            genes = self.scout.get_genes(panel)
-            if genes:
-                panel_genes.extend(genes)
+            panel_genes.extend(self.scout.get_genes(panel))
 
         panel_gene_ids = [gene.get('hgnc_id') for gene in panel_genes]
 

--- a/cg/meta/report/templates/report.html
+++ b/cg/meta/report/templates/report.html
@@ -137,10 +137,12 @@
         <div class="card-block">
           <table class="table table-bordered">
             <thead>
-              <th>Familj</th>
-              <th>MIP-version</th>
-              <th>Genpaneler</th>
-              <th>Genomversion</th>
+              <tr>
+                <th>Familj</th>
+                <th>MIP-version</th>
+                <th>Genpaneler</th>
+                <th>Genomversion</th>
+              </tr>
             </thead>
             <tbody>
               <tr>


### PR DESCRIPTION
This PR separates the upload of the delivery report from the regular case upload.

How to test separation from regular upload:
0. install this branch of cg on stage on hasta
1. us
1. cg upload -f [CASE-ID]

Expected outcome:
The case uploads without mention delivery report

How to test separation into its own upload:
1. us
1. cg upload delivery-report [CASE-ID]

Expected outcome:
A delivery report is created and uploaded to housekeeper and scout
