### PR TITLE
Upload auto skip obsoleted

### DIFF
--- a/cg/cli/upload.py
+++ b/cg/cli/upload.py
@@ -446,6 +446,12 @@ def auto(context):
 
     exit_code = 0
     for analysis_obj in context.obj['status'].analyses_to_upload():
+
+        if analysis_obj.family.analyses[0].uploaded_at is not None:
+            LOG.warning("Newer analysis already uploaded for %s, skipping",
+                        analysis_obj.family.internal_id)
+            continue
+
         LOG.info(f"uploading family: {analysis_obj.family.internal_id}")
         try:
             context.invoke(upload, family_id=analysis_obj.family.internal_id)

--- a/tests/cli/test_cli_upload.py
+++ b/tests/cli/test_cli_upload.py
@@ -50,7 +50,7 @@ def test_upload_fails_hard_on_faulty_analysis(invoke_cli, disk_store: Store):
     # THEN it fails hard and reports that it is missing the analysis
     assert result.exit_code != 0
     assert family_id in result.output
-    assert 'no analyse exists' in result.output
+    assert 'no analysis exists' in result.output
 
 
 def test_upload_doesnt_invoke_dually_for_same_case(invoke_cli, disk_store: Store):


### PR DESCRIPTION
This PR adds a fix for the broken upload auto

**How to prepare for test**:
- [x] install on stage of the coffee machine: `bash servers/resources/hasta.scilifelab.se/update-cg-stage.sh [BRANCHNAME]`
- [x] activate stage: `us`

**How to test**:
- [x] run following command: `cg upload auto`

**Expected test outcome**:
- [x] `cg` should upload all analyses not yet uploaded, and show a warning if an analysis has been obsoleted and skip that upload.
- [x] Take a screenshot and attach or copy/paste the output.
![image](https://user-images.githubusercontent.com/6697636/68590463-d2fec300-048e-11ea-9d49-0e04679ce48e.png)

**Review:**
- [x] code approved by @ingkebil 
- [x] tests executed by @patrikgrenfeldt 
- [x] "Merge and deploy" approved by @ingkebil 
Thanks for filling in who performed the code review and the test!

This is minor **version bump** because we fix a broken command but we introduce a skip that wasn't there before