### PR TITLE
Adds NEURODEG to master list

### DIFF
--- a/cg/meta/analysis.py
+++ b/cg/meta/analysis.py
@@ -16,7 +16,7 @@ from cg.store import models, Store
 
 COLLABORATORS = ('cust000', 'cust002', 'cust003', 'cust004', 'cust042')
 MASTER_LIST = ('ENDO', 'EP', 'IEM', 'IBMFS', 'mtDNA', 'MIT', 'PEDHEP', 'OMIM-AUTO',
-               'PIDCAD', 'PID', 'SKD', 'NMD', 'CTD', 'IF')
+               'PIDCAD', 'PID', 'SKD', 'NMD', 'CTD', 'IF', 'NEURODEG')
 COMBOS = {
     'DSD': ('DSD', 'HYP', 'SEXDIF', 'SEXDET'),
     'CM': ('CNM', 'CM'),


### PR DESCRIPTION
This PR adds the NEURODEG gene list to the master list for MIP analysis.

How to test:
0. install the branch on stage on hasta
1. us
2. `cg analysis panel briefbull --print`

Expected outcome:
The first block of output on the screen should look like below plus include `Fetching gene panels NEURODEG from database` + `##gene_panel=NEURODEG,version=X.X,updated_at=XXXX-XX-XX,display_name= Neurodegeneration `:

```
Fetching gene panels ENDO from database
Fetching gene panels EP from database
Fetching gene panels IEM from database
Fetching gene panels IBMFS from database
Fetching gene panels mtDNA from database
Fetching gene panels MIT from database
Fetching gene panels PEDHEP from database
Fetching gene panels OMIM-AUTO from database
Fetching gene panels PIDCAD from database
Fetching gene panels PID from database
Fetching gene panels SKD from database
Fetching gene panels NMD from database
Fetching gene panels CTD from database
Fetching gene panels IF from database
Building hgncid_to_gene
##genome_build=37
##gene_panel=ENDO,version=12.0,updated_at=2018-02-05,display_name=Endocrinology
##gene_panel=EP,version=12.0,updated_at=2018-02-05,display_name=Epilepsy
##gene_panel=IEM,version=12.0,updated_at=2018-02-05,display_name=Inborn Errors of Metabolism
##gene_panel=IBMFS,version=13.0,updated_at=2018-01-31,display_name=Inherited Bone Marrow Failure Syndromes
##gene_panel=mtDNA,version=8.0,updated_at=2015-11-30,display_name=Mitochondrial DNA
##gene_panel=MIT,version=12.0,updated_at=2018-02-05,display_name=Mitochondrial nuclear
##gene_panel=PEDHEP,version=12.0,updated_at=2018-02-16,display_name=Pediatric Hepatology
##gene_panel=OMIM-AUTO,version=3.0,updated_at=2018-07-05,display_name=OMIM-AUTO
##gene_panel=PIDCAD,version=11.1,updated_at=2016-09-28,display_name=PID Candidates
##gene_panel=PID,version=14.0,updated_at=2018-01-02,display_name=Primary Immune Deficiency
##gene_panel=SKD,version=65.0,updated_at=2018-05-07,display_name=Skeletal dysplasia
##gene_panel=NMD,version=66.0,updated_at=2018-12-18,display_name=Neuromuscular diseases
##gene_panel=CTD,version=55.0,updated_at=2017-11-27,display_name=Connective Tissue Diseases
##gene_panel=IF,version=1.0,updated_at=2018-10-31,display_name=Intellektuell funktionsnedsättning
```

## Reviewed:
- [x] code approved by @barrystokman 
- [x] test approved by @barrystokman 
- [x] deploy approved by @ingkebil 

patch: feature doesn't change intended functionality