### PR TITLE
Rename usalt config param to microsalt

### DIFF
--- a/cg/apps/usalt/fastq.py
+++ b/cg/apps/usalt/fastq.py
@@ -36,7 +36,7 @@ class USaltFastqHandler(BaseFastqHandler):
 
     def __init__(self, config):
         super().__init__(config)
-        self.root_dir = config['usalt']['root']
+        self.root_dir = config['microsalt']['root']
 
     def link(self, case: str, sample: str, files: List):
         """Link FASTQ files for a usalt sample.

--- a/tests/apps/usalt/conftest.py
+++ b/tests/apps/usalt/conftest.py
@@ -79,7 +79,7 @@ def create_file_data(file_path, flowcell, lane, read):
 @pytest.fixture
 def cg_config(tmpdir):
     """mock relevant parts of a cg-config"""
-    return {'usalt': {'root': tmpdir}}
+    return {'microsalt': {'root': tmpdir}}
 
 
 @pytest.fixture

--- a/tests/meta/conftest.py
+++ b/tests/meta/conftest.py
@@ -216,7 +216,7 @@ class MockUsaltFastq(USaltFastqHandler):
     """Mock FastqHandler for analysis_api"""
 
     def __init__(self):
-        super().__init__(config={'usalt': {'root': tmpdir}})
+        super().__init__(config={'microsalt': {'root': tmpdir}})
 
 
 def safe_loader(path):


### PR DESCRIPTION
This PR renames key in the cg config from usalt -> microsalt as to make it more consistent with how to name microsalt.

**How to prepare for test**:
- [ ] install on stage of the coffee machine: `bash servers/resources/coffee.scilifelab.se/update-cg-stage.sh [BRANCHNAME]`
- [ ] activate stage: `us`

**How to test**:
- [ ] run following command: `cg get coffee`

**Expected test outcome**:
- [ ] `cg` should be providing you with a progress report of your coffee making. The coffee machine should not be leaking.
- [ ] Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This is patch|minor|major **version bump** because ...
