### PR TITLE
mutacc rankscore bug

### DIFF
--- a/cg/meta/upload/mutacc.py
+++ b/cg/meta/upload/mutacc.py
@@ -119,7 +119,7 @@ def remap(input_dict: dict, mapper_list: list) -> dict:
     """
     output_dict = {}
     for field in mapper_list:
-        if input_dict.get(field.field_name_1):
+        if input_dict.get(field.field_name_1) is not None:
             output_dict[field.field_name_2] = field.conv(input_dict[field.field_name_1])
     return output_dict
 


### PR DESCRIPTION
This PR fixes a bug in the mutacc-scout meta api. If rankscore is set to 0 for a variant in scout, rankscore is not passed to mutacc.

**How to test**:
- [x] travis

**Review:**
- [x] code approved by @ingkebil 
- [x] tests executed by @octocat
- [x] "Merge and deploy" approved by @ingkebil 
Thanks for filling in who performed the code review and the test!

This is a patch **version bump** because it fixes a bug


