### PR TITLE
find bed-version by shortname

### DIFF
--- a/cg/cli/workflow/balsamic/base.py
+++ b/cg/cli/workflow/balsamic/base.py
@@ -201,16 +201,20 @@ def config_case(
         else:
             normal_paths.add(concatenated_paths[1])
 
-        target_bed_shortname = context.obj["lims_api"].capture_kit(
-            link_obj.sample.internal_id
-        )
-        if target_bed_shortname:
-            target_bed_obj = context.obj["db"].latest_bed_version(target_bed_shortname)
+        if not target_bed:
+            target_bed_shortname = context.obj["lims_api"].capture_kit(
+                link_obj.sample.internal_id
+            )
 
-            if not target_bed_obj:
-                raise CgError("Bed-version %s does not exist" % target_bed_shortname)
+            if target_bed_shortname:
+                bed_version_obj = context.obj["db"].bed_version(target_bed_shortname)
 
-            target_beds.add(target_bed_obj.filename)
+                if not bed_version_obj:
+                    raise CgError(
+                        "Bed-version %s does not exist" % target_bed_shortname
+                    )
+
+                target_beds.add(bed_version_obj.filename)
 
     nr_paths = len(tumor_paths) if tumor_paths else 0
     if nr_paths != 1:

--- a/cg/store/api/findbasicdata.py
+++ b/cg/store/api/findbasicdata.py
@@ -37,6 +37,10 @@ class FindBasicDataHandler(BaseHandler):
         """Find a bed by name."""
         return self.Bed.query.filter_by(name=name).first()
 
+    def bed_version(self, shortname):
+        """Find a bed version by shortname."""
+        return self.BedVersion.query.filter_by(shortname=shortname).first()
+
     def beds(self, hide_archived: bool = False):
         """Returns all beds."""
         bed_q = self.Bed.query

--- a/tests/cli/workflow/balsamic/conftest.py
+++ b/tests/cli/workflow/balsamic/conftest.py
@@ -185,7 +185,9 @@ def ensure_bed_version(disk_store, bed_name="dummy_bed"):
 
     version = disk_store.latest_bed_version(bed_name)
     if not version:
-        version = disk_store.add_bed_version(bed, 1, "dummy_filename")
+        version = disk_store.add_bed_version(
+            bed, 1, "dummy_filename", shortname=bed_name
+        )
         disk_store.add_commit(version)
     return version
 


### PR DESCRIPTION
This PR adds/fixes the problem with cg checking bed-version in status db with --target-bed-version flag

**How to prepare for test**:
- [x] ssh to hasta depending on type of change
- [x] install on stage:
`bash servers/resources/hasta.sclifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

**How to test**:
- [x] login to hasta
- [x] us
- [x] cg workflow balsamic config-case --target-bed /home/proj/production/cancer/reference/panel/twistexomerefseq_9.1_hg19_design.bed -c helpeddrake -e keyvan.elhami@scilifelab.se --dry-run

**Expected test outcome**:
- [x] check that cg does not raise cg.exc.CgError
- [x] Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @hassanfa 
- [x] tests executed by @patrikgrenfeldt 
- [x] "Merge and deploy" approved by @patrikgrenfeldt 
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
