### PR TITLE
Skip missing non mandatory files

### DIFF
--- a/cg/cli/upload/scout.py
+++ b/cg/cli/upload/scout.py
@@ -32,7 +32,6 @@ def scout(context, re_upload, print_console, case_id):
 
     family_obj = status_api.family(case_id)
     scout_config = scout_upload_api.generate_config(family_obj.analyses[0])
-
     if print_console:
         click.echo(scout_config)
         return

--- a/cg/meta/upload/scoutapi.py
+++ b/cg/meta/upload/scoutapi.py
@@ -171,7 +171,7 @@ class UploadScoutAPI:
 
     def _include_files(self, data, hk_version, scout_hk_map, **kwargs):
         extra_tag = kwargs.get("extra_tag")
-        skip_missing = kwargs.get("skip_missing", False)
+        skip_missing = kwargs.get("skip_missing", True)
         for scout_key, hk_tag in scout_hk_map:
 
             if extra_tag:

--- a/tests/cli/upload/conftest.py
+++ b/tests/cli/upload/conftest.py
@@ -149,13 +149,16 @@ class MockHK(HousekeeperAPI):
     def __init__(self):
         """Mock the init"""
         self.delivery_report = True
+        self.missing_mandatory = False
 
     def files(self, **kwargs):
         """docstring for file"""
-        if (
-            "delivery-report" in kwargs.get("tags", [])
-            and self.delivery_report is False
-        ):
+        tags = set(kwargs.get("tags", []))
+        delivery = set(["delivery-report"])
+        mandatory = set(["vcf-snv-clinical"])
+        if tags.intersection(delivery) and self.delivery_report is False:
+            return MockFile(empty_first=True)
+        if tags.intersection(mandatory) and self.missing_mandatory is True:
             return MockFile(empty_first=True)
         return MockFile()
 

--- a/tests/cli/upload/conftest.py
+++ b/tests/cli/upload/conftest.py
@@ -97,6 +97,12 @@ def fixture_analysis_store_single(base_store, analysis_family_single_case):
     yield base_store
 
 
+@pytest.fixture
+def hk_mock():
+    """docstring for hk_mock"""
+    return MockHK()
+
+
 class MockTB(TrailblazerAPI):
     """Mock of trailblazer """
 
@@ -119,12 +125,15 @@ class MockVersion:
 class MockFile:
     """Mock a file object"""
 
-    def __init__(self, path="", to_archive=False, tags=None):
+    def __init__(self, path="", to_archive=False, tags=None, **kwargs):
         self.path = path
         self.to_archive = to_archive
         self.tags = tags or []
+        self._empty_first = kwargs.get("empty_first", False)
 
     def first(self):
+        if self._empty_first:
+            return None
         return MockFile()
 
     def full_path(self):
@@ -139,10 +148,15 @@ class MockHK(HousekeeperAPI):
 
     def __init__(self):
         """Mock the init"""
-        pass
+        self.delivery_report = True
 
     def files(self, **kwargs):
         """docstring for file"""
+        if (
+            "delivery-report" in kwargs.get("tags", [])
+            and self.delivery_report is False
+        ):
+            return MockFile(empty_first=True)
         return MockFile()
 
     def version(self, arg1: str, arg2: str):
@@ -179,7 +193,7 @@ class MockAnalysisApi(AnalysisAPI):
 
 
 class MockScoutUploadApi(UploadScoutAPI):
-    def __init__(self):
+    def __init__(self, **kwargs):
         """docstring for __init__"""
         self.mock_generate_config = True
         self.housekeeper = MockHK()
@@ -206,7 +220,6 @@ class MockScoutUploadApi(UploadScoutAPI):
         """docstring for add_scout_config_to_hk"""
         if self.file_exists:
             raise FileExistsError("Scout config already exists")
-        pass
 
 
 class MockLims(LimsAPI):

--- a/tests/cli/upload/test_cli_upload_scout.py
+++ b/tests/cli/upload/test_cli_upload_scout.py
@@ -15,6 +15,32 @@ def test_produce_load_config(base_context, cli_runner, analysis_family_single_ca
     # THEN assert mother: '0' and father: '0'
     assert "'mother': '0'" in result.output
     assert "'father': '0'" in result.output
+    assert "'delivery_report'" in result.output
+
+
+def test_produce_load_config_no_delivery(
+    base_context, cli_runner, analysis_family_single_case, hk_mock
+):
+    # GIVEN a singleton WGS case
+
+    base_context["scout_upload_api"].mock_generate_config = False
+
+    # GIVEN a housekeeper that does not return delivery files
+    hk_mock.delivery_report = False
+    base_context["scout_upload_api"].housekeeper = hk_mock
+    assert hk_mock.files(tags=["delivery-report"]).first() is None
+
+    case_id = analysis_family_single_case["internal_id"]
+
+    # WHEN running cg upload scout -p <caseid>
+    result = cli_runner.invoke(scout, [case_id, "--print"], obj=base_context)
+
+    # THEN assert the command succeded since delivery report is not mandatory
+    assert result.exit_code == 0
+    # THEN assert the output has some content
+    assert result.output
+    # THEN there is no delivery report in the output
+    assert "'delivery_report'" not in result.output
 
 
 def test_upload_scout_cli_file_exists(


### PR DESCRIPTION
This PR fixes an bug that scout upload failed when non mandatory files where missing. This was introduced in #513 

The actual fix is very small but I added some tests to this scenario as well.

**How to prepare for test**:
Tests are automated

**Review:**
- [x] code approved by @moahaegglund 
- [x] tests executed by @moonso 
- [x] "Merge and deploy" approved by @patrikgrenfeldt 
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
This is a bugfix
