### PR TITLE
add missing branch name for external script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ jobs:
     - name: "Pylint score"
       if: type = pull_request
       install: pip install pylint
-      script: bash <(curl https://raw.githubusercontent.com/Clinical-Genomics/snippets/check_pylint_score.sh)
+      script: bash <(curl https://raw.githubusercontent.com/Clinical-Genomics/snippets/master/check_pylint_score.sh)
 
     - name: "Linting"
       if: type = pull_request


### PR DESCRIPTION
This PR adds/fixes the broken pylint score job on CI 

**How to test**:
- [x] open travis pr check
- [x] open pylint score job

**Expected test outcome**:
- [x] check that the pylint score script can be fetched and executed
- [x] Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @patrikgrenfeldt 
- [x] tests executed by @patrikgrenfeldt 
- [x] "Merge and deploy" approved by @patrikgrenfeldt 
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
