### PR TITLE
microbial fastqs are linked in housekeeper

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.3.0
+current_version = 3.4.0
 commit = True
 tag = True
 tag_name = v{new_version}

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -19,6 +19,15 @@ flowcell_sample = Table(
 )
 
 
+flowcell_microbial_sample = Table(
+    'flowcell_microbial_sample',
+    Model.metadata,
+    Column('flowcell_id', types.Integer, ForeignKey('flowcell.id'), nullable=False),
+    Column('microbial_sample_id', types.Integer, ForeignKey('microbial_sample.id'), nullable=False),
+    UniqueConstraint('flowcell_id', 'microbial_sample_id', name='_flowcell_microbial_sample_uc'),
+)
+
+
 class PriorityMixin:
 
     @property
@@ -285,15 +294,18 @@ class Flowcell(Model):
     status = Column(types.Enum(*FLOWCELL_STATUS), default='ondisk')
 
     samples = orm.relationship('Sample', secondary=flowcell_sample, backref='flowcells')
+    microbial_samples = orm.relationship('MicrobialSample', secondary=flowcell_microbial_sample, backref='flowcells')
 
     def __str__(self):
         return self.name
 
-    def to_dict(self, samples: bool = False):
+    def to_dict(self, samples: bool = False, microbial_samples: bool = False):
         """Override dictify method."""
         data = super(Flowcell, self).to_dict()
         if samples:
             data['samples'] = [sample.to_dict() for sample in self.samples]
+        if microbial_samples:
+            data['microbial_samples'] = [sample.to_dict() for sample in self.microbial_samples]
         return data
 
 

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -294,7 +294,8 @@ class Flowcell(Model):
     status = Column(types.Enum(*FLOWCELL_STATUS), default='ondisk')
 
     samples = orm.relationship('Sample', secondary=flowcell_sample, backref='flowcells')
-    microbial_samples = orm.relationship('MicrobialSample', secondary=flowcell_microbial_sample, backref='flowcells')
+    microbial_samples = orm.relationship('MicrobialSample', secondary=flowcell_microbial_sample,
+                                         backref='flowcells')
 
     def __str__(self):
         return self.name

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ class PyTest(TestCommand):
 
 setup(
     name='cg',
-    version='3.3.0',
+    version='3.4.0',
     description='Clinical Genomics command center.',
     author='Patrik Grenfeldt',
     author_email='patrik.grenfeldt@scilifelab.se',


### PR DESCRIPTION
Fixes issue https://github.com/Clinical-Genomics/cg/issues/337

How to test:

1. Install branch on stage: ```bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh link-microbial-fastqs-in-hk```
2. Check if the table ```flowcell_microbial_sample``` exists in cg-stage.
3. If the table exists, remove all entries using ```DELETE FROM `cg-stage`.flowcell_microbial_sample```
4. If the table doesn't exist, create it running the following script: 
```
CREATE TABLE `flowcell_microbial_sample` (
  `flowcell_id` int(11) NOT NULL,
  `microbial_sample_id` int(11) NOT NULL,
  UNIQUE KEY `_flowcell_sample_uc` (`flowcell_id`,`microbial_sample_id`),
  KEY `microbial_sample_id` (`microbial_sample_id`),
  CONSTRAINT `flowcell_microbial_sample_ibfk_1` FOREIGN KEY (`flowcell_id`) REFERENCES `flowcell` (`id`),
  CONSTRAINT `flowcell_microbial_sample_ibfk_2` FOREIGN KEY (`microbial_sample_id`) REFERENCES `microbial_sample` (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=latin1;
```
5. Prepare test data, step 1: 
 - copy ```/home/proj/production/demultiplexed-runs/190412_A00689_0021_AHJM7LDSXX``` to ```/home/proj/state/demultiplexed-runs/``` (this is already in place)
- copy ```/home/proj/production/demultiplexed-runs/190518_A00621_0076_BH7MMVDRXX``` to ```/home/proj/state/demultiplexed-runs/``` (this is already in place)

6. Prepare test data, step 2 (used in TC1):
 - We need to remove bundles already in housekeeper-stage:
    - Microbial sample 1: ```housekeeper delete bundle ACC5476A100```
    - Delete row in ```housekeeper-stage```: ```DELETE FROM `housekeeper-stage`.bundle where name = 'ACC5476A100'``` or remove manually.
    - Microbial sample 2: ```housekeeper delete bundle ACC5476A101```
    - Delete row in ```housekeeper-stage```: ```DELETE FROM `housekeeper-stage`.bundle where name = 'ACC5476A101'``` or remove manually.
    - Microbial sample 3: ```housekeeper delete bundle ACC5484A8```
    - Delete row in ```housekeeper-stage```: ```DELETE FROM `housekeeper-stage`.bundle where name = 'ACC5484A8'``` or remove manually.
    - WGS sample: ```housekeeper delete bundle ACC5492A13```
    - Delete row in ```housekeeper-stage```: ```DELETE FROM `housekeeper-stage`.bundle where name = 'ACC5492A13'``` or remove manually.

7. Prepare test data, step 3 (used in TC2):
 - We need to remove bundles already in housekeeper-stage:
    - WGS sample 1: ```housekeeper delete bundle ACC5717A2```
    - Delete row in ```housekeeper-stage```: ```DELETE FROM `housekeeper-stage`.bundle where name = 'ACC5717A2'``` or remove manually.

_NB: If you need more microbial samples to test with, flowcell HJM7LDSXX has microbial samples in the following projects: Project_538754, Project_550957, Project_590753, Project_632761, Project_846394, Project_935782, Project_990207!_

**### Test Case 1: FC with both microbial and wgs samples**
 - Transfer the flowcell: ```cg transfer flowcell HJM7LDSXX```
 - Expected outcome: the following messages are shown during execution:
```
added new Housekeeper bundle: ACC5476A100
found FASTQ file: /home/proj/stage/demultiplexed-runs/190412_A00689_0021_AHJM7LDSXX/Unaligned-Y151I10I10Y151/Project_538754/Sample_ACC5476A100/HJM7LDSXX_538754_S36_L002_R2_001.fastq.gz
found FASTQ file: /home/proj/stage/demultiplexed-runs/190412_A00689_0021_AHJM7LDSXX/Unaligned-Y151I10I10Y151/Project_538754/Sample_ACC5476A100/HJM7LDSXX_538754_S36_L002_R1_001.fastq.gz
found FASTQ file: /home/proj/stage/demultiplexed-runs/190412_A00689_0021_AHJM7LDSXX/Unaligned-Y151I10I10Y151/Project_538754/Sample_ACC5476A100/HJM7LDSXX_538754_S36_L001_R1_001.fastq.gz
found FASTQ file: /home/proj/stage/demultiplexed-runs/190412_A00689_0021_AHJM7LDSXX/Unaligned-Y151I10I10Y151/Project_538754/Sample_ACC5476A100/HJM7LDSXX_538754_S36_L003_R1_001.fastq.gz
found FASTQ file: /home/proj/stage/demultiplexed-runs/190412_A00689_0021_AHJM7LDSXX/Unaligned-Y151I10I10Y151/Project_538754/Sample_ACC5476A100/HJM7LDSXX_538754_S36_L004_R2_001.fastq.gz
found FASTQ file: /home/proj/stage/demultiplexed-runs/190412_A00689_0021_AHJM7LDSXX/Unaligned-Y151I10I10Y151/Project_538754/Sample_ACC5476A100/HJM7LDSXX_538754_S36_L001_R2_001.fastq.gz
found FASTQ file: /home/proj/stage/demultiplexed-runs/190412_A00689_0021_AHJM7LDSXX/Unaligned-Y151I10I10Y151/Project_538754/Sample_ACC5476A100/HJM7LDSXX_538754_S36_L003_R2_001.fastq.gz
found FASTQ file: /home/proj/stage/demultiplexed-runs/190412_A00689_0021_AHJM7LDSXX/Unaligned-Y151I10I10Y151/Project_538754/Sample_ACC5476A100/HJM7LDSXX_538754_S36_L004_R1_001.fastq.gz
```
```
added new Housekeeper bundle: ACC5476A101
found FASTQ file: /home/proj/stage/demultiplexed-runs/190412_A00689_0021_AHJM7LDSXX/Unaligned-Y151I10I10Y151/Project_538754/Sample_ACC5476A101/HJM7LDSXX_538754_S47_L002_R2_001.fastq.gz
found FASTQ file: /home/proj/stage/demultiplexed-runs/190412_A00689_0021_AHJM7LDSXX/Unaligned-Y151I10I10Y151/Project_538754/Sample_ACC5476A101/HJM7LDSXX_538754_S47_L002_R1_001.fastq.gz
found FASTQ file: /home/proj/stage/demultiplexed-runs/190412_A00689_0021_AHJM7LDSXX/Unaligned-Y151I10I10Y151/Project_538754/Sample_ACC5476A101/HJM7LDSXX_538754_S47_L004_R1_001.fastq.gz
found FASTQ file: /home/proj/stage/demultiplexed-runs/190412_A00689_0021_AHJM7LDSXX/Unaligned-Y151I10I10Y151/Project_538754/Sample_ACC5476A101/HJM7LDSXX_538754_S47_L003_R2_001.fastq.gz
found FASTQ file: /home/proj/stage/demultiplexed-runs/190412_A00689_0021_AHJM7LDSXX/Unaligned-Y151I10I10Y151/Project_538754/Sample_ACC5476A101/HJM7LDSXX_538754_S47_L001_R2_001.fastq.gz
found FASTQ file: /home/proj/stage/demultiplexed-runs/190412_A00689_0021_AHJM7LDSXX/Unaligned-Y151I10I10Y151/Project_538754/Sample_ACC5476A101/HJM7LDSXX_538754_S47_L004_R2_001.fastq.gz
found FASTQ file: /home/proj/stage/demultiplexed-runs/190412_A00689_0021_AHJM7LDSXX/Unaligned-Y151I10I10Y151/Project_538754/Sample_ACC5476A101/HJM7LDSXX_538754_S47_L003_R1_001.fastq.gz
found FASTQ file: /home/proj/stage/demultiplexed-runs/190412_A00689_0021_AHJM7LDSXX/Unaligned-Y151I10I10Y151/Project_538754/Sample_ACC5476A101/HJM7LDSXX_538754_S47_L001_R1_001.fastq.gz

```
```
added new Housekeeper bundle: ACC5484A8
found FASTQ file: /home/proj/stage/demultiplexed-runs/190412_A00689_0021_AHJM7LDSXX/Unaligned-Y151I10I10Y151/Project_632761/Sample_ACC5484A8/HJM7LDSXX_632761_S146_L001_R2_001.fastq.gz
found FASTQ file: /home/proj/stage/demultiplexed-runs/190412_A00689_0021_AHJM7LDSXX/Unaligned-Y151I10I10Y151/Project_632761/Sample_ACC5484A8/HJM7LDSXX_632761_S146_L004_R1_001.fastq.gz
found FASTQ file: /home/proj/stage/demultiplexed-runs/190412_A00689_0021_AHJM7LDSXX/Unaligned-Y151I10I10Y151/Project_632761/Sample_ACC5484A8/HJM7LDSXX_632761_S146_L004_R2_001.fastq.gz
found FASTQ file: /home/proj/stage/demultiplexed-runs/190412_A00689_0021_AHJM7LDSXX/Unaligned-Y151I10I10Y151/Project_632761/Sample_ACC5484A8/HJM7LDSXX_632761_S146_L003_R1_001.fastq.gz
found FASTQ file: /home/proj/stage/demultiplexed-runs/190412_A00689_0021_AHJM7LDSXX/Unaligned-Y151I10I10Y151/Project_632761/Sample_ACC5484A8/HJM7LDSXX_632761_S146_L002_R1_001.fastq.gz
found FASTQ file: /home/proj/stage/demultiplexed-runs/190412_A00689_0021_AHJM7LDSXX/Unaligned-Y151I10I10Y151/Project_632761/Sample_ACC5484A8/HJM7LDSXX_632761_S146_L001_R1_001.fastq.gz
found FASTQ file: /home/proj/stage/demultiplexed-runs/190412_A00689_0021_AHJM7LDSXX/Unaligned-Y151I10I10Y151/Project_632761/Sample_ACC5484A8/HJM7LDSXX_632761_S146_L002_R2_001.fastq.gz
found FASTQ file: /home/proj/stage/demultiplexed-runs/190412_A00689_0021_AHJM7LDSXX/Unaligned-Y151I10I10Y151/Project_632761/Sample_ACC5484A8/HJM7LDSXX_632761_S146_L003_R2_001.fastq.gz

```
```
added new Housekeeper bundle: ACC5492A13
found FASTQ file: /home/proj/stage/demultiplexed-runs/190412_A00689_0021_AHJM7LDSXX/Unaligned-Y151I10I10Y151/Project_777982/Sample_ACC5492A13/HJM7LDSXX_777982_S239_L004_R1_001.fastq.gz
found FASTQ file: /home/proj/stage/demultiplexed-runs/190412_A00689_0021_AHJM7LDSXX/Unaligned-Y151I10I10Y151/Project_777982/Sample_ACC5492A13/HJM7LDSXX_777982_S239_L001_R1_001.fastq.gz
found FASTQ file: /home/proj/stage/demultiplexed-runs/190412_A00689_0021_AHJM7LDSXX/Unaligned-Y151I10I10Y151/Project_777982/Sample_ACC5492A13/HJM7LDSXX_777982_S239_L002_R2_001.fastq.gz
found FASTQ file: /home/proj/stage/demultiplexed-runs/190412_A00689_0021_AHJM7LDSXX/Unaligned-Y151I10I10Y151/Project_777982/Sample_ACC5492A13/HJM7LDSXX_777982_S239_L002_R1_001.fastq.gz
found FASTQ file: /home/proj/stage/demultiplexed-runs/190412_A00689_0021_AHJM7LDSXX/Unaligned-Y151I10I10Y151/Project_777982/Sample_ACC5492A13/HJM7LDSXX_777982_S239_L003_R1_001.fastq.gz
found FASTQ file: /home/proj/stage/demultiplexed-runs/190412_A00689_0021_AHJM7LDSXX/Unaligned-Y151I10I10Y151/Project_777982/Sample_ACC5492A13/HJM7LDSXX_777982_S239_L003_R2_001.fastq.gz
found FASTQ file: /home/proj/stage/demultiplexed-runs/190412_A00689_0021_AHJM7LDSXX/Unaligned-Y151I10I10Y151/Project_777982/Sample_ACC5492A13/HJM7LDSXX_777982_S239_L001_R2_001.fastq.gz
found FASTQ file: /home/proj/stage/demultiplexed-runs/190412_A00689_0021_AHJM7LDSXX/Unaligned-Y151I10I10Y151/Project_777982/Sample_ACC5492A13/HJM7LDSXX_777982_S239_L004_R2_001.fastq.gz

```

 - Check that the bundles and the fastq files are now in housekeeper:
    - ```housekeeper get ACC5476A100``` should display the fastq files
    - ```housekeeper get ACC5476A101``` should display the fastq files
    - ```housekeeper get ACC5484A8``` should display the fastq files
    - ```housekeeper get ACC5492A13``` should display the fastq files
 - the table \`cg-stage`.flowcell_microbial_sample now contains 172 rows with flowcell_id 1246

**### Test Case 2: only wgs samples (regression test)**
 - Transfer the flowcell: ```cg transfer flowcell H7MMVDRXX```
 - Expected outcome: the following messages are shown during execution:
```
added new Housekeeper bundle: ACC5709A10
found FASTQ file: /home/proj/stage/demultiplexed-runs/190518_A00621_0076_BH7MMVDRXX/Unaligned-Y151I10I10Y151/Project_190510/Sample_ACC5709A10/H7MMVDRXX_190510_S4_L001_R2_001.fastq.gz
found FASTQ file: /home/proj/stage/demultiplexed-runs/190518_A00621_0076_BH7MMVDRXX/Unaligned-Y151I10I10Y151/Project_190510/Sample_ACC5709A10/H7MMVDRXX_190510_S4_L001_R1_001.fastq.gz
found FASTQ file: /home/proj/stage/demultiplexed-runs/190518_A00621_0076_BH7MMVDRXX/Unaligned-Y151I10I10Y151/Project_190510/Sample_ACC5709A10/H7MMVDRXX_190510_S4_L002_R1_001.fastq.gz
found FASTQ file: /home/proj/stage/demultiplexed-runs/190518_A00621_0076_BH7MMVDRXX/Unaligned-Y151I10I10Y151/Project_190510/Sample_ACC5709A10/H7MMVDRXX_190510_S4_L002_R2_001.fastq.gz
added reads to sample: ACC5709A10 - 993454496 [DONE]
```

 - Check that the bundles and the fastq files are now in housekeeper:
    - ```housekeeper get ACC5709A10``` should display the fastq files

**### Test Case 3: only microbial samples**
- no flowcells with only microbial samples available, no test.

### Review

- [x] code review by @ingkebil 
- [x] test by @emiliaol 
- [x] merge and deploy approved by @ingkebil 

Minor bump: backwards compatible changes