### PR TITLE
don't truncate long madeline labels

### DIFF
--- a/cg/apps/madeline.py
+++ b/cg/apps/madeline.py
@@ -47,7 +47,8 @@ def run(executable: str, ped_stream: List[str]):
         madeline_content = '\n'.join(ped_stream)
         in_file.write(madeline_content)
         in_file.flush()
-        subprocess.call([madeline_exe, '--color', '--outputprefix',
+        subprocess.call([madeline_exe, '--color', '--nolabeltruncation',
+                        '--outputprefix',
                          output_prefix, in_file.name])
 
     with open(out_path, 'r') as output:

--- a/cg/apps/madeline.py
+++ b/cg/apps/madeline.py
@@ -48,7 +48,7 @@ def run(executable: str, ped_stream: List[str]):
         in_file.write(madeline_content)
         in_file.flush()
         subprocess.call([madeline_exe, '--color', '--nolabeltruncation',
-                        '--outputprefix',
+                         '--outputprefix',
                          output_prefix, in_file.name])
 
     with open(out_path, 'r') as output:


### PR DESCRIPTION
This PR adds a fix for the nonsense labels created for long sample names

**How to test**:
1. install on stage
1. activate stage: `us`
1. Upload family with long names beginning with same characters

**Expected outcome**:
The full labels are shown in the madeline picture
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @northwestwitch 
- [x] tests executed by @northwestwitch 
- [x] "Merge and deploy" approved by @ingkebil 
Thanks for filling in who performed the code review and the test!

This is patch **version bump** because it's a backwards compatible fix
