### PR TITLE
add automatic Black as a pre-commit event

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.41.0
+current_version = 4.42.0
 commit = True
 tag = True
 tag_name = v{new_version}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+-   repo: https://github.com/psf/black
+    rev: 19.3b0
+    hooks:
+    -   id: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
--   repo: https://github.com/psf/black
+  - repo: https://github.com/psf/black
     rev: 19.3b0
     hooks:
-    -   id: black
+      - id: black

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
 # command to install dependencies
 install:
   - pip install --upgrade pip
+  - pip install pip==18.1
   - pip install cython
   - pip install -U -r requirements.txt pytest-mock .
 # command to run tests
@@ -21,16 +22,19 @@ jobs:
         - pip check
     - name: "coverage"
       script:
+        - pip install --upgrade pip
         - pip install -U -r requirements-dev.txt .
         - coverage run --branch --omit="*.html" --source cg setup.py test
         - coveralls
     - name: "code formatting"
       script:
+        - pip install --upgrade pip
         - pip install black
         - black --check cg tests
     - name: "linting"
       script:
-        - pip install -r requirements-dev.txt
+        - pip install --upgrade pip
+        - pip install -U -r requirements-dev.txt
         - git reset --soft ${TRAVIS_COMMIT_RANGE%...*} && git lint
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.7"
 
 # command to install dependencies
+# pip locked to version in P_main
 install:
   - pip install pip==18.1
   - pip install cython

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,13 @@ cache: pip
 jobs:
   include:
     - name: "dependencies"
+    - name: "production dependencies"
       script:
         - pip check
+    - name: "development dependencies"
+        script:
+          - pip install -U -r requirements.txt -r requirements-dev.txt .
+          - pip check
     - name: "coverage"
       script:
         - pip install --upgrade pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,10 @@ jobs:
         - pip install -U -r requirements-dev.txt .
         - coverage run --branch --omit="*.html" --source cg setup.py test
         - coveralls
+    - name: "code formatting"
+      script:
+        - pip install black
+        - black --check cg tests
     - name: "linting"
       script:
         - pip install -r requirements-dev.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
 
 # command to install dependencies
 install:
-  - pip install --upgrade pip
   - pip install pip==18.1
   - pip install cython
   - pip install -U -r requirements.txt pytest-mock .

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ jobs:
       script:
         - pip install --upgrade pip
         - pip install black
-        - black --check cg tests
+        - git --no-pager diff --name-only --diff-filter=ACMRT FETCH_HEAD $(git merge-base FETCH_HEAD master) | grep ".py" | xargs black --check
     - name: "linting"
       script:
         - pip install --upgrade pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ jobs:
         - pip check
     - name: "development dependencies"
       script:
-        - pip install -U -r requirements.txt -r requirements-dev.txt .
+        - pip install -U -r requirements-dev.txt .
         - pip check
     - name: "coverage"
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ cache: pip
 
 jobs:
   include:
-    - name: "dependencies"
     - name: "production dependencies"
       script:
         - pip check

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ jobs:
       script:
         - pip check
     - name: "development dependencies"
-        script:
-          - pip install -U -r requirements.txt -r requirements-dev.txt .
-          - pip check
+      script:
+        - pip install -U -r requirements.txt -r requirements-dev.txt .
+        - pip check
     - name: "coverage"
       script:
         - pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -26,7 +26,13 @@ If you would like to install the latest development version:
 ```bash
 git clone https://github.com/Clinical-Genomics/cg
 cd cg
-pip install --editable .
+pip install -r requirements-dev.txt -r requiremets.txt --editable .
+```
+
+If you would like to automatically [Black][black] format your commits: 
+
+```
+pre-commit install
 ```
 
 ## Contributing
@@ -348,3 +354,5 @@ Another module `/exc.py` contains the custom Exception classes that are used acr
 
 [coveralls-url]: https://coveralls.io/github/Clinical-Genomics/cg
 [coveralls-image]: https://coveralls.io/repos/github/Clinical-Genomics/cg/badge.svg?branch=master
+
+[black]: https://black.readthedocs.io/en/stable/

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,3 +13,4 @@ html-linter
 tidy
 six==1.12                   # due to astroid 2.3.2
 python-coveralls>=2.9.3     # due to conflict on coverage package
+black

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,3 +14,4 @@ tidy
 six==1.12                   # due to astroid 2.3.2
 python-coveralls>=2.9.3     # due to conflict on coverage package
 black
+pre-commit

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ class PyTest(TestCommand):
 
 setup(
     name='cg',
-    version='4.41.0',
+    version='4.42.0',
     description='Clinical Genomics command center.',
     author='Patrik Grenfeldt',
     author_email='patrik.grenfeldt@scilifelab.se',


### PR DESCRIPTION
This PR add automatic Black as a pre-commit event

**How to prepare for test**:

**How to test**:
- [x] checkout branch 
- [x] make a commit 

**Expected test outcome**:
- [x] black runns on the commit
- [x] Take a screenshot and attach or copy/paste the output.

**How to test CI**:
- [x] open the travis-PR-build

**Expected test outcome**:
- [x] `cg` production dependencies section should be there and green.
- [x] `cg` development dependencies section should be there and green.
- [x] `cg` production dependencies section should not be there.
- [x] `cg` black section should be red (since cg is not yet Black formatted).

**Review:**
- [x] code approved by @ingkebil 
- [x] tests executed by @patrikgrenfeldt 
- [x] developers informed on Operations meeting by @patrikgrenfeldt 
- [x] mentioned in the cg/README.md  
- [x] "Merge and deploy" approved by @ingkebil 
Thanks for filling in who performed the code review and the test!

This is minor **version bump** because it adds some dev func. without altering the end user func of the project