### PR TITLE
Log more information on ticket creation failures

### DIFF
--- a/cg/apps/osticket.py
+++ b/cg/apps/osticket.py
@@ -37,5 +37,4 @@ class OsTicket(object):
             return res.text
         else:
             LOG.error("res.text: %s, reason: %s", res.text, res.reason)
-
             raise TicketCreationError(res)

--- a/cg/apps/osticket.py
+++ b/cg/apps/osticket.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
+import logging
 import os.path
 
 from flask import Flask
 import requests
 
 from cg.exc import TicketCreationError
+
+LOG = logging.getLogger(__name__)
 
 
 class OsTicket(object):
@@ -17,12 +20,14 @@ class OsTicket(object):
 
     def init_app(self, app: Flask):
         """Initialize the API in Flask."""
-        self.setup(api_key=app.config['OSTICKET_API_KEY'], domain=app.config['OSTICKET_DOMAIN'])
+        self.setup(
+            api_key=app.config["OSTICKET_API_KEY"], domain=app.config["OSTICKET_DOMAIN"]
+        )
 
-    def setup(self, api_key: str=None, domain: str=None):
+    def setup(self, api_key: str = None, domain: str = None):
         """Initialize the API."""
-        self.headers = {'X-API-Key': api_key}
-        self.url = os.path.join(domain, 'api/tickets.json')
+        self.headers = {"X-API-Key": api_key}
+        self.url = os.path.join(domain, "api/tickets.json")
 
     def open_ticket(self, name: str, email: str, subject: str, message: str) -> str:
         """Open a new ticket through the REST API."""
@@ -31,4 +36,6 @@ class OsTicket(object):
         if res.ok:
             return res.text
         else:
+            LOG.error("res.text: %s, reason: %s", res.text, res.reason)
+
             raise TicketCreationError(res)

--- a/tests/apps/conftest.py
+++ b/tests/apps/conftest.py
@@ -1,0 +1,32 @@
+"""Fixtures for testing apps"""
+
+import pytest
+import requests
+
+
+@pytest.fixture
+def response():
+    """Mock a requests.response object"""
+
+    class MockResponse(requests.Response):
+        """Mock requests.response class"""
+
+        def __init__(self):
+            pass
+
+        @property
+        def ok(self):
+            """Mock ok"""
+            return False
+
+        @property
+        def text(self):
+            """Mock text"""
+            return "response text"
+
+        @property
+        def reason(self):
+            """Mock reason"""
+            return "response reason"
+
+    return MockResponse()

--- a/tests/apps/test_osticket.py
+++ b/tests/apps/test_osticket.py
@@ -3,22 +3,17 @@
 import logging
 
 import pytest
-import requests
 
 from cg.apps.osticket import OsTicket
 from cg.exc import TicketCreationError
 
 
-def test_osticket_respone_500(monkeypatch, caplog):
+def test_osticket_respone_500(monkeypatch, caplog, response):
     """Test that we log properly when we get a non successful response"""
 
     # GIVEN a ticket server always gives a failure in response
     osticket_api = OsTicket()
-    result = requests.Response
-    result.ok = False
-    result.reason = "response reason"
-    result.text = "response text"
-    monkeypatch.setattr(requests, "post", lambda *args, **kwargs: result)
+    monkeypatch.setattr("requests.post", lambda *args, **kwargs: response)
 
     # WHEN we call open_ticket with ok ticket data
     caplog.set_level(logging.ERROR)
@@ -31,5 +26,5 @@ def test_osticket_respone_500(monkeypatch, caplog):
         )
 
     # THEN the response text and reason was logged and a ticket creation error raised
-    assert result.reason in caplog.text
-    assert result.text in caplog.text
+    assert response.reason in caplog.text
+    assert response.text in caplog.text

--- a/tests/apps/test_osticket.py
+++ b/tests/apps/test_osticket.py
@@ -4,9 +4,9 @@ import logging
 
 import pytest
 import requests
+
 from cg.apps.osticket import OsTicket
 from cg.exc import TicketCreationError
-from requests import Response
 
 
 def test_osticket_respone_500(monkeypatch, caplog):
@@ -14,7 +14,7 @@ def test_osticket_respone_500(monkeypatch, caplog):
 
     # GIVEN a ticket server always gives a failure in response
     osticket_api = OsTicket()
-    result = Response
+    result = requests.Response
     result.ok = False
     result.reason = "response reason"
     result.text = "response text"

--- a/tests/apps/test_osticket.py
+++ b/tests/apps/test_osticket.py
@@ -1,0 +1,35 @@
+""" Test the osticket app """
+
+import logging
+
+import pytest
+import requests
+from cg.apps.osticket import OsTicket
+from cg.exc import TicketCreationError
+from requests import Response
+
+
+def test_osticket_respone_500(monkeypatch, caplog):
+    """Test that we log properly when we get a non successful response"""
+
+    # GIVEN a ticket server always gives a failure in response
+    osticket_api = OsTicket()
+    result = Response
+    result.ok = False
+    result.reason = "response reason"
+    result.text = "response text"
+    monkeypatch.setattr(requests, "post", lambda *args, **kwargs: result)
+
+    # WHEN we call open_ticket with ok ticket data
+    caplog.set_level(logging.ERROR)
+    with pytest.raises(TicketCreationError):
+        osticket_api.open_ticket(
+            name="dummy_name",
+            email="dummy_email",
+            subject="dummy_subject",
+            message="dummy_message",
+        )
+
+    # THEN the response text and reason was logged and a ticket creation error raised
+    assert result.reason in caplog.text
+    assert result.text in caplog.text


### PR DESCRIPTION
This PR adds more information in the log when ticket creation fails

**How to test**:
- [x] open travis-CI checks

**Expected test outcome**:
- [x] tests should pass
- [x] Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @ingkebil 
- [x] tests executed by @patrikgrenfeldt 
- [x] "Merge and deploy" approved by @patrikgrenfeldt 
Thanks for filling in who performed the code review and the test!

This is minor **version bump** because we only add logging capability to the OsTicket module
