### PR TITLE
Microbial invoice issue - bug fix

### DIFF
--- a/cg/store/api/status.py
+++ b/cg/store/api/status.py
@@ -513,7 +513,7 @@ class StatusHandler(BaseHandler):
         records = (
             self.MicrobialSample.query.filter(
                 models.MicrobialSample.delivered_at is not None,
-                models.MicrobialSample.invoice_id is None
+                models.MicrobialSample.invoice_id == None
             )
         )
         customers_to_invoice = [record.microbial_order.customer for record in records.all()]

--- a/cg/store/api/status.py
+++ b/cg/store/api/status.py
@@ -513,7 +513,7 @@ class StatusHandler(BaseHandler):
         records = (
             self.MicrobialSample.query.filter(
                 models.MicrobialSample.delivered_at is not None,
-                models.MicrobialSample.invoice_id == None
+                models.MicrobialSample.invoice_id == None # pylint: disable=singleton-comparison
             )
         )
         customers_to_invoice = [record.microbial_order.customer for record in records.all()]


### PR DESCRIPTION
This is a old discussion that needs to be brought up again. For some reason the microbial samples are not found when the the filter is set to "is None", but "== None" does the trick. Vallteri needs to invoice microbial samples and the fix is therefor important to get into prod soon.

**How to test and Expected outcome**:
Install on stage and go to https://clinical-api-stage.scilifelab.se/invoices/new/Microbial
The dropdown should show a list of customers to invoice. See screen shot. This compared to the [current version in production](https://clinical-api.scilifelab.se/invoices/new/Microbial), where no customers show up in the scroll down list. 

![Skärmavbild 2019-09-10 kl  15 03 13](https://user-images.githubusercontent.com/1306333/64616161-4aa36980-d3dc-11e9-9693-ae188a8d50c1.png)

**Review:**
- [x] code approved by @ingkebil 
- [x] tests executed by @ingkebil 
- [x] "Merge and deploy" approved by @ingkebil 
Thanks for filling in who performed the code review and the test!

This is patch **version bump** because no new functionality nor change in functionality.
