### PR TITLE
MIP pedigree uses 'case' instead of 'family'

### DIFF
--- a/cg/meta/analysis.py
+++ b/cg/meta/analysis.py
@@ -111,7 +111,7 @@ class AnalysisAPI:
     def build_config(self, family_obj: models.Family) -> dict:
         """Fetch data for creating a MIP config file."""
         data = {
-            'family': family_obj.internal_id,
+            'case': family_obj.internal_id,
             'default_gene_panels': family_obj.panels,
             'samples': [],
         }


### PR DESCRIPTION
This PR changes the key `family` in the MIP config file to `case`.
See also https://github.com/Clinical-Genomics/trailblazer/pull/55

**How to test**:
1. install on stage on hasta: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh mip-pedigree`
1. activate stage: `us`

#### Test Case 0:

1. run following command: `cg analysis config -d justhusky`

**Expected outcome**:
Trailblazer should complain about missing information



#### Test Case 1: Config file dry run

1. install the accompanying branch of trailblazer on stage on hasta: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-trailblazer-stage.sh mip-pedigree`
1. run following command: `cg analysis config -d justhusky`

**Expected outcome**:
Preview of the pedigree file is printed to the terminal:
```
{'case': 'justhusky', 'default_gene_panels': ['OMIM-AUTO'], 'samples': [{'sample_id': 'earlycasualcaiman', 'analysis_type': 'wgs', 'sex': 'male', 'phenotype': 'unaffected', 'expected_coverage': 1, 'mother': '0', 'father': '0', 'capture_kit': 'agilent_sureselect_cre.v1'}, {'sample_id': 'slowlycivilbuck', 'analysis_type': 'wgs', 'sex': 'female', 'phenotype': 'unaffected', 'expected_coverage': 1, 'mother': '0', 'father': '0', 'capture_kit': 'agilent_sureselect_cre.v1'}, {'sample_id': 'hugelymodelbat', 'analysis_type': 'wgs', 'sex': 'male', 'phenotype': 'affected', 'expected_coverage': 1, 'mother': 'slowlycivilbuck', 'father': 'earlycasualcaiman', 'capture_kit': 'agilent_sureselect_cre.v1'}]}
```

Take a screenshot and attach or copy/paste the output.

#### Test Case 2: Create config file

1. run following command: `cg analysis config justhusky`

**Expected outcome**:
The name and location of the created file is printed to the terminal:
`saved config to: /home/proj/stage/rare-disease/cases/justhusky/pedigree.yaml`
The file exists and has the same contents as shown in the dry run above.

Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @ingkebil 
- [x] tests executed by @b4ckm4n @ingkebil 
- [x] "Merge and deploy" approved by @ingkebil 
Thanks for filling in who performed the code review and the test!

This is major **version bump** because it's part of the MIP 7.1 release. The bump will be performed once merged into master.
