### PR TITLE
fix-invokation-with-subcommand

### DIFF
--- a/cg/cli/upload.py
+++ b/cg/cli/upload.py
@@ -93,26 +93,27 @@ def upload(context, family_id, force_restart):
         analysis_api=context.obj['analysis_api']
     )
 
-    if not family_id:
-        _suggest_cases_to_upload(context)
-        context.abort()
+    if context.invoked_subcommand is None:
+        if not family_id:
+            _suggest_cases_to_upload(context)
+            context.abort()
 
-    family_obj = context.obj['status'].family(family_id)
-    analysis_obj = family_obj.analyses[0]
-    if analysis_obj.uploaded_at is not None:
-        message = f"analysis already uploaded: {analysis_obj.uploaded_at.date()}"
-        click.echo(click.style(message, fg='yellow'))
-    else:
-        analysis_obj.upload_started_at = dt.datetime.now()
-        context.obj['status'].commit()
-        context.invoke(coverage, re_upload=True, family_id=family_id)
-        context.invoke(validate, family_id=family_id)
-        context.invoke(genotypes, re_upload=False, family_id=family_id)
-        context.invoke(observations, case_id=family_id)
-        context.invoke(scout, family_id=family_id)
-        analysis_obj.uploaded_at = dt.datetime.now()
-        context.obj['status'].commit()
-        click.echo(click.style(f"{family_id}: analysis uploaded!", fg='green'))
+        family_obj = context.obj['status'].family(family_id)
+        analysis_obj = family_obj.analyses[0]
+        if analysis_obj.uploaded_at is not None:
+            message = f"analysis already uploaded: {analysis_obj.uploaded_at.date()}"
+            click.echo(click.style(message, fg='yellow'))
+        else:
+            analysis_obj.upload_started_at = dt.datetime.now()
+            context.obj['status'].commit()
+            context.invoke(coverage, re_upload=True, family_id=family_id)
+            context.invoke(validate, family_id=family_id)
+            context.invoke(genotypes, re_upload=False, family_id=family_id)
+            context.invoke(observations, case_id=family_id)
+            context.invoke(scout, family_id=family_id)
+            analysis_obj.uploaded_at = dt.datetime.now()
+            context.obj['status'].commit()
+            click.echo(click.style(f"{family_id}: analysis uploaded!", fg='green'))
 
 
 @upload.command('delivery-report')


### PR DESCRIPTION
This PR adds a fix for broken crontab run of mutacc and loqus-db.

**How to prepare for test**:
- [x] install on stage of the coffee machine: `bash servers/resources/coffee.scilifelab.se/update-cg-stage.sh [BRANCHNAME]`
- [x] activate stage: `us`

**How to test**:
- [ ] run following command: `cg upload process-solved --days-ago 1 -C cust002 -C cust003 -C cust004`

**Expected test outcome**:
- [x] `----------------- UPLOAD ----------------------
----------------- PROCESS-SOLVED ----------------` 
- [x] Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @adrosenbaum 
- [x] tests executed by @patrikgrenfeldt 
- [x] "Merge and deploy" approved by @patrikgrenfeldt 
Thanks for filling in who performed the code review and the test!

This is patch|| **version bump** because ...
