### PR TITLE
Stop storing instead of duplicating analysis

### DIFF
--- a/cg/cli/store.py
+++ b/cg/cli/store.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import click
 
 from cg.apps import hk, tb
-from cg.exc import AnalysisNotFinishedError
+from cg.exc import AnalysisNotFinishedError, AnalysisDuplicationError
 from cg.store import Store
 
 LOG = logging.getLogger(__name__)
@@ -77,7 +77,10 @@ def _include_files_in_housekeeper(bundle_obj, context, hk_api, version_obj):
 def _add_new_complete_analysis_record(bundle_data, family_obj, status, version_obj):
 
     pipeline = family_obj.links[0].sample.data_analysis
-    pipeline = pipeline if pipeline else 'mip' # TODO remove this default from here
+
+    if status.analysis(family=family_obj, started_at=version_obj.created_at):
+        raise AnalysisDuplicationError(
+            f'Analysis object already exists for {family_obj.internal_id}{version_obj.created_at}')
 
     new_analysis = status.add_analysis(
         pipeline=pipeline,

--- a/cg/exc.py
+++ b/cg/exc.py
@@ -14,6 +14,10 @@ class AnalysisNotFinishedError(CgError):
     pass
 
 
+class AnalysisDuplicationError(CgError):
+    """Error related to trying to create duplicate analysis objects"""
+
+
 class LimsDataError(CgError):
     """Error related to missing/incomplete data in LIMS."""
     pass

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,3 +1,4 @@
+"""Fixtures for cli tests"""
 from functools import partial
 
 from cg.apps import hk

--- a/tests/cli/test_cli_store.py
+++ b/tests/cli/test_cli_store.py
@@ -1,5 +1,9 @@
-from cg.apps import hk
+"""Tests for cg.cli.store._add_new_complete_analysis_record"""
+from datetime import datetime
+
+import pytest
 from cg.cli.store import _add_new_complete_analysis_record
+from cg.exc import AnalysisDuplicationError
 from cg.store import Store
 
 
@@ -10,6 +14,7 @@ def test_add_new_complete_analysis_record(analysis_store: Store, hk_version_obj)
     family_with_samples = analysis_store.families().first()
     family_with_samples.links[0].sample.data_analysis = pipeline
     dummy_bundle_data = {'pipeline_version': 'dummy_version'}
+    hk_version_obj.created_at = datetime.now()
 
     # WHEN calling add_new_complete_analysis_record
     new_analysis = _add_new_complete_analysis_record(dummy_bundle_data, family_with_samples,
@@ -17,3 +22,21 @@ def test_add_new_complete_analysis_record(analysis_store: Store, hk_version_obj)
 
     # THEN it should put the pipeline in analysis record
     assert new_analysis['pipeline'] == pipeline
+
+
+def test_duplicate_add_new_complete_analysis_record_raises(analysis_store: Store, hk_version_obj):
+
+    # GIVEN A family has samples with data_analysis on them
+    pipeline = 'test-pipeline'
+    family_with_samples = analysis_store.families().first()
+    family_with_samples.links[0].sample.data_analysis = pipeline
+    dummy_bundle_data = {'pipeline_version': 'dummy_version'}
+    hk_version_obj.created_at = datetime.now()
+    _add_new_complete_analysis_record(dummy_bundle_data, family_with_samples,
+                                      analysis_store, hk_version_obj)
+
+    # WHEN calling add_new_complete_analysis_record
+    # THEN it should throw an AnalysisDuplicationError
+    with pytest.raises(AnalysisDuplicationError):
+        _add_new_complete_analysis_record(dummy_bundle_data, family_with_samples,
+                                          analysis_store, hk_version_obj)


### PR DESCRIPTION
This PR makes cg throw an error if try to store an analysis that has already been created in status-db

How to test duplication check:
0. install on stage (add instructions on how to as needed)
1. us
1. find/create case that has been stored already
1. remove bundle in `housekeeper delete bundle [casename]`
1. `cg store analysis [path_to_analysis_config]`

Expected outcome:
cg should raise an AnalysisDuplicationError exception 

How to test normal behaviour:
0. install on stage (add instructions on how to as needed)
1. us
1. find/create case that has NOT been stored already
1. `cg store analysis [path_to_analysis_config]`

Expected outcome:
cg should store the analysis, i.e. create analysis record in status db and upload to housekeeper