### PR TITLE
add updated date

### DIFF
--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -145,9 +145,10 @@ class AnalysisView(BaseView):
 class FlowcellView(BaseView):
     """Admin view for Model.Flowcell"""
 
-    column_searchable_list = ['name']
-    column_filters = ['sequencer_type', 'sequencer_name']
     column_editable_list = ['status']
+    column_exclude_list = ['archived_at']
+    column_filters = ['sequencer_type', 'sequencer_name']
+    column_searchable_list = ['name']
 
 
 class InvoiceView(BaseView):

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -304,7 +304,7 @@ class Flowcell(Model):
     sequencer_name = Column(types.String(32))
     sequenced_at = Column(types.DateTime)
     status = Column(types.Enum(*FLOWCELL_STATUS), default='ondisk')
-
+    archived_at = Column(types.DateTime)
     updated_at = Column(types.DateTime, onupdate=dt.datetime.now)
 
     samples = orm.relationship('Sample', secondary=flowcell_sample, backref='flowcells')

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -303,8 +303,9 @@ class Flowcell(Model):
     sequencer_type = Column(types.Enum('hiseqga', 'hiseqx'))
     sequencer_name = Column(types.String(32))
     sequenced_at = Column(types.DateTime)
-    archived_at = Column(types.DateTime)
     status = Column(types.Enum(*FLOWCELL_STATUS), default='ondisk')
+
+    updated_at = Column(types.DateTime, onupdate=dt.datetime.now)
 
     samples = orm.relationship('Sample', secondary=flowcell_sample, backref='flowcells')
     microbial_samples = orm.relationship('MicrobialSample', secondary=flowcell_microbial_sample,

--- a/scripts/add-updated_at-to-flowcell.sql
+++ b/scripts/add-updated_at-to-flowcell.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `flowcell`
+ADD COLUMN `updated_at` datetime DEFAULT NULL;


### PR DESCRIPTION
This PR adds the date when a flowcell was updated

**How to install**:
1. install clinicla-api on stage of hasta add-updated-date-to-flowcell
1. install cgweb on stage of hasta add-updated-date-to-flowcell
1. run the sql-script: cg/scripts/add-updated_at-to-flowcell.sql

**How to test clinical-api**:
1. login to clinical-api-stage
1. go to flowcell view
1. change the flowcell status of the first flowcell
1. refresh the page 

**Expected outcome**:
The date and time when the flowcell was edited should be visible


**How to test OP**:
1. login to OP
1. go to items/flowcell view
1. find the flowcell thatwas changed in the first test 

**Expected outcome**:
The date and time when the flowcell was edited should be visible

Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @ingkebil 
- [x] tests executed by @patrikgrenfeldt 
- [x] "Merge and deploy" approved by @ingkebil 
Thanks for filling in who performed the code review and the test!

This is |minor| **version bump** because it adds func in a backwards compatible manner
