### PR TITLE
change default inbox to point to hasta inbox

### DIFF
--- a/cg/cli/deliver.py
+++ b/cg/cli/deliver.py
@@ -23,7 +23,9 @@ def deliver(context):
 @click.option('-d', '--dry', is_flag=True, help='print config to console')
 @click.option('-V', '--version', help='version (date) of bundle')
 @click.option('-t', '--tag', multiple=True, help='the housekeeper tag(s)')
-@click.option('-i', '--inbox', default='/home/proj/production/customers/{customer}/inbox/{family}/', help='customer inbox')
+@click.option('-i', '--inbox',
+              default='/home/proj/production/customers/{customer}/inbox/{family}/',
+              help='customer inbox')
 @click.argument('family')
 @click.pass_context
 def inbox(context, dry, family, version, tag, inbox):

--- a/cg/cli/deliver.py
+++ b/cg/cli/deliver.py
@@ -23,7 +23,7 @@ def deliver(context):
 @click.option('-d', '--dry', is_flag=True, help='print config to console')
 @click.option('-V', '--version', help='version (date) of bundle')
 @click.option('-t', '--tag', multiple=True, help='the housekeeper tag(s)')
-@click.option('-i', '--inbox', default='/mnt/hds/proj/{customer}/INBOX/{family}/', help='customer inbox')
+@click.option('-i', '--inbox', default='/home/proj/production/customers/{customer}/inbox/{family}/', help='customer inbox')
 @click.argument('family')
 @click.pass_context
 def inbox(context, dry, family, version, tag, inbox):


### PR DESCRIPTION
Previously default inbox pointed to rasta inbox. Will now point to hasta inbox.

This PR fixes the faulty delivery default path for the customer inbox.

How to test:
1. install on hasta stage
1. Activate stage:
   1. `$ us`
1. find case with deliverable files by running `ll /home/proj/stage/housekeeper-bundles/*/*/*.bcf`
1. In stage, deliver CASE_ID to CUSTOMER_ID like this:
   1. `$ cg deliver inbox CASE_ID`

Expected outcome:
Should deliver mintraven to cust002, no error messages.


- [x] code review @patrikgrenfeldt 
- [x] test @patrikgrenfeldt 
- [x] deploy ready