### PR TITLE
Retrieve to hasta instead

### DIFF
--- a/cg/apps/pdc.py
+++ b/cg/apps/pdc.py
@@ -13,7 +13,7 @@ class PdcApi():
         """Fetch a flowcell back from the backup solution."""
         dest_server = {
             'hiseqga': 'thalamus',
-            'hiseqx': 'rasta',
+            'hiseqx': 'hasta',
         }.get(sequencer_type)
         if dest_server is None:
             raise ValueError(f"{sequencer_type}: invalid sequencer type")


### PR DESCRIPTION
This PR fixes retrieval to hasta instead!

**How to test:**
1. Following happens all on nas-9: 
  - `cd /home/hiseq.clinical/SCRIPTS/git/backup`
  - `git pull`
  - `git checkout retrieve-to-hasta`
1. Following happens all on hasta:
  - `bash update-cg-stage.sh`
  - `us`
  - `cg backup fetch-flowcell`

**Expected outcome:**
A flowcells show start to retrieve. Wait 12h. A flowcell from the backup queue should now be on hasta:$PRODUCTION_HOME/flowcells/hiseqx/

- [x] function tested by @emiliaol 
- [x] approved for deploy by @ingkebil 