### PR TITLE
reintroduce snv-gbcf tag

### DIFF
--- a/cg/apps/tb/add.py
+++ b/cg/apps/tb/add.py
@@ -61,11 +61,11 @@ class AddHandler:
             'archive': True,
         }, {
             'path': sampleinfo_data['snv']['bcf'],
-            'tags': ['snv-bcf'],
+            'tags': ['snv-bcf', 'snv-gbcf'],
             'archive': True,
         }, {
             'path': f"{sampleinfo_data['snv']['bcf']}.csi",
-            'tags': ['snv-bcf-index'],
+            'tags': ['snv-bcf-index', 'snv-gbcf-index'],
             'archive': True,
         }, {
             'path': sampleinfo_data['sv']['bcf'],

--- a/tests/apps/tb/mip/test_get_files.py
+++ b/tests/apps/tb/mip/test_get_files.py
@@ -36,6 +36,12 @@ def test_get_files(files_data) -> dict:
         'qcmetrics': {
             'path': sampleinfo['qcmetrics_path'],
         },
+        'snv-gbcf': {
+            'path': sampleinfo['snv']['bcf'],
+        },
+        'snv-gbcf-index': {
+            'path': f"{sampleinfo['snv']['bcf']}.csi",
+        },
         'snv-bcf': {
             'path': sampleinfo['snv']['bcf'],
         },


### PR DESCRIPTION
This PR reintroduces the 'snv-gbcf' tag in housekeeper used in uploads to loqus and genotype

**How to test loqusdb upload**:
1. pip install on lts on hasta
1. activate stage: `usemip7`
1. upload case to loqus 'cg upload observations CASEID'

**Expected outcome**:
cg should tell you the upload succeeded

**How to test genotype upload**:
1. install on lts on hasta
1. activate stage: `usemip7`
1. upload case to loqus 'cg upload genotype CASEID'

**Expected outcome**:
cg should tell you the upload succeeded

Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This is not a version bump since it is part of the validation of RC