### PR TITLE
Allow elution buffer in balsamic order

### DIFF
--- a/cg/meta/orders/schema.py
+++ b/cg/meta/orders/schema.py
@@ -141,6 +141,7 @@ BALSAMIC_SAMPLE = {
     'family_name': validators.RegexValidator(NAME_PATTERN),
     'require_qcok': bool,
     'tumour': bool,
+    'elution_buffer': str,
     'source': OptionalNone(TypeValidatorNone(str)),
     'priority': OptionalNone(validators.Any(PRIORITY_OPTIONS)),
 


### PR DESCRIPTION
This PR allow the 'elution buffer' for balsamic orders. Now the order portal will complain on submission that the 'elution_buffer key not allowed'.

**How to test**:
1. install on stage on clinical-db: `bash update-clinical-api-stage.sh balsamic-op`
2. Submit the faulty order (ask @ingkebil or @KarinSollander for form causing error)

**Expected outcome**:
The order should pass through without errors.

**Review:**
- [x] code approved by @ingkebil 
- [x] tests executed by @KarinSollander 
- [x] "Merge and deploy" approved by @ingkebil 
Thanks for filling in who performed the code review and the test!

This is patch **version bump** because we are fixing a bug.
