### PR TITLE
vcf_str loading to Scout (bug-fix)

### DIFF
--- a/cg/meta/upload/scoutapi.py
+++ b/cg/meta/upload/scoutapi.py
@@ -105,7 +105,7 @@ class UploadScoutAPI(object):
                 data[scout_key] = str(hk_file.full_path)
             else:
                 if skip_missing:
-                    LOG.debug(f"skipping missing file: {scout_key}")
+                    LOG.debug("skipping missing file: %s", scout_key)
                 else:
                     raise FileNotFoundError(f"missing file: {scout_key}")
 


### PR DESCRIPTION
This PR adds a fix for the missing str vcf in Scout. At least I think it does, the vcf_str key somehow ended up in the wrong list when mip7.1-dev was merged with master (that contained the key in the correct place). Please take over from here :)

I have not tested the fix, I'll leave that to you guys @ingkebil, @patrikgrenfeldt, @barrystokman. Perhaps also make a unit test to be able to pick these things up in the future?

**How to test non-inclusion with wes**:
1. install on stage of the coffee machine: `bash servers/resources/hasta.scilifelab.se/update-cg-stage.sh vcf_str_loading_in_scout`
1. activate stage: `us`
1. run following command: `cg upload scout -p [wes-case]`

**Expected outcome**:
upload completes w/o errors

**How to test inclusion with wgs**:
1. install on stage of the coffee machine: `bash servers/resources/hasta.scilifelab.se/update-cg-stage.sh vcf_str_loading_in_scout`
1. activate stage: `us`
1. run following command: `cg upload scout -p [wgs-case]`
1. open the case in scout

**Expected outcome**:
make sure the 'vcf-str' exists and has a path

Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @ingkebil 
- [X] tests executed by @emiliaol 
- [x] "Merge and deploy" approved by @ingkebil 
Thanks for filling in who performed the code review and the test!

This is patch **version bump** because it only fixes a bug 