### PR TITLE
add options for balsamic

### DIFF
--- a/cg/cli/balsamic.py
+++ b/cg/cli/balsamic.py
@@ -145,7 +145,7 @@ def config(context, dry, target_bed, singularity, umi_trim_length, quality_trim,
     if adapter_trim:
         command_str += f" --adapter_trim "
 
-    command = ["bash -c 'source activate P_BALSAMIC-base_3.0.1; balsamic"]
+    command = ["bash -c 'source activate P_BALSAMIC-base_3.2.0; balsamic"]
     command_str += "'"  # add ending quote from above line
     command.extend(command_str.split(' '))
 

--- a/cg/cli/balsamic.py
+++ b/cg/cli/balsamic.py
@@ -26,7 +26,7 @@ def balsamic(context):
 @balsamic.command()
 @click.option('-d', '--dry', is_flag=True, help='print config to console')
 @click.option('--target-bed', required=False, help='Optional')
-@click.option('--singularity', default="/home/proj/production/cancer/BALSAMIC/BALSAMIC/containers/BALSAMIC.3.2.0", required=False,
+@click.option('--singularity', default="/home/proj/production/cancer/BALSAMIC/BALSAMIC/containers/BALSAMIC.3.2.0.sif", required=False,
               help='Optional')
 @click.option('--umi-trim-length', default=5, required=False, help='Default 5')
 @click.option('--quality-trim', is_flag=True, required=False, help='Optional')

--- a/cg/cli/balsamic.py
+++ b/cg/cli/balsamic.py
@@ -26,8 +26,7 @@ def balsamic(context):
 @balsamic.command()
 @click.option('-d', '--dry', is_flag=True, help='print config to console')
 @click.option('--target-bed', required=False, help='Optional')
-@click.option('--singularity', default="/home/proj/production/cancer/cases/github_issue_analysis"
-                                       "/issue_29/BALSAMIC.3.2.0.sif", required=False,
+@click.option('--singularity', default="/home/proj/production/cancer/BALSAMIC/BALSAMIC/containers/BALSAMIC.3.2.0", required=False,
               help='Optional')
 @click.option('--umi-trim-length', default=5, required=False, help='Default 5')
 @click.option('--quality-trim', is_flag=True, required=False, help='Optional')

--- a/cg/cli/balsamic.py
+++ b/cg/cli/balsamic.py
@@ -141,7 +141,7 @@ def config(context, dry, target_bed, singularity, umi_trim_length, quality_trim,
     if umi_trim_length:
         command_str += f" --umi_trim_length {umi_trim_length} "
     if quality_trim:
-        command_str += f" --quality_trim "
+        command_str += f" --quality-trim "
     if adapter_trim:
         command_str += f" --adapter-trim "
 

--- a/cg/cli/balsamic.py
+++ b/cg/cli/balsamic.py
@@ -143,7 +143,7 @@ def config(context, dry, target_bed, singularity, umi_trim_length, quality_trim,
     if quality_trim:
         command_str += f" --quality_trim "
     if adapter_trim:
-        command_str += f" --adapter_trim "
+        command_str += f" --adapter-trim "
 
     command = ["bash -c 'source activate P_BALSAMIC-base_3.2.0; balsamic"]
     command_str += "'"  # add ending quote from above line

--- a/cg/cli/balsamic.py
+++ b/cg/cli/balsamic.py
@@ -26,8 +26,8 @@ def balsamic(context):
 @balsamic.command()
 @click.option('-d', '--dry', is_flag=True, help='print config to console')
 @click.option('--target-bed', required=False, help='Optional')
-@click.option('--singularity', default="/home/proj/production/cancer/BALSAMIC/BALSAMIC/containers/BALSAMIC.3.2.0.sif", required=False,
-              help='Optional')
+@click.option('--singularity', default="/home/proj/production/cancer/BALSAMIC/BALSAMIC/containers"
+                                       "/BALSAMIC.3.2.0.sif", required=False, help='Optional')
 @click.option('--umi-trim-length', default=5, required=False, help='Default 5')
 @click.option('--quality-trim', is_flag=True, required=False, help='Optional')
 @click.option('--adapter-trim', is_flag=True, required=False, help='Optional')

--- a/cg/cli/balsamic.py
+++ b/cg/cli/balsamic.py
@@ -188,8 +188,7 @@ def run(context, dry, run_analysis, config_path, analysis_type, priority, email,
     if priority:
         command_str += f" --qos {priority} "
 
-    # TODO mv the env name to cg config file
-    command = ["bash -c 'source activate {conda_env}; balsamic"]
+    command = [f"bash -c 'source activate {conda_env}; balsamic"]
     command_str += "'"
     command.extend(command_str.split(' '))
 

--- a/cg/cli/balsamic.py
+++ b/cg/cli/balsamic.py
@@ -139,7 +139,7 @@ def config(context, dry, target_bed, singularity, umi_trim_length, quality_trim,
     if umi:
         command_str += f" --umi "
     if umi_trim_length:
-        command_str += f" --umi_trim_length {umi_trim_length} "
+        command_str += f" --umi-trim-length {umi_trim_length} "
     if quality_trim:
         command_str += f" --quality-trim "
     if adapter_trim:

--- a/tests/cli/balsamic/conftest.py
+++ b/tests/cli/balsamic/conftest.py
@@ -1,0 +1,13 @@
+"""Fixtures for cli balsamic tests"""
+import pytest
+
+
+@pytest.fixture
+def base_context():
+    """context to use in cli"""
+    return {
+        'balsamic': {'conda_env': 'conda_env',
+                     'root': 'root',
+                     'slurm': {'account': 'account', 'qos': 'qos'}
+                     }
+    }

--- a/tests/cli/balsamic/test_cli_balsamic_run.py
+++ b/tests/cli/balsamic/test_cli_balsamic_run.py
@@ -1,0 +1,123 @@
+"""This script tests the cli methods to handle balsamic"""
+
+from cg.cli.balsamic import run
+
+EXIT_SUCCESS = 0
+
+
+def test_without_options(cli_runner):
+    """Test command with dry option"""
+
+    # GIVEN
+
+    # WHEN dry running without anything specified
+    result = cli_runner.invoke(run)
+
+    # THEN command should mention argument
+    assert result.exit_code != EXIT_SUCCESS
+    assert "Missing argument" in result.output
+
+
+def test_with_case(cli_runner, base_context):
+    """Test command with case to start with"""
+
+    # GIVEN case-id, and malconfigured pipeline
+    case_id = 'soberelephant'
+
+    context = base_context
+
+    # WHEN running
+    result = cli_runner.invoke(run, [case_id], obj=context)
+
+    # THEN command should successfully call the comamnd it creates
+    assert result.exit_code == EXIT_SUCCESS
+
+
+def test_dry(cli_runner, base_context):
+    """Test command with dry option"""
+
+    # GIVEN case-id
+    case_id = 'sillyshark'
+
+    context = base_context
+
+    # WHEN dry running with dry specified
+    result = cli_runner.invoke(run, [case_id, '--dry'], obj=context)
+
+    # THEN command should print the balsamic command-string
+    assert result.exit_code == EXIT_SUCCESS
+    assert "balsamic" in result.output
+    assert case_id in result.output
+
+
+def test_run_analysis(cli_runner, base_context):
+    """Test command with run-analysis option"""
+
+    # GIVEN case-id
+    case_id = 'slimwhale'
+
+    context = base_context
+
+    # WHEN dry running with option specified
+    result = cli_runner.invoke(run, [case_id, '--dry', '--run-analysis'], obj=context)
+
+    # THEN dry-print should include the option
+    assert result.exit_code == EXIT_SUCCESS
+    assert "--run-analysis" in result.output
+
+
+def test_config(cli_runner, base_context):
+    """Test command with config option"""
+
+    # GIVEN case-id
+    case_id = 'analogeel'
+    option_key = '--config'
+    option_value = 'config-path'
+
+    context = base_context
+
+    # WHEN dry running with option specified
+    result = cli_runner.invoke(run, [case_id, '--dry', option_key, option_value], obj=context)
+
+    # THEN dry-print should include the the option-value but not the case-id
+    assert result.exit_code == EXIT_SUCCESS
+    assert option_value in result.output
+    assert case_id not in result.output
+
+
+def test_email(cli_runner, base_context):
+    """Test command with config option"""
+
+    # GIVEN case-id
+    case_id = 'mightymonkey'
+    option_key = '--email'
+    option_value = 'salmon.moose@test.com'
+
+    context = base_context
+
+    # WHEN dry running with option specified
+    result = cli_runner.invoke(run, [case_id, '--dry', option_key, option_value], obj=context)
+
+    # THEN dry-print should include the the option-value but not the case-id
+    assert result.exit_code == EXIT_SUCCESS
+    assert '--slurm-mail-user' in result.output
+    assert option_value in result.output
+
+
+def test_priority(cli_runner, base_context):
+    """Test command with priority option"""
+
+    # GIVEN case-id
+    case_id = 'weakgorilla'
+    option_key = '--priority'
+    option_value = 'high'
+
+    context = base_context
+
+    # WHEN dry running with option specified
+    result = cli_runner.invoke(run, [case_id, '--dry', option_key, option_value], obj=context)
+
+    # THEN dry-print should include the the option-value
+    assert result.exit_code == EXIT_SUCCESS
+    assert '--qos' in result.output
+    assert option_value in result.output

--- a/tests/cli/test_cli_status_cases.py
+++ b/tests/cli/test_cli_status_cases.py
@@ -1,4 +1,4 @@
-"""This script tests the cli methods to add families to status-db"""
+"""This script tests the cli methods to view aggregated info on a case"""
 from datetime import datetime
 
 from cg.store import Store


### PR DESCRIPTION
This PR adds options to start balsamic with:


**How to test**:
1. install on stage of the hasta machine: `bash servers/resources/hasta.scilifelab.se/update-cg-stage.sh add-balsamic-config-options
1. activate stage: `us`

**How to test default options**:
- [x] run following command: `cg analysis balsamic firmshiner --dry`

**Expected outcome**:
- [x] `cg` should have the --singularity specified with a value of "/home/proj/production/cancer/BALSAMIC/BALSAMIC/containers/BALSAMIC.3.2.0" in the command output that we start balsamic with
- [x] `cg` should have the --umi-trim-length specified with a value of 5 in the command output 

**How to test option --singularity **:
- [x] run following command: `cg analysis balsamic firmshiner --dry --singularity SINGULARITYPATH`

**Expected outcome**:
- [x] `cg` should have the --singularity specified in the command output with the value SINGULARITYPATH that we start balsamic with

**How to test option --umi-trim-length**:
- [x] run following command: `cg analysis balsamic firmshiner --dry --umi-trim-length`

**Expected outcome**:
- [x] `cg` should have the --umi-trim-length specified in the command output that we start balsamic with

**How to test option --quality-trim**:
- [x] run following command: `cg analysis balsamic firmshiner --dry --quality-trim`

**Expected outcome**:
- [x] `cg` should have the --quality-trim specified in the command output that we start balsamic with

**How to test option --adapter-trim**:
- [x] run following command: `cg analysis balsamic config firmshiner --dry --adapter-trim`

**Expected outcome**:
- [x] `cg` should have the --adapter-trim specified in the command output that we start balsamic with

**How to test option --umi**:
- [x] run following command: `cg analysis balsamic config firmshiner --dry --umi`

**Expected outcome**:
- [x] `cg` should have the --umi specified in the command output that we start balsamic with

**How to test options with balsamic**:
- [x] run following command: `cg analysis balsamic config firmshiner --quality-trim --adapter-trim --umi`

**Expected outcome**:
- [x] `balsamic` should not complain on any of the options given 

Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @ingkebil 
- [x] tests executed by @emiliaol 
- [x] "Merge and deploy" approved by @ingkebil 
Thanks for filling in who performed the code review and the test!

This is |minor|**version bump** because options should have been added in a way that it starts balsamic just as before but it is possible to give new options as well
