### PR TITLE
Fix/allow any capture kit for balsamic

### DIFF
--- a/cg/meta/orders/schema.py
+++ b/cg/meta/orders/schema.py
@@ -150,7 +150,7 @@ BALSAMIC_SAMPLE = {
     "container_name": OptionalNone(TypeValidatorNone(str)),
     "well_position": OptionalNone(TypeValidatorNone(str)),
     # This information is required for panel analysis
-    "capture_kit": str,
+    "capture_kit": OptionalNone(TypeValidatorNone(str)),
     # This information is required for panel- or exome analysis
     "elution_buffer": OptionalNone(TypeValidatorNone(str)),
     "tumour_purity": OptionalNone(TypeValidatorNone(str)),

--- a/cg/meta/orders/schema.py
+++ b/cg/meta/orders/schema.py
@@ -144,7 +144,6 @@ BALSAMIC_SAMPLE = {
     "family_name": validators.RegexValidator(NAME_PATTERN),
     "require_qcok": bool,
     "tumour": bool,
-    "elution_buffer": str,
     "source": OptionalNone(TypeValidatorNone(str)),
     "priority": OptionalNone(validators.Any(PRIORITY_OPTIONS)),
     # Required if Plate for new samples


### PR DESCRIPTION
This PR adds a fix for the faulty required capture-kit for balsamic samples

**How to prepare for test**:
- [x] install on stage of clinical-db

**How to test**:
- [x] submit an balsamic order in OP w/o capture-kit and any applications except PAN

**Expected test outcome**:
- [x] the order should submit successfully 
- [x] Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @annagellerbring 
- [x] tests executed by @patrikgrenfeldt 
- [x] "Merge and deploy" approved by @patrikgrenfeldt 
Thanks for filling in who performed the code review and the test!

This is patch **version bump** because it is a fix
