### PR TITLE
Use correct symbol if parent is missing. Fix #468

### DIFF
--- a/cg/meta/upload/scoutapi.py
+++ b/cg/meta/upload/scoutapi.py
@@ -58,8 +58,8 @@ class UploadScoutAPI(object):
             sample = {
                 'analysis_type': link_obj.sample.application_version.application.analysis_type,
                 'sample_id': sample_id, 'capture_kit': None,
-                'father': link_obj.father.internal_id if link_obj.father else None,
-                'mother': link_obj.mother.internal_id if link_obj.mother else None,
+                'father': link_obj.father.internal_id if link_obj.father else '0',
+                'mother': link_obj.mother.internal_id if link_obj.mother else '0',
                 'sample_name': link_obj.sample.name, 'phenotype': link_obj.status,
                 'sex': link_obj.sample.sex, 'bam_path': bam_path, 'mt_bam': mt_bam_path,
                 'vcf2cytosure': vcf2cytosure_path}

--- a/tests/cli/upload/conftest.py
+++ b/tests/cli/upload/conftest.py
@@ -9,10 +9,11 @@ from cg.apps.scoutapi import ScoutAPI
 from cg.apps.tb import TrailblazerAPI
 from cg.meta.upload.scoutapi import UploadScoutAPI
 from cg.store import Store
+from cg.meta.analysis import AnalysisAPI
 
 
-@pytest.fixture
-def base_context(base_store: Store) -> dict:
+@pytest.fixture(scope='function', name='base_context')
+def fixture_base_context(analysis_store_single_case: Store) -> dict:
     """context to use in cli"""
 
     return {
@@ -20,8 +21,67 @@ def base_context(base_store: Store) -> dict:
         'scout_upload_api': MockScoutUploadApi(),
         'housekeeper_api': MockHK(),
         'tb_api': MockTB(),
-        'status': MockStore()
+        'status': analysis_store_single_case,
     }
+
+
+@pytest.fixture(scope='function', name='analysis_family_single_case')
+def fixture_analysis_family_single():
+    """Build an example family."""
+    family = {
+        'name': 'family',
+        'internal_id': 'yellowhog',
+        'panels': ['IEM', 'EP'],
+        'samples': [{
+            'name': 'proband',
+            'sex': 'male',
+            'internal_id': 'ADM1',
+            'status': 'affected',
+            'ticket_number': 123456,
+            'reads': 5000000,
+        }]
+    }
+    return family
+
+
+@pytest.yield_fixture(scope='function', name='analysis_store_single_case')
+def fixture_analysis_store_single(base_store, analysis_family_single_case):
+    """Setup a store instance for testing analysis API."""
+    analysis_family = analysis_family_single_case
+    customer = base_store.customer('cust000')
+    family = base_store.Family(name=analysis_family['name'], panels=analysis_family[
+        'panels'], internal_id=analysis_family['internal_id'], priority='standard')
+    family.customer = customer
+    base_store.add(family)
+    application_version = base_store.application('WGTPCFC030').versions[0]
+    for sample_data in analysis_family['samples']:
+        sample = base_store.add_sample(name=sample_data['name'], sex=sample_data['sex'],
+                                       internal_id=sample_data['internal_id'],
+                                       ticket=sample_data['ticket_number'],
+                                       reads=sample_data['reads'], )
+        sample.family = family
+        sample.application_version = application_version
+        sample.customer = customer
+        base_store.add(sample)
+    base_store.commit()
+    for sample_data in analysis_family['samples']:
+        sample_obj = base_store.sample(sample_data['internal_id'])
+        link = base_store.relate_sample(
+            family=family,
+            sample=sample_obj,
+            status=sample_data['status'],
+            father=base_store.sample(sample_data['father']) if sample_data.get('father') else None,
+            mother=base_store.sample(sample_data['mother']) if sample_data.get('mother') else None,
+        )
+        base_store.add(link)
+
+    _analysis = base_store.add_analysis(pipeline='pipeline', version='version')
+    _analysis.family = family
+    _analysis.config_path = 'dummy_path'
+
+    base_store.commit()
+    yield base_store
+
 
 
 class MockTB(TrailblazerAPI):
@@ -36,12 +96,45 @@ class MockTB(TrailblazerAPI):
         return Path('hej')
 
 
+class MockVersion:
+    """Mock a version object"""
+
+    @property
+    def id(self):
+        return ''
+
+
+class MockFile:
+    """Mock a file object"""
+
+    def __init__(self, path='', to_archive=False, tags=None):
+        self.path = path
+        self.to_archive = to_archive
+        self.tags = tags or []
+
+    def first(self):
+        return MockFile()
+
+    def full_path(self):
+        return ''
+
+    def is_included(self):
+        return False
+
 class MockHK(HousekeeperAPI):
     """Mock of housekeeper """
 
     def __init__(self):
         """Mock the init"""
         pass
+    
+    def files(self, **kwargs):
+        """docstring for file"""
+        return MockFile()
+    
+    def version(self, arg1: str, arg2: str):
+        """Fetch version from the database."""
+        return MockVersion()
 
 
 class MockFamily(object):
@@ -50,17 +143,6 @@ class MockFamily(object):
     def __init__(self):
         """Mock the init"""
         self.analyses = ['analysis_obj']
-
-
-class MockStore(Store):
-    """Mock of store """
-    def __init__(self):
-        pass
-
-    def family(self, internal_id: str):
-        """docstring for family"""
-        return MockFamily()
-
 
 class MockScoutApi(ScoutAPI):
     def __init__(self):
@@ -71,16 +153,35 @@ class MockScoutApi(ScoutAPI):
         """docstring for upload"""
         pass
 
+class MockAnalysisApi(AnalysisAPI):
+    def __init__(self):
+        """docstring for __init__"""
+        pass
+
+    def get_latest_metadata(self, internal_id):
+        """docstring for upload"""
+        return {}
+
 
 class MockScoutUploadApi(UploadScoutAPI):
     def __init__(self):
         """docstring for __init__"""
+        self.mock_generate_config = True
+        self.housekeeper = MockHK()
+        self.analysis = MockAnalysisApi()
         self.config = {}
         self.file_exists = False
 
-    def generate_config(self, analysis):
+    @pytest.fixture(autouse=True)
+    def _request_analysis(self, analysis_store_single_case):
+        self.analysis = analysis_store_single_case
+
+    def generate_config(self, analysis_obj, **kwargs):
         """Mock the generate config"""
-        return self.config
+        if self.mock_generate_config:
+            return self.config
+        
+        return super().generate_config(analysis_obj, **kwargs)
 
     def save_config_file(self, scout_config, file_path):
         """docstring for save_config_file"""

--- a/tests/cli/upload/test_cli_upload_scout.py
+++ b/tests/cli/upload/test_cli_upload_scout.py
@@ -1,16 +1,31 @@
+"""Test the cli for uploading to scout"""
 import logging
 
 from cg.cli.upload import scout
 
 
-def test_upload_scout_cli_file_exists(base_context, cli_runner, caplog):
+def test_produce_load_config(base_context, cli_runner, analysis_family_single_case):
+    # GIVEN a singleton WGS case
+
+    base_context['scout_upload_api'].mock_generate_config = False
+    case_id = analysis_family_single_case['internal_id']
+
+    # WHEN running cg upload scout -p <caseid>
+    result = cli_runner.invoke(scout, [case_id, '--print'], obj=base_context)
+    # THEN assert mother: '0' and father: '0'
+    assert "'mother': '0'" in result.output
+    assert "'father': '0'" in result.output
+
+
+def test_upload_scout_cli_file_exists(base_context, cli_runner, caplog,
+                                      analysis_family_single_case):
     # GIVEN a case_id where the case exists in status db with at least one analysis
     # GIVEN that the analysis is done and exists in tb
     # GIVEN that the upload file already exists
     config = {'dummy': 'data'}
     base_context['scout_upload_api'].config = config
     base_context['scout_upload_api'].file_exists = True
-    case_id = 'dummy_case_id'
+    case_id = analysis_family_single_case['internal_id']
     # WHEN uploading a case with the cli and printing the upload config
     result = cli_runner.invoke(scout, [case_id], obj=base_context)
 
@@ -24,26 +39,26 @@ def test_upload_scout_cli_file_exists(base_context, cli_runner, caplog):
     assert warned
 
 
-def test_upload_scout_cli(base_context, cli_runner):
+def test_upload_scout_cli(base_context, cli_runner, analysis_family_single_case):
     # GIVEN a case_id where the case exists in status db with at least one analysis
     # GIVEN that the analysis is done and exists in tb
-    # WHEN uploading a case with the cli and printing the upload config
     config = {'dummy': 'data'}
     base_context['scout_upload_api'].config = config
-    case_id = 'dummy_case_id'
+    case_id = analysis_family_single_case['internal_id']
+    # WHEN uploading a case with the cli and printing the upload config
     result = cli_runner.invoke(scout, [case_id], obj=base_context)
 
     # THEN assert that the call exits without errors
     assert result.exit_code == 0
 
 
-def test_upload_scout_cli_print_console(base_context, cli_runner):
+def test_upload_scout_cli_print_console(base_context, cli_runner, analysis_family_single_case):
     # GIVEN a case_id where the case exists in status db with at least one analysis
     # GIVEN that the analysis is done and exists in tb
-    # WHEN uploading a case with the cli and printing the upload config
     config = {'dummy': 'data'}
     base_context['scout_upload_api'].config = config
-    case_id = 'dummy_case_id'
+    case_id = analysis_family_single_case['internal_id']
+    # WHEN uploading a case with the cli and printing the upload config
     result = cli_runner.invoke(scout, [case_id, '--print'], obj=base_context)
 
     # THEN assert that the call exits without errors


### PR DESCRIPTION
This PR fixes a bug when printing a scout load config if parents are missing

**How to prepare for test**:
- [x] install on stage of hasta: `bash /home/proj/stage/servers/resources/hasta.scilifelab.se/update-cg-stage.sh correct-scout-config`
- [x] activate stage: `us`

**How to test**:
1. run cg upload scout -p vitalmouse
1. look at output, potentially using output to load a case to scout-stage for verification. The individuals without parents has `None` as `mother` and `father`
![Skärmavbild 2019-11-27 kl  11 42 13](https://user-images.githubusercontent.com/405278/69716777-07b77f00-110b-11ea-8d25-ecb0202069fd.png)

1. Upload one case to scout

**Expected test outcome**:
- [x] `cg` should now output '0' instead of nothing when parent are absent
- [x] Take a screenshot and attach or copy/paste the output.

![Skärmavbild 2019-11-27 kl  11 48 44](https://user-images.githubusercontent.com/405278/69717233-ef942f80-110b-11ea-8794-2ac75f4ee08e.png)



**Review:**
- [x] code approved by @patrikgrenfeldt 
- [x] tests executed by @moonso 
- [x] "Merge and deploy" approved by @patrikgrenfeldt 
Thanks for filling in who performed the code review and the test!

This is patch **version bump**
