### PR TITLE
allow elution buffer for fastq

### DIFF
--- a/cg/meta/orders/schema.py
+++ b/cg/meta/orders/schema.py
@@ -203,7 +203,7 @@ EXTERNAL_SAMPLE = {
 }
 
 FASTQ_SAMPLE = {
-    # Orderform 1508:18
+    # Orderform 1508:?
     # "required"
     "name": validators.RegexValidator(NAME_PATTERN),
     "container": OptionalNone(validators.Any(CONTAINER_OPTIONS)),
@@ -222,6 +222,7 @@ FASTQ_SAMPLE = {
     # "Required if data analysis in Scout or vcf delivery" => not valid for fastq
     # 'panels': ListValidator(str, min_items=1),
     # 'status': OptionalNone(validators.Any(STATUS_OPTIONS),
+    "elution_buffer": str,
     # "Required if samples are part of trio/family"
     "mother": OptionalNone(RegexValidatorNone(NAME_PATTERN)),
     "father": OptionalNone(RegexValidatorNone(NAME_PATTERN)),

--- a/tests/fixtures/orders/fastq.json
+++ b/tests/fixtures/orders/fastq.json
@@ -15,7 +15,8 @@
             "well_position": "",
             "source": "blood",
             "priority": "priority",
-            "require_qcok": true
+            "require_qcok": true,
+            "elution_buffer": "Nuclease-free water"
         },
         {
             "name": "prov2",
@@ -29,7 +30,8 @@
             "well_position": "",
             "source": "cell line",
             "priority": "priority",
-            "require_qcok": false
+            "require_qcok": false,
+            "elution_buffer": "Nuclease-free water"
         }
     ]
 }


### PR DESCRIPTION
This PR adds a fix for the missing elution buffers from Orderportal

**How to prepare for test**:
- [x] test through [cgweb](https://github.com/Clinical-Genomics/cgweb/pull/174)

**Review:**
- [x] code approved by CR
- [x] tests executed by @patrikgrenfeldt 
- [x] "Merge and deploy" approved by @patrikgrenfeldt 
Thanks for filling in who performed the code review and the test!

This is patch **version bump** because it fixes a non-concordance with the current orderform
