### PR TITLE
show requested customer fields

### DIFF
--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -102,14 +102,9 @@ class CustomerView(BaseView):
 
     column_editable_list = ['name', 'scout_access', 'loqus_upload', 'return_samples', 'priority',
                             'customer_group', 'comment']
-    column_exclude_list = [
-        'agreement_date',
-        'organisation_number',
-        'invoice_address',
-        'primary_contact',
-        'delivery_contact',
-        'invoice_contact',
-        'customer_group'
+    column_list = [
+        'internal_id', 'name', 'priority', 'primary_contact', 'delivery_contact', 'scout_access',
+        'return_samples', 'project_account_KI', 'project_account_kth', 'comment'
     ]
     column_filters = ['priority', 'scout_access']
     column_searchable_list = ['internal_id', 'name']


### PR DESCRIPTION
"ska vi prova ändra till att följande fält visas på customer-fliken? :slightly_smiling_face: internal ID, Name, priority, primary contact, delivery contact, scout access, return samples, project account KI, project account kth och comment. Valtteri hade även ett förslag om att ha två fält för kommentarer och att ett skulle kunna vara ett sånt som inte visas och dit man kan föra in kommentarer som blir väldigt långa och jobbiga att visa men som man vill ha kvar."

**How to prepare for test**:
- [x] install on stage of the coffee machine: `bash servers/resources/coffee.scilifelab.se/update-cg-stage.sh [BRANCHNAME]`
- [x] activate stage: `us`

**How to test**:
- [x] open custview in admin

**Expected test outcome**:
- [x] internal ID, Name, 
- [x] priority, primary contact, 
- [x] delivery contact, 
- [x] scout access, 
- [x] return samples, 
- [x] project account KI, 
- [x] project account kth och comment
- [x] Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @ingkebil 
- [x] tests executed by @patrikgrenfeldt 
- [x] "Merge and deploy" approved by @ingkebil 
Thanks for filling in who performed the code review and the test!

This is minor **version bump** because it's only minor ui changes
