### PR TITLE
Move versioned bed columns to bed-version

### DIFF
--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -95,6 +95,7 @@ class ApplicationVersionView(BaseView):
     }
     column_searchable_list = ['application.tag']
     edit_modal = True
+    form_excluded_columns = ['samples', 'pools', 'microbial_samples']
 
 
 class BedView(BaseView):
@@ -125,7 +126,7 @@ class BedVersionView(BaseView):
     column_default_sort = ('updated_at', True)
     column_editable_list = ['description', 'filename', 'comment', 'designer', 'checksum']
     column_exclude_list = ['created_at']
-    form_excluded_columns = ['created_at', 'updated_at']
+    form_excluded_columns = ['created_at', 'updated_at', 'samples']
     column_filters = []
     column_formatters = {
         'bed': BedView.view_bed_link
@@ -145,6 +146,7 @@ class CustomerView(BaseView):
     ]
     column_filters = ['priority', 'scout_access']
     column_searchable_list = ['internal_id', 'name']
+    form_excluded_columns = ['families', 'samples', 'pools', 'orders', 'invoices']
 
 
 class CustomerGroupView(BaseView):

--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -123,7 +123,7 @@ class BedVersionView(BaseView):
     """Admin view for Model.BedVersion"""
 
     column_default_sort = ('updated_at', True)
-    column_editable_list = ['description', 'filename', 'comment', 'designer', 'shasum']
+    column_editable_list = ['description', 'filename', 'comment', 'designer', 'checksum']
     column_exclude_list = ['created_at']
     form_excluded_columns = ['created_at', 'updated_at']
     column_filters = []

--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -100,8 +100,8 @@ class ApplicationVersionView(BaseView):
 class BedView(BaseView):
     """Admin view for Model.Bed"""
 
-    column_default_sort = ('name')
-    column_editable_list = ['description', 'filename', 'comment']
+    column_default_sort = 'name'
+    column_editable_list = ['comment']
     column_exclude_list = ['created_at']
     column_filters = []
     column_searchable_list = ['name']
@@ -123,7 +123,7 @@ class BedVersionView(BaseView):
     """Admin view for Model.BedVersion"""
 
     column_default_sort = ('updated_at', True)
-    column_editable_list = []
+    column_editable_list = ['description', 'filename', 'comment', 'designer', 'shasum']
     column_exclude_list = ['created_at']
     form_excluded_columns = ['created_at', 'updated_at']
     column_filters = []

--- a/cg/server/app.py
+++ b/cg/server/app.py
@@ -80,16 +80,17 @@ def _register_blueprints(app: Flask):
 
 def _register_admin_views():
     # Base data views
-    ext.admin.add_view(admin.CustomerView(models.Customer, ext.db.session))
-    ext.admin.add_view(admin.CustomerGroupView(models.CustomerGroup, ext.db.session))
-    ext.admin.add_view(admin.UserView(models.User, ext.db.session))
-    ext.admin.add_view(admin.OrganismView(models.Organism, ext.db.session))
     ext.admin.add_view(admin.ApplicationView(models.Application, ext.db.session))
     ext.admin.add_view(admin.ApplicationVersionView(models.ApplicationVersion, ext.db.session))
-    ext.admin.add_view(admin.PanelView(models.Panel, ext.db.session))
     ext.admin.add_view(admin.BedView(models.Bed, ext.db.session))
     ext.admin.add_view(admin.BedVersionView(models.BedVersion, ext.db.session))
-    # Business data view
+    ext.admin.add_view(admin.CustomerView(models.Customer, ext.db.session))
+    ext.admin.add_view(admin.CustomerGroupView(models.CustomerGroup, ext.db.session))
+    ext.admin.add_view(admin.OrganismView(models.Organism, ext.db.session))
+    ext.admin.add_view(admin.PanelView(models.Panel, ext.db.session))
+    ext.admin.add_view(admin.UserView(models.User, ext.db.session))
+
+    # Business data views
     ext.admin.add_view(admin.FamilyView(models.Family, ext.db.session))
     ext.admin.add_view(admin.FamilySampleView(models.FamilySample, ext.db.session))
     ext.admin.add_view(admin.SampleView(models.Sample, ext.db.session))

--- a/cg/store/api/add.py
+++ b/cg/store/api/add.py
@@ -62,21 +62,20 @@ class AddHandler(BaseHandler):
         new_record.application = application
         return new_record
 
-    def add_bed(self, name: str, description: str, file: str, **kwargs) -> models.Bed:
+    def add_bed(self, name: str, **kwargs) -> models.Bed:
         """Build a new bed record."""
 
         new_record = self.Bed(
             name=name,
-            description=description,
-            file=file,
             **kwargs,
         )
         return new_record
 
-    def add_bed_version(self, bed: models.Bed, version: int, **kwargs) -> models.BedVersion:
+    def add_bed_version(self, bed: models.Bed, version: int, filename: str,
+                        **kwargs) -> models.BedVersion:
         """Build a new bed version record."""
 
-        new_record = self.BedVersion(version=version, **kwargs)
+        new_record = self.BedVersion(version=version, filename=filename, **kwargs)
         new_record.bed = bed
         return new_record
 

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -180,7 +180,7 @@ class BedVersion(Model):
     description = Column(types.String(256))
     version = Column(types.Integer, nullable=False)
     filename = Column(types.String(256), nullable=False)
-    shasum = Column(types.String(32))
+    checksum = Column(types.String(32))
     panel_size = Column(types.Integer)
     genome_version = Column(types.String(32))
     designer = Column(types.String(256))

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -160,9 +160,6 @@ class Bed(Model):
     """Model for bed target captures """
     id = Column(types.Integer, primary_key=True)
     name = Column(types.String(32), unique=True, nullable=False)
-    description = Column(types.String(256), nullable=False)
-    filename = Column(types.String(256))
-    designer = Column(types.String(256))
     comment = Column(types.Text)
     is_archived = Column(types.Boolean, default=False)
     created_at = Column(types.DateTime, default=dt.datetime.now)
@@ -180,14 +177,19 @@ class BedVersion(Model):
     __table_args__ = (UniqueConstraint('bed_id', 'version', name='_app_version_uc'),)
 
     id = Column(types.Integer, primary_key=True)
+    description = Column(types.String(256))
     version = Column(types.Integer, nullable=False)
+    filename = Column(types.String(256), nullable=False)
+    shasum = Column(types.String(32))
+    panel_size = Column(types.Integer)
+    genome_version = Column(types.String(32))
+    designer = Column(types.String(256))
     genes = Column(types.Integer)
     unique_transcripts = Column(types.Integer)
     transcripts_with_all_exons_covered = Column(types.Integer)
     transcripts_with_at_least_one_exon_covered = Column(types.Integer)
     padding = Column(types.Integer)
-    panel_size = Column(types.Integer)
-    genome_version = Column(types.String(32))
+
     cosmic_snps = Column(types.Integer)
     non_genic_regions = Column(types.Integer)
     independent_segments = Column(types.Integer)
@@ -195,6 +197,7 @@ class BedVersion(Model):
     created_at = Column(types.DateTime, default=dt.datetime.now)
     updated_at = Column(types.DateTime, onupdate=dt.datetime.now)
     bed_id = Column(ForeignKey(Bed.id), nullable=False)
+
     samples = orm.relationship('Sample', backref='bed_version')
 
     def __str__(self) -> str:

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -169,7 +169,7 @@ class Bed(Model):
                                 backref='bed')
 
     def __str__(self) -> str:
-        return self.tag
+        return self.name
 
 
 class BedVersion(Model):

--- a/scripts/move-columns-to-bed-version
+++ b/scripts/move-columns-to-bed-version
@@ -1,0 +1,26 @@
+ALTER TABLE bed_version
+  ADD COLUMN  `description` varchar(256),
+  ADD COLUMN  `filename` varchar(256),
+  ADD COLUMN  `shasum` varchar(32),
+  ADD COLUMN  `designer` varchar(256);
+
+Update bed_version
+    SET description = ( SELECT description FROM bed where bed.id = bed_version.bed_id )
+        Where description is null;
+
+Update bed_version
+    SET filename = ( SELECT filename  FROM bed where bed.id = bed_version.bed_id )
+        Where filename is null;
+
+Update bed_version
+        SET designer = ( SELECT designer FROM bed where bed.id = bed_version.bed_id )
+        Where designer is null;
+
+ALTER TABLE bed_version
+  MODIFY COLUMN  `filename` varchar(256) NOT NULL;
+
+ALTER TABLE bed
+  DROP COLUMN  `description`,
+  DROP COLUMN  `filename` ,
+  DROP COLUMN  `designer`;
+

--- a/scripts/move-columns-to-bed-version
+++ b/scripts/move-columns-to-bed-version
@@ -1,7 +1,7 @@
 ALTER TABLE bed_version
   ADD COLUMN  `description` varchar(256),
   ADD COLUMN  `filename` varchar(256),
-  ADD COLUMN  `shasum` varchar(32),
+  ADD COLUMN  `checksum` varchar(32),
   ADD COLUMN  `designer` varchar(256);
 
 Update bed_version

--- a/tests/cli/balsamic/test_cli_balsamic_auto.py
+++ b/tests/cli/balsamic/test_cli_balsamic_auto.py
@@ -1,4 +1,6 @@
 """This script tests the cli methods to auto run balsamic"""
+import logging
+
 from cg.cli.balsamic import auto
 
 EXIT_SUCCESS = 0
@@ -29,7 +31,8 @@ def test_balsamic_case_included(cli_runner, base_context, balsamic_case, caplog)
     assert not balsamic_case.analyses
 
     # WHEN running command
-    result = cli_runner.invoke(auto, ['--dry-run'], obj=base_context)
+    with caplog.at_level(logging.INFO):
+        result = cli_runner.invoke(auto, ['--dry-run'], obj=base_context)
 
     # THEN command should have printed the case id
     assert result.exit_code == EXIT_SUCCESS
@@ -49,7 +52,8 @@ def test_mip_only_case_excluded(cli_runner, base_context, mip_case, caplog):
     assert not mip_case.analyses
 
     # WHEN running command
-    result = cli_runner.invoke(auto, ['--dry-run'], obj=base_context)
+    with caplog.at_level(logging.INFO):
+        result = cli_runner.invoke(auto, ['--dry-run'], obj=base_context)
 
     # THEN command should not have printed the case id
     assert result.exit_code == EXIT_SUCCESS

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -169,9 +169,9 @@ def base_store(store) -> Store:
                 for application in applications]
     store.add_commit(versions)
 
-    beds = [store.add_bed('Bed', 'Bed desc', 'Bed.bed')]
+    beds = [store.add_bed('Bed')]
     store.add_commit(beds)
-    bed_versions = [store.add_bed_version(bed, 1)
+    bed_versions = [store.add_bed_version(bed, 1, 'Bed.bed')
                     for bed in beds]
     store.add_commit(bed_versions)
 


### PR DESCRIPTION
This PR moves versioned bed columns to bed-version
**How to prepare for test**:
- [x] run database migration (cg/scripts/move-columns-to-bed-version.sql) on cg-stage database
- [x] install on stage of the hasta machine: `bash servers/resources/hasta.scilifelab.se/update-cg-stage.sh move-cols-to-bed-version`
- [x] install on stage of the clinical-db machine: `bash servers/resources/clinical-db.scilifelab.se/update-clinical-api-stage.sh move-cols-to-bed-version`
- [x] login to clinical-api-stage

**How to test bed relevant cols**:
- [x] open the bed view

**Expected test outcome**:
- [x] it should only contain static information for a bed

**How to test bed-version relevant cols**:
- [x] open the bed-version view

**Expected test outcome**:
- [x] it should only contain dynamic (version related) information for a bed

**How to test creating a bed**:
- [x] open the bed view
- [x] press create
- [x] add some information in each field
- [x] press save 

**Expected test outcome**:
- [x] the new record should be listed

**How to test creating a bed-version**:
- [x] open the bed-version view
- [x] press create
- [x] add some information in each field
- [x] press save 

**Expected test outcome**:
- [x] the new record should be listed

**How to test hidden form fields in ApplicationVersionView**:
- [x] open the view
- [x] press edit(pen) on the first row

**Expected test outcome**:
- [x] 'samples', 'pools', 'microbial_samples' should not be editable

**How to test hidden form fields in CustomerView**:
- [x] open the view
- [x] press edit(pen) on the first row

**Expected test outcome**:
- [x] 'families', 'samples', 'pools', 'orders', 'invoices' should not be editable

- [x] Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @barrystokman 
- [x] tests executed by @barrystokman 
- [x] "Merge and deploy" approved by @patrikgrenfeldt 
Thanks for filling in who performed the code review and the test!

This is minor **version bump** because the change updates the system in a backwards compatible manner
