### PR TITLE
Use scout load config when loading from CG CLI

### DIFF
--- a/cg/apps/scoutapi.py
+++ b/cg/apps/scoutapi.py
@@ -34,9 +34,11 @@ class ScoutAPI(MongoAdapter):
             else:
                 existing_date = existing_case['analysis_date'].date()
                 LOG.warning(f"analysis of case already loaded: {existing_date}")
-        else:
-            LOG.debug("load new Scout case")
-            load_scout(self, config_data)
+            return
+
+        LOG.debug("load new Scout case")
+        load_scout(self, config_data)
+        LOG.info("Case loaded successfully to Scout")
 
     def export_panels(self, panels: List[str], versions=None):
         """Pass through to export of a list of gene panels."""

--- a/cg/apps/tb/api.py
+++ b/cg/apps/tb/api.py
@@ -6,10 +6,10 @@ from typing import List
 
 import click
 import ruamel.yaml
+from trailblazer.cli.utils import environ_email
+from trailblazer.mip import fastq, files, trending
 from trailblazer.mip.start import MipCli
 from trailblazer.store import Store, models
-from trailblazer.cli.utils import environ_email
-from trailblazer.mip import files, fastq, trending
 
 from .add import AddHandler
 
@@ -82,7 +82,7 @@ class TrailblazerAPI(Store, AddHandler, fastq.FastqHandler):
 
     def delete_analysis(self, family: str, date: dt.datetime, yes: bool = False):
         """Delete the analysis output."""
-        if self.analyses(family=family, temp=True).count() > 0:
+        if len([analysis for analysis in self.analyses(family=family, temp=True)]) > 0:
             raise ValueError("analysis for family already running")
         analysis_obj = self.find_analysis(family, date, "completed")
         assert analysis_obj.is_deleted is False

--- a/cg/cli/upload/upload.py
+++ b/cg/cli/upload/upload.py
@@ -131,16 +131,7 @@ def upload(context, family_id, force_restart):
         message = f"analysis already uploaded: {analysis_obj.uploaded_at.date()}"
         click.echo(click.style(message, fg="yellow"))
     else:
-        analysis_obj.upload_started_at = dt.datetime.now()
-        context.obj["status"].commit()
-        context.invoke(coverage, re_upload=True, family_id=family_id)
-        context.invoke(validate, family_id=family_id)
-        context.invoke(genotypes, re_upload=False, family_id=family_id)
-        context.invoke(observations, case_id=family_id)
-        context.invoke(scout, case_id=family_id)
-        analysis_obj.uploaded_at = dt.datetime.now()
-        context.obj["status"].commit()
-        click.echo(click.style(f"{family_id}: analysis uploaded!", fg="green"))
+        families_to_upload = context.obj["status"].observations_to_upload()
 
 
 @upload.command()

--- a/cg/cli/upload/upload.py
+++ b/cg/cli/upload/upload.py
@@ -5,11 +5,13 @@ import sys
 import traceback
 
 import click
+import yaml
 
+from cg.apps import beacon as beacon_app
 from cg.apps import coverage as coverage_app
-from cg.apps import gt, hk, lims, madeline, scoutapi, tb
-from cg.cli.workflow.mip_dna.deliver import CASE_TAGS, SAMPLE_TAGS
-from cg.meta.deliver import DeliverAPI
+from cg.apps import gt, hk, lims, loqus, mutacc_auto, scoutapi, tb
+from cg.exc import DuplicateRecordError, DuplicateSampleError
+from cg.meta.deliver.mip_dna import DeliverAPI
 from cg.meta.report.api import ReportAPI
 from cg.meta.upload.scoutapi import UploadScoutAPI
 from cg.meta.workflow.mip_dna import AnalysisAPI
@@ -17,7 +19,8 @@ from cg.store import Store
 
 from .beacon import beacon
 from .coverage import coverage
-from .delivery import delivery_report, delivery_report_to_scout, delivery_reports
+from .delivery import (delivery_report, delivery_report_to_scout,
+                       delivery_reports)
 from .genotype import genotypes
 from .mutacc import process_solved, processed_solved
 from .observations import observations

--- a/cg/meta/upload/scoutapi.py
+++ b/cg/meta/upload/scoutapi.py
@@ -1,4 +1,4 @@
-"""File includes api to uploading data into Scout"""
+"""Code for preparing data before uploading to scout"""
 
 import logging
 from pathlib import Path

--- a/cg/meta/upload/scoutapi.py
+++ b/cg/meta/upload/scoutapi.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from ruamel import yaml
 
-from cg.apps import hk, scoutapi
+from cg.apps import hk
 from cg.apps.madeline.api import MadelineAPI
 from cg.meta.workflow.mip_dna import AnalysisAPI
 from cg.store import models
@@ -19,12 +19,10 @@ class UploadScoutAPI:
     def __init__(
         self,
         hk_api: hk.HousekeeperAPI,
-        scout_api: scoutapi.ScoutAPI,
         analysis_api: AnalysisAPI,
         madeline_api: MadelineAPI,
     ):
         self.housekeeper = hk_api
-        self.scout = scout_api
         self.madeline_api = madeline_api
         self.analysis = analysis_api
 

--- a/cg/meta/upload/scoutapi.py
+++ b/cg/meta/upload/scoutapi.py
@@ -113,6 +113,11 @@ class UploadScoutAPI:
         return data
 
     @staticmethod
+    def get_load_config_tag() -> str:
+        """Get the hk tag for a scout load config"""
+        return "scout-load-config"
+
+    @staticmethod
     def save_config_file(upload_config: dict, file_path: Path):
         """Save a scout load config file to <file_path>"""
 
@@ -125,7 +130,7 @@ class UploadScoutAPI:
         config_file_path: Path, hk_api: hk.HousekeeperAPI, case_id: str
     ):
         """Add scout load config to hk bundle"""
-        tag_name = "scout-load-config"
+        tag_name = UploadScoutAPI.get_load_config_tag()
         version_obj = hk_api.last_version(bundle=case_id)
         uploaded_config_files = hk_api.get_files(
             bundle=case_id, tags=[tag_name], version=version_obj.id

--- a/tests/cli/upload/conftest.py
+++ b/tests/cli/upload/conftest.py
@@ -16,9 +16,7 @@ LOG = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="function", name="base_context")
-def fixture_base_context(
-    analysis_store_single_case: Store, hk_api: HousekeeperAPI
-) -> dict:
+def fixture_base_context(analysis_store_single_case: Store) -> dict:
     """context to use in cli"""
 
     return {

--- a/tests/cli/upload/conftest.py
+++ b/tests/cli/upload/conftest.py
@@ -16,7 +16,9 @@ LOG = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="function", name="base_context")
-def fixture_base_context(analysis_store_single_case: Store) -> dict:
+def fixture_base_context(
+    analysis_store_single_case: Store, hk_api: HousekeeperAPI
+) -> dict:
     """context to use in cli"""
 
     return {
@@ -92,10 +94,10 @@ def analysis_family_trio():
 
 
 @pytest.fixture(scope="function")
-def hk_api():
+def hk_api(scout_load_config):
     """Return a hkapi"""
     api = MockHK()
-    api._files.append("scout-load_config.yaml")
+    api.add_file(scout_load_config, None, None)
 
     return api
 
@@ -203,8 +205,9 @@ class MockFile:
     def first(self):
         return MockFile()
 
+    @property
     def full_path(self):
-        return ""
+        return str(self.path)
 
     def is_included(self):
         return False
@@ -226,7 +229,9 @@ class MockHK(HousekeeperAPI):
     def add_file(self, file, version_obj, tag_name, to_archive=False):
         """docstring for add_file"""
         self._file_added = True
-        return MockFile(path=file)
+        new_file = MockFile(path=file)
+        self._files.append(new_file)
+        return new_file
 
     def version(self, arg1: str, arg2: str):
         """Fetch version from the database."""

--- a/tests/cli/upload/conftest.py
+++ b/tests/cli/upload/conftest.py
@@ -47,6 +47,23 @@ def fixture_analysis_family_single():
     return family
 
 
+@pytest.fixture(scope="function")
+def hk_api():
+    """Return a hkapi"""
+    api = MockHK()
+    api._files.append("scout-load_config.yaml")
+
+    return api
+
+
+@pytest.fixture(scope="function")
+def upload_scout_api():
+    """Return a upload scout api"""
+    api = MockScoutUploadApi()
+
+    return api
+
+
 @pytest.yield_fixture(scope="function", name="analysis_store_single_case")
 def fixture_analysis_store_single(base_store, analysis_family_single_case):
     """Setup a store instance for testing analysis API."""
@@ -135,19 +152,38 @@ class MockFile:
 
 
 class MockHK(HousekeeperAPI):
-    """Mock of housekeeper """
-
     def __init__(self):
-        """Mock the init"""
-        pass
+        self._file_added = False
+        self._file_included = False
+        self._files = []
 
-    def files(self, **kwargs):
-        """docstring for file"""
+    def files(self, version, tags):
         return MockFile()
+
+    def get_files(self, bundle, tags, version="1.0"):
+        """docstring for get_files"""
+        return self._files
+
+    def add_file(self, file, version_obj, tag_name, to_archive=False):
+        """docstring for add_file"""
+        self._file_added = True
+        return MockFile(path=file)
 
     def version(self, arg1: str, arg2: str):
         """Fetch version from the database."""
         return MockVersion()
+
+    def last_version(self, bundle: str):
+        """docstring for last_version"""
+        return MockVersion()
+
+    def include_file(self, file_obj, version_obj):
+        """docstring for include_file"""
+        self._file_included = True
+
+    def add_commit(self, file_obj):
+        """docstring for include_file"""
+        pass
 
 
 class MockFamily(object):

--- a/tests/cli/upload/test_cli_upload_scout.py
+++ b/tests/cli/upload/test_cli_upload_scout.py
@@ -3,6 +3,7 @@ import logging
 
 from cg.cli.upload.upload import scout
 
+
 def check_log(caplog, string=None, warning=None):
     """Parse the log output"""
     found = False
@@ -16,12 +17,19 @@ def check_log(caplog, string=None, warning=None):
     return found
 
 
-def test_upload_with_load_config(hk_api, upload_scout_api, analysis_store_single_case, 
-    analysis_family_single_case, cli_runner, base_context, caplog):
+def test_upload_with_load_config(
+    hk_api,
+    upload_scout_api,
+    analysis_store_single_case,
+    analysis_family_single_case,
+    cli_runner,
+    base_context,
+    caplog,
+):
     # GIVEN a case with a scout load config in housekeeper
     case_id = analysis_store_single_case.families().first().internal_id
     tag_name = upload_scout_api.get_load_config_tag()
-    
+
     load_config_file = hk_api.get_files(case_id, [tag_name])[0]
     assert load_config_file
 
@@ -34,19 +42,19 @@ def test_upload_with_load_config(hk_api, upload_scout_api, analysis_store_single
     # WHEN invoking command to upload case to scout
     with caplog.at_level(logging.INFO):
         result = cli_runner.invoke(scout, [case_id], obj=base_context)
-    
-    # THEN 
+
+    # THEN
     def case_loaded_succesfully(caplog):
         """Check output that case was loaded"""
         return check_log(caplog, string="Case loaded successfully to Scout")
-    
+
     assert case_loaded_succesfully(caplog)
 
     def load_file_mentioned_in_result(result, load_config_file):
         """Check output that load file is mentioned"""
         assert load_config_file in result.output
 
-    assert load_file_mentioned_in_result(result)    
+    assert load_file_mentioned_in_result(result)
 
 
 def test_produce_load_config(base_context, cli_runner, analysis_family_single_case):
@@ -84,11 +92,14 @@ def test_upload_scout_cli_file_exists(
     assert warned
 
 
-def test_upload_scout_cli(base_context, cli_runner, analysis_family_single_case):
+def test_upload_scout_cli(
+    base_context, cli_runner, analysis_family_single_case, scout_load_config
+):
     # GIVEN a case_id where the case exists in status db with at least one analysis
     # GIVEN that the analysis is done and exists in tb
     config = {"dummy": "data"}
     base_context["scout_upload_api"].config = config
+    base_context["housekeeper_api"].add_file(scout_load_config, None, None)
     case_id = analysis_family_single_case["internal_id"]
     # WHEN uploading a case with the cli and printing the upload config
     result = cli_runner.invoke(scout, [case_id], obj=base_context)

--- a/tests/cli/upload/test_cli_upload_scout.py
+++ b/tests/cli/upload/test_cli_upload_scout.py
@@ -3,7 +3,25 @@ import logging
 
 from cg.cli.upload.upload import scout
 
-
+def test_upload_with_load_config(hk_api, upload_scout_api, analysis_store_single_case, 
+    analysis_family_single_case):
+    # GIVEN a case with a scout load config in housekeeper
+    case_id = analysis_store_single_case.families().first().internal_id
+    tag_name = upload_scout_api.get_load_config_tag()
+    
+    load_config_file = hk_api.get_files(case_id, [tag_name])[0]
+    assert load_config_file
+    assert case_exists_in_status(case_id, store)
+    assert the_case_has_parent_not_in_the_file(case_id, load_file)
+    
+    # WHEN invoking command to upload case to scout
+    result = cli_runner.invoke(scout, [case_id, ''], obj=base_context)
+    
+    # THEN the file was used to upload to scout
+    assert file_was_used_in_the_upload(load_file)
+    # THEN assert that the changes made in status is not transered to scout
+    assert scout_case_lacks_parent_not_in_the_file(parent)    
+    
 def test_produce_load_config(base_context, cli_runner, analysis_family_single_case):
     # GIVEN a singleton WGS case
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,6 +66,12 @@ def madeline_api(madeline_output):
 
 
 @pytest.fixture
+def scout_load_config():
+    """Yaml file with load information from scout"""
+    return "tests/fixtures/apps/scout/643594.config.yaml"
+
+
+@pytest.fixture
 def balsamic_orderform():
     """Orderform fixture for Balsamic samples"""
     return "tests/fixtures/orderforms/1508.19.balsamic.xlsx"

--- a/tests/fixtures/apps/scout/643594.config.yaml
+++ b/tests/fixtures/apps/scout/643594.config.yaml
@@ -1,0 +1,75 @@
+---
+
+owner: cust000
+
+family: 'internal_id'
+family_name: '643594'
+samples:
+  - analysis_type: wes
+    sample_id: ADM1059A2
+    capture_kit: Agilent_SureSelectCRE.V1
+    father: ADM1059A1
+    mother: ADM1059A3
+    sample_name: NA12882
+    phenotype: affected
+    sex: male
+    expected_coverage: 30
+    mt_bam: scout/demo/reduced_mt.bam
+    vcf2cytosure: scout/demo/ADM1059A2.dummy.cgh
+    tissue_type: blood
+
+  - analysis_type: wes
+    sample_id: ADM1059A1
+    capture_kit: Agilent_SureSelectCRE.V1
+    father: '0'
+    mother: '0'
+    sample_name: NA12877
+    phenotype: unaffected
+    sex: male
+    expected_coverage: 30
+    mt_bam: scout/demo/reduced_mt.bam
+    vcf2cytosure: scout/demo/ADM1059A1.dummy.cgh
+    tissue_type: blood
+
+  - analysis_type: wes
+    sample_id: ADM1059A3
+    capture_kit: Agilent_SureSelectCRE.V1
+    father: '0'
+    mother: '0'
+    sample_name: NA12878
+    phenotype: unaffected
+    sex: female
+    expected_coverage: 30
+    mt_bam: scout/demo/reduced_mt.bam
+    vcf2cytosure: scout/demo/ADM1059A3.dummy.cgh
+    tissue_type: blood
+
+vcf_snv: scout/demo/643594.clinical.vcf.gz
+vcf_sv: scout/demo/643594.clinical.SV.vcf.gz
+vcf_str: scout/demo/643594.clinical.str.annotated.vcf.gz
+vcf_snv_research: scout/demo/643594.research.vcf.gz
+vcf_sv_research: scout/demo/643594.research.SV.vcf.gz
+
+madeline: scout/demo/madeline.xml
+
+peddy_ped: scout/demo/643594.peddy.ped
+peddy_ped_check: scout/demo/643594.ped_check.csv
+peddy_sex_check: scout/demo/643594.sex_check.csv
+
+delivery_report: scout/demo/delivery_report.html
+
+default_gene_panels: [panel1]
+gene_panels: [panel1]
+chromograph_image_files: scout/demo/images
+chromograph_prefixes:
+    'roh': "roh_chr"
+    'upd': "upd_chr"
+    'chr': "cytoband.txt.chr"
+
+
+# meta data
+rank_model_version: '1.20'
+sv_rank_model_version: '1.5'
+rank_score_threshold: -100
+analysis_date: 2016-10-12 14:00:46
+human_genome_build: 37

--- a/tests/fixtures/apps/scout/643594.config.yaml
+++ b/tests/fixtures/apps/scout/643594.config.yaml
@@ -62,9 +62,9 @@ default_gene_panels: [panel1]
 gene_panels: [panel1]
 chromograph_image_files: scout/demo/images
 chromograph_prefixes:
-    'roh': "roh_chr"
-    'upd': "upd_chr"
-    'chr': "cytoband.txt.chr"
+  'roh': "roh_chr"
+  'upd': "upd_chr"
+  'chr': "cytoband.txt.chr"
 
 
 # meta data

--- a/tests/meta/upload/conftest.py
+++ b/tests/meta/upload/conftest.py
@@ -232,7 +232,7 @@ def upload_observations_api_wes(analysis_store):
 
 
 @pytest.yield_fixture(scope="function")
-def upload_scout_api(scout_store, madeline_api):
+def upload_scout_api():
     """Fixture for upload_scout_api"""
     hk_mock = MockHouseKeeper()
     hk_mock.add_file(file="/mock/path", version_obj="", tag_name="")
@@ -240,9 +240,9 @@ def upload_scout_api(scout_store, madeline_api):
 
     _api = UploadScoutAPI(
         hk_api=hk_mock,
-        scout_api=scout_store,
-        madeline_api=madeline_api,
         analysis_api=analysis_mock,
+        madeline_exe="",
+        madeline=madeline_mock,
     )
 
     yield _api


### PR DESCRIPTION
This PR moves one step closer to decouple scout from CG.
Here we will use a load config on disc to load a case from cg and not create one on the fly as earlier.

**How to prepare for test**:
- [ ] install on stage of the hasta: `bash servers/resources/hasta.scilifelab.se/update-cg-stage.sh use-scout-load-config`
- [ ] activate stage: `us`
- [ ] find a case that has not been uploaded to stage
- [ ] create a load config

**How to test**:
- [ ] run following command: `cg upload scout <case_id>`

**Expected test outcome**:
- [ ] `cg` should successfully upload the case to scout
- [ ] `cg` should print that the load config was used
- [ ] Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This is minor **version bump** because internal API has changed
