### PR TITLE
install all requirements when pylinting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ jobs:
 
     - name: "Pylint score"
       if: type = pull_request
-      install: pip install pylint . -r requirements-dev.txt
+      install: pip install pylint
       script: bash <(curl https://raw.githubusercontent.com/Clinical-Genomics/snippets/master/check_pylint_score.sh)
 
     - name: "Linting"

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ jobs:
 
     - name: "Pylint score"
       if: type = pull_request
-      install: pip install pylint
+      install: pip install pylint . -r requirements-dev.txt
       script: bash <(curl https://raw.githubusercontent.com/Clinical-Genomics/snippets/master/check_pylint_score.sh)
 
     - name: "Linting"

--- a/setup.py
+++ b/setup.py
@@ -64,8 +64,8 @@ setup(
     zip_safe=False,
     packages=find_packages(exclude=("tests*", "docs", "examples")),
     entry_points={"console_scripts": ["cg=cg.cli:base"]},
-    tests_require=["pytest", "pytest-mock"],
     install_requires=parse_requirements(),
+    tests_require=parse_requirements("requirements-dev.txt"),
     cmdclass=dict(test=PyTest),
     classifiers=[
         "Programming Language :: Python",

--- a/setup.py
+++ b/setup.py
@@ -64,8 +64,6 @@ setup(
     zip_safe=False,
     packages=find_packages(exclude=("tests*", "docs", "examples")),
     entry_points={"console_scripts": ["cg=cg.cli:base"]},
-    # install requirements loaded from "./requirements.txt"
-    # Install requirements loaded from ``requirements.txt``
     tests_require=["pytest", "pytest-mock"],
     install_requires=parse_requirements(),
     cmdclass=dict(test=PyTest),

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ if sys.argv[-1] == "publish":
     sys.exit()
 
 
-def parse_reqs(req_path="./requirements.txt"):
+def parse_requirements(req_path="./requirements.txt"):
     """Recursively parse requirements from nested pip files."""
     install_requires = []
     with open(req_path, "r") as handle:
@@ -22,7 +22,7 @@ def parse_reqs(req_path="./requirements.txt"):
             # check for nested requirements files
             if line.startswith("-r"):
                 # recursively call this function
-                install_requires += parse_reqs(req_path=line[3:])
+                install_requires += parse_requirements(req_path=line[3:])
             else:
                 # add the line as a new requirement
                 install_requires.append(line)
@@ -66,8 +66,8 @@ setup(
     entry_points={"console_scripts": ["cg=cg.cli:base"]},
     # install requirements loaded from "./requirements.txt"
     # Install requirements loaded from ``requirements.txt``
-    install_requires=parse_reqs(),
     tests_require=["pytest", "pytest-mock"],
+    install_requires=parse_requirements(),
     cmdclass=dict(test=PyTest),
     classifiers=[
         "Programming Language :: Python",


### PR DESCRIPTION
This PR installs dependencies which should avoid pylint import errors

**How to test**:
- [x] in any repo with  pylint score check change line with pip install pylint to include package reqs in .travis.yml
- [x] open PR check
- [x] open pylint score check
- [x] revert .travis.yml
- [x] open PR check
- [x] open pylint score check

**Expected test outcome**:
- [x] There should not be any import errors from missing imports (unless there is an actual promblem..)
- [x] Take a screenshot and attach or copy/paste the output.

**How to test setup.py (changed python file in previous test)**:
- [x] run python setup.py test

**Expected test outcome**:
- [x] Tests run

**Review:**
- [x] code approved by @moonso 
- [x] tests executed by @patrikgrenfeldt 
- [x] "Merge and deploy" approved by @patrikgrenfeldt 
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
