### PR TITLE
Filter mutacc cases by customer ID

### DIFF
--- a/cg/cli/upload.py
+++ b/cg/cli/upload.py
@@ -458,10 +458,10 @@ def validate(context, family_id):
 @upload.command('process-solved')
 @click.option('-c', '--case-id', help='internal case id, leave empty to process all')
 @click.option('-d', '--days-ago', type=int, default=1, help='days since solved')
-@click.option('-i', '--institutes', type=str, multiple=True, help="Filter on customers")
+@click.option('-C', '--customers', type=str, multiple=True, help="Filter on customers")
 @click.option('--dry-run', is_flag=True, help='only print cases to be processed')
 @click.pass_context
-def process_solved(context, case_id, days_ago, institutes, dry_run):
+def process_solved(context, case_id, days_ago, customers, dry_run):
 
     """Process cases with mutacc that has been marked as solved in scout.
     This prepares them to be uploaded to the mutacc database"""
@@ -485,8 +485,8 @@ def process_solved(context, case_id, days_ago, institutes, dry_run):
     for case in finished_cases:
 
         number_processed += 1
-        if institutes:
-            if case['owner'] not in institutes:
+        if customers:
+            if case['owner'] not in customers:
                 LOG.info("skipping %s: Not valid customer %s", case['_id'], case['owner'])
                 continue
         if dry_run:

--- a/cg/cli/upload.py
+++ b/cg/cli/upload.py
@@ -458,9 +458,10 @@ def validate(context, family_id):
 @upload.command('process-solved')
 @click.option('-c', '--case-id', help='internal case id, leave empty to process all')
 @click.option('-d', '--days-ago', type=int, default=1, help='days since solved')
+@click.option('-i', '--institutes', type=str, multiple=True, help="Filter on customers")
 @click.option('--dry-run', is_flag=True, help='only print cases to be processed')
 @click.pass_context
-def process_solved(context, case_id, days_ago, dry_run):
+def process_solved(context, case_id, days_ago, institutes, dry_run):
 
     """Process cases with mutacc that has been marked as solved in scout.
     This prepares them to be uploaded to the mutacc database"""
@@ -483,13 +484,17 @@ def process_solved(context, case_id, days_ago, dry_run):
     number_processed = 0
     for case in finished_cases:
 
+        number_processed += 1
+        if institutes:
+            if case['owner'] not in institutes:
+                LOG.info("skipping %s: Not valid customer %s", case['_id'], case['owner'])
+                continue
         if dry_run:
             LOG.info("Would process case %s with mutacc", case['_id'])
             continue
 
         LOG.info("Start processing case %s with mutacc", case['_id'])
         mutacc_upload.extract_reads(case)
-        number_processed += 1
 
     if number_processed == 0:
         LOG.info("No cases were solved within the last %s days", days_ago)


### PR DESCRIPTION
This PR adds a option to only process certain customers by mutacc

Added option `-C/--customers` to command 'cg upload process-solved' to filter cases by owning customer. Several customer IDs can be passed repeating the option, e.g. `... -C cust_1 -C cust_2`.

**How to test**:
1. install on stage : `bash /home/proj/stage/servers/resources/hasta.scilifelab.se/update-cg-stage.sh mutacc-cust-filter`
1. activate stage: `us`
1. run `cg upload process-solved --dry-run --days-ago 100 -C cust12345`
1. run `cg upload process-solved --dry-run --days-ago 100 -C cust000`
1. run `cg upload process-solved --dry-run --days-ago 100 -C cust002`
1. run `cg upload process-solved --dry-run --days-ago 100 -C cust000 -C cust002`
1. run `cg upload process-solved --dry-run --days-ago 100`

**Expected outcome**:
Running `cg upload process-solved --dry-run --days-ago 100 -C cust12345` should log that all cases that are found are skipped (since no case belongs to customer 'cust12345').

Running `cg upload process-solved --dry-run --days-ago 100 -C cust000` should log that only the cases belonging to cust000 would be processed, all other are skipped.

Running `cg upload process-solved --dry-run --days-ago 100 -C cust002` should log that only the cases belonging to cust002 would be processed, all other are skipped.

Running `cg upload process-solved --dry-run --days-ago 100 -C cust000 -C cust002` should log that only the cases belonging to cust002 or cust000 would be processed, all other are skipped.

Running `cg upload process-solved --dry-run --days-ago 100` Should log that all cases found would be processed


**outcome**
```
[S_main] 16s $ cg upload process-solved --dry-run --days-ago 100 -C cust12345
----------------- UPLOAD ----------------------
----------------- PROCESS-SOLVED ----------------
skipping casualgannet: Not valid customer cust000
skipping cuddlyoryx: Not valid customer cust002
skipping cust000-15026-miptest: Not valid customer cust000
skipping easybeetle: Not valid customer cust002
skipping epicasp: Not valid customer cust002
skipping firstfawn: Not valid customer cust002
skipping grownliger: Not valid customer cust002
skipping hotskink: Not valid customer cust002
skipping rightmacaw: Not valid customer cust002
skipping strongbison: Not valid customer cust000
skipping topsrhino: Not valid customer cust002
skipping usablemarten: Not valid customer cust002
skipping vitalmouse: Not valid customer cust002
[S_main] 15s $ cg upload process-solved --dry-run --days-ago 100 -C cust000
----------------- UPLOAD ----------------------
----------------- PROCESS-SOLVED ----------------
Would process case casualgannet with mutacc
skipping cuddlyoryx: Not valid customer cust002
Would process case cust000-15026-miptest with mutacc
skipping easybeetle: Not valid customer cust002
skipping epicasp: Not valid customer cust002
skipping firstfawn: Not valid customer cust002
skipping grownliger: Not valid customer cust002
skipping hotskink: Not valid customer cust002
skipping rightmacaw: Not valid customer cust002
Would process case strongbison with mutacc
skipping topsrhino: Not valid customer cust002
skipping usablemarten: Not valid customer cust002
skipping vitalmouse: Not valid customer cust002
[S_main] 4s $ cg upload process-solved --dry-run --days-ago 100 -C cust002
----------------- UPLOAD ----------------------
----------------- PROCESS-SOLVED ----------------
skipping casualgannet: Not valid customer cust000
Would process case cuddlyoryx with mutacc
skipping cust000-15026-miptest: Not valid customer cust000
Would process case easybeetle with mutacc
Would process case epicasp with mutacc
Would process case firstfawn with mutacc
Would process case grownliger with mutacc
Would process case hotskink with mutacc
Would process case rightmacaw with mutacc
skipping strongbison: Not valid customer cust000
Would process case topsrhino with mutacc
Would process case usablemarten with mutacc
Would process case vitalmouse with mutacc
[S_main] 2s $ cg upload process-solved --dry-run --days-ago 100 -C cust000 -C cust002
----------------- UPLOAD ----------------------
----------------- PROCESS-SOLVED ----------------
Would process case casualgannet with mutacc
Would process case cuddlyoryx with mutacc
Would process case cust000-15026-miptest with mutacc
Would process case easybeetle with mutacc
Would process case epicasp with mutacc
Would process case firstfawn with mutacc
Would process case grownliger with mutacc
Would process case hotskink with mutacc
Would process case rightmacaw with mutacc
Would process case strongbison with mutacc
Would process case topsrhino with mutacc
Would process case usablemarten with mutacc
Would process case vitalmouse with mutacc
[S_main] 17s $ cg upload process-solved --dry-run --days-ago 100
----------------- UPLOAD ----------------------
----------------- PROCESS-SOLVED ----------------
Would process case casualgannet with mutacc
Would process case cuddlyoryx with mutacc
Would process case cust000-15026-miptest with mutacc
Would process case easybeetle with mutacc
Would process case epicasp with mutacc
Would process case firstfawn with mutacc
Would process case grownliger with mutacc
Would process case hotskink with mutacc
Would process case rightmacaw with mutacc
Would process case strongbison with mutacc
Would process case topsrhino with mutacc
Would process case usablemarten with mutacc
Would process case vitalmouse with mutacc

```

**Review:**
- [x] code approved by @ingkebil 
- [x] tests executed by @adrosenbaum 
- [x] "Merge and deploy" approved by @ingkebil 
Thanks for filling in who performed the code review and the test!

This is minor **version bump** because because a feature is added in a backwards compatible manner
