### PR TITLE
fix balsamic config

### DIFF
--- a/cg/cli/balsamic.py
+++ b/cg/cli/balsamic.py
@@ -34,9 +34,10 @@ def config(context, dry, target_bed, case_id):
     # missing sample_id and files
     case_obj = context.obj['db'].family(case_id)
     link_objs = case_obj.links
-
+    tumor_paths = set()
+    normal_paths = set()
     for link_obj in link_objs:
-        LOGGER.info("%s: link FASTQ files", link_obj.sample.internal_id)
+        LOGGER.info("%s: config FASTQ file", link_obj.sample.internal_id)
         root_dir = context.obj['balsamic']['root']
         wrk_dir = Path(f'{root_dir}/{case_id}/fastq')
 
@@ -65,9 +66,6 @@ def config(context, dry, target_bed, case_id):
             files.append(data)
 
         sorted_files = sorted(files, key=lambda k: k['path'])
-
-        tumor_paths = set()
-        normal_paths = set()
 
         for fastq_data in sorted_files:
             original_fastq_path = Path(fastq_data['path'])


### PR DESCRIPTION
This PR adds a fix broken config creation for the second(!) link/sample

**How to test**:
1. install on stage of the hasta machine: `bash servers/resources/hasta.scilifelab.se/update-cg-stage.sh fix-balsamic-config`
1. activate stage: `us`
1. run following command: `cg analysis balsamic config --dry firmshiner`

**Expected outcome**:
both --normal and --tumor should be in the dry output 
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @ingkebil 
- [x] tests executed by @emiliaol @patrikgrenfeldt 
- [x] "Merge and deploy" approved by @ingkebil 
Thanks for filling in who performed the code review and the test!

This is patch **version bump** because its a fix
