### PR TITLE
Add Cardiology to master list

### DIFF
--- a/cg/meta/workflow/mip_dna.py
+++ b/cg/meta/workflow/mip_dna.py
@@ -32,7 +32,7 @@ MASTER_LIST = (
     "IF",
     "NEURODEG",
     "mcarta",
-    "Cardiology"
+    "Cardiology",
 )
 COMBOS = {
     "DSD": ("DSD", "HYP", "SEXDIF", "SEXDET"),

--- a/cg/meta/workflow/mip_dna.py
+++ b/cg/meta/workflow/mip_dna.py
@@ -32,6 +32,7 @@ MASTER_LIST = (
     "IF",
     "NEURODEG",
     "mcarta",
+    "Cardiology"
 )
 COMBOS = {
     "DSD": ("DSD", "HYP", "SEXDIF", "SEXDET"),


### PR DESCRIPTION
This PR adds a new gene panel for the master list used in MIP

**How to prepare for test**:
- [ ] install on stage of hasta: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh Add-Cardiology-to-master-list`
- [ ] activate stage: `us`

**How to test**:
- [ ] run following command: `cg workflow mip-dna panel -p funoriole`

**Expected test outcome**:
- [ ] `cg` should now print the included genepanels to the prompt. Gene panel "Cardiology" should be included in the list at the top.
- [ ] Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @barrystokman 
- [x] tests executed by @emiliaol 
- [x] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This is minor **version bump** because no new functionality was added.
