### PR TITLE
Validate special requirements for PAx and EXx applications in Orderportal

### DIFF
--- a/cg/meta/orders/schema.py
+++ b/cg/meta/orders/schema.py
@@ -94,15 +94,16 @@ MIP_SAMPLE = {
 
     # "required for new samples"
     'name': validators.RegexValidator(NAME_PATTERN),
-    'container': OptionalNone(validators.Any(CONTAINER_OPTIONS)),
+    # customer
     'data_analysis': str,
     'application': str,
-    'sex': OptionalNone(validators.Any(SEX_OPTIONS)),
     'family_name': validators.RegexValidator(NAME_PATTERN),
-    'require_qcok': bool,
-    'source': OptionalNone(TypeValidatorNone(str)),
+    'sex': OptionalNone(validators.Any(SEX_OPTIONS)),
     'tumour': bool,
+    'source': OptionalNone(TypeValidatorNone(str)),
     'priority': OptionalNone(validators.Any(PRIORITY_OPTIONS)),
+    'require_qcok': bool,
+    'container': OptionalNone(validators.Any(CONTAINER_OPTIONS)),
 
     # "required if plate for new samples"
     'container_name': OptionalNone(TypeValidatorNone(str)),
@@ -115,6 +116,13 @@ MIP_SAMPLE = {
     # "Required if samples are part of trio/family"
     'mother': OptionalNone(RegexValidatorNone(NAME_PATTERN)),
     'father': OptionalNone(RegexValidatorNone(NAME_PATTERN)),
+
+    # This information is required for panel analysis
+    'capture_kit': OptionalNone(validators.Any(CAPTUREKIT_CANCER_OPTIONS)),
+
+    # This information is required for panel- or exome analysis
+    'elution_buffer': OptionalNone(TypeValidatorNone(str)),
+    'tumour_purity': OptionalNone(TypeValidatorNone(str)),
 
     # "This information is optional for FFPE-samples for new samples"
     'formalin_fixation_time': OptionalNone(TypeValidatorNone(str)),
@@ -148,8 +156,11 @@ BALSAMIC_SAMPLE = {
     'container_name': OptionalNone(TypeValidatorNone(str)),
     'well_position': OptionalNone(TypeValidatorNone(str)),
 
-    # This information is required for Balsamic analysis (cancer) for new samples
+    # This information is required for panel analysis
     'capture_kit': OptionalNone(validators.Any(CAPTUREKIT_CANCER_OPTIONS)),
+
+    # This information is required for panel- or exome analysis
+    'elution_buffer': OptionalNone(TypeValidatorNone(str)),
     'tumour_purity': OptionalNone(TypeValidatorNone(str)),
 
     # This information is optional for FFPE-samples for new samples


### PR DESCRIPTION
This PR adds the requirement of elution buffer for mip exome and panel applications 

Contact: @annagellerbring @annaengstrom 

How to install: 
1. install or ask someone to install cgweb and clinical-api branch on clinical-db

How to test validation of elution buffer:
1. create mip order in op
1. add family
1. add sample
1. select any application starting with PA or EX
1. try to save sample

Expected outcome:
Red box around elution buffer

How to test validation of capture-kit:
1. create mip order in op
1. add family
1. add sample
1. select any application starting with PA
1. try to save sample

Expected outcome:
Red box around capture kit

How to test submission of elution buffer:
1. create mip order in op
1. add family
1. add sample
1. select any application starting with PA or EX
1. select elution buffer
1. submit
1. open sample in LIMS

Expected outcome:
Elution buffer on the LIMS sample

How to test submission of capture_kit buffer:
1. create mip order in op
1. add family
1. add sample
1. select any application starting with PA 
1. select capture_kit buffer
1. submit
1. open sample in LIMS

Expected outcome:
capture_kit buffer on the LIMS sample

- [x] Code reviewed by @ingkebil 
- [x] Tested by @barrystokman
- [x] Deploy OK:d by @ingkebil

This is a minor **version bump** because it is a bug fix