### PR TITLE
Update/set microbial samples apptag in LIMS via cli

### DIFF
--- a/cg/cli/set.py
+++ b/cg/cli/set.py
@@ -143,6 +143,11 @@ def sample(context, sex, customer, comment, downsampled_to, apptag, capture_kit,
                                f"{str(application_version)}.", fg='green'))
         context.obj['status'].commit()
 
+        click.echo(click.style('update LIMS/application', fg='blue'))
+        if context.obj.get('lims'):
+            LimsAPI(context.obj).update_sample(sample_id, application=apptag)
+
+
     if capture_kit:
         sample_obj.capture_kit = capture_kit
         click.echo(click.style(f"Capture kit {capture_kit} added to sample "


### PR DESCRIPTION
This PR fixes the Changing sample apptags in LIMS

How to test set apptag:
1. us
1. `cg set sample [LIMSID] [SIGNATURE] -a/--apptag [apptag]`

Expected outcome:
```
Application tag for sample [LIMSID] set to [apptag].
Comment added to sample [LIMSID]
update LIMS/application
```
sample apptag has been set to the specified, an comment has been added to the order specifying who did what and when
Apptag has been set to [apptag] in LIMS for sample with [LIMSID] 
