### PR TITLE
Wrong family/sample name condition in analysis link

### DIFF
--- a/cg/cli/analysis.py
+++ b/cg/cli/analysis.py
@@ -104,10 +104,16 @@ def link(context, family_id, sample_id):
     if family_id and (sample_id is None):
         # link all samples in a family
         family_obj = context.obj['db'].family(family_id)
+        if family_obj is None:
+            LOG.error(f"Family '{family}' does not exist.")
+            context.abort()
         link_objs = family_obj.links
     elif sample_id and (family_id is None):
         # link sample in all its families
         sample_obj = context.obj['db'].sample(sample_id)
+        if sample_obj is None:
+            LOG.error(f"Sample '{family}' does not exist.")
+            context.abort()
         link_objs = sample_obj.links
     elif sample_id and family_id:
         # link only one sample in a family

--- a/cg/cli/analysis.py
+++ b/cg/cli/analysis.py
@@ -112,7 +112,7 @@ def link(context, family_id, sample_id):
         # link sample in all its families
         sample_obj = context.obj['db'].sample(sample_id)
         if sample_obj is None:
-            LOG.error(f"Sample '{family}' does not exist.")
+            LOG.error(f"Sample '{sample}' does not exist.")
             context.abort()
         link_objs = sample_obj.links
     elif sample_id and family_id:
@@ -123,6 +123,9 @@ def link(context, family_id, sample_id):
         context.abort()
 
     for link_obj in link_objs:
+        if link_obj is None:
+            LOG.error(f"Sample '{sample}' or family '{family}' does not exist.")
+            context.abort()
         LOG.info("%s: link FASTQ files", link_obj.sample.internal_id)
         if link_obj.sample.data_analysis and 'balsamic' in link_obj.sample.data_analysis.lower():
             context.obj['api'].link_sample(BalsamicFastqHandler(context.obj),

--- a/tests/cli/test_analysis_link.py
+++ b/tests/cli/test_analysis_link.py
@@ -1,0 +1,122 @@
+"""Test methods for cg/cli/set/sample"""
+from datetime import datetime
+
+from cg.store import Store
+
+
+def test_analysis_link_valid_family(invoke_cli, disk_store: Store):
+    """Test to get a sample using only the required argument"""
+    # GIVEN a database with a family, sample, and relationship
+    family = add_family(disk_store)
+    sample = add_sample(disk_store)
+    add_relationship(disk_store, sample, family)
+
+    db_uri = disk_store.uri
+    result = invoke_cli(
+        ['--database', db_uri, 'analysis', 'link', '-f', family.internal_id])
+    assert result.exit_code == 1
+
+
+def ensure_application_version(disk_store,
+                               application_tag='dummy_tag',
+                               is_external=False):
+    """utility function to return existing or create application version for tests"""
+    application = disk_store.application(tag=application_tag)
+    if not application:
+        application = disk_store.add_application(
+            tag=application_tag,
+            category='wgs',
+            description='dummy_description',
+            is_external=is_external)
+        disk_store.add_commit(application)
+
+    prices = {'standard': 10, 'priority': 20, 'express': 30, 'research': 5}
+    version = disk_store.application_version(application, 1)
+    if not version:
+        version = disk_store.add_version(application,
+                                         1,
+                                         valid_from=datetime.now(),
+                                         prices=prices)
+
+        disk_store.add_commit(version)
+    return version
+
+
+def ensure_customer(disk_store, customer_id='cust_test'):
+    """utility function to return existing or create customer for tests"""
+    customer_group = disk_store.customer_group('dummy_group')
+    if not customer_group:
+        customer_group = disk_store.add_customer_group('dummy_group',
+                                                       'dummy group')
+
+        customer = disk_store.add_customer(internal_id=customer_id,
+                                           name="Test Customer",
+                                           scout_access=False,
+                                           customer_group=customer_group,
+                                           invoice_address='dummy_address',
+                                           invoice_reference='dummy_reference')
+        disk_store.add_commit(customer)
+    customer = disk_store.customer(customer_id)
+    return customer
+
+
+def add_sample(disk_store,
+               sample_id='test_sample',
+               is_external=False,
+               flowcell=None):
+    """utility function to add a sample to use in tests"""
+    customer = ensure_customer(disk_store)
+    application_version_id = ensure_application_version(
+        disk_store, is_external=is_external).id
+    sample = disk_store.add_sample(name=sample_id, sex='female')
+    sample.application_version_id = application_version_id
+    sample.customer = customer
+    sample.is_external = is_external
+    if flowcell:
+        sample.flowcells.append(flowcell)
+    disk_store.add_commit(sample)
+    return sample
+
+
+def add_flowcell(disk_store, sample_id='flowcell_test', sample=None):
+    """utility function to get a flowcell to use in tests"""
+    flowcell = disk_store.add_flowcell(name=sample_id,
+                                       sequencer='dummy_sequencer',
+                                       sequencer_type='hiseqx',
+                                       date=datetime.now())
+    if sample:
+        flowcell.samples.append(sample)
+    disk_store.add_commit(flowcell)
+    return flowcell
+
+
+def add_panel(disk_store, panel_id='panel_test', customer_id='cust_test'):
+    """utility function to add a panel to use in tests"""
+    customer = ensure_customer(disk_store, customer_id)
+    panel = disk_store.add_panel(customer=customer,
+                                 name=panel_id,
+                                 abbrev=panel_id,
+                                 version=1.0,
+                                 date=datetime.now(),
+                                 genes=1)
+    disk_store.add_commit(panel)
+    return panel
+
+
+def add_family(disk_store, family_id='family_test', customer_id='cust_test'):
+    """utility function to add a family to use in tests"""
+    panel_name = add_panel(disk_store).name
+    customer = ensure_customer(disk_store, customer_id)
+    family = disk_store.add_family(name=family_id, panels=panel_name)
+    family.customer = customer
+    disk_store.add_commit(family)
+    return family
+
+
+def add_relationship(disk_store, sample, family):
+    """utility function to add a sample to use in tests"""
+    link = disk_store.relate_sample(sample=sample,
+                                    family=family,
+                                    status='unknown')
+    disk_store.add_commit(link)
+    return link


### PR DESCRIPTION
This PR adds a fix for the leaking wrong family/name.

Note: still working on the test as it is failing. I don't know much about fixtures on cg, and I get the following error: `<Result KeyError('housekeeper')>`. Any input or help is welcome :-). Of course, the def add_* are shameless copy from other tests.

**How to test**:

TBA

**Expected outcome**:
`cg analysis link -f wrong_family_name` should provide a proper error message

**Review:**
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This is patch|minor|major **version bump** because ...
