### PR TITLE
Fix duplicated expansionhunter entry in cg store analysis

### DIFF
--- a/cg/apps/tb/add.py
+++ b/cg/apps/tb/add.py
@@ -87,10 +87,6 @@ class AddHandler:
             'path': sampleinfo_data['peddy']['sex_check'],
             'tags': ['peddy', 'sex-check'],
             'archive': False,
-        }, {
-            'path': sampleinfo_data['str_vcf'],
-            'tags': ['vcf-str'],
-            'archive': True
         }]
 
         # this key exists only for wgs

--- a/tests/fixtures/apps/tb/case/case_qc_sample_info.yaml
+++ b/tests/fixtures/apps/tb/case/case_qc_sample_info.yaml
@@ -84,9 +84,8 @@ recipe:
     path: /path_to/case/case/plink/info/plink_case.0.stdout.txt
   plink_sexcheck:
     path: /path_to/case/case/plink/case_gatkcomb.plink_sexcheck.sexcheck
-  qccollect:
+  qccollect_ar:
     path: /path_to/case/case_qc_metrics.yaml
-  qccollect_ar: {}
   relation_check:
     path: /path_to/case/case/plink/case_gatkcomb.relation_check.mibs
   rhocall_ar:


### PR DESCRIPTION
This PR adds a fix for the broken cg store

**How to test**:
1. install on stage of the hasta machine: `bash servers/resources/hasta.scilifelab.se/update-cg-stage.sh fix-cg-store-vcf-str`
1. activate stage: `us`
1. run following command: `cg store analysis [CONFIG-PATH]` for a case that has not yet been stored

**Expected outcome**:
`cg` should store the analysis without trying to store the same expansionhunter file twice.
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @ingkebil 
- [x] tests executed by @moahaegglund 
- [ ] "Merge and deploy" approved by @ingkebil 
Thanks for filling in who performed the code review and the test!

This is patch **version bump** because it only fixes a bug without adding/removing functionality
