### PR TITLE
lock pysam version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache: pip
 
 install:
     - pip install cython
-    - pip install -r requirements.txt -r requirements-dev.txt .
+    - pip install -U -r requirements.txt -r requirements-dev.txt .
     - pip check
 
 script:

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,7 @@ pymongo<3.7
 colorclass
 setuptools>=39.2.0      # due to WeasyPrint 45, tinycss2 1.0.1 and cairocffi file-.cairocffi-VERSION
 cairocffi==0.9.0        # due to strange version number in package
+pysam==0.15.2           # due to inability to rebuild newer pysam version
 
 # apps
 genologics


### PR DESCRIPTION
This PR adds a fix for the malfunctioning clinical-update-.sh scripts

**How to test**:
1. install on stage of the clinical-db machine: `bash servers/resources/clinical.scilifelab.se/update-clinical-api-stage.sh [BRANCH]`

**Expected outcome**:
`cg` should install without getting stuck on pysam build.
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @ingkebil 
- [x] tests executed by @ingkebil 
- [x] "Merge and deploy" approved by @ingkebil 
Thanks for filling in who performed the code review and the test!

This is patch **version bump** because it fixes existing func without aletering
