### PR TITLE
fix for the broken analysis auto

### DIFF
--- a/cg/cli/analysis.py
+++ b/cg/cli/analysis.py
@@ -209,7 +209,12 @@ def start(context: click.Context, family_id: str, priority: str = None, email: s
 def auto(context: click.Context, dry_run):
     """Start all analyses that are ready for analysis."""
     exit_code = 0
-    for case_obj in context.obj['db'].cases_to_mip_analyze():
+
+    cases = [case_obj.internal_id for case_obj in context.obj['db'].cases_to_mip_analyze()]
+
+    for case_id in cases:
+
+        case_obj = context.obj['db'].family(case_id)
 
         if AnalysisAPI.is_dna_only_case(case_obj):
             LOG.info("%s: start analysis", case_obj.internal_id)


### PR DESCRIPTION
This PR adds a fix for the broken analysis auto by fetching each case from db when needed to avoid using lazy loading on a stale connection

**How to prepare for test**:
- [ ] install on stage of the hasta machine: `bash servers/resources/hasta.scilifelab.se/update-cg-stage.sh [BRANCHNAME]`
- [ ] activate stage: `us`

**How to test**:
- [ ] run following command: `cg analysis auto`

**Expected test outcome**:
- [ ] `cg` should be able to start MIP for more than one case in a row
- [ ] Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @ingkebil 
- [ ] tests executed by @b4ckm4n 
- [ ] "Merge and deploy" approved by @ingkebil 
Thanks for filling in who performed the code review and the test!

This is patch **version bump** because we fix functionality without altering any API/CLIs
