### PR TITLE
Adds dry-run option to scout clean command

### DIFF
--- a/cg/cli/clean.py
+++ b/cg/cli/clean.py
@@ -78,8 +78,9 @@ def mip(context, yes, sample_info):
 @clean.command()
 @click.argument("bundle")
 @click.option("-y", "--yes", is_flag=True, help="skip checks")
+@click.oprtion("-d", "--dry-run", is_flag=True, help="show files that would be cleaned")
 @click.pass_context
-def scout(context, bundle, yes):
+def scout(context, bundle, yes, dry_run):
     files = []
     for tag in ["bam", "bai", "bam-index"]:
         files.extend(context.obj["hk"].get_files(bundle=bundle, tags=[tag]))
@@ -92,17 +93,22 @@ def scout(context, bundle, yes):
         if yes or click.confirm(question):
             file_name = file_obj.full_path
             if file_obj.is_included and Path(file_name).exists():
-                Path(file_name).unlink()
+                if not dry_run:
+                    Path(file_name).unlink()
 
-            file_obj.delete()
-            context.obj["hk"].commit()
-            click.echo(f"{file_name} deleted")
+            if not dry_run:
+                file_obj.delete()
+                context.obj["hk"].commit()
+                click.echo(f"{file_name} deleted")
 
 
 @clean.command()
 @click.option("-y", "--yes", is_flag=True, help="skip checks")
+@click.oprtion(
+    "-d", "--dry-run", is_flag=True, help="Shows cases and files that would be cleaned"
+)
 @click.pass_context
-def scoutauto(context, yes):
+def scoutauto(context, yes, dry_run):
     """Automatically clean up solved and archived scout cases"""
     bundles = []
     for status in "archived", "solved":
@@ -116,7 +122,7 @@ def scoutauto(context, yes):
         LOG.info(f"{cases_added} cases marked for bam removal :)")
 
     for bundle in bundles:
-        context.invoke(scout, bundle=bundle, yes=yes)
+        context.invoke(scout, bundle=bundle, yes=yes, dry_run=dry_run)
 
 
 @clean.command()

--- a/cg/cli/clean.py
+++ b/cg/cli/clean.py
@@ -78,7 +78,7 @@ def mip(context, yes, sample_info):
 @clean.command()
 @click.argument("bundle")
 @click.option("-y", "--yes", is_flag=True, help="skip checks")
-@click.oprtion("-d", "--dry-run", is_flag=True, help="show files that would be cleaned")
+@click.option("-d", "--dry-run", is_flag=True, help="show files that would be cleaned")
 @click.pass_context
 def scout(context, bundle, yes, dry_run):
     files = []
@@ -104,7 +104,7 @@ def scout(context, bundle, yes, dry_run):
 
 @clean.command()
 @click.option("-y", "--yes", is_flag=True, help="skip checks")
-@click.oprtion(
+@click.option(
     "-d", "--dry-run", is_flag=True, help="Shows cases and files that would be cleaned"
 )
 @click.pass_context

--- a/cg/cli/clean.py
+++ b/cg/cli/clean.py
@@ -82,7 +82,7 @@ def mip(context, yes, sample_info):
 @click.pass_context
 def scout(context, bundle, yes, dry_run):
     files = []
-    for tag in ["bam", "bai", "bam-index"]:
+    for tag in ["bam", "bai", "bam-index", "cram", "crai", "cram-index"]:
         files.extend(context.obj["hk"].get_files(bundle=bundle, tags=[tag]))
     for file_obj in files:
         if file_obj.is_included:


### PR DESCRIPTION
This adds a dry-run option for removing bam-files from solved/archived cases in scout.

**How to prepare for test**:
- [ ] ssh to hasta
- [ ] install on stage:
`bash servers/resources/hasta.sclifelab.se/update-cg-stage.sh dry-clean`
- [ ] assure there are cases in scout marked as solved/archived (if there are none, enter scout-stage in the browser and mark as solved by pinning a causative variant)

**How to test**:
- [ ] source stage env `us`
- [ ] run `cg clean scoutauto --dry-run` (In interactive mode)
- [ ] run `cg clean scoutauto --dry-run --yes` (Non-interactive)


**Expected test outcome**:
- [ ] Files that have been logged by the command still exist!
- [ ] Will only log files for cases that have been solved/archived in scout

**Review:**
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
