### PR TITLE
Feat/min depth on applications

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 7.7.2
+current_version = 7.7.3
 commit = True
 tag = True
 tag_name = v{new_version}

--- a/cg/meta/workflow/mip_dna.py
+++ b/cg/meta/workflow/mip_dna.py
@@ -150,7 +150,7 @@ class AnalysisAPI:
                 "analysis_type": link.sample.application_version.application.analysis_type,
                 "sex": link.sample.sex,
                 "phenotype": link.status,
-                "expected_coverage": link.sample.application_version.application.sequencing_depth,
+                "expected_coverage": link.sample.application_version.application.min_sequencing_depth,
             }
             if sample_data["analysis_type"] in ("tgs", "wes"):
                 if link.sample.capture_kit:

--- a/cg/meta/workflow/mip_dna.py
+++ b/cg/meta/workflow/mip_dna.py
@@ -150,7 +150,8 @@ class AnalysisAPI:
                 "analysis_type": link.sample.application_version.application.analysis_type,
                 "sex": link.sample.sex,
                 "phenotype": link.status,
-                "expected_coverage": link.sample.application_version.application.min_sequencing_depth,
+                "expected_coverage":
+                    link.sample.application_version.application.min_sequencing_depth,
             }
             if sample_data["analysis_type"] in ("tgs", "wes"):
                 if link.sample.capture_kit:

--- a/cg/meta/workflow/mip_dna.py
+++ b/cg/meta/workflow/mip_dna.py
@@ -81,13 +81,13 @@ class AnalysisAPI:
         flowcells = self.db.flowcells(family=family_obj)
         statuses = []
         for flowcell_obj in flowcells:
-            self.LOG.debug(f"{flowcell_obj.name}: checking flowcell")
+            self.LOG.debug("%s: checking flowcell", flowcell_obj.name)
             statuses.append(flowcell_obj.status)
             if flowcell_obj.status == "removed":
-                self.LOG.info(f"{flowcell_obj.name}: requesting removed flowcell")
+                self.LOG.info("%s: requesting removed flowcell", flowcell_obj.name)
                 flowcell_obj.status = "requested"
             elif flowcell_obj.status != "ondisk":
-                self.LOG.warning(f"{flowcell_obj.name}: {flowcell_obj.status}")
+                self.LOG.warning("%s: {flowcell_obj.status}", flowcell_obj.name)
         return all(status == "ondisk" for status in statuses)
 
     def run(self, family_obj: models.Family, **kwargs):
@@ -150,8 +150,7 @@ class AnalysisAPI:
                 "analysis_type": link.sample.application_version.application.analysis_type,
                 "sex": link.sample.sex,
                 "phenotype": link.status,
-                "expected_coverage":
-                    link.sample.application_version.application.min_sequencing_depth,
+                "expected_coverage": link.sample.application_version.application.min_sequencing_depth,
             }
             if sample_data["analysis_type"] in ("tgs", "wes"):
                 if link.sample.capture_kit:
@@ -163,21 +162,21 @@ class AnalysisAPI:
                 else:
                     if link.sample.downsampled_to:
                         self.LOG.debug(
-                            f"{link.sample.name}: downsampled sample, skipping"
+                            "%s: downsampled sample, skipping", link.sample.name
                         )
                     else:
                         try:
                             capture_kit = self.lims.capture_kit(link.sample.internal_id)
                             if capture_kit is None or capture_kit == "NA":
                                 self.LOG.warning(
-                                    f"%s: capture kit not found",
+                                    "%s: capture kit not found",
                                     link.sample.internal_id,
                                 )
                             else:
                                 sample_data["capture_kit"] = CAPTUREKIT_MAP[capture_kit]
                         except HTTPError:
                             self.LOG.warning(
-                                f"{link.sample.internal_id}: not found (LIMS)"
+                                "%s: not found (LIMS)", link.sample.internal_id
                             )
             if link.mother:
                 sample_data["mother"] = link.mother.internal_id

--- a/cg/meta/workflow/mip_dna.py
+++ b/cg/meta/workflow/mip_dna.py
@@ -144,14 +144,7 @@ class AnalysisAPI:
             "samples": [],
         }
         for link in family_obj.links:
-            sample_data = {
-                "sample_id": link.sample.internal_id,
-                "sample_display_name": link.sample.name,
-                "analysis_type": link.sample.application_version.application.analysis_type,
-                "sex": link.sample.sex,
-                "phenotype": link.status,
-                "expected_coverage": link.sample.application_version.application.min_sequencing_depth,
-            }
+            sample_data = self._get_sample_data(link)
             if sample_data["analysis_type"] in ("tgs", "wes"):
                 if link.sample.capture_kit:
                     # set the capture kit from status: key or custom file name
@@ -184,6 +177,19 @@ class AnalysisAPI:
                 sample_data["father"] = link.father.internal_id
             data["samples"].append(sample_data)
         return data
+
+    @staticmethod
+    def _get_sample_data(link: models.FamilySample) -> dict:
+        """Build sample data for MIP config file"""
+
+        return {
+            "sample_id": link.sample.internal_id,
+            "sample_display_name": link.sample.name,
+            "analysis_type": link.sample.application_version.application.analysis_type,
+            "sex": link.sample.sex,
+            "phenotype": link.status,
+            "expected_coverage": link.sample.application_version.application.min_sequencing_depth,
+        }
 
     @staticmethod
     def fastq_header(line):

--- a/cg/meta/workflow/mip_rna.py
+++ b/cg/meta/workflow/mip_rna.py
@@ -41,13 +41,13 @@ class AnalysisAPI:
         flowcells = self.db.flowcells(family=family_obj)
         statuses = []
         for flowcell_obj in flowcells:
-            self.LOG.debug(f"{flowcell_obj.name}: checking flowcell")
+            self.LOG.debug("%s: checking flowcell", flowcell_obj.name)
             statuses.append(flowcell_obj.status)
             if flowcell_obj.status == "removed":
-                self.LOG.info(f"{flowcell_obj.name}: requesting removed flowcell")
+                self.LOG.info("%s: requesting removed flowcell", flowcell_obj.name)
                 flowcell_obj.status = "requested"
             elif flowcell_obj.status != "ondisk":
-                self.LOG.warning(f"{flowcell_obj.name}: {flowcell_obj.status}")
+                self.LOG.warning("%s: %s", flowcell_obj.name, flowcell_obj.status)
         return all(status == "ondisk" for status in statuses)
 
     def run(self, family_obj: models.Family, **kwargs):
@@ -109,8 +109,7 @@ class AnalysisAPI:
                 "analysis_type": link.sample.application_version.application.analysis_type,
                 "sex": link.sample.sex,
                 "phenotype": link.status,
-                "expected_coverage":
-                    link.sample.application_version.application.min_sequencing_depth,
+                "expected_coverage": link.sample.application_version.application.min_sequencing_depth,
             }
             if link.mother:
                 sample_data["mother"] = link.mother.internal_id

--- a/cg/meta/workflow/mip_rna.py
+++ b/cg/meta/workflow/mip_rna.py
@@ -104,19 +104,26 @@ class AnalysisAPI:
             "samples": [],
         }
         for link in family_obj.links:
-            sample_data = {
-                "sample_id": link.sample.internal_id,
-                "analysis_type": link.sample.application_version.application.analysis_type,
-                "sex": link.sample.sex,
-                "phenotype": link.status,
-                "expected_coverage": link.sample.application_version.application.min_sequencing_depth,
-            }
+            sample_data = self._get_sample_data(link)
             if link.mother:
                 sample_data["mother"] = link.mother.internal_id
             if link.father:
                 sample_data["father"] = link.father.internal_id
             data["samples"].append(sample_data)
         return data
+
+    @staticmethod
+    def _get_sample_data(link: models.FamilySample) -> dict:
+        """Build sample data for MIP sample file"""
+
+        return {
+            "sample_id": link.sample.internal_id,
+            "sample_display_name": link.sample.name,
+            "analysis_type": link.sample.application_version.application.analysis_type,
+            "sex": link.sample.sex,
+            "phenotype": link.status,
+            "expected_coverage": link.sample.application_version.application.min_sequencing_depth,
+        }
 
     @staticmethod
     def fastq_header(line):

--- a/cg/meta/workflow/mip_rna.py
+++ b/cg/meta/workflow/mip_rna.py
@@ -3,7 +3,7 @@ import gzip
 import logging
 import re
 from pathlib import Path
-from typing import List, Any
+from typing import Any
 from ruamel.yaml import safe_load
 
 from cg.apps import tb, hk, lims
@@ -109,7 +109,8 @@ class AnalysisAPI:
                 "analysis_type": link.sample.application_version.application.analysis_type,
                 "sex": link.sample.sex,
                 "phenotype": link.status,
-                "expected_coverage": link.sample.application_version.application.min_sequencing_depth,
+                "expected_coverage":
+                    link.sample.application_version.application.min_sequencing_depth,
             }
             if link.mother:
                 sample_data["mother"] = link.mother.internal_id

--- a/cg/meta/workflow/mip_rna.py
+++ b/cg/meta/workflow/mip_rna.py
@@ -109,7 +109,7 @@ class AnalysisAPI:
                 "analysis_type": link.sample.application_version.application.analysis_type,
                 "sex": link.sample.sex,
                 "phenotype": link.status,
-                "expected_coverage": link.sample.application_version.application.sequencing_depth,
+                "expected_coverage": link.sample.application_version.application.min_sequencing_depth,
             }
             if link.mother:
                 sample_data["mother"] = link.mother.internal_id

--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -59,6 +59,7 @@ class ApplicationView(BaseView):
         "comment",
         "prep_category",
         "sequencing_depth",
+        "min_sequencing_depth",
         "is_external",
         "turnaround_time",
         "sample_concentration",

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -3,6 +3,8 @@ import datetime as dt
 from typing import List
 
 import alchy
+from sqlalchemy import Column, ForeignKey, orm, types, UniqueConstraint, Table
+
 from cg.constants import (
     REV_PRIORITY_MAP,
     PRIORITY_MAP,
@@ -10,7 +12,6 @@ from cg.constants import (
     FLOWCELL_STATUS,
     PREP_CATEGORIES,
 )
-from sqlalchemy import Column, ForeignKey, orm, types, UniqueConstraint, Table
 
 Model = alchy.make_declarative_base(Base=alchy.ModelBase)
 

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -74,6 +74,7 @@ class Application(Model):
     turnaround_time = Column(types.Integer)
     minimum_order = Column(types.Integer, default=1)
     sequencing_depth = Column(types.Integer)
+    min_sequencing_depth = Column(types.Integer)
     target_reads = Column(types.BigInteger, default=0)
     sample_amount = Column(types.Integer)
     sample_volume = Column(types.Text)

--- a/scripts/add-min_depth_to_application.sql
+++ b/scripts/add-min_depth_to_application.sql
@@ -1,7 +1,7 @@
 ALTER TABLE `application`
 ADD COLUMN `min_sequencing_depth` int(11) DEFAULT NULL;
 
-Update application SET min_sequencing_depth = sequencing_depth;
+UPDATE application SET min_sequencing_depth = sequencing_depth;
 
-Update application SET min_sequencing_depth = sequencing_depth * 0.87
-    where application.tag like 'WGS%'
+UPDATE application SET min_sequencing_depth = 26
+    WHERE application.tag LIKE 'WG%030';

--- a/scripts/add-min_depth_to_application.sql
+++ b/scripts/add-min_depth_to_application.sql
@@ -1,0 +1,7 @@
+ALTER TABLE `application`
+ADD COLUMN `min_sequencing_depth` int(11) DEFAULT NULL;
+
+Update application SET min_sequencing_depth = sequencing_depth;
+
+Update application SET min_sequencing_depth = sequencing_depth * 0.87
+    where application.tag like 'WGS%'

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ class PyTest(TestCommand):
 
 setup(
     name="cg",
-    version="7.7.2",
+    version="7.7.3",
     description="Clinical Genomics command center.",
     author="Patrik Grenfeldt",
     author_email="patrik.grenfeldt@scilifelab.se",


### PR DESCRIPTION
Creates a new column called min sequencing depth for all applications and sets it to 26 for the following applications: 
- WGLLIFC030
- WGLPCFC030
- WGSLIFC030
- WGSPCFC030
- WGTLIFC030
- WGTPCFC030

...and feeds the value to MIP via the pedigree.yaml file

**How to prepare for test**:
- [x] ssh to hasta/clinical-db depending on type of change
- [x] install on stage:
`bash servers/resources/hasta.sclifelab.se/update-cg-stage.sh feat/min-depth-on-applications`
- [x] install on stage:
`bash servers/resources/clinical-db.sclifelab.se/update-clinical-api-stage.sh feat/min-depth-on-applications`


**How to test**:
- [x] run scripts/add-min_depth_to_application.sql
- [x] run cg workflow mip-dna config-case -d poeticox

**Expected test outcome**:
- [x] Check that the min sequencing depth column appears in the Application view of status db stage
- [x] Check that output from the cg command includes `'expected_coverage': 26`
- [x] Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @emmser @b4ckm4n @moahaegglund 
- [x] tests executed by @emmser @b4ckm4n @moahaegglund 
- [x] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
