### PR TITLE
Use load config upload scout2

### DIFF
--- a/cg/apps/scoutapi.py
+++ b/cg/apps/scoutapi.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
-import logging
 import datetime as dt
+import logging
 from typing import List
 from pathlib import Path
 
 from pymongo import MongoClient
 from scout.adapter.mongo import MongoAdapter
-from scout.load.report import load_delivery_report
 from scout.export.panel import export_panels as scout_export_panels
 from scout.load import load_scout
+from scout.load.report import load_delivery_report
 from scout.parse.case import parse_case_data
 from cg.utils.commands import Process
 
@@ -44,6 +44,7 @@ class ScoutAPI(MongoAdapter):
         else:
             LOG.debug("load new Scout case")
             load_scout(self, config_data)
+            LOG.debug("Case loaded successfully to Scout")
 
     def update_alignment_file(self, case_id: str, sample_id: str, alignment_path: Path):
         """Update alignment file for individual in case"""

--- a/cg/apps/scoutapi.py
+++ b/cg/apps/scoutapi.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+"""Code for talking to Scout regarding uploads"""
+
 import datetime as dt
 import logging
 from typing import List
@@ -36,15 +37,15 @@ class ScoutAPI(MongoAdapter):
         )
         if existing_case:
             if force or config_data["analysis_date"] > existing_case["analysis_date"]:
-                LOG.info(f"update existing Scout case")
+                LOG.info("update existing Scout case")
                 load_scout(self, config_data, update=True)
             else:
                 existing_date = existing_case["analysis_date"].date()
-                LOG.warning(f"analysis of case already loaded: {existing_date}")
-        else:
-            LOG.debug("load new Scout case")
-            load_scout(self, config_data)
-            LOG.debug("Case loaded successfully to Scout")
+                LOG.warning("analysis of case already loaded: %s", existing_date)
+            return
+        LOG.debug("load new Scout case")
+        load_scout(self, config_data)
+        LOG.debug("Case loaded successfully to Scout")
 
     def update_alignment_file(self, case_id: str, sample_id: str, alignment_path: Path):
         """Update alignment file for individual in case"""

--- a/cg/cli/upload/base.py
+++ b/cg/cli/upload/base.py
@@ -22,7 +22,7 @@ from .delivery_report import delivery_report, delivery_report_to_scout, delivery
 from .genotype import genotypes
 from .mutacc import process_solved, processed_solved
 from .observations import observations
-from .scout import scout
+from .scout import scout, upload_case_to_scout
 from .utils import _suggest_cases_to_upload
 from .validate import validate
 
@@ -174,6 +174,7 @@ upload.add_command(processed_solved)
 upload.add_command(validate)
 upload.add_command(beacon)
 upload.add_command(scout)
+upload.add_command(upload_case_to_scout)
 upload.add_command(observations)
 upload.add_command(genotypes)
 upload.add_command(coverage)

--- a/cg/cli/upload/scout.py
+++ b/cg/cli/upload/scout.py
@@ -2,6 +2,7 @@
 import logging
 
 import click
+import yaml
 
 from cg.apps import hk
 
@@ -57,7 +58,7 @@ def scout(context, re_upload, print_console, case_id):
         )
         context.abort()
 
-    context.invoke(upload_case_to_scout, case_id=case_id)
+    context.invoke(upload_case_to_scout, case_id=case_id, re_upload=re_upload)
 
 
 @click.command()
@@ -76,7 +77,7 @@ def upload_case_to_scout(context, re_upload, dry_run, case_id):
         scout_config_files = hk_api.get_files(
             bundle=case_id, tags=[tag_name], version=version_obj.id
         )
-        if len([conf_file for conf_file in scout_config_files]) == 0:
+        if len(list(scout_config_files)) == 0:
             raise FileNotFoundError(
                 f"No scout load config was found in housekeeper for {case_id}"
             )

--- a/cg/cli/upload/scout.py
+++ b/cg/cli/upload/scout.py
@@ -5,6 +5,7 @@ import click
 import yaml
 
 from cg.apps import hk
+from cg.meta.upload.scoutapi import UploadScoutAPI
 
 from .utils import _suggest_cases_to_upload
 
@@ -72,7 +73,7 @@ def upload_case_to_scout(context, re_upload, dry_run, case_id):
     click.echo(click.style("----------------- CONFIG -----------------------"))
 
     def _get_load_config_from_hk(hk_api: hk.HousekeeperAPI, case_id):
-        tag_name = "scout-load-config"
+        tag_name = UploadScoutAPI.get_load_config_tag()
         version_obj = hk_api.last_version(case_id)
         scout_config_files = hk_api.get_files(
             bundle=case_id, tags=[tag_name], version=version_obj.id

--- a/cg/cli/upload/scout.py
+++ b/cg/cli/upload/scout.py
@@ -14,9 +14,7 @@ LOG = logging.getLogger(__name__)
 
 @click.command()
 @click.option("-r", "--re-upload", is_flag=True, help="re-upload existing analysis")
-@click.option(
-    "-p", "--print", "print_console", is_flag=True, help="print config values"
-)
+@click.option("-p", "--print", "print_console", is_flag=True, help="print config values")
 @click.argument("case_id", required=False)
 @click.pass_context
 def scout(context, re_upload, print_console, case_id):
@@ -54,9 +52,7 @@ def scout(context, re_upload, print_console, case_id):
         LOG.info("Upload file to housekeeper: %s", file_path)
         scout_upload_api.add_scout_config_to_hk(file_path, hk_api, case_id)
     except FileExistsError as err:
-        LOG.warning(
-            "%s, consider removing the file from housekeeper and try again", str(err)
-        )
+        LOG.warning("%s, consider removing the file from housekeeper and try again", str(err))
         context.abort()
 
     context.invoke(upload_case_to_scout, case_id=case_id, re_upload=re_upload)
@@ -79,9 +75,7 @@ def upload_case_to_scout(context, re_upload, dry_run, case_id):
             bundle=case_id, tags=[tag_name], version=version_obj.id
         )
         if len(list(scout_config_files)) == 0:
-            raise FileNotFoundError(
-                f"No scout load config was found in housekeeper for {case_id}"
-            )
+            raise FileNotFoundError(f"No scout load config was found in housekeeper for {case_id}")
 
         return scout_config_files[0].full_path
 
@@ -98,7 +92,5 @@ def upload_case_to_scout(context, re_upload, dry_run, case_id):
         scout_api.upload(scout_configs, force=re_upload)
 
     click.echo(
-        click.style(
-            "uploaded to scout using load config {}".format(load_config), fg="green"
-        )
+        click.style("uploaded to scout using load config {}".format(load_config), fg="green")
     )

--- a/cg/cli/upload/scout.py
+++ b/cg/cli/upload/scout.py
@@ -3,6 +3,8 @@ import logging
 
 import click
 
+from cg.apps import hk
+
 from .utils import _suggest_cases_to_upload
 
 LOG = logging.getLogger(__name__)
@@ -24,7 +26,6 @@ def scout(context, re_upload, print_console, case_id):
         _suggest_cases_to_upload(context)
         context.abort()
 
-    scout_api = context.obj["scout_api"]
     tb_api = context.obj["tb_api"]
     status_api = context.obj["status"]
     scout_upload_api = context.obj["scout_upload_api"]
@@ -56,4 +57,46 @@ def scout(context, re_upload, print_console, case_id):
         )
         context.abort()
 
-    scout_api.upload(scout_config, force=re_upload)
+    context.invoke(upload_case_to_scout, case_id=case_id)
+
+
+@click.command()
+@click.option("-r", "--re-upload", is_flag=True, help="re-upload existing analysis")
+@click.option("--dry-run", is_flag=True)
+@click.argument("case_id")
+@click.pass_context
+def upload_case_to_scout(context, re_upload, dry_run, case_id):
+    """Upload variants and case from analysis to Scout."""
+
+    click.echo(click.style("----------------- CONFIG -----------------------"))
+
+    def _get_load_config_from_hk(hk_api: hk.HousekeeperAPI, case_id):
+        tag_name = "scout-load-config"
+        version_obj = hk_api.last_version(case_id)
+        scout_config_files = hk_api.get_files(
+            bundle=case_id, tags=[tag_name], version=version_obj.id
+        )
+        if len([conf_file for conf_file in scout_config_files]) == 0:
+            raise FileNotFoundError(
+                f"No scout load config was found in housekeeper for {case_id}"
+            )
+
+        return scout_config_files[0].full_path
+
+    scout_api = context.obj["scout_api"]
+    hk_api = context.obj["housekeeper_api"]
+
+    load_config = _get_load_config_from_hk(hk_api, case_id)
+
+    LOG.info("uploading case %s to scout", case_id)
+    with open(load_config, "r") as stream:
+        scout_configs = yaml.safe_load(stream)
+
+    if not dry_run:
+        scout_api.upload(scout_configs, force=re_upload)
+
+    click.echo(
+        click.style(
+            "uploaded to scout using load config {}".format(load_config), fg="green"
+        )
+    )

--- a/cg/meta/upload/scoutapi.py
+++ b/cg/meta/upload/scoutapi.py
@@ -117,6 +117,11 @@ class UploadScoutAPI:
         return data
 
     @staticmethod
+    def get_load_config_tag() -> str:
+        """Get the hk tag for a scout load config"""
+        return "scout-load-config"
+
+    @staticmethod
     def save_config_file(upload_config: dict, file_path: Path):
         """Save a scout load config file to <file_path>"""
 
@@ -127,7 +132,7 @@ class UploadScoutAPI:
     @staticmethod
     def add_scout_config_to_hk(config_file_path: Path, hk_api: hk.HousekeeperAPI, case_id: str):
         """Add scout load config to hk bundle"""
-        tag_name = "scout-load-config"
+        tag_name = UploadScoutAPI.get_load_config_tag()
         version_obj = hk_api.last_version(bundle=case_id)
         uploaded_config_files = hk_api.get_files(
             bundle=case_id, tags=[tag_name], version=version_obj.id

--- a/tests/cli/upload/conftest.py
+++ b/tests/cli/upload/conftest.py
@@ -100,12 +100,8 @@ def load_family(store, family):
             family=family,
             sample=sample_obj,
             status=sample_data["status"],
-            father=base_store.sample(sample_data["father"])
-            if sample_data.get("father")
-            else None,
-            mother=base_store.sample(sample_data["mother"])
-            if sample_data.get("mother")
-            else None,
+            father=base_store.sample(sample_data["father"]) if sample_data.get("father") else None,
+            mother=base_store.sample(sample_data["mother"]) if sample_data.get("mother") else None,
         )
         base_store.add(link)
 

--- a/tests/cli/upload/conftest.py
+++ b/tests/cli/upload/conftest.py
@@ -1,8 +1,8 @@
 """Fixtures for cli balsamic tests"""
+import json
 import logging
 from pathlib import Path
 
-import json
 import pytest
 
 from cg.apps.hk import HousekeeperAPI
@@ -45,48 +45,6 @@ def fixture_analysis_family_single():
                 "ticket_number": 123456,
                 "reads": 5000000,
             }
-        ],
-    }
-    return family
-
-
-@pytest.fixture
-def analysis_family_trio():
-    """Build an example family."""
-    family = {
-        "name": "trio",
-        "internal_id": "yellowtrio",
-        "panels": ["IEM", "EP"],
-        "samples": [
-            {
-                "name": "son",
-                "sex": "male",
-                "internal_id": "ADM1",
-                "data_analysis": "mip",
-                "father": "ADM2",
-                "mother": "ADM3",
-                "status": "affected",
-                "ticket_number": 123456,
-                "reads": 5000000,
-            },
-            {
-                "name": "father",
-                "sex": "male",
-                "internal_id": "ADM2",
-                "data_analysis": "mip",
-                "status": "unaffected",
-                "ticket_number": 123456,
-                "reads": 6000000,
-            },
-            {
-                "name": "mother",
-                "sex": "female",
-                "internal_id": "ADM3",
-                "data_analysis": "mip",
-                "status": "unaffected",
-                "ticket_number": 123456,
-                "reads": 7000000,
-            },
         ],
     }
     return family
@@ -159,9 +117,9 @@ def load_family(store, family):
 
 
 @pytest.yield_fixture(scope="function", name="analysis_store_trio")
-def fixture_analysis_store_trio(base_store, analysis_family_trio):
+def fixture_analysis_store_trio(base_store, analysis_family):
     """Setup a store instance for testing analysis API."""
-    load_family(base_store, analysis_family_trio)
+    load_family(base_store, analysis_family)
 
     yield base_store
 

--- a/tests/cli/upload/conftest.py
+++ b/tests/cli/upload/conftest.py
@@ -1,5 +1,5 @@
 """Fixtures for cli balsamic tests"""
-
+import logging
 from pathlib import Path
 
 import json
@@ -12,6 +12,8 @@ from cg.apps.tb import TrailblazerAPI
 from cg.meta.upload.scoutapi import UploadScoutAPI
 from cg.meta.workflow.mip_dna import AnalysisAPI
 from cg.store import Store
+
+LOG = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="function", name="base_context")

--- a/tests/cli/upload/conftest.py
+++ b/tests/cli/upload/conftest.py
@@ -242,7 +242,7 @@ class MockHK(HousekeeperAPI):
         return MockFile()
 
     def get_files(self, bundle, tags, version="1.0"):
-        """docstring for get_files"""
+        """Mock get files sub from Housekeeper"""
         return self._files
 
     def add_file(self, file, version_obj, tag_name, to_archive=False):

--- a/tests/cli/upload/conftest.py
+++ b/tests/cli/upload/conftest.py
@@ -246,7 +246,7 @@ class MockHK(HousekeeperAPI):
         return self._files
 
     def add_file(self, file, version_obj, tag_name, to_archive=False):
-        """docstring for add_file"""
+        """Mock add file to the HK database"""
         self._file_added = True
         new_file = MockFile(path=file)
         self._files.append(new_file)

--- a/tests/cli/upload/conftest.py
+++ b/tests/cli/upload/conftest.py
@@ -118,18 +118,20 @@ def load_family(store, family):
 
 @pytest.yield_fixture(scope="function", name="analysis_store_trio")
 def fixture_analysis_store_trio(base_store, analysis_family):
-    """Setup a store instance for testing analysis API."""
-    load_family(base_store, analysis_family)
+    """Setup a store instance with a trion loaded for testing analysis API."""
+    _store = base_store
+    load_family(_store, analysis_family)
 
-    yield base_store
+    yield _store
 
 
 @pytest.yield_fixture(scope="function", name="analysis_store_single_case")
 def fixture_analysis_store_single(base_store, analysis_family_single_case):
-    """Setup a store instance for testing analysis API."""
-    load_family(base_store, analysis_family_single_case)
+    """Setup a store instance with a single ind case for testing analysis API."""
+    _store = base_store
+    load_family(_store, analysis_family_single_case)
 
-    yield base_store
+    yield _store
 
 
 @pytest.fixture

--- a/tests/cli/upload/test_cli_upload_scout.py
+++ b/tests/cli/upload/test_cli_upload_scout.py
@@ -8,13 +8,11 @@ def check_log(caplog, string=None, warning=None):
     """Parse the log output"""
     found = False
     for _, level, message in caplog.record_tuples:
-        print(message)
         if warning:
             if level == logging.WARNING:
                 found = True
-        if string:
-            if string in message:
-                found = True
+        if string and string in message:
+            found = True
     return found
 
 

--- a/tests/cli/upload/test_cli_upload_scout.py
+++ b/tests/cli/upload/test_cli_upload_scout.py
@@ -139,9 +139,7 @@ def test_upload_scout_cli_file_exists(
     assert warned
 
 
-def test_upload_scout_cli(
-    base_context, cli_runner, analysis_family_single_case, scout_load_config
-):
+def test_upload_scout_cli(base_context, cli_runner, analysis_family_single_case, scout_load_config):
     """Test to upload a case to scout using cg upload scout command"""
     # GIVEN a case_id where the case exists in status db with at least one analysis
     # GIVEN that the analysis is done and exists in tb
@@ -156,9 +154,7 @@ def test_upload_scout_cli(
     assert result.exit_code == 0
 
 
-def test_upload_scout_cli_print_console(
-    base_context, cli_runner, analysis_family_single_case
-):
+def test_upload_scout_cli_print_console(base_context, cli_runner, analysis_family_single_case):
     """Test to dry run a case upload"""
     # GIVEN a case_id where the case exists in status db with at least one analysis
     # GIVEN that the analysis is done and exists in tb

--- a/tests/cli/upload/test_cli_upload_scout.py
+++ b/tests/cli/upload/test_cli_upload_scout.py
@@ -8,6 +8,7 @@ def check_log(caplog, string=None, warning=None):
     """Parse the log output"""
     found = False
     for _, level, message in caplog.record_tuples:
+        print(message)
         if warning:
             if level == logging.WARNING:
                 found = True
@@ -49,7 +50,6 @@ def test_upload_with_load_config(
     # THEN assert that the load config was used
     def load_file_mentioned_in_result(result, load_config_file):
         """Check output that load file is mentioned"""
-        print(result.output)
         return load_config_file in result.output
 
     assert load_file_mentioned_in_result(result, load_config_file.full_path)

--- a/tests/cli/upload/test_cli_upload_scout.py
+++ b/tests/cli/upload/test_cli_upload_scout.py
@@ -49,6 +49,7 @@ def test_upload_with_load_config(
     # THEN assert that the load config was used
     def load_file_mentioned_in_result(result, load_config_file):
         """Check output that load file is mentioned"""
+        print(result.output)
         return load_config_file in result.output
 
     assert load_file_mentioned_in_result(result, load_config_file.full_path)

--- a/tests/cli/upload/test_cli_upload_scout.py
+++ b/tests/cli/upload/test_cli_upload_scout.py
@@ -4,7 +4,58 @@ import logging
 from cg.cli.upload.base import scout
 
 
+def check_log(caplog, string=None, warning=None):
+    """Parse the log output"""
+    found = False
+    for _, level, message in caplog.record_tuples:
+        if warning:
+            if level == logging.WARNING:
+                found = True
+        if string:
+            if string in message:
+                found = True
+    return found
+
+
+def test_upload_with_load_config(
+    base_context, scout_load_config, upload_scout_api, cli_runner, caplog
+):
+    """Test to upload a case to scout using a load config"""
+    # GIVEN a case with a scout load config in housekeeper
+    case_id = base_context["status"].families().first().internal_id
+    tag_name = upload_scout_api.get_load_config_tag()
+
+    base_context["housekeeper_api"].add_file(scout_load_config, None, None)
+    load_config_file = base_context["housekeeper_api"].get_files(case_id, [tag_name])[0]
+    assert load_config_file
+
+    def case_exists_in_status(case_id, store):
+        """Check if case exists in status database"""
+        return store.families().first().internal_id == case_id
+
+    assert case_exists_in_status(case_id, base_context["status"])
+
+    # WHEN invoking command to upload case to scout
+    with caplog.at_level(logging.INFO):
+        result = cli_runner.invoke(scout, [case_id], obj=base_context)
+
+    # THEN assert that the case was loaded succesfully
+    def case_loaded_succesfully(caplog):
+        """Check output that case was loaded"""
+        return check_log(caplog, string="Case loaded successfully to Scout")
+
+    assert case_loaded_succesfully(caplog)
+
+    # THEN assert that the load config was used
+    def load_file_mentioned_in_result(result, load_config_file):
+        """Check output that load file is mentioned"""
+        return load_config_file in result.output
+
+    assert load_file_mentioned_in_result(result, load_config_file.full_path)
+
+
 def test_produce_load_config(base_context, cli_runner, analysis_family_single_case):
+    """Test create a scout load config with the scout upload api"""
     # GIVEN a singleton WGS case
 
     base_context["scout_upload_api"].mock_generate_config = False
@@ -68,6 +119,7 @@ def test_produce_load_config_missing_mandatory_file(
 def test_upload_scout_cli_file_exists(
     base_context, cli_runner, caplog, analysis_family_single_case
 ):
+    """Test to upload a case when the load config already exists"""
     # GIVEN a case_id where the case exists in status db with at least one analysis
     # GIVEN that the analysis is done and exists in tb
     # GIVEN that the upload file already exists
@@ -83,18 +135,19 @@ def test_upload_scout_cli_file_exists(
     assert result.exit_code == 1
 
     # THEN assert that a warning is logged
-    warned = False
-    for _, level, _ in caplog.record_tuples:
-        if level == logging.WARNING:
-            warned = True
+    warned = check_log(caplog, warning=True)
     assert warned
 
 
-def test_upload_scout_cli(base_context, cli_runner, analysis_family_single_case):
+def test_upload_scout_cli(
+    base_context, cli_runner, analysis_family_single_case, scout_load_config
+):
+    """Test to upload a case to scout using cg upload scout command"""
     # GIVEN a case_id where the case exists in status db with at least one analysis
     # GIVEN that the analysis is done and exists in tb
     config = {"dummy": "data"}
     base_context["scout_upload_api"].config = config
+    base_context["housekeeper_api"].add_file(scout_load_config, None, None)
     case_id = analysis_family_single_case["internal_id"]
     # WHEN uploading a case with the cli and printing the upload config
     result = cli_runner.invoke(scout, [case_id], obj=base_context)
@@ -103,7 +156,10 @@ def test_upload_scout_cli(base_context, cli_runner, analysis_family_single_case)
     assert result.exit_code == 0
 
 
-def test_upload_scout_cli_print_console(base_context, cli_runner, analysis_family_single_case):
+def test_upload_scout_cli_print_console(
+    base_context, cli_runner, analysis_family_single_case
+):
+    """Test to dry run a case upload"""
     # GIVEN a case_id where the case exists in status db with at least one analysis
     # GIVEN that the analysis is done and exists in tb
     config = {"dummy": "data"}

--- a/tests/cli/upload/test_cli_upload_scout.py
+++ b/tests/cli/upload/test_cli_upload_scout.py
@@ -8,9 +8,8 @@ def check_log(caplog, string=None, warning=None):
     """Parse the log output"""
     found = False
     for _, level, message in caplog.record_tuples:
-        if warning:
-            if level == logging.WARNING:
-                found = True
+        if level == logging.WARNING and warning:
+            found = True
         if string and string in message:
             found = True
     return found
@@ -71,6 +70,7 @@ def test_produce_load_config(base_context, cli_runner, analysis_family_single_ca
 def test_produce_load_config_no_delivery(
     base_context, cli_runner, analysis_family_single_case, hk_mock
 ):
+    """Test to produce a load config without a delivery report"""
     # GIVEN a singleton WGS case
 
     base_context["scout_upload_api"].mock_generate_config = False
@@ -96,6 +96,7 @@ def test_produce_load_config_no_delivery(
 def test_produce_load_config_missing_mandatory_file(
     base_context, cli_runner, analysis_family_single_case, hk_mock
 ):
+    """Test to produce a load config when mandatory files are missing"""
     # GIVEN a singleton WGS case
     base_context["scout_upload_api"].mock_generate_config = False
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,12 @@ CRUNCHY_CONFIG = {
 
 
 @pytest.fixture
+def scout_load_config():
+    """Yaml file with load information from scout"""
+    return "tests/fixtures/apps/scout/643594.config.yaml"
+
+
+@pytest.fixture
 def chanjo_config_dict():
     """Chanjo configs"""
     _config = dict()

--- a/tests/fixtures/apps/scout/643594.config.yaml
+++ b/tests/fixtures/apps/scout/643594.config.yaml
@@ -1,0 +1,75 @@
+---
+
+owner: cust000
+
+family: 'internal_id'
+family_name: '643594'
+samples:
+  - analysis_type: wes
+    sample_id: ADM1059A2
+    capture_kit: Agilent_SureSelectCRE.V1
+    father: ADM1059A1
+    mother: ADM1059A3
+    sample_name: NA12882
+    phenotype: affected
+    sex: male
+    expected_coverage: 30
+    mt_bam: scout/demo/reduced_mt.bam
+    vcf2cytosure: scout/demo/ADM1059A2.dummy.cgh
+    tissue_type: blood
+
+  - analysis_type: wes
+    sample_id: ADM1059A1
+    capture_kit: Agilent_SureSelectCRE.V1
+    father: '0'
+    mother: '0'
+    sample_name: NA12877
+    phenotype: unaffected
+    sex: male
+    expected_coverage: 30
+    mt_bam: scout/demo/reduced_mt.bam
+    vcf2cytosure: scout/demo/ADM1059A1.dummy.cgh
+    tissue_type: blood
+
+  - analysis_type: wes
+    sample_id: ADM1059A3
+    capture_kit: Agilent_SureSelectCRE.V1
+    father: '0'
+    mother: '0'
+    sample_name: NA12878
+    phenotype: unaffected
+    sex: female
+    expected_coverage: 30
+    mt_bam: scout/demo/reduced_mt.bam
+    vcf2cytosure: scout/demo/ADM1059A3.dummy.cgh
+    tissue_type: blood
+
+vcf_snv: scout/demo/643594.clinical.vcf.gz
+vcf_sv: scout/demo/643594.clinical.SV.vcf.gz
+vcf_str: scout/demo/643594.clinical.str.annotated.vcf.gz
+vcf_snv_research: scout/demo/643594.research.vcf.gz
+vcf_sv_research: scout/demo/643594.research.SV.vcf.gz
+
+madeline: scout/demo/madeline.xml
+
+peddy_ped: scout/demo/643594.peddy.ped
+peddy_ped_check: scout/demo/643594.ped_check.csv
+peddy_sex_check: scout/demo/643594.sex_check.csv
+
+delivery_report: scout/demo/delivery_report.html
+
+default_gene_panels: [panel1]
+gene_panels: [panel1]
+chromograph_image_files: scout/demo/images
+chromograph_prefixes:
+  'roh': "roh_chr"
+  'upd': "upd_chr"
+  'chr': "cytoband.txt.chr"
+
+
+# meta data
+rank_model_version: '1.20'
+sv_rank_model_version: '1.5'
+rank_score_threshold: -100
+analysis_date: 2016-10-12 14:00:46
+human_genome_build: 37


### PR DESCRIPTION
**Second attempt!!**
This PR moves one step closer to decouple scout from CG.
Here we will use a load config on disc to load a case from cg and not create one on the fly as earlier.

**How to prepare for test**:
- [x] install on stage of the hasta: `bash servers/resources/hasta.scilifelab.se/update-cg-stage.sh use-load-config-upload-scout2`
- [x] activate stage: `us`
- [x] find a case that has not been uploaded to stage (worthylouse)

**How to test**:
- [x] run following command: `cg upload scout <case_id>`

**Expected test outcome**:
- [x] `cg` should successfully upload the case to scout
- [x] `cg` should print that the load config was used
- [x] Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @henrikstranneheim 
- [x] tests executed by @barrystokman 
- [x] "Merge and deploy" approved by @patrikgrenfeldt 
Thanks for filling in who performed the code review and the test!

This is minor **version bump** because internal API has changed
