### PR TITLE
Fix: rename aggregate_master.bed -> gene_panels.bed

### DIFF
--- a/cg/apps/tb/api.py
+++ b/cg/apps/tb/api.py
@@ -58,7 +58,7 @@ class TrailblazerAPI(Store, AddHandler, fastq.FastqHandler):
         """Write the gene panel to the defined location."""
         out_dir = Path(self.families_dir) / family_id
         out_dir.mkdir(parents=True, exist_ok=True)
-        out_path = out_dir / 'aggregated_master.bed'
+        out_path = out_dir / 'gene_panels.bed'
         with out_path.open('w') as out_handle:
             for line in content:
                 click.echo(line, file=out_handle)

--- a/tests/fixtures/apps/tb/family/family_config.yaml
+++ b/tests/fixtures/apps/tb/family/family_config.yaml
@@ -220,7 +220,7 @@ sv_vcfanno_config: vcfanno_config.v1.0.toml
 sv_vcfanno_lua: vcfanno_custom.v1.0.lua
 sv_vcfannotation_header_lines_file: vcfanno_headerLines.v1.0.txt
 sv_vcfparser_per_gene: '1'
-sv_vcfparser_select_file: /mnt/hds/proj/bioinfo/MIP_ANALYSIS/customers/cust003/family/aggregated_master.bed
+sv_vcfparser_select_file: /mnt/hds/proj/bioinfo/MIP_ANALYSIS/customers/cust003/family/gene_panels.bed
 sv_vcfparser_select_file_matching_column: '3'
 sv_vcfparser_vep_transcripts: '1'
 sv_vep_features:
@@ -247,7 +247,7 @@ sv_vep_plugins:
 sv_vt_decompose: '1'
 temp_directory: /scratch/$SLURM_JOB_ID
 vcfparser_outfile_count: 2
-vcfparser_select_file: /mnt/hds/proj/bioinfo/MIP_ANALYSIS/customers/cust003/family/aggregated_master.bed
+vcfparser_select_file: /mnt/hds/proj/bioinfo/MIP_ANALYSIS/customers/cust003/family/gene_panels.bed
 vcfparser_select_file_matching_column: '3'
 vcfparser_vep_transcripts: '1'
 vep_directory_cache: /mnt/hds/proj/bioinfo/SERVER/apps/mip/resources/ensembl-tools-release-87/cache

--- a/tests/fixtures/apps/tb/family/family_qc_sample_info.yaml
+++ b/tests/fixtures/apps/tb/family/family_qc_sample_info.yaml
@@ -456,7 +456,7 @@ sv_vcfparser:
         gene_panel: mtDNA
         updated_at: 2015-11-30
         version: '8.0'
-    path: /path_to/family/aggregated_master.bed
+    path: /path_to/family/gene_panels.bed
 vcf_binary_file:
   clinical:
     path: /path_to/family_sorted_md_brecal_gvcf_vrecal_comb_vt_vep_parsed_snpeff_ranked_BOTH.selected.vcf.gz
@@ -562,5 +562,5 @@ vcfparser:
         gene_panel: mtDNA
         updated_at: 2015-11-30
         version: '8.0'
-    path: /path_to/family/aggregated_master.bed
+    path: /path_to/family/gene_panels.bed
 


### PR DESCRIPTION
The one where we rename aggregate_master.bed to gene_panels.bed.

**How to test**:
1. install on stage of the coffee machine: `bash servers/resources/coffee.selecta.se/update-cg-stage.sh panels`
1. activate stage: `us`
1. run following command: `cg analysis panel justhusky`

**Expected outcome**:
`cg` should be have created a `/home/proj/stage/rare-disease/cases/justhusky/gene_panels.bed`.
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @barrystokman 
- [x] tests executed by @barrystokman 
- [x] "Merge and deploy" approved by @ingkebil 
Thanks for filling in who performed the code review and the test!

This is not getting merged into master and doesn't warrent a version bump.
