### PR TITLE
Add python 3.7 to travisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 
 python:
     - '3.6'
+    - '3.7'
 
 cache: pip
 


### PR DESCRIPTION
This PR adds python 3.7 to travisCI

**How to test**:
1. Check TravisCI output

**Expected outcome**:
Travis should be rnu on both python 3.6 and 3.7

**Review:**
- [x] code approved by @barrystokman 
- [x] tests executed by @barrystokman 
- [x] "Merge and deploy" approved by @ingkebil 
Thanks for filling in who performed the code review and the test!

This is patch **version bump** because no added functionality.
