### PR TITLE
Make log in Process __init__ method debug (patch)

### DIFF
--- a/cg/utils/commands.py
+++ b/cg/utils/commands.py
@@ -25,11 +25,11 @@ class Process:
         """
         super(Process, self).__init__()
         self.binary = binary
-        LOG.info("Initialising Process with binary: %s", self.binary)
+        LOG.debug("Initialising Process with binary: %s", self.binary)
         self.base_call = [self.binary]
         if config:
             self.base_call.extend([config_parameter, config])
-        LOG.info("Use base call %s", self.base_call)
+        LOG.debug("Use base call %s", self.base_call)
         self._stdout = ""
         self._stderr = ""
 


### PR DESCRIPTION
This PR silences the log message in the Process __init__ method if not run in debug mode.

Currently, running `cg upload ...` all APIs using this process will log with what binary the CLI commands of each app will be run, even if the app is not used.

**How to prepare for test**:
install on hasta

**How to test**:
launch an upload command

**Expected test outcome**:
no log entry from initialization of Process 

**Review:**
- [x] code approved by @patrikgrenfeldt 
- [x] tests executed by @patrikgrenfeldt 
- [x] "Merge and deploy" approved by @patrikgrenfeldt 
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
