### PR TITLE
Add comment on customer

### DIFF
--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -83,7 +83,11 @@ class CustomerView(BaseView):
     column_exclude_list = [
         'agreement_date',
         'organisation_number',
-        'invoice_address'
+        'invoice_address',
+        'primary_contact',
+        'delivery_contact',
+        'invoice_contact',
+        'customer_group'
     ]
     column_searchable_list = ['internal_id', 'name']
     column_filters = ['priority', 'scout_access']

--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -88,7 +88,7 @@ class CustomerView(BaseView):
     column_searchable_list = ['internal_id', 'name']
     column_filters = ['priority', 'scout_access']
     column_editable_list = ['name', 'scout_access', 'loqus_upload', 'return_samples', 'priority',
-                            'customer_group']
+                            'customer_group', 'comment']
     
 
 class CustomerGroupView(BaseView):

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -172,6 +172,7 @@ class Customer(Model):
     invoice_address = Column(types.Text, nullable=False)
     invoice_reference = Column(types.String(32), nullable=False)
     uppmax_account = Column(types.String(32))
+    comment = Column(types.Text)
 
     primary_contact_id = Column(ForeignKey('user.id'))
     primary_contact = orm.relationship("User", foreign_keys=[primary_contact_id])

--- a/scripts/add-comment-to-customer.sql
+++ b/scripts/add-comment-to-customer.sql
@@ -1,0 +1,1 @@
+ALTER TABLE customer ADD COLUMN comment text;


### PR DESCRIPTION
This PR adds a possibility to add comments on customers

**How to install**:
1. install on clinical-api-stage of the clinical-db machine: `bash servers/resources/clinical-db.scilifelab.se/update-clinical-api-stage.sh add-comment-on-customer`
1. run script cg/scripts/add-comment-to-customer.sql on the cg-stage db

**How to test**:
1. login to clinical-api-stage
1. open customer view
1. click on empty on a customer in the comment column
1. add a comment

**Expected outcome**:
- [x] comment should be visible
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @ingkebil 
- [x] tests executed by @patrikgrenfeldt 
- [x] "Merge and deploy" approved by @ingkebil 
Thanks for filling in who performed the code review and the test!

This is minor **version bump** because we add func in backwards compatible manner