### PR TITLE
Add novaseq sequencer type to model

### DIFF
--- a/cg/apps/pdc.py
+++ b/cg/apps/pdc.py
@@ -6,22 +6,26 @@ import subprocess
 LOG = logging.getLogger(__name__)
 
 
-class PdcApi():
+class PdcApi:
     """ Group PDC related commands """
 
     @classmethod
-    def retrieve_flowcell(cls, flowcell_id: str, sequencer_type: str, dry: bool = False) -> str:
+    def retrieve_flowcell(
+        cls, flowcell_id: str, sequencer_type: str, dry: bool = False
+    ) -> str:
         """Fetch a flowcell back from the backup solution."""
         server, path = {
-            'novaseq': ('thalamus', '/home/hiseq.clinical/novaseq/runs/'),
-            'hiseqga': ('thalamus', '/home/hiseq.clinica/RUNS/'),
-            'hiseqx': ('hasta', '/home/proj/production/flowcells/hiseqx/'),
+            "novaseq": ("thalamus", "/home/hiseq.clinical/novaseq/runs/"),
+            "hiseqga": ("thalamus", "/home/hiseq.clinica/RUNS/"),
+            "hiseqx": ("hasta", "/home/proj/production/flowcells/hiseqx/"),
         }.get(sequencer_type)
         if server is None:
             raise ValueError(f"{sequencer_type}: invalid sequencer type")
 
-        bash_command = f"bash SCRIPTS/retrieve_run_nas.bash {flowcell_id} {server} {path}"
-        command = ['ssh', 'nas-9.scilifelab.se', bash_command]
-        LOG.info(' '.join(command))
+        bash_command = (
+            f"bash SCRIPTS/retrieve_run_nas.bash {flowcell_id} {server} {path}"
+        )
+        command = ["ssh", "nas-9.scilifelab.se", bash_command]
+        LOG.info(" ".join(command))
         if not dry:
             subprocess.check_call(command)

--- a/cg/apps/pdc.py
+++ b/cg/apps/pdc.py
@@ -1,3 +1,5 @@
+""" Module to group PDC related commands """
+
 import logging
 import subprocess
 
@@ -5,11 +7,10 @@ LOG = logging.getLogger(__name__)
 
 
 class PdcApi():
+    """ Group PDC related commands """
 
-    def __init__(self, config: dict):
-        pass
-
-    def retrieve_flowcell(self, flowcell_id: str, sequencer_type: str) -> str:
+    @classmethod
+    def retrieve_flowcell(cls, flowcell_id: str, sequencer_type: str, dry: bool = False) -> str:
         """Fetch a flowcell back from the backup solution."""
         server, path = {
             'novaseq': ('thalamus', '/home/hiseq.clinical/novaseq/runs/'),
@@ -22,4 +23,5 @@ class PdcApi():
         bash_command = f"bash SCRIPTS/retrieve_run_nas.bash {flowcell_id} {server} {path}"
         command = ['ssh', 'nas-9.scilifelab.se', bash_command]
         LOG.info(' '.join(command))
-        subprocess.check_call(command)
+        if not dry:
+            subprocess.check_call(command)

--- a/cg/apps/pdc.py
+++ b/cg/apps/pdc.py
@@ -11,14 +11,15 @@ class PdcApi():
 
     def retrieve_flowcell(self, flowcell_id: str, sequencer_type: str) -> str:
         """Fetch a flowcell back from the backup solution."""
-        dest_server = {
-            'hiseqga': 'thalamus',
-            'hiseqx': 'hasta',
+        server, path = {
+            'novaseq': ('thalamus', '/home/hiseq.clinical/novaseq/runs/'),
+            'hiseqga': ('thalamus', '/home/hiseq.clinica/RUNS/'),
+            'hiseqx': ('hasta', '/home/proj/production/flowcells/hiseqx/'),
         }.get(sequencer_type)
-        if dest_server is None:
+        if server is None:
             raise ValueError(f"{sequencer_type}: invalid sequencer type")
 
-        bash_command = f"bash SCRIPTS/retrieve_run_nas.bash {flowcell_id} {dest_server}"
+        bash_command = f"bash SCRIPTS/retrieve_run_nas.bash {flowcell_id} {server} {path}"
         command = ['ssh', 'nas-9.scilifelab.se', bash_command]
         LOG.info(' '.join(command))
         subprocess.check_call(command)

--- a/cg/cli/backup.py
+++ b/cg/cli/backup.py
@@ -17,12 +17,13 @@ def backup(context: click.Context):
 
 
 @backup.command('fetch-flowcell')
-@click.option('-f', '--flowcell', help='Retrieive a specific flowcell')
+@click.option('-f', '--flowcell', help='Retreive a specific flowcell')
+@click.option('--dry', is_flag=True, help='Only log, do not contact PDC')
 @click.pass_context
-def fetch_flowcell(context: click.Context, flowcell: str):
+def fetch_flowcell(context: click.Context, dry: bool, flowcell: str):
     """Fetch the first flowcell in the requested queue from backup."""
     status_api = Store(context.obj['database'])
-    pdc_api = PdcApi(context.obj)
+    pdc_api = PdcApi()
     backup_api = BackupApi(status=status_api, pdc_api=pdc_api)
     if flowcell:
         flowcell_obj = status_api.flowcell(flowcell)
@@ -31,12 +32,13 @@ def fetch_flowcell(context: click.Context, flowcell: str):
             context.abort()
     else:
         flowcell_obj = None
-    retrieval_time = backup_api.fetch_flowcell(flowcell_obj=flowcell_obj)
+    retrieval_time = backup_api.fetch_flowcell(flowcell_obj=flowcell_obj, dry=dry)
     if retrieval_time is None:
         if flowcell:
             LOG.info(f"{flowcell}: updating flowcell status to requested")
-            flowcell_obj.status = 'requested'
-            status_api.commit()
+            if not dry:
+                flowcell_obj.status = 'requested'
+                status_api.commit()
     else:
         hours = retrieval_time / 60 / 60
         LOG.info(f"Retrieval time: {hours:.1}h")

--- a/cg/cli/backup.py
+++ b/cg/cli/backup.py
@@ -16,13 +16,13 @@ def backup(context: click.Context):
     pass
 
 
-@backup.command('fetch-flowcell')
-@click.option('-f', '--flowcell', help='Retreive a specific flowcell')
-@click.option('--dry', is_flag=True, help='Only log, do not contact PDC')
+@backup.command("fetch-flowcell")
+@click.option("-f", "--flowcell", help="Retreive a specific flowcell")
+@click.option("--dry", is_flag=True, help="Only log, do not contact PDC")
 @click.pass_context
 def fetch_flowcell(context: click.Context, dry: bool, flowcell: str):
     """Fetch the first flowcell in the requested queue from backup."""
-    status_api = Store(context.obj['database'])
+    status_api = Store(context.obj["database"])
     pdc_api = PdcApi()
     backup_api = BackupApi(status=status_api, pdc_api=pdc_api)
     if flowcell:
@@ -37,7 +37,7 @@ def fetch_flowcell(context: click.Context, dry: bool, flowcell: str):
         if flowcell:
             LOG.info(f"{flowcell}: updating flowcell status to requested")
             if not dry:
-                flowcell_obj.status = 'requested'
+                flowcell_obj.status = "requested"
                 status_api.commit()
     else:
         hours = retrieval_time / 60 / 60

--- a/cg/meta/backup.py
+++ b/cg/meta/backup.py
@@ -39,7 +39,7 @@ class BackupApi():
             self.status.commit()
         return flowcell_obj
 
-    def fetch_flowcell(self, flowcell_obj: models.Flowcell = None):
+    def fetch_flowcell(self, flowcell_obj: models.Flowcell = None, dry: bool = False):
         """Start fetching a flowcell from backup if possible.
 
         1. The processing queue is not full
@@ -62,11 +62,12 @@ class BackupApi():
         LOG.info("%s: retreiving from PDC", flowcell_obj.name)
         tic = time.time()
         try:
-            self.pdc.retrieve_flowcell(flowcell_obj.name, flowcell_obj.sequencer_type)
+            self.pdc.retrieve_flowcell(flowcell_obj.name, flowcell_obj.sequencer_type, dry)
         except subprocess.CalledProcessError as error:
             LOG.error("%s: retrieval failed", flowcell_obj.name)
-            flowcell_obj.status = 'requested'
-            self.status.commit()
+            if not dry:
+                flowcell_obj.status = 'requested'
+                self.status.commit()
             raise error
         toc = time.time()
         return toc - tic

--- a/cg/meta/backup.py
+++ b/cg/meta/backup.py
@@ -9,7 +9,7 @@ from cg.store import Store, models
 LOG = logging.getLogger(__name__)
 
 
-class BackupApi():
+class BackupApi:
     """ Class for retrieving FCs from backup """
 
     def __init__(self, status: Store, pdc_api: PdcApi):
@@ -18,13 +18,13 @@ class BackupApi():
 
     def maximum_flowcells_ondisk(self, max_flowcells: int = 1000) -> bool:
         """Check if there's too many flowcells already "ondisk"."""
-        ondisk_flowcells = self.status.flowcells(status='ondisk').count()
+        ondisk_flowcells = self.status.flowcells(status="ondisk").count()
         LOG.debug("ondisk flowcells: %s", ondisk_flowcells)
         return ondisk_flowcells > max_flowcells
 
     def check_processing(self, max_flowcells: int = 3) -> bool:
         """Check if the processing queue for flowcells is not full."""
-        processing_flowcells = self.status.flowcells(status='processing').count()
+        processing_flowcells = self.status.flowcells(status="processing").count()
         LOG.debug("processing flowcells: %s", processing_flowcells)
         return processing_flowcells < max_flowcells
 
@@ -33,9 +33,9 @@ class BackupApi():
         Get the top flowcell from the requested queue and update status to
         "processing".
         """
-        flowcell_obj = self.status.flowcells(status='requested').first()
+        flowcell_obj = self.status.flowcells(status="requested").first()
         if flowcell_obj is not None:
-            flowcell_obj.status = 'processing'
+            flowcell_obj.status = "processing"
             self.status.commit()
         return flowcell_obj
 
@@ -46,27 +46,29 @@ class BackupApi():
         2. The requested queue is not emtpy
         """
         if self.check_processing() is False:
-            LOG.info('processing queue is full')
+            LOG.info("processing queue is full")
             return None
 
         if self.maximum_flowcells_ondisk() is True:
-            LOG.info('maximum flowcells ondisk reached')
+            LOG.info("maximum flowcells ondisk reached")
             return None
 
         if flowcell_obj is None:
             flowcell_obj = self.pop_flowcell()
             if flowcell_obj is None:
-                LOG.info('no flowcells requested')
+                LOG.info("no flowcells requested")
                 return None
 
         LOG.info("%s: retreiving from PDC", flowcell_obj.name)
         tic = time.time()
         try:
-            self.pdc.retrieve_flowcell(flowcell_obj.name, flowcell_obj.sequencer_type, dry)
+            self.pdc.retrieve_flowcell(
+                flowcell_obj.name, flowcell_obj.sequencer_type, dry
+            )
         except subprocess.CalledProcessError as error:
             LOG.error("%s: retrieval failed", flowcell_obj.name)
             if not dry:
-                flowcell_obj.status = 'requested'
+                flowcell_obj.status = "requested"
                 self.status.commit()
             raise error
         toc = time.time()

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -391,7 +391,7 @@ class FamilySample(Model):
 class Flowcell(Model):
     id = Column(types.Integer, primary_key=True)
     name = Column(types.String(32), unique=True, nullable=False)
-    sequencer_type = Column(types.Enum("hiseqga", "hiseqx"))
+    sequencer_type = Column(types.Enum("hiseqga", "hiseqx", "novaseq"))
     sequencer_name = Column(types.String(32))
     sequenced_at = Column(types.DateTime)
     status = Column(types.Enum(*FLOWCELL_STATUS), default="ondisk")

--- a/scripts/alter-flowcell-type.sql
+++ b/scripts/alter-flowcell-type.sql
@@ -1,3 +1,3 @@
-ALTER TABLE `cg-stage`.`flowcell` 
+ALTER TABLE `cg`.`flowcell` 
 CHANGE COLUMN `sequencer_type` `sequencer_type` ENUM('hiseqga', 'hiseqx', 'novaseq') NULL DEFAULT NULL ;
 

--- a/scripts/alter-flowcell-type.sql
+++ b/scripts/alter-flowcell-type.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `cg-stage`.`flowcell` 
+CHANGE COLUMN `sequencer_type` `sequencer_type` ENUM('hiseqga', 'hiseqx', 'novaseq') NULL DEFAULT NULL ;
+

--- a/scripts/update-flowcell-type.sql
+++ b/scripts/update-flowcell-type.sql
@@ -1,0 +1,2 @@
+update flowcell set sequencer_type = 'novaseq'
+where substr(sequencer_name, 1, 3) = 'A00'


### PR DESCRIPTION
This PR adds/fixes adding a novaseq flowcell type to the flowcell model, so that we can retrieve novaseq flowcells from pdc based on said flowcell type.

**How to prepare for test**:
- ssh to hasta/clinical-db
- [x] install on stage:
`bash servers/resources/hasta.sclifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`
- [x] install on stage:
`bash servers/resources/clinical-db.sclifelab.se/update-clinical-api-stage.sh [THIS-BRANCH-NAME]`
- copy databases cg and housekeeper to stage
- on clinical-db: run `scripts/alter-flowcell-type.sql` on cg-stage database.
- rename the latest novaseq flowcell in the flowcell table on clinical-api-stage, e.g. HY2N7DSXX -> HY2N7DSX_

**How to test**:
- hasta: `cg transfer flowcell HY2N7DSXX`
- hasta: `cg backup fetch-flowcell -f HVCYNCCXY --dry`

**Expected test outcome**:
- [x] on clinical-api-stage the flowcell HY2N7DSXX should now have novaseq as sequencing type.
- [x] cg fetch-flowcell should print out the command.

**Review:**
- [x] code approved by @patrikgrenfeldt 
- [x] tests executed by @patrikgrenfeldt @ingkebil 
- [x] "Merge and deploy" approved by @patrikgrenfeldt 
Thanks for filling in who performed the code review and the test!

- [x] After merging, please run following script to update all missing sequencer types in statusdb:
`update-flowcell-type.sql`

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
