### PR TITLE
cli for vogue load samples and vogue load flowcells

### DIFF
--- a/cg/apps/vogue.py
+++ b/cg/apps/vogue.py
@@ -38,3 +38,23 @@ class VogueAPI:
         # Execute command and print its stdout+stderr as it executes
         for line in self.process.stderr_lines():
             LOG.info("vogue output: %s", line)
+
+    def load_samples(self, days):
+        """Running vogue load samples."""
+
+        load_call = ["load", "samples", "-d", days]
+        self.process.run_command(load_call)
+
+        # Execute command and print its stdout+stderr as it executes
+        for line in self.process.stderr_lines():
+            LOG.info("vogue output: %s", line)
+
+    def load_flowcells(self, days):
+        """Running vogue load samples."""
+
+        load_call = ["load", "flowcells", "-d", days]
+        self.process.run_command(load_call)
+
+        # Execute command and print its stdout+stderr as it executes
+        for line in self.process.stderr_lines():
+            LOG.info("vogue output: %s", line)

--- a/cg/apps/vogue.py
+++ b/cg/apps/vogue.py
@@ -42,7 +42,7 @@ class VogueAPI:
     def load_samples(self, days):
         """Running vogue load samples."""
 
-        load_call = ["load", "samples", "-d", days]
+        load_call = ["load", "sample", "-d", days]
         self.process.run_command(load_call)
 
         # Execute command and print its stdout+stderr as it executes
@@ -52,7 +52,7 @@ class VogueAPI:
     def load_flowcells(self, days):
         """Running vogue load samples."""
 
-        load_call = ["load", "flowcells", "-d", days]
+        load_call = ["load", "flowcell", "-d", days]
         self.process.run_command(load_call)
 
         # Execute command and print its stdout+stderr as it executes

--- a/cg/apps/vogue.py
+++ b/cg/apps/vogue.py
@@ -50,7 +50,7 @@ class VogueAPI:
             LOG.info("vogue output: %s", line)
 
     def load_flowcells(self, days):
-        """Running vogue load samples."""
+        """Running vogue load flowcells."""
 
         load_call = ["load", "flowcell", "-d", days]
         self.process.run_command(load_call)

--- a/cg/cli/upload/vogue.py
+++ b/cg/cli/upload/vogue.py
@@ -54,3 +54,29 @@ def apptags(context):
     )
 
     context.obj["vogue_upload_api"].load_apptags()
+
+
+@vogue.command("flowcells", short_help="Getting flowcell data from the lims.")
+@click.option(
+    "-d", "--days", required="True", help="load X days old runs from lims to vogue",
+)
+@click.pass_context
+def flowcells(context, days: int):
+    """Loading runs from lims to the trending database"""
+
+    click.echo(click.style("----------------- FLOWCELLS -----------------------"))
+
+    context.obj["vogue_upload_api"].load_flowcells(days=days)
+
+
+@vogue.command("samples", short_help="Getting sample data from lims.")
+@click.option(
+    "-d", "--days", required="True", help="load X days old sampels from lims to vogue",
+)
+@click.pass_context
+def samples(context, days: int):
+    """Loading samples from lims to the trending database"""
+
+    click.echo(click.style("----------------- SAMPLES -----------------------"))
+
+    context.obj["vogue_upload_api"].load_samples(days=days)

--- a/cg/meta/upload/vogue.py
+++ b/cg/meta/upload/vogue.py
@@ -41,3 +41,13 @@ class UploadVogueAPI:
             )
 
         self.vogue_api.load_apptags(apptags_for_vogue)
+
+    def load_samples(self, days):
+        """Loading samples from lims into the trending database"""
+
+        self.vogue_api.load_samples(days=days)
+
+    def load_flowcells(self, days):
+        """Loading flowcells from lims into the trending database"""
+
+        self.vogue_api.load_flowcells(days=days)


### PR DESCRIPTION
 This PR adds CLI to run vogue load samples and vogue load flowcells

**How to test**:

On hasta
cd /home/proj/stage/servers/resources/hasta.scilifelab.se

1. bash update-servers-stage.sh master

2. bash update-cg-stage.sh vogue_api

3. bash update-vogue-stage.sh master

4.  run: 
usestage
export VOGUE_MONGO_URI=mongodb://localhost:27030
export VOGUE_MONGO_DBNAME=vogue-stage 
export VOGUE_FLASK_DEBUG=1
export VOGUE_SECRET_KEY=hej

- cg upload vogue samples -d 1

- cg upload vogue flowcells -d 1

**Expected test outcome**:
Both upload commands should run without errors and tell weter samples/flowcells were updated.

**Review:**
- [x] code approved by @patrikgrenfeldt 
- [x] tests executed by @mayabrandi 
- [x] "Merge and deploy" approved by @patrikgrenfeldt 
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
