### PR TITLE
add codeowner for version bump rights

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @ingkebil @patrikgrenfeldt
+*       @ingkebil @patrikgrenfeldt @barrystokman


### PR DESCRIPTION
This PR adds a codeowner to the cg repository

**How to test**:
1. Create dummy PR in cg
**Expected outcome**:
New code owner should be added to reviewers automatically

2. New codeowner bumps the version of a master branch about to be deployed (maybe even this one!) and pushes the tags to master.
**Expected outcome**:
Master branch updated to new version

**Review:**
- [x] code approved by @ingkebil 
- [ ] tests executed by 
- [x] "Merge and deploy" approved by @ingkebil 
Thanks for filling in who performed the code review and the test!

This is patch **version bump** because it fixes the bug where I couldn't do a bumpversion in cg ;)
