### PR TITLE
add link to family sample in sample and family views

### DIFF
--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -24,7 +24,7 @@ def view_family_sample_link(unused1, unused2, model, unused3):
     return Markup(
         u"<a href='%s'>%s</a>" % (
             url_for('familysample.index_view', search=model.internal_id),
-            model
+            model.internal_id
         )
     )
 

--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -17,6 +17,18 @@ class BaseView(ModelView):
         return redirect(url_for('google.login', next=request.url))
 
 
+def view_family_sample_link(unused1, unused2, model, unused3):
+    """column formatter to open the family-sample view"""
+    del unused1, unused2, unused3
+
+    return Markup(
+        u"<a href='%s'>%s</a>" % (
+            url_for('familysample.index_view', search=model.internal_id),
+            model
+        )
+    )
+
+
 class ApplicationView(BaseView):
     """Admin view for Model.Application"""
     column_exclude_list = [
@@ -95,6 +107,10 @@ class FamilyView(BaseView):
     column_searchable_list = ['internal_id', 'name', 'customer.internal_id']
     column_filters = ['customer.internal_id', 'priority', 'action']
     column_editable_list = ['action']
+
+    column_formatters = {
+        'internal_id': view_family_sample_link
+    }
 
     @staticmethod
     def view_family_link(unused1, unused2, model, unused3):
@@ -209,6 +225,7 @@ class SampleView(BaseView):
     form_excluded_columns = ['is_external']
 
     column_formatters = {
+        'internal_id': view_family_sample_link,
         'invoice': InvoiceView.view_invoice_link,
     }
 


### PR DESCRIPTION
This PR add link to family sample in sample and family views

**How to test Family link to FamilySample**:
1. install on stage of the clinical-db machine: `bash servers/resources/clinical-db.scilifelab.se/update-clinical-api-stage.sh link-family-and-sample-to-familysample`
1. login to clinical-api-stage
1. go to family view
1. click the link in the column internal id in a family

**Expected outcome**:
The familysample view is shown for the family that was chosen

**How to test Sample link to FamilySample**:
1. go to sample view
1. click the link in the column internal id in a sample

**Expected outcome**:
The familysample view is shown for the sample that was chosen

**Review:**
- [x] code approved by @ingkebil 
- [x] tests executed by @patrikgrenfeldt 
- [x] "Merge and deploy" approved by @ingkebil 
Thanks for filling in who performed the code review and the test!

This is minor **version bump** because it adds functionality in a backwards compatible manner
