### PR TITLE
Fix/hide archived beds for Orderportal

### DIFF
--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -17,13 +17,14 @@ from cg.meta.orders import OrdersAPI, OrderType
 from .ext import db, lims, osticket
 
 LOG = logging.getLogger(__name__)
-BLUEPRINT = Blueprint('api', __name__, url_prefix='/api/v1')
+BLUEPRINT = Blueprint("api", __name__, url_prefix="/api/v1")
 
 
 def public(route_function):
     @wraps(route_function)
     def public_endpoint(*args, **kwargs):
         return route_function(*args, **kwargs)
+
     public_endpoint.is_public = True
     return public_endpoint
 
@@ -31,46 +32,52 @@ def public(route_function):
 @BLUEPRINT.before_request
 def before_request():
     """Authorize API routes with JSON Web Tokens."""
-    if request.method == 'OPTIONS':
+    if request.method == "OPTIONS":
         return make_response(jsonify(ok=True), 204)
 
     endpoint_func = current_app.view_functions[request.endpoint]
-    if not getattr(endpoint_func, 'is_public', None):
-        auth_header = request.headers.get('Authorization')
+    if not getattr(endpoint_func, "is_public", None):
+        auth_header = request.headers.get("Authorization")
         if auth_header:
-            jwt_token = auth_header.split('Bearer ')[-1]
+            jwt_token = auth_header.split("Bearer ")[-1]
         else:
-            return abort(403, 'no JWT token found on request')
+            return abort(403, "no JWT token found on request")
         try:
-            user_data = jwt.decode(jwt_token, certs=current_app.config['GOOGLE_OAUTH_CERTS'])
+            user_data = jwt.decode(
+                jwt_token, certs=current_app.config["GOOGLE_OAUTH_CERTS"]
+            )
         except ValueError as error:
-            return abort(make_response(jsonify(message='outdated login certificate'), 403))
-        user_obj = db.user(user_data['email'])
+            return abort(
+                make_response(jsonify(message="outdated login certificate"), 403)
+            )
+        user_obj = db.user(user_data["email"])
         if user_obj is None:
             message = f"{user_data['email']} doesn't have access"
             return abort(make_response(jsonify(message=message), 403))
         g.current_user = user_obj
 
 
-@BLUEPRINT.route('/submit_order/<order_type>', methods=['POST'])
+@BLUEPRINT.route("/submit_order/<order_type>", methods=["POST"])
 def submit_order(order_type):
     """Submit an order for samples."""
     api = OrdersAPI(lims=lims, status=db, osticket=osticket)
     post_data = request.get_json()
     LOG.info("processing '%s' order: %s", order_type, post_data)
     try:
-        ticket = {'name': g.current_user.name, 'email': g.current_user.email}
+        ticket = {"name": g.current_user.name, "email": g.current_user.email}
         result = api.submit(OrderType[order_type.upper()], post_data, ticket=ticket)
     except (DuplicateRecordError, OrderError) as error:
         return abort(make_response(jsonify(message=error.message), 401))
     except HTTPError as error:
         return abort(make_response(jsonify(message=error.args[0]), 401))
 
-    return jsonify(project=result['project'],
-                   records=[record.to_dict() for record in result['records']])
+    return jsonify(
+        project=result["project"],
+        records=[record.to_dict() for record in result["records"]],
+    )
 
 
-@BLUEPRINT.route('/customers')
+@BLUEPRINT.route("/customers")
 def customers():
     """Fetch customers."""
     query = db.Customer.query
@@ -78,7 +85,7 @@ def customers():
     return jsonify(customers=data)
 
 
-@BLUEPRINT.route('/panels')
+@BLUEPRINT.route("/panels")
 def panels():
     """Fetch panels."""
     query = db.Panel.query
@@ -86,7 +93,7 @@ def panels():
     return jsonify(panels=data)
 
 
-@BLUEPRINT.route('/cases')
+@BLUEPRINT.route("/cases")
 def cases():
     """Fetch cases."""
     records = db.cases(days=31)
@@ -95,18 +102,18 @@ def cases():
     return jsonify(cases=records, total=count)
 
 
-@BLUEPRINT.route('/families')
+@BLUEPRINT.route("/families")
 def families():
     """Fetch families."""
-    if request.args.get('status') == 'analysis':
+    if request.args.get("status") == "analysis":
         records = db.cases_to_mip_analyze()
         count = len(records)
     else:
         customer_obj = None if g.current_user.is_admin else g.current_user.customer
         families_q = db.families(
-            enquiry=request.args.get('enquiry'),
+            enquiry=request.args.get("enquiry"),
             customer=customer_obj,
-            action=request.args.get('action'),
+            action=request.args.get("action"),
         )
         count = families_q.count()
         records = families_q.limit(30)
@@ -114,13 +121,12 @@ def families():
     return jsonify(families=data, total=count)
 
 
-@BLUEPRINT.route('/families_in_customer_group')
+@BLUEPRINT.route("/families_in_customer_group")
 def families_in_customer_group():
     """Fetch families in customer_group."""
     customer_obj = None if g.current_user.is_admin else g.current_user.customer
     families_q = db.families_in_customer_group(
-        enquiry=request.args.get('enquiry'),
-        customer=customer_obj,
+        enquiry=request.args.get("enquiry"), customer=customer_obj
     )
     count = families_q.count()
     records = families_q.limit(30)
@@ -128,100 +134,103 @@ def families_in_customer_group():
     return jsonify(families=data, total=count)
 
 
-@BLUEPRINT.route('/families/<family_id>')
+@BLUEPRINT.route("/families/<family_id>")
 def family(family_id):
     """Fetch a family with links."""
     family_obj = db.family(family_id)
     if family_obj is None:
         return abort(404)
-    elif not g.current_user.is_admin and (g.current_user.customer != family_obj.customer):
+    elif not g.current_user.is_admin and (
+        g.current_user.customer != family_obj.customer
+    ):
         return abort(401)
 
     data = family_obj.to_dict(links=True, analyses=True)
     return jsonify(**data)
 
 
-@BLUEPRINT.route('/families_in_customer_group/<family_id>')
+@BLUEPRINT.route("/families_in_customer_group/<family_id>")
 def family_in_customer_group(family_id):
     """Fetch a family with links."""
     family_obj = db.family(family_id)
     if family_obj is None:
         return abort(404)
-    elif not g.current_user.is_admin and (g.current_user.customer.customer_group !=
-                                          family_obj.customer.customer_group):
+    elif not g.current_user.is_admin and (
+        g.current_user.customer.customer_group != family_obj.customer.customer_group
+    ):
         return abort(401)
 
     data = family_obj.to_dict(links=True, analyses=True)
     return jsonify(**data)
 
 
-@BLUEPRINT.route('/samples')
+@BLUEPRINT.route("/samples")
 def samples():
     """Fetch samples."""
-    if request.args.get('status') and not g.current_user.is_admin:
+    if request.args.get("status") and not g.current_user.is_admin:
         return abort(401)
-    if request.args.get('status') == 'incoming':
+    if request.args.get("status") == "incoming":
         samples_q = db.samples_to_recieve()
-    elif request.args.get('status') == 'labprep':
+    elif request.args.get("status") == "labprep":
         samples_q = db.samples_to_prepare()
-    elif request.args.get('status') == 'sequencing':
+    elif request.args.get("status") == "sequencing":
         samples_q = db.samples_to_sequence()
     else:
         customer_obj = None if g.current_user.is_admin else g.current_user.customer
         samples_q = db.samples(
-            enquiry=request.args.get('enquiry'),
-            customer=customer_obj,
+            enquiry=request.args.get("enquiry"), customer=customer_obj
         )
-    limit = int(request.args.get('limit', 50))
+    limit = int(request.args.get("limit", 50))
     data = [sample_obj.to_dict() for sample_obj in samples_q.limit(limit)]
     return jsonify(samples=data, total=samples_q.count())
 
 
-@BLUEPRINT.route('/samples_in_customer_group')
+@BLUEPRINT.route("/samples_in_customer_group")
 def samples_in_customer_group():
     """Fetch samples in a customer group."""
     customer_obj = None if g.current_user.is_admin else g.current_user.customer
     samples_q = db.samples_in_customer_group(
-        enquiry=request.args.get('enquiry'),
-        customer=customer_obj,
+        enquiry=request.args.get("enquiry"), customer=customer_obj
     )
-    limit = int(request.args.get('limit', 50))
+    limit = int(request.args.get("limit", 50))
     data = [sample_obj.to_dict() for sample_obj in samples_q.limit(limit)]
     return jsonify(samples=data, total=samples_q.count())
 
 
-@BLUEPRINT.route('/samples/<sample_id>')
+@BLUEPRINT.route("/samples/<sample_id>")
 def sample(sample_id):
     """Fetch a single sample."""
     sample_obj = db.sample(sample_id)
     if sample_obj is None:
         return abort(404)
-    elif not g.current_user.is_admin and (g.current_user.customer != sample_obj.customer):
+    elif not g.current_user.is_admin and (
+        g.current_user.customer != sample_obj.customer
+    ):
         return abort(401)
     data = sample_obj.to_dict(links=True, flowcells=True)
     return jsonify(**data)
 
-  
-@BLUEPRINT.route('/samples_in_customer_group/<sample_id>')
+
+@BLUEPRINT.route("/samples_in_customer_group/<sample_id>")
 def sample_in_customer_group(sample_id):
     """Fetch a single sample."""
     sample_obj = db.sample(sample_id)
     if sample_obj is None:
         return abort(404)
-    elif not g.current_user.is_admin and (g.current_user.customer.customer_group !=
-                                          sample_obj.customer.customer_group):
+    elif not g.current_user.is_admin and (
+        g.current_user.customer.customer_group != sample_obj.customer.customer_group
+    ):
         return abort(401)
     data = sample_obj.to_dict(links=True, flowcells=True)
     return jsonify(**data)
 
-    
-@BLUEPRINT.route('/microbial_orders')
+
+@BLUEPRINT.route("/microbial_orders")
 def microbial_orders():
     """Fetch microbial orders."""
     customer_obj = None if g.current_user.is_admin else g.current_user.customer
     orders_q = db.microbial_orders(
-        enquiry=request.args.get('enquiry'),
-        customer=customer_obj
+        enquiry=request.args.get("enquiry"), customer=customer_obj
     )
     count = orders_q.count()
     records = orders_q.limit(30)
@@ -229,55 +238,56 @@ def microbial_orders():
     return jsonify(microbial_orders=data, total=count)
 
 
-@BLUEPRINT.route('/microbial_orders/<order_id>')
+@BLUEPRINT.route("/microbial_orders/<order_id>")
 def microbial_order(order_id):
     """Fetch a order with samples."""
     order_obj = db.microbial_order(order_id)
     if order_obj is None:
         return abort(404)
-    elif not g.current_user.is_admin and (g.current_user.customer != order_obj.customer):
+    elif not g.current_user.is_admin and (
+        g.current_user.customer != order_obj.customer
+    ):
         return abort(401)
     data = order_obj.to_dict(samples=True)
     return jsonify(**data)
 
 
-@BLUEPRINT.route('/microbial_samples')
+@BLUEPRINT.route("/microbial_samples")
 def microbial_samples():
     """Fetch microbial samples."""
     customer_obj = None if g.current_user.is_admin else g.current_user.customer
     samples_q = db.microbial_samples(
-        enquiry=request.args.get('enquiry'),
-        customer=customer_obj,
+        enquiry=request.args.get("enquiry"), customer=customer_obj
     )
-    limit = int(request.args.get('limit', 50))
+    limit = int(request.args.get("limit", 50))
     data = [sample_obj.to_dict(order=True) for sample_obj in samples_q.limit(limit)]
     return jsonify(samples=data, total=samples_q.count())
 
 
-@BLUEPRINT.route('/microbial_samples/<sample_id>')
+@BLUEPRINT.route("/microbial_samples/<sample_id>")
 def microbial_sample(sample_id):
     """Fetch a single sample."""
     sample_obj = db.microbial_sample(sample_id)
     if sample_obj is None:
         return abort(404)
-    elif not g.current_user.is_admin and (g.current_user.customer !=
-                                          sample_obj.microbial_order.customer):
+    elif not g.current_user.is_admin and (
+        g.current_user.customer != sample_obj.microbial_order.customer
+    ):
         return abort(401)
     data = sample_obj.to_dict()
     return jsonify(**data)
 
 
-@BLUEPRINT.route('/pools')
+@BLUEPRINT.route("/pools")
 def pools():
     """Fetch pools."""
     customer_obj = None if g.current_user.is_admin else g.current_user.customer
-    pools_q = db.pools(customer=customer_obj,
-                       enquiry=request.args.get('enquiry'))
+    pools_q = db.pools(customer=customer_obj, enquiry=request.args.get("enquiry"))
     data = [pool_obj.to_dict() for pool_obj in pools_q.limit(30)]
     return jsonify(pools=data, total=pools_q.count())
 
 
-@BLUEPRINT.route('/pools/<pool_id>')
+@BLUEPRINT.route("/pools/<pool_id>")
 def pool(pool_id):
     """Fetch a single pool."""
     record = db.pool(pool_id)
@@ -288,18 +298,17 @@ def pool(pool_id):
     return jsonify(**record.to_dict())
 
 
-@BLUEPRINT.route('/flowcells')
+@BLUEPRINT.route("/flowcells")
 def flowcells():
     """Fetch flowcells."""
     query = db.flowcells(
-        status=request.args.get('status'),
-        enquiry=request.args.get('enquiry'),
+        status=request.args.get("status"), enquiry=request.args.get("enquiry")
     )
     data = [record.to_dict() for record in query.limit(50)]
     return jsonify(flowcells=data, total=query.count())
 
 
-@BLUEPRINT.route('/flowcells/<flowcell_id>')
+@BLUEPRINT.route("/flowcells/<flowcell_id>")
 def flowcell(flowcell_id):
     """Fetch a single flowcell."""
     record = db.flowcell(flowcell_id)
@@ -308,12 +317,12 @@ def flowcell(flowcell_id):
     return jsonify(**record.to_dict(samples=True))
 
 
-@BLUEPRINT.route('/analyses')
+@BLUEPRINT.route("/analyses")
 def analyses():
     """Fetch analyses."""
-    if request.args.get('status') == 'delivery':
+    if request.args.get("status") == "delivery":
         analyses_q = db.analyses_to_deliver()
-    elif request.args.get('status') == 'upload':
+    elif request.args.get("status") == "upload":
         analyses_q = db.analyses_to_upload()
     else:
         analyses_q = db.Analysis.query
@@ -321,47 +330,56 @@ def analyses():
     return jsonify(analyses=data, total=analyses_q.count())
 
 
-@BLUEPRINT.route('/options')
+@BLUEPRINT.route("/options")
 def options():
     """Fetch various options."""
-    customer_objs = db.Customer.query.all() if g.current_user.is_admin else [g.current_user.customer]
-    apptag_groups = {'ext': []}
+    customer_objs = (
+        db.Customer.query.all()
+        if g.current_user.is_admin
+        else [g.current_user.customer]
+    )
+    apptag_groups = {"ext": []}
     for application_obj in db.applications(archived=False):
         if application_obj.is_external:
-            apptag_groups['ext'].append(application_obj.tag)
+            apptag_groups["ext"].append(application_obj.tag)
         else:
             if application_obj.prep_category not in apptag_groups:
                 apptag_groups[application_obj.prep_category] = []
             apptag_groups[application_obj.prep_category].append(application_obj.tag)
 
-    source_groups = {'metagenome': METAGENOME_SOURCES, 'analysis': ANALYSIS_SOURCES}
-
+    source_groups = {"metagenome": METAGENOME_SOURCES, "analysis": ANALYSIS_SOURCES}
 
     return jsonify(
-        customers=[{
-            'text': f"{customer.name} ({customer.internal_id})",
-            'value': customer.internal_id,
-        } for customer in customer_objs],
+        customers=[
+            {
+                "text": f"{customer.name} ({customer.internal_id})",
+                "value": customer.internal_id,
+            }
+            for customer in customer_objs
+        ],
         applications=apptag_groups,
         panels=[panel.abbrev for panel in db.panels()],
-        organisms=[{
-            'name': organism.name,
-            'reference_genome': organism.reference_genome,
-            'internal_id': organism.internal_id,
-            'verified': organism.verified,
-        } for organism in db.organisms()],
+        organisms=[
+            {
+                "name": organism.name,
+                "reference_genome": organism.reference_genome,
+                "internal_id": organism.internal_id,
+                "verified": organism.verified,
+            }
+            for organism in db.organisms()
+        ],
         sources=source_groups,
         beds=[bed.name for bed in db.beds()],
     )
 
 
-@BLUEPRINT.route('/me')
+@BLUEPRINT.route("/me")
 def me():
     """Fetch information about current user."""
     return jsonify(user=g.current_user.to_dict())
 
 
-@BLUEPRINT.route('/applications')
+@BLUEPRINT.route("/applications")
 @public
 def applications():
     """Fetch application tags."""
@@ -370,24 +388,24 @@ def applications():
     return jsonify(applications=data)
 
 
-@BLUEPRINT.route('/applications/<tag>')
+@BLUEPRINT.route("/applications/<tag>")
 @public
 def application(tag):
     """Fetch an application tag."""
     record = db.application(tag)
     if record is None:
-        return abort(make_response(jsonify(message='application not found'), 404))
+        return abort(make_response(jsonify(message="application not found"), 404))
     return jsonify(**record.to_dict())
 
 
-@BLUEPRINT.route('/orderform', methods=['POST'])
+@BLUEPRINT.route("/orderform", methods=["POST"])
 def orderform():
     """Parse an orderform/JSON export."""
-    input_file = request.files.get('file')
+    input_file = request.files.get("file")
     filename = secure_filename(input_file.filename)
 
     try:
-        if filename.lower().endswith('.xlsx'):
+        if filename.lower().endswith(".xlsx"):
             temp_dir = Path(tempfile.gettempdir())
             saved_path = str(temp_dir / filename)
             input_file.save(saved_path)
@@ -401,7 +419,7 @@ def orderform():
     return jsonify(**project_data)
 
 
-@BLUEPRINT.route('/trends/samples/<year>')
+@BLUEPRINT.route("/trends/samples/<year>")
 def trends_samples(year):
     """Samples per month."""
 

--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -369,7 +369,7 @@ def options():
             for organism in db.organisms()
         ],
         sources=source_groups,
-        beds=[bed.name for bed in db.beds()],
+        beds=[bed.name for bed in db.beds(hide_archived=True)],
     )
 
 

--- a/cg/store/api/findbasicdata.py
+++ b/cg/store/api/findbasicdata.py
@@ -41,7 +41,7 @@ class FindBasicDataHandler(BaseHandler):
         """Returns all beds."""
         bed_q = self.Bed.query
         if hide_archived:
-            bed_q = bed_q.filter(self.Bed.is_archived == False)
+            bed_q = bed_q.filter(self.Bed.is_archived.is_(False))
 
         return bed_q.order_by(models.Bed.name)
 

--- a/cg/store/api/findbasicdata.py
+++ b/cg/store/api/findbasicdata.py
@@ -24,25 +24,31 @@ class FindBasicDataHandler(BaseHandler):
             records = records.filter_by(is_archived=archived)
         return records.order_by(self.Application.prep_category, self.Application.tag)
 
-    def application_version(self, application: models.Application,
-                            version: int) -> models.ApplicationVersion:
+    def application_version(
+        self, application: models.Application, version: int
+    ) -> models.ApplicationVersion:
         """Fetch an application version."""
-        query = self.ApplicationVersion.query.filter_by(application=application, version=version)
+        query = self.ApplicationVersion.query.filter_by(
+            application=application, version=version
+        )
         return query.first()
 
     def bed(self, name):
         """Find a bed by name."""
         return self.Bed.query.filter_by(name=name).first()
 
-    def beds(self):
+    def beds(self, hide_archived: bool = False):
         """Returns all beds."""
-        return self.Bed.query.order_by(models.Bed.name)
+        bed_q = self.Bed.query
+        if hide_archived:
+            bed_q = bed_q.filter(self.Bed.is_archived == False)
+
+        return bed_q.order_by(models.Bed.name)
 
     def latest_bed_version(self, name: str) -> models.BedVersion:
         """Fetch the latest bed version for a bed name."""
         bed_obj = self.Bed.query.filter_by(name=name).first()
-        return bed_obj.versions[-1] if bed_obj and bed_obj.versions else \
-            None
+        return bed_obj.versions[-1] if bed_obj and bed_obj.versions else None
 
     def customer(self, internal_id: str) -> models.Customer:
         """Fetch a customer by internal id from the store."""
@@ -75,8 +81,11 @@ class FindBasicDataHandler(BaseHandler):
     def latest_version(self, tag: str) -> models.ApplicationVersion:
         """Fetch the latest application version for an application tag."""
         application_obj = self.Application.query.filter_by(tag=tag).first()
-        return application_obj.versions[-1] if application_obj and application_obj.versions else \
-            None
+        return (
+            application_obj.versions[-1]
+            if application_obj and application_obj.versions
+            else None
+        )
 
     def organism(self, internal_id: str) -> models.Organism:
         """Find an Organism by internal_id."""


### PR DESCRIPTION
This PR adds the possibility to hide archived beds from being shown to customers in the Orderportal

**How to prepare for test**:
- [x] ssh to hasta/clinical-db depending on type of change
- [x] install on stage:
`bash servers/resources/clinical-db.sclifelab.se/update-clinical-api-stage.sh [THIS-BRANCH-NAME]`

**How to test**:
- [x] login to the clinical-api-stage
- [x] archive a bed in the bed view
- [x] login to the Orderportal
- [x] create Balsamic order
- [x] add sample and open bed drop down

**Expected test outcome**:
- [x] check that the bed that was archived is not listed
- [x] Take a screenshot and attach or copy/paste the output

**Review:**
- [ ] code approved by
- [x] tests executed by @patrikgrenfeldt 
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
