### PR TITLE
Fix family check

### DIFF
--- a/cg/meta/upload/scoutapi.py
+++ b/cg/meta/upload/scoutapi.py
@@ -1,21 +1,28 @@
+"""File includes api to uploading data into Scout"""
 # -*- coding: utf-8 -*-
 import logging
 from pathlib import Path
 
-from cg.apps import hk, scoutapi, madeline
+from cg.apps import hk, madeline, scoutapi
 from cg.meta.analysis import AnalysisAPI
-from cg.store import models, Store
+from cg.store import Store, models
 from ruamel import yaml
 
 LOG = logging.getLogger(__name__)
 
 
-class UploadScoutAPI(object):
+class UploadScoutAPI:
+    """Class that handles everything that has to do with uploading to Scout"""
 
-    def __init__(self, status_api: Store, hk_api: hk.HousekeeperAPI,
-                 scout_api: scoutapi.ScoutAPI,
-                 analysis_api: AnalysisAPI, madeline_exe: str, madeline=madeline,
-                 ):
+    def __init__(
+        self,
+        status_api: Store,
+        hk_api: hk.HousekeeperAPI,
+        scout_api: scoutapi.ScoutAPI,
+        analysis_api: AnalysisAPI,
+        madeline_exe: str,
+        madeline=madeline,
+    ):
         self.status = status_api
         self.housekeeper = hk_api
         self.scout = scout_api
@@ -23,47 +30,70 @@ class UploadScoutAPI(object):
         self.madeline = madeline
         self.analysis = analysis_api
 
-    def generate_config(self, analysis_obj: models.Analysis) -> dict:
-        """Fetch data about an analysis to load Scout."""
-        analysis_date = analysis_obj.started_at or analysis_obj.completed_at
-        hk_version = self.housekeeper.version(analysis_obj.family.internal_id, analysis_date)
-        analysis_data = self.analysis.get_latest_metadata(analysis_obj.family.internal_id)
-
-        data = {
-            'owner': analysis_obj.family.customer.internal_id,
-            'family': analysis_obj.family.internal_id,
-            'family_name': analysis_obj.family.name,
-            'samples': list(),
-            'analysis_date': analysis_obj.completed_at,
-            'gene_panels': self.analysis.convert_panels(analysis_obj.family.customer.internal_id,
-                                                        analysis_obj.family.panels),
-            'default_gene_panels': analysis_obj.family.panels,
-            'human_genome_build': analysis_data.get('genome_build'),
-            'rank_model_version': analysis_data.get('rank_model_version'),
-            'sv_rank_model_version': analysis_data.get('sv_rank_model_version')
-        }
+    def build_samples(self, analysis_obj: models.Analysis, hk_version_id: int = None):
+        """Loop over the samples in an analysis and build dicts from them"""
 
         for link_obj in analysis_obj.family.links:
             sample_id = link_obj.sample.internal_id
-            bam_tags = ['bam', sample_id]
-            bam_file = self.housekeeper.files(version=hk_version.id, tags=bam_tags).first()
+            bam_tags = ["bam", sample_id]
+            bam_file = self.housekeeper.files(
+                version=hk_version_id, tags=bam_tags
+            ).first()
             bam_path = bam_file.full_path if bam_file else None
-            mt_bam_tags = ['bam-mt', sample_id]
-            mt_bam_file = self.housekeeper.files(version=hk_version.id, tags=mt_bam_tags).first()
+            mt_bam_tags = ["bam-mt", sample_id]
+            mt_bam_file = self.housekeeper.files(
+                version=hk_version_id, tags=mt_bam_tags
+            ).first()
             mt_bam_path = mt_bam_file.full_path if mt_bam_file else None
-            vcf2cytosure_tags = ['vcf2cytosure', sample_id]
-            vcf2cytosure_file = self.housekeeper.files(version=hk_version.id,
-                                                       tags=vcf2cytosure_tags).first()
-            vcf2cytosure_path = vcf2cytosure_file.full_path if vcf2cytosure_file else None
+            vcf2cytosure_tags = ["vcf2cytosure", sample_id]
+            vcf2cytosure_file = self.housekeeper.files(
+                version=hk_version_id, tags=vcf2cytosure_tags
+            ).first()
+            vcf2cytosure_path = (
+                vcf2cytosure_file.full_path if vcf2cytosure_file else None
+            )
             sample = {
-                'analysis_type': link_obj.sample.application_version.application.analysis_type,
-                'sample_id': sample_id, 'capture_kit': None,
-                'father': link_obj.father.internal_id if link_obj.father else '0',
-                'mother': link_obj.mother.internal_id if link_obj.mother else '0',
-                'sample_name': link_obj.sample.name, 'phenotype': link_obj.status,
-                'sex': link_obj.sample.sex, 'bam_path': bam_path, 'mt_bam': mt_bam_path,
-                'vcf2cytosure': vcf2cytosure_path}
-            data['samples'].append(sample)
+                "analysis_type": link_obj.sample.application_version.application.analysis_type,
+                "sample_id": sample_id,
+                "capture_kit": None,
+                "father": link_obj.father.internal_id if link_obj.father else "0",
+                "mother": link_obj.mother.internal_id if link_obj.mother else "0",
+                "sample_name": link_obj.sample.name,
+                "phenotype": link_obj.status,
+                "sex": link_obj.sample.sex,
+                "bam_path": bam_path,
+                "mt_bam": mt_bam_path,
+                "vcf2cytosure": vcf2cytosure_path,
+            }
+            yield sample
+
+    def generate_config(self, analysis_obj: models.Analysis) -> dict:
+        """Fetch data about an analysis to load Scout."""
+        analysis_date = analysis_obj.started_at or analysis_obj.completed_at
+        hk_version = self.housekeeper.version(
+            analysis_obj.family.internal_id, analysis_date
+        )
+        analysis_data = self.analysis.get_latest_metadata(
+            analysis_obj.family.internal_id
+        )
+
+        data = {
+            "owner": analysis_obj.family.customer.internal_id,
+            "family": analysis_obj.family.internal_id,
+            "family_name": analysis_obj.family.name,
+            "samples": list(),
+            "analysis_date": analysis_obj.completed_at,
+            "gene_panels": self.analysis.convert_panels(
+                analysis_obj.family.customer.internal_id, analysis_obj.family.panels
+            ),
+            "default_gene_panels": analysis_obj.family.panels,
+            "human_genome_build": analysis_data.get("genome_build"),
+            "rank_model_version": analysis_data.get("rank_model_version"),
+            "sv_rank_model_version": analysis_data.get("sv_rank_model_version"),
+        }
+
+        for sample in self.build_samples(analysis_obj, hk_version.id):
+            data["samples"].append(sample)
 
         self._include_mandatory_files(data, hk_version)
         self._include_peddy_files(data, hk_version)
@@ -72,11 +102,11 @@ class UploadScoutAPI(object):
         if self._is_multi_sample_case(data):
             if self._is_family_case(data):
                 svg_path = self._run_madeline(analysis_obj.family)
-                data['madeline'] = svg_path
+                data["madeline"] = svg_path
             else:
-                LOG.info('family of unconnected samples - skip pedigree graph')
+                LOG.info("family of unconnected samples - skip pedigree graph")
         else:
-            LOG.info('family of 1 sample - skip pedigree graph')
+            LOG.info("family of 1 sample - skip pedigree graph")
 
         return data
 
@@ -89,13 +119,15 @@ class UploadScoutAPI(object):
         yml.dump(upload_config, file_path)
 
     @staticmethod
-    def add_scout_config_to_hk(config_file_path: Path, hk_api: hk.HousekeeperAPI, case_id: str):
+    def add_scout_config_to_hk(
+        config_file_path: Path, hk_api: hk.HousekeeperAPI, case_id: str
+    ):
         """Add scout load config to hk bundle"""
-        tag_name = 'scout-load-config'
+        tag_name = "scout-load-config"
         version_obj = hk_api.last_version(bundle=case_id)
-        uploaded_config_files = hk_api.get_files(bundle=case_id,
-                                                 tags=[tag_name],
-                                                 version=version_obj.id)
+        uploaded_config_files = hk_api.get_files(
+            bundle=case_id, tags=[tag_name], version=version_obj.id
+        )
 
         number_of_configs = sum(1 for i in uploaded_config_files)
         bundle_config_exists = number_of_configs > 0
@@ -111,20 +143,29 @@ class UploadScoutAPI(object):
         return file_obj
 
     def _include_optional_files(self, data, hk_version):
-        scout_hk_map = [('delivery_report', 'delivery-report'), ('vcf_str', 'vcf-str')]
+        scout_hk_map = [("delivery_report", "delivery-report"), ("vcf_str", "vcf-str")]
         self._include_files(data, hk_version, scout_hk_map)
 
     def _include_peddy_files(self, data, hk_version):
-        scout_hk_map = [('peddy_ped', 'ped'), ('peddy_sex', 'sex-check'),
-                        ('peddy_check', 'ped-check')]
-        self._include_files(data, hk_version, scout_hk_map, 'peddy')
+        scout_hk_map = [
+            ("peddy_ped", "ped"),
+            ("peddy_sex", "sex-check"),
+            ("peddy_check", "ped-check"),
+        ]
+        self._include_files(data, hk_version, scout_hk_map, "peddy")
 
     def _include_mandatory_files(self, data, hk_version):
-        scout_hk_map = {('vcf_snv', 'vcf-snv-clinical'), ('vcf_snv_research', 'vcf-snv-research'),
-                        ('vcf_sv', 'vcf-sv-clinical'), ('vcf_sv_research', 'vcf-sv-research')}
+        scout_hk_map = {
+            ("vcf_snv", "vcf-snv-clinical"),
+            ("vcf_snv_research", "vcf-snv-research"),
+            ("vcf_sv", "vcf-sv-clinical"),
+            ("vcf_sv_research", "vcf-sv-research"),
+        }
         self._include_files(data, hk_version, scout_hk_map, skip_missing=False)
 
-    def _include_files(self, data, hk_version, scout_hk_map, extra_tag=None, skip_missing=True):
+    def _include_files(
+        self, data, hk_version, scout_hk_map, extra_tag=None, skip_missing=True
+    ):
         for scout_key, hk_tag in scout_hk_map:
 
             if extra_tag:
@@ -142,22 +183,31 @@ class UploadScoutAPI(object):
                     raise FileNotFoundError(f"missing file: {scout_key}")
 
     @staticmethod
-    def _is_family_case(data):
-        return any(sample['father'] or sample['mother'] for sample in data['samples'])
+    def _is_family_case(data: dict):
+        """Check if there are any linked individuals in a case"""
+        for sample in data["samples"]:
+            if sample["mother"] and sample["mother"] != "0":
+                return True
+            if sample["father"] and sample["father"] != "0":
+                return True
+        return False
 
     @staticmethod
     def _is_multi_sample_case(data):
-        return len(data['samples']) > 1
+        return len(data["samples"]) > 1
 
     def _run_madeline(self, family_obj: models.Family):
         """Generate a madeline file for an analysis."""
-        samples = [{
-            'sample': link_obj.sample.name,
-            'sex': link_obj.sample.sex,
-            'father': link_obj.father.name if link_obj.father else None,
-            'mother': link_obj.mother.name if link_obj.mother else None,
-            'status': link_obj.status,
-        } for link_obj in family_obj.links]
+        samples = [
+            {
+                "sample": link_obj.sample.name,
+                "sex": link_obj.sample.sex,
+                "father": link_obj.father.name if link_obj.father else None,
+                "mother": link_obj.mother.name if link_obj.mother else None,
+                "status": link_obj.status,
+            }
+            for link_obj in family_obj.links
+        ]
         ped_stream = self.madeline.make_ped(family_obj.name, samples=samples)
         svg_path = self.madeline.run(self.madeline_exe, ped_stream)
         return svg_path

--- a/cg/meta/upload/scoutapi.py
+++ b/cg/meta/upload/scoutapi.py
@@ -3,10 +3,11 @@
 import logging
 from pathlib import Path
 
+from ruamel import yaml
+
 from cg.apps import hk, madeline, scoutapi
 from cg.meta.analysis import AnalysisAPI
 from cg.store import Store, models
-from ruamel import yaml
 
 LOG = logging.getLogger(__name__)
 

--- a/cg/store/utils.py
+++ b/cg/store/utils.py
@@ -3,8 +3,20 @@ import logging
 from typing import Callable
 
 import petname
+from cg.store import models
 
 LOG = logging.getLogger(__name__)
+
+
+def get_links(case: models.Family) -> models.Sample:
+    """Return all samples from a family object"""
+    for sample_obj in case.links:
+        yield sample_obj
+
+
+def get_samples(analysis_obj: models.Analysis) -> models.Sample:
+    """Search a analysis object and return the samples"""
+    return get_links(analysis_obj.family)
 
 
 def get_unique_id(availability_func: Callable) -> str:
@@ -14,7 +26,7 @@ def get_unique_id(availability_func: Callable) -> str:
     already exists.
     """
     while True:
-        random_id = petname.Generate(3, separator='')
+        random_id = petname.Generate(3, separator="")
         if availability_func(random_id) is None:
             return random_id
         else:

--- a/tests/meta/upload/conftest.py
+++ b/tests/meta/upload/conftest.py
@@ -1,4 +1,6 @@
+"""Fixtures for meta/upload tests"""
 import pytest
+
 from cg.apps.hk import HousekeeperAPI
 from cg.meta.upload.mutacc import UploadToMutaccAPI
 from cg.meta.upload.observations import UploadObservationsAPI
@@ -6,52 +8,73 @@ from cg.meta.upload.scoutapi import UploadScoutAPI
 
 
 class MockVersion:
+    """Mock a version object"""
 
+    # In this case we need to disable since this needsto be mocked
+    # pylint: disable=invalid-name
     @property
     def id(self):
-        return ''
+        """Mock out the id"""
+        return ""
+
+    @property
+    def app_root(self):
+        """Mock out the app_root"""
+        return None
 
 
 class MockFile:
+    """Mock the housekeeper File class"""
 
-    def __init__(self, path='', to_archive=False, tags=[]):
+    def __init__(self, path="", to_archive=False, tags=None):
         self.path = path
         self.to_archive = to_archive
-        self.tags = tags
+        self.tags = tags or []
 
     def first(self):
+        """Mock the first method"""
         return MockFile(path=self.path)
 
     @property
     def full_path(self):
+        """Mock the full path attribute"""
         return self.path
 
-    def is_included(self):
+    @staticmethod
+    def is_included():
+        """Mock the is_included method to always return False"""
         return False
 
 
 class MockHouseKeeper(HousekeeperAPI):
+    """Mock the housekeeper API"""
 
+    # In this mock we want to override __init__ so disable here
+    # pylint: disable=super-init-not-called
     def __init__(self):
         self._file_added = False
         self._file_included = False
         self._files = []
         self._file = MockFile()
 
+    # This is overriding a housekeeper object so ok to not include all arguments
+    # pylint: disable=arguments-differ
+    # pylint: disable=unused-argument
     def files(self, version, tags):
+        """Mock the files method to return a list of files"""
         return self._file
 
-    def get_files(self, bundle, tags, version='1.0'):
-        """docstring for get_files"""
+    def get_files(self, bundle, tags, version="1.0"):
+        """Mock the get_files method to return a list of files"""
         return self._files
 
     def add_file(self, file, version_obj, tag_name, to_archive=False):
-        """docstring for add_file"""
+        """Mock the add_files method to add a MockFile to the list of files"""
         self._file_added = True
         self._file = MockFile(path=file)
         return self._file
 
-    def version(self, arg1: str, arg2: str):
+    def version(self, bundle: str, date: str):
         """Fetch version from the database."""
         return MockVersion()
 
@@ -63,41 +86,54 @@ class MockHouseKeeper(HousekeeperAPI):
         """docstring for include_file"""
         self._file_included = True
 
+    # This is overriding an sqlalchemy method
+    # pylint: disable=arguments-differ
     def add_commit(self, file_obj):
-        """docstring for include_file"""
-        pass
+        """Overrides sqlalchemy method"""
+        return file_obj
 
 
 class MockMadeline:
+    """Mock the madeline module methods"""
 
-    def make_ped(self, name, samples):
-        return ''
+    # pylint: disable=unused-argument
+    @staticmethod
+    def make_ped(name, samples):
+        """Mock the make ped function"""
+        return ""
 
-    def run(self, arg1: str, arg2: str):
+    @staticmethod
+    def run(arg1: str, arg2: str):
         """Fetch version from the database."""
         return MockVersion()
 
 
 class MockAnalysis:
+    """Mock an analysis object"""
 
-    def get_latest_metadata(self, family_id):
+    @staticmethod
+    def get_latest_metadata(family_id=None):
+        """Mock get_latest_metadata"""
         # Returns: dict: parsed data
-        ### Define output dict
+        # Define output dict
         outdata = {
-            'analysis_sex': {'ADM1': 'female', 'ADM2': 'female', 'ADM3': 'female'},
-            'family': 'yellowhog',
-            'duplicates': {'ADM1': 13.525, 'ADM2': 12.525, 'ADM3': 14.525},
-            'genome_build': 'hg19',
-            'rank_model_version': '1.18',
-            'mapped_reads': {'ADM1': 98.8, 'ADM2': 99.8, 'ADM3': 97.8},
-            'mip_version': 'v4.0.20',
-            'sample_ids': ['2018-20203', '2018-20204'],
+            "analysis_sex": {"ADM1": "female", "ADM2": "female", "ADM3": "female"},
+            "family": family_id or "yellowhog",
+            "duplicates": {"ADM1": 13.525, "ADM2": 12.525, "ADM3": 14.525},
+            "genome_build": "hg19",
+            "rank_model_version": "1.18",
+            "mapped_reads": {"ADM1": 98.8, "ADM2": 99.8, "ADM3": 97.8},
+            "mip_version": "v4.0.20",
+            "sample_ids": ["2018-20203", "2018-20204"],
         }
 
         return outdata
 
-    def convert_panels(self, customer_id, panels):
-        return ''
+    # pylint: disable=unused-argument
+    @staticmethod
+    def convert_panels(customer_id, panels):
+        """Mock convert_panels"""
+        return ""
 
 
 class MockMutaccAuto:
@@ -115,7 +151,7 @@ class MockMutaccAuto:
 
 
 class MockScoutApi:
-    """ Mock class for Scout api"""
+    """Mock class for Scout api"""
 
     @staticmethod
     def get_causative_variants(case_id):
@@ -123,11 +159,29 @@ class MockScoutApi:
         _ = case_id
         return []
 
+    @property
+    def client(self):
+        """Client URI"""
+        return "mongodb://"
+
+    @property
+    def name(self):
+        """Name property"""
+        return self._name
+
+    @name.setter
+    def name(self, value):
+        self._name = value
+
+    @name.deleter
+    def name(self):
+        del self._name
+
 
 class MockLoqusAPI:
     """ Mock LoqusAPI class"""
 
-    def __init__(self, analysis_type='wgs'):
+    def __init__(self, analysis_type="wgs"):
         self.analysis_type = analysis_type
 
     @staticmethod
@@ -142,77 +196,75 @@ class MockLoqusAPI:
         """ Mock get_case method"""
         _ = args
         _ = kwargs
-        return {'case_id': 'case_id', '_id': '123'}
+        return {"case_id": "case_id", "_id": "123"}
 
     @staticmethod
     def get_duplicate(*args, **kwargs):
         """Mock get_duplicate method"""
         _ = args
         _ = kwargs
-        return {'case_id': 'case_id'}
+        return {"case_id": "case_id"}
 
 
-@pytest.yield_fixture(scope='function')
+@pytest.yield_fixture(scope="function")
 def housekeeper_api():
+    """housekeeper_api fixture"""
     _api = MockHouseKeeper()
 
     yield _api
 
 
-@pytest.yield_fixture(scope='function')
+@pytest.yield_fixture(scope="function")
 def upload_observations_api(analysis_store):
     """ Create mocked UploadObservationsAPI object"""
 
     loqus_mock = MockLoqusAPI()
     hk_mock = MockHouseKeeper()
-    hk_mock.add_file(file='.', version_obj='', tag_name='')
+    hk_mock.add_file(file=".", version_obj="", tag_name="")
 
     _api = UploadObservationsAPI(
-        status_api=analysis_store,
-        hk_api=hk_mock,
-        loqus_api=loqus_mock
+        status_api=analysis_store, hk_api=hk_mock, loqus_api=loqus_mock
     )
 
     yield _api
 
 
-@pytest.yield_fixture(scope='function')
+@pytest.yield_fixture(scope="function")
 def upload_observations_api_wes(analysis_store):
     """ Create mocked UploadObservationsAPI object"""
 
-    loqus_mock = MockLoqusAPI(analysis_type='wes')
+    loqus_mock = MockLoqusAPI(analysis_type="wes")
     hk_mock = MockHouseKeeper()
-    hk_mock.add_file(file='.', version_obj='', tag_name='')
+    hk_mock.add_file(file=".", version_obj="", tag_name="")
 
     _api = UploadObservationsAPI(
-        status_api=analysis_store,
-        hk_api=hk_mock,
-        loqus_api=loqus_mock
+        status_api=analysis_store, hk_api=hk_mock, loqus_api=loqus_mock
     )
 
     yield _api
 
 
-@pytest.yield_fixture(scope='function')
+@pytest.yield_fixture(scope="function")
 def upload_scout_api(analysis_store, scout_store):
+    """Fixture for upload_scout_api"""
     madeline_mock = MockMadeline()
     hk_mock = MockHouseKeeper()
-    hk_mock.add_file(file='/mock/path', version_obj='', tag_name='')
+    hk_mock.add_file(file="/mock/path", version_obj="", tag_name="")
     analysis_mock = MockAnalysis()
 
     _api = UploadScoutAPI(
         status_api=analysis_store,
         hk_api=hk_mock,
         scout_api=scout_store,
-        madeline_exe='',
+        madeline_exe="",
         madeline=madeline_mock,
-        analysis_api=analysis_mock
+        analysis_api=analysis_mock,
     )
 
     yield _api
 
 
-@pytest.yield_fixture(scope='function')
+@pytest.yield_fixture(scope="function")
 def mutacc_upload_api():
     """
         Fixture for a mutacc upload api
@@ -226,9 +278,10 @@ def mutacc_upload_api():
     return _api
 
 
-@pytest.yield_fixture(scope='function')
+@pytest.yield_fixture(scope="function")
 def analysis(analysis_store):
-    _analysis = analysis_store.add_analysis(pipeline='pipeline', version='version')
-    _analysis.family = analysis_store.family('yellowhog')
-    _analysis.config_path = 'dummy_path'
+    """Fixture to mock an analysis"""
+    _analysis = analysis_store.add_analysis(pipeline="pipeline", version="version")
+    _analysis.family = analysis_store.family("yellowhog")
+    _analysis.config_path = "dummy_path"
     yield _analysis

--- a/tests/meta/upload/test_meta_upload_scoutapi.py
+++ b/tests/meta/upload/test_meta_upload_scoutapi.py
@@ -9,7 +9,6 @@ from cg.meta.upload.scoutapi import UploadScoutAPI
 from cg.store import Store
 
 
-# pylint: disable=protected-access
 def test_unlinked_family_is_linked(upload_scout_api):
     """Test that is_family check fails when samples are not linked"""
     # GIVEN a upload scout api and case data for a family without linked individuals

--- a/tests/meta/upload/test_meta_upload_scoutapi.py
+++ b/tests/meta/upload/test_meta_upload_scoutapi.py
@@ -1,15 +1,17 @@
 """Tests for the scout upload API"""
 from pathlib import Path
 
+import pytest
 import yaml
 
-import pytest
 from cg.apps.hk import HousekeeperAPI
 from cg.meta.upload.scoutapi import UploadScoutAPI
 from cg.store import Store
 
 
+# pylint: disable=protected-access
 def test_unlinked_family_is_linked(upload_scout_api):
+    """Test that is_family check fails when samples are not linked"""
     # GIVEN a upload scout api and case data for a family without linked individuals
     family_data = {
         "samples": [
@@ -23,7 +25,9 @@ def test_unlinked_family_is_linked(upload_scout_api):
     assert res is False
 
 
+# pylint: disable=protected-access
 def test_family_is_linked(upload_scout_api):
+    """Test that is_family returns true when samples are linked"""
     # GIVEN a upload scout api and case data for a linked family
     family_data = {
         "samples": [
@@ -41,6 +45,7 @@ def test_family_is_linked(upload_scout_api):
 def test_generate_config_adds_rank_model_version(
     analysis: Store.Analysis, upload_scout_api: UploadScoutAPI
 ):
+    """Test that generate config adds rank model version"""
     # GIVEN a status db and hk with an analysis
     assert analysis
 
@@ -55,6 +60,7 @@ def test_generate_config_adds_rank_model_version(
 def test_generate_config_adds_vcf2cytosure(
     analysis: Store.Analysis, upload_scout_api: UploadScoutAPI
 ):
+    """Test that generate config adds vcf2cytosure file"""
     # GIVEN a status db and hk with an analysis
     assert analysis
 
@@ -77,7 +83,7 @@ def _file_is_yaml(file_path):
     with open(file_path, "r") as stream:
         try:
             data = yaml.safe_load(stream)
-        except yaml.YAMLError as exc:
+        except yaml.YAMLError:
             return False
     return data is not None
 
@@ -89,9 +95,7 @@ def test_save_config_creates_file(upload_scout_api: UploadScoutAPI, tmp_file):
     scout_config = {"dummy": "data"}
 
     # WHEN calling method to save config
-    result_data = upload_scout_api.save_config_file(
-        upload_config=scout_config, file_path=tmp_file
-    )
+    upload_scout_api.save_config_file(upload_config=scout_config, file_path=tmp_file)
 
     # THEN the config should exist on disk
     assert _file_exists_on_disk(tmp_file)
@@ -104,9 +108,7 @@ def test_save_config_creates_yaml(upload_scout_api: UploadScoutAPI, tmp_file):
     scout_config = {"dummy": "data"}
 
     # WHEN calling method to save config
-    result_data = upload_scout_api.save_config_file(
-        upload_config=scout_config, file_path=tmp_file
-    )
+    upload_scout_api.save_config_file(upload_config=scout_config, file_path=tmp_file)
 
     # THEN the should be of yaml type
     assert _file_is_yaml(tmp_file)
@@ -115,9 +117,10 @@ def test_save_config_creates_yaml(upload_scout_api: UploadScoutAPI, tmp_file):
 def test_add_scout_config_to_hk(
     upload_scout_api: UploadScoutAPI, housekeeper_api: HousekeeperAPI, tmp_file
 ):
+    """Test that scout load config is added to housekeeper"""
     # GIVEN a hk_mock and a file path to scout load config
     # WHEN adding the file path to hk_api
-    file_obj = upload_scout_api.add_scout_config_to_hk(
+    upload_scout_api.add_scout_config_to_hk(
         config_file_path=tmp_file, hk_api=housekeeper_api, case_id="dummy"
     )
     # THEN assert that the file path is added to hk
@@ -130,12 +133,13 @@ def test_add_scout_config_to_hk(
 def test_add_scout_config_to_hk_existing_files(
     upload_scout_api: UploadScoutAPI, housekeeper_api: HousekeeperAPI, tmp_file
 ):
+    """Test that scout config is not updated in housekeeper if it already exists"""
     # GIVEN a hk_mock with an scout upload file and a file path to scout load config
     housekeeper_api._files = ["a file path"]
     # WHEN adding the file path to hk_api
     with pytest.raises(FileExistsError):
         # THEN assert File exists exception is raised
-        file_obj = upload_scout_api.add_scout_config_to_hk(
+        upload_scout_api.add_scout_config_to_hk(
             config_file_path=tmp_file, hk_api=housekeeper_api, case_id="dummy"
         )
     # THEN assert file is not added to hk-db

--- a/tests/meta/upload/test_meta_upload_scoutapi.py
+++ b/tests/meta/upload/test_meta_upload_scoutapi.py
@@ -1,15 +1,46 @@
 """Tests for the scout upload API"""
 from pathlib import Path
 
-import pytest
 import yaml
+
+import pytest
 from cg.apps.hk import HousekeeperAPI
 from cg.meta.upload.scoutapi import UploadScoutAPI
 from cg.store import Store
 
 
-def test_generate_config_adds_rank_model_version(analysis: Store.Analysis, upload_scout_api:
-                                                 UploadScoutAPI):
+def test_unlinked_family_is_linked(upload_scout_api):
+    # GIVEN a upload scout api and case data for a family without linked individuals
+    family_data = {
+        "samples": [
+            {"sample_id": "ADM2", "father": "0", "mother": "0"},
+            {"sample_id": "ADM3", "father": "0", "mother": "0"},
+        ]
+    }
+    # WHEN running the check if family is linked
+    res = upload_scout_api._is_family_case(family_data)
+    # THEN assert that the test returns False
+    assert res is False
+
+
+def test_family_is_linked(upload_scout_api):
+    # GIVEN a upload scout api and case data for a linked family
+    family_data = {
+        "samples": [
+            {"sample_id": "ADM1", "father": "ADM2", "mother": "ADM3"},
+            {"sample_id": "ADM2", "father": "0", "mother": "0"},
+            {"sample_id": "ADM3", "father": "0", "mother": "0"},
+        ]
+    }
+    # WHEN running the check if family is linked
+    res = upload_scout_api._is_family_case(family_data)
+    # THEN assert that the test returns True
+    assert res is True
+
+
+def test_generate_config_adds_rank_model_version(
+    analysis: Store.Analysis, upload_scout_api: UploadScoutAPI
+):
     # GIVEN a status db and hk with an analysis
     assert analysis
 
@@ -17,12 +48,13 @@ def test_generate_config_adds_rank_model_version(analysis: Store.Analysis, uploa
     result_data = upload_scout_api.generate_config(analysis)
 
     # THEN the config should contain the rank model version used
-    assert result_data['human_genome_build']
-    assert result_data['rank_model_version']
+    assert result_data["human_genome_build"]
+    assert result_data["rank_model_version"]
 
 
-def test_generate_config_adds_vcf2cytosure(analysis: Store.Analysis, upload_scout_api:
-                                           UploadScoutAPI):
+def test_generate_config_adds_vcf2cytosure(
+    analysis: Store.Analysis, upload_scout_api: UploadScoutAPI
+):
     # GIVEN a status db and hk with an analysis
     assert analysis
 
@@ -30,8 +62,8 @@ def test_generate_config_adds_vcf2cytosure(analysis: Store.Analysis, upload_scou
     result_data = upload_scout_api.generate_config(analysis)
 
     # THEN the config should contain the vcf2cytosure cgh file path on each sample
-    for sample in result_data['samples']:
-        assert sample['vcf2cytosure']
+    for sample in result_data["samples"]:
+        assert sample["vcf2cytosure"]
 
 
 def _file_exists_on_disk(file_path: Path):
@@ -42,7 +74,7 @@ def _file_exists_on_disk(file_path: Path):
 def _file_is_yaml(file_path):
     """Returns if the file successfully was loaded as yaml"""
     data = None
-    with open(file_path, 'r') as stream:
+    with open(file_path, "r") as stream:
         try:
             data = yaml.safe_load(stream)
         except yaml.YAMLError as exc:
@@ -54,11 +86,12 @@ def test_save_config_creates_file(upload_scout_api: UploadScoutAPI, tmp_file):
     """"Tests that save config creates a file"""
 
     # GIVEN a scout_config dict and a path to save it on
-    scout_config = {'dummy': 'data'}
+    scout_config = {"dummy": "data"}
 
     # WHEN calling method to save config
-    result_data = upload_scout_api.save_config_file(upload_config=scout_config,
-                                                    file_path=tmp_file)
+    result_data = upload_scout_api.save_config_file(
+        upload_config=scout_config, file_path=tmp_file
+    )
 
     # THEN the config should exist on disk
     assert _file_exists_on_disk(tmp_file)
@@ -68,23 +101,25 @@ def test_save_config_creates_yaml(upload_scout_api: UploadScoutAPI, tmp_file):
     """Tests that the file created by save_config_file create a yaml """
 
     # GIVEN a scout_config dict and a path to save it on
-    scout_config = {'dummy': 'data'}
+    scout_config = {"dummy": "data"}
 
     # WHEN calling method to save config
-    result_data = upload_scout_api.save_config_file(upload_config=scout_config,
-                                                    file_path=tmp_file)
+    result_data = upload_scout_api.save_config_file(
+        upload_config=scout_config, file_path=tmp_file
+    )
 
     # THEN the should be of yaml type
     assert _file_is_yaml(tmp_file)
 
 
-def test_add_scout_config_to_hk(upload_scout_api: UploadScoutAPI, housekeeper_api: HousekeeperAPI,
-                                tmp_file):
+def test_add_scout_config_to_hk(
+    upload_scout_api: UploadScoutAPI, housekeeper_api: HousekeeperAPI, tmp_file
+):
     # GIVEN a hk_mock and a file path to scout load config
     # WHEN adding the file path to hk_api
-    file_obj = upload_scout_api.add_scout_config_to_hk(config_file_path=tmp_file,
-                                                       hk_api=housekeeper_api,
-                                                       case_id='dummy')
+    file_obj = upload_scout_api.add_scout_config_to_hk(
+        config_file_path=tmp_file, hk_api=housekeeper_api, case_id="dummy"
+    )
     # THEN assert that the file path is added to hk
     # file added to hk-db
     assert housekeeper_api._file_added is True
@@ -92,17 +127,17 @@ def test_add_scout_config_to_hk(upload_scout_api: UploadScoutAPI, housekeeper_ap
     assert housekeeper_api._file_included is True
 
 
-def test_add_scout_config_to_hk_existing_files(upload_scout_api: UploadScoutAPI,
-                                               housekeeper_api: HousekeeperAPI,
-                                               tmp_file):
+def test_add_scout_config_to_hk_existing_files(
+    upload_scout_api: UploadScoutAPI, housekeeper_api: HousekeeperAPI, tmp_file
+):
     # GIVEN a hk_mock with an scout upload file and a file path to scout load config
-    housekeeper_api._files = ['a file path']
+    housekeeper_api._files = ["a file path"]
     # WHEN adding the file path to hk_api
     with pytest.raises(FileExistsError):
         # THEN assert File exists exception is raised
-        file_obj = upload_scout_api.add_scout_config_to_hk(config_file_path=tmp_file,
-                                                           hk_api=housekeeper_api,
-                                                           case_id='dummy')
+        file_obj = upload_scout_api.add_scout_config_to_hk(
+            config_file_path=tmp_file, hk_api=housekeeper_api, case_id="dummy"
+        )
     # THEN assert file is not added to hk-db
     assert housekeeper_api._file_added is False
     # THEN assert file is not included in hk-db

--- a/tests/meta/upload/test_meta_upload_scoutapi.py
+++ b/tests/meta/upload/test_meta_upload_scoutapi.py
@@ -25,7 +25,6 @@ def test_unlinked_family_is_linked(upload_scout_api):
     assert res is False
 
 
-# pylint: disable=protected-access
 def test_family_is_linked(upload_scout_api):
     """Test that is_family returns true when samples are linked"""
     # GIVEN a upload scout api and case data for a linked family

--- a/tests/store/conftest.py
+++ b/tests/store/conftest.py
@@ -1,5 +1,5 @@
 """Fixtures for store tests"""
-# -*- coding: utf-8 -*-
+# pylint: disable=redefined-outer-name
 import datetime as dt
 
 import pytest

--- a/tests/store/conftest.py
+++ b/tests/store/conftest.py
@@ -1,3 +1,4 @@
+"""Fixtures for store tests"""
 # -*- coding: utf-8 -*-
 import datetime as dt
 
@@ -7,89 +8,158 @@ import pytest
 @pytest.fixture
 def microbial_submitted_order():
     """Build an example order as it looks after submission to ."""
-    order = {'customer': 'cust000',
-             'name': 'test order',
-             'internal_id': 'lims_reference',
-             'comment': 'test comment',
-             'ticket_number': '123456',
-             'items': [
-                 dict(name='Jag', internal_id='ms1', reads='1000', container='96 well plate',
-                      container_name='hej',
-                      rml_plate_name=None,
-                      well_position='D:5', well_position_rml=None, sex=None, panels=None,
-                      require_qcok=True,
-                      application='MWRNXTR003', source=None, status=None, customer='cust015',
-                      family=None,
-                      priority='standard', capture_kit=None, comment=None, index=None,
-                      reagent_label=None,
-                      tumour=False, custom_index=None, elution_buffer='Nuclease-free water',
-                      organism='C. Jejuni', reference_genome='NC_111',
-                      extraction_method='MagNaPure 96 (contact Clinical Genomics before '
-                                        'submission)',
-                      analysis='fastq', concentration_weight='1', mother=None, father=None),
-                 dict(name='testar', internal_id='ms2', reads='1000', container='96 well plate',
-                      container_name='hej',
-                      rml_plate_name=None,
-                      well_position='H:5', well_position_rml=None, sex=None, panels=None,
-                      require_qcok=True,
-                      application='MWRNXTR003', source=None, status=None, customer='cust015',
-                      family=None,
-                      priority='standard', capture_kit=None, comment=None, index=None,
-                      reagent_label=None,
-                      tumour=False, custom_index=None, elution_buffer='Nuclease-free water',
-                      organism='M.upium', reference_genome='NC_222',
-                      extraction_method='MagNaPure 96 (contact Clinical Genomics before '
-                                        'submission)',
-                      analysis='fastq', quantity='2', mother=None, father=None),
-                 dict(name='lite', internal_id='ms3', reads='1000', container='96 well plate',
-                      container_name='hej',
-                      rml_plate_name=None,
-                      well_position='A:6', well_position_rml=None, sex=None, panels=None,
-                      require_qcok=True,
-                      application='MWRNXTR003', source=None, status=None, customer='cust015',
-                      family=None,
-                      priority='standard', capture_kit=None, comment='3', index=None,
-                      reagent_label=None,
-                      tumour=False, custom_index=None, elution_buffer='Nuclease-free water',
-                      organism='C. difficile', reference_genome='NC_333',
-                      extraction_method='MagNaPure 96 (contact Clinical Genomics before '
-                                        'submission)',
-                      analysis='fastq', mother=None, father=None)], 'project_type': 'microbial'}
+    order = {
+        "customer": "cust000",
+        "name": "test order",
+        "internal_id": "lims_reference",
+        "comment": "test comment",
+        "ticket_number": "123456",
+        "items": [
+            dict(
+                name="Jag",
+                internal_id="ms1",
+                reads="1000",
+                container="96 well plate",
+                container_name="hej",
+                rml_plate_name=None,
+                well_position="D:5",
+                well_position_rml=None,
+                sex=None,
+                panels=None,
+                require_qcok=True,
+                application="MWRNXTR003",
+                source=None,
+                status=None,
+                customer="cust015",
+                family=None,
+                priority="standard",
+                capture_kit=None,
+                comment=None,
+                index=None,
+                reagent_label=None,
+                tumour=False,
+                custom_index=None,
+                elution_buffer="Nuclease-free water",
+                organism="C. Jejuni",
+                reference_genome="NC_111",
+                extraction_method="MagNaPure 96 (contact Clinical Genomics before "
+                "submission)",
+                analysis="fastq",
+                concentration_weight="1",
+                mother=None,
+                father=None,
+            ),
+            dict(
+                name="testar",
+                internal_id="ms2",
+                reads="1000",
+                container="96 well plate",
+                container_name="hej",
+                rml_plate_name=None,
+                well_position="H:5",
+                well_position_rml=None,
+                sex=None,
+                panels=None,
+                require_qcok=True,
+                application="MWRNXTR003",
+                source=None,
+                status=None,
+                customer="cust015",
+                family=None,
+                priority="standard",
+                capture_kit=None,
+                comment=None,
+                index=None,
+                reagent_label=None,
+                tumour=False,
+                custom_index=None,
+                elution_buffer="Nuclease-free water",
+                organism="M.upium",
+                reference_genome="NC_222",
+                extraction_method="MagNaPure 96 (contact Clinical Genomics before "
+                "submission)",
+                analysis="fastq",
+                quantity="2",
+                mother=None,
+                father=None,
+            ),
+            dict(
+                name="lite",
+                internal_id="ms3",
+                reads="1000",
+                container="96 well plate",
+                container_name="hej",
+                rml_plate_name=None,
+                well_position="A:6",
+                well_position_rml=None,
+                sex=None,
+                panels=None,
+                require_qcok=True,
+                application="MWRNXTR003",
+                source=None,
+                status=None,
+                customer="cust015",
+                family=None,
+                priority="standard",
+                capture_kit=None,
+                comment="3",
+                index=None,
+                reagent_label=None,
+                tumour=False,
+                custom_index=None,
+                elution_buffer="Nuclease-free water",
+                organism="C. difficile",
+                reference_genome="NC_333",
+                extraction_method="MagNaPure 96 (contact Clinical Genomics before "
+                "submission)",
+                analysis="fastq",
+                mother=None,
+                father=None,
+            ),
+        ],
+        "project_type": "microbial",
+    }
     return order
 
 
-@pytest.yield_fixture(scope='function')
+@pytest.yield_fixture(scope="function")
 def microbial_store(base_store, microbial_submitted_order):
     """Setup a store instance for testing analysis API."""
-    customer = base_store.customer(microbial_submitted_order['customer'])
+    customer = base_store.customer(microbial_submitted_order["customer"])
 
-    order = base_store.MicrobialOrder(internal_id=microbial_submitted_order['internal_id'],
-                                      name=microbial_submitted_order['name'],
-                                      ticket_number=microbial_submitted_order['ticket_number'],
-                                      comment=microbial_submitted_order['comment'],
-                                      created_at=dt.datetime(2012, 3, 3, 10, 10, 10),
-                                      updated_at=dt.datetime(
-                                          2012, 3, 3, 10, 10, 10),
-                                      ordered_at=dt.datetime(2012, 3, 3, 10, 10, 10))
+    order = base_store.MicrobialOrder(
+        internal_id=microbial_submitted_order["internal_id"],
+        name=microbial_submitted_order["name"],
+        ticket_number=microbial_submitted_order["ticket_number"],
+        comment=microbial_submitted_order["comment"],
+        created_at=dt.datetime(2012, 3, 3, 10, 10, 10),
+        updated_at=dt.datetime(2012, 3, 3, 10, 10, 10),
+        ordered_at=dt.datetime(2012, 3, 3, 10, 10, 10),
+    )
 
     order.customer = customer
     base_store.add(order)
 
-    for sample_data in microbial_submitted_order['items']:
-        application_version = base_store.application(sample_data['application']).versions[0]
-        organism = base_store.Organism(internal_id=sample_data['organism'], name=sample_data[
-            'organism'])
+    for sample_data in microbial_submitted_order["items"]:
+        application_version = base_store.application(
+            sample_data["application"]
+        ).versions[0]
+        organism = base_store.Organism(
+            internal_id=sample_data["organism"], name=sample_data["organism"]
+        )
         base_store.add(organism)
-        sample = base_store.add_microbial_sample(name=sample_data['name'], sex=sample_data['sex'],
-                                                 internal_id=sample_data['internal_id'],
-                                                 ticket=microbial_submitted_order['ticket_number'],
-                                                 reads=sample_data['reads'],
-                                                 comment=sample_data['comment'],
-                                                 organism=organism,
-                                                 priority=sample_data['priority'],
-                                                 reference_genome=sample_data['reference_genome'],
-                                                 application_version=application_version
-                                                 )
+        sample = base_store.add_microbial_sample(
+            name=sample_data["name"],
+            sex=sample_data["sex"],
+            internal_id=sample_data["internal_id"],
+            ticket=microbial_submitted_order["ticket_number"],
+            reads=sample_data["reads"],
+            comment=sample_data["comment"],
+            organism=organism,
+            priority=sample_data["priority"],
+            reference_genome=sample_data["reference_genome"],
+            application_version=application_version,
+        )
         sample.microbial_order = order
         sample.application_version = application_version
         sample.customer = customer
@@ -104,71 +174,142 @@ def microbial_store(base_store, microbial_submitted_order):
 def _analysis_family():
     """Build an example family."""
     family = {
-        'name': 'family',
-        'internal_id': 'yellowhog',
-        'panels': ['IEM', 'EP'],
-        'samples': [{
-            'name': 'son',
-            'sex': 'male',
-            'internal_id': 'ADM1',
-            'father': 'ADM2',
-            'mother': 'ADM3',
-            'status': 'affected',
-            'ticket_number': 123456,
-            'reads': 5000000,
-        }, {
-            'name': 'father',
-            'sex': 'male',
-            'internal_id': 'ADM2',
-            'status': 'unaffected',
-            'ticket_number': 123456,
-            'reads': 6000000,
-        }, {
-            'name': 'mother',
-            'sex': 'female',
-            'internal_id': 'ADM3',
-            'status': 'unaffected',
-            'ticket_number': 123456,
-            'reads': 7000000,
-        }]
+        "name": "family",
+        "internal_id": "yellowhog",
+        "panels": ["IEM", "EP"],
+        "samples": [
+            {
+                "name": "son",
+                "sex": "male",
+                "internal_id": "ADM1",
+                "father": "ADM2",
+                "mother": "ADM3",
+                "status": "affected",
+                "ticket_number": 123456,
+                "reads": 5000000,
+            },
+            {
+                "name": "father",
+                "sex": "male",
+                "internal_id": "ADM2",
+                "status": "unaffected",
+                "ticket_number": 123456,
+                "reads": 6000000,
+            },
+            {
+                "name": "mother",
+                "sex": "female",
+                "internal_id": "ADM3",
+                "status": "unaffected",
+                "ticket_number": 123456,
+                "reads": 7000000,
+            },
+        ],
     }
     return family
 
 
-@pytest.yield_fixture(scope='function')
-def analysis_store(base_store):
-    """Setup a store instance for testing analysis API."""
+@pytest.yield_fixture(scope="function")
+def analysis_obj(base_store):
+    """Setup a store instance for testing analysis API and create a family obj."""
     analysis_family = _analysis_family()
-    customer = base_store.customer('cust000')
-    family = base_store.Family(name=analysis_family['name'], panels=analysis_family[
-        'panels'], internal_id=analysis_family['internal_id'], priority='standard')
+    customer = base_store.customer("cust000")
+    family = base_store.Family(
+        name=analysis_family["name"],
+        panels=analysis_family["panels"],
+        internal_id=analysis_family["internal_id"],
+        priority="standard",
+    )
     family.customer = customer
     base_store.add(family)
-    application_version = base_store.application('WGTPCFC030').versions[0]
-    for sample_data in analysis_family['samples']:
-        sample = base_store.add_sample(name=sample_data['name'], sex=sample_data['sex'],
-                                       internal_id=sample_data['internal_id'],
-                                       ticket=sample_data['ticket_number'],
-                                       reads=sample_data['reads'], )
+    application_version = base_store.application("WGTPCFC030").versions[0]
+    for sample_data in analysis_family["samples"]:
+        sample = base_store.add_sample(
+            name=sample_data["name"],
+            sex=sample_data["sex"],
+            internal_id=sample_data["internal_id"],
+            ticket=sample_data["ticket_number"],
+            reads=sample_data["reads"],
+        )
         sample.family = family
         sample.application_version = application_version
         sample.customer = customer
         base_store.add(sample)
     base_store.commit()
-    for sample_data in analysis_family['samples']:
-        sample_obj = base_store.sample(sample_data['internal_id'])
+    for sample_data in analysis_family["samples"]:
+        sample_obj = base_store.sample(sample_data["internal_id"])
         link = base_store.relate_sample(
             family=family,
             sample=sample_obj,
-            status=sample_data['status'],
-            father=base_store.sample(sample_data['father']) if sample_data.get('father') else None,
-            mother=base_store.sample(sample_data['mother']) if sample_data.get('mother') else None,
+            status=sample_data["status"],
+            father=base_store.sample(sample_data["father"])
+            if sample_data.get("father")
+            else None,
+            mother=base_store.sample(sample_data["mother"])
+            if sample_data.get("mother")
+            else None,
         )
         base_store.add(link)
 
-    _analysis = base_store.add_analysis(pipeline='pipeline', version='version')
+    _analysis = base_store.add_analysis(pipeline="pipeline", version="version")
     _analysis.family = family
-    _analysis.config_path = 'dummy_path'
+    _analysis.config_path = "dummy_path"
+
+    base_store.commit()
+    yield _analysis
+
+
+@pytest.yield_fixture(scope="function")
+def family_obj(analysis_obj):
+    """Return a family models object."""
+    return analysis_obj.family
+
+
+@pytest.yield_fixture(scope="function")
+def analysis_store(base_store):
+    """Setup a store instance for testing analysis API."""
+    analysis_family = _analysis_family()
+    customer = base_store.customer("cust000")
+    family = base_store.Family(
+        name=analysis_family["name"],
+        panels=analysis_family["panels"],
+        internal_id=analysis_family["internal_id"],
+        priority="standard",
+    )
+    family.customer = customer
+    base_store.add(family)
+    application_version = base_store.application("WGTPCFC030").versions[0]
+    for sample_data in analysis_family["samples"]:
+        sample = base_store.add_sample(
+            name=sample_data["name"],
+            sex=sample_data["sex"],
+            internal_id=sample_data["internal_id"],
+            ticket=sample_data["ticket_number"],
+            reads=sample_data["reads"],
+        )
+        sample.family = family
+        sample.application_version = application_version
+        sample.customer = customer
+        base_store.add(sample)
+    base_store.commit()
+    for sample_data in analysis_family["samples"]:
+        sample_obj = base_store.sample(sample_data["internal_id"])
+        link = base_store.relate_sample(
+            family=family,
+            sample=sample_obj,
+            status=sample_data["status"],
+            father=base_store.sample(sample_data["father"])
+            if sample_data.get("father")
+            else None,
+            mother=base_store.sample(sample_data["mother"])
+            if sample_data.get("mother")
+            else None,
+        )
+        base_store.add(link)
+
+    _analysis = base_store.add_analysis(pipeline="pipeline", version="version")
+    _analysis.family = family
+    _analysis.config_path = "dummy_path"
 
     base_store.commit()
     yield base_store

--- a/tests/store/test_store_utils.py
+++ b/tests/store/test_store_utils.py
@@ -1,3 +1,4 @@
+"""Tests for utils in store"""
 from cg.store.models import FamilySample
 from cg.store.utils import get_links, get_samples
 

--- a/tests/store/test_store_utils.py
+++ b/tests/store/test_store_utils.py
@@ -1,0 +1,22 @@
+from cg.store.models import FamilySample
+from cg.store.utils import get_links, get_samples
+
+
+def test_get_samples(analysis_obj):
+    """Test function to get all samples from a analysis object"""
+    # GIVEN an analysis object
+    # WHEN fetching all samples
+    samples = get_samples(analysis_obj)
+    # THEN assert the samples are FamilySamples
+    for sample in samples:
+        assert isinstance(sample, FamilySample)
+
+
+def test_link(family_obj):
+    """Test function to get all samples from a family"""
+    # GIVEN an family object
+    # WHEN fetching all links
+    link_objs = get_links(family_obj)
+    # THEN assert the link objs are samples
+    for link_obj in link_objs:
+        assert isinstance(link_obj, FamilySample)


### PR DESCRIPTION
This PR adds fixes a bug that the scout upload fails when individuals in a case are unlinked

**How to prepare for test**:
On hasta:
- [x] activate stage: `us`
- [x] try to upload `usableyak` with command `cg upload scout usableyak` where all individuals are unlinked. Check that it fails
- [x] install on stage of hasta: `bash servers/resources/hasta.scilifelab.se/update-cg-stage.sh fix-family-check`

**How to test**:
- [x] Try to upload the same case again

**Expected test outcome**:
- [x] The case should now be uploaded to scout
- [x] Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by @moonso and @b4ckm4n 
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This is patch **version bump** because it is a small bug fix 
