### PR TITLE
stop on all already existing files (disk&hk)

### DIFF
--- a/cg/cli/upload.py
+++ b/cg/cli/upload.py
@@ -433,7 +433,10 @@ def scout(context, re_upload, print_console, case_id):
     file_path = tb_api.get_family_root_dir(case_id) / 'scout_load.yaml'
 
     if file_path.exists():
-        LOG.warning("Scout load config %s already exists", file_path)
+        message = "Scout load config %s already exists, remove file and try again, consider you " \
+                  "might also have it in housekeeper" % file_path
+        LOG.warning(message)
+        context.abort()
 
     scout_upload_api.save_config_file(scout_config, file_path)
     hk_api = context.obj['housekeeper_api']
@@ -441,7 +444,8 @@ def scout(context, re_upload, print_console, case_id):
         LOG.info("Upload file to housekeeper: %s", file_path)
         scout_upload_api.add_scout_config_to_hk(file_path, hk_api, case_id)
     except FileExistsError as err:
-        LOG.warning(err)
+        LOG.warning(str(err) + ", consider removing the file from housekeeper and try again")
+        context.abort()
 
     scout_api.upload(scout_config, force=re_upload)
 

--- a/cg/cli/upload.py
+++ b/cg/cli/upload.py
@@ -433,8 +433,8 @@ def scout(context, re_upload, print_console, case_id):
     file_path = tb_api.get_family_root_dir(case_id) / 'scout_load.yaml'
 
     if file_path.exists():
-        message = "Scout load config %s already exists, remove file and try again, consider you " \
-                  "might also have it in housekeeper" % file_path
+        message = "Scout load config %s already exists, you might remove the file and try " \
+                  "again, consider that you might also have it in housekeeper" % file_path
         LOG.warning(message)
         context.abort()
 

--- a/cg/cli/upload.py
+++ b/cg/cli/upload.py
@@ -444,7 +444,7 @@ def scout(context, re_upload, print_console, case_id):
         LOG.info("Upload file to housekeeper: %s", file_path)
         scout_upload_api.add_scout_config_to_hk(file_path, hk_api, case_id)
     except FileExistsError as err:
-        LOG.warning(str(err) + ", consider removing the file from housekeeper and try again")
+        LOG.warning("%s, consider removing the file from housekeeper and try again", str(err))
         context.abort()
 
     scout_api.upload(scout_config, force=re_upload)

--- a/cg/meta/orders/schema.py
+++ b/cg/meta/orders/schema.py
@@ -159,7 +159,7 @@ BALSAMIC_SAMPLE = {
     'well_position': OptionalNone(TypeValidatorNone(str)),
 
     # This information is required for panel analysis
-    'capture_kit': OptionalNone(validators.Any(CAPTUREKIT_CANCER_OPTIONS)),
+    'capture_kit': str,
 
     # This information is required for panel- or exome analysis
     'elution_buffer': OptionalNone(TypeValidatorNone(str)),

--- a/tests/cli/upload/test_cli_upload_scout.py
+++ b/tests/cli/upload/test_cli_upload_scout.py
@@ -26,11 +26,13 @@ def test_upload_scout_cli_file_exists(base_context, cli_runner, caplog,
     base_context['scout_upload_api'].config = config
     base_context['scout_upload_api'].file_exists = True
     case_id = analysis_family_single_case['internal_id']
+
     # WHEN uploading a case with the cli and printing the upload config
     result = cli_runner.invoke(scout, [case_id], obj=base_context)
 
     # THEN assert that the call exits without errors
-    assert result.exit_code == 0
+    assert result.exit_code == 1
+
     # THEN assert that a warning is logged
     warned = False
     for _, level, message in caplog.record_tuples:


### PR DESCRIPTION
This PR adds a fix for the leaking coffee machine.

**How to prepare for test**:
- [x] install on stage
- [x] activate stage: `us`

**How to test file already on disk**:
- [x] find a case that already been uploaded to scout after 2019-11-27
- [x] run following command: `cg upload scout CASE-ID`

**Expected test outcome**:
- [x] the command should exit with a warning

**How to test file already in hk**:
- [x] find a case that already been uploaded to scout after 2019-11-27
- [x] remove the case scout load config on disk (not in hk)
- [x] run following command: `cg upload scout CASE-ID`

**Expected test outcome**:
- [x] the command should exit with a warning

- [x] Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @ingkebil 
- [x] tests executed by @patrikgrenfeldt 
- [x] "Merge and deploy" approved by @patrikgrenfeldt  
Thanks for filling in who performed the code review and the test!

This is minor **version bump** because we change the logic a bit but in a transparent way from the automation side
