### PR TITLE
Add option for time-limit when cleaning bam-files

### DIFF
--- a/cg/cli/clean.py
+++ b/cg/cli/clean.py
@@ -85,7 +85,7 @@ def mip(context, yes, case_id, sample_info, dry_run: bool = False):
 @click.option("-d", "--dry-run", is_flag=True, help="show files that would be cleaned")
 @click.pass_context
 def scout(context, bundle, yes: bool = False, dry_run: bool = False):
-    """Clean bam related files for a bundle in Housekeeper"""
+    """Clean alignment related files for a bundle in Housekeeper"""
     files = []
     for tag in ["bam", "bai", "bam-index", "cram", "crai", "cram-index"]:
         files.extend(context.obj["hk"].get_files(bundle=bundle, tags=[tag]))
@@ -113,7 +113,7 @@ def scout(context, bundle, yes: bool = False, dry_run: bool = False):
     "--days-old",
     type=int,
     default=300,
-    help="Clean bam files with analysis dates oldar then given number of days",
+    help="Clean alignment files with analysis dates oldar then given number of days",
 )
 @click.option("-y", "--yes", is_flag=True, help="skip checks")
 @click.option(

--- a/cg/cli/clean.py
+++ b/cg/cli/clean.py
@@ -109,7 +109,6 @@ def scout(context, bundle, yes: bool = False, dry_run: bool = False):
 
 @clean.command()
 @click.option(
-    "-o",
     "--days-old",
     type=int,
     default=300,

--- a/cg/cli/clean.py
+++ b/cg/cli/clean.py
@@ -108,12 +108,19 @@ def scout(context, bundle, yes: bool = False, dry_run: bool = False):
 
 
 @clean.command()
+@click.option(
+    "-o",
+    "--days-old",
+    type=int,
+    default=30,
+    help="Clean bam files with analysis dates oldar then given number of days",
+)
 @click.option("-y", "--yes", is_flag=True, help="skip checks")
 @click.option(
     "-d", "--dry-run", is_flag=True, help="Shows cases and files that would be cleaned"
 )
 @click.pass_context
-def scoutauto(context, yes: bool = False, dry_run: bool = False):
+def scoutauto(context, days_old: int, yes: bool = False, dry_run: bool = False):
     """Automatically clean up solved and archived scout cases"""
     bundles = []
     for status in "archived", "solved":
@@ -121,7 +128,7 @@ def scoutauto(context, yes: bool = False, dry_run: bool = False):
         cases_added = 0
         for case in cases:
             x_days_ago = datetime.now() - case.get("analysis_date")
-            if x_days_ago.days > 30:
+            if x_days_ago.days > days_old:
                 bundles.append(case.get("_id"))
                 cases_added += 1
         LOG.info("%s cases marked for bam removal :)", cases_added)

--- a/cg/cli/clean.py
+++ b/cg/cli/clean.py
@@ -112,7 +112,7 @@ def scout(context, bundle, yes: bool = False, dry_run: bool = False):
     "-o",
     "--days-old",
     type=int,
-    default=90,
+    default=300,
     help="Clean bam files with analysis dates oldar then given number of days",
 )
 @click.option("-y", "--yes", is_flag=True, help="skip checks")

--- a/cg/cli/clean.py
+++ b/cg/cli/clean.py
@@ -112,7 +112,7 @@ def scout(context, bundle, yes: bool = False, dry_run: bool = False):
     "-o",
     "--days-old",
     type=int,
-    default=30,
+    default=90,
     help="Clean bam files with analysis dates oldar then given number of days",
 )
 @click.option("-y", "--yes", is_flag=True, help="skip checks")


### PR DESCRIPTION
This PR adds option to clean bam-files for cases with an analysis data older than a given number of days, e.g.
```cg clean scoutauto --days-old <int> --dry-run``` 

**How to prepare for test**:
install branch on stage

**How to test**:
- us
- ```cg clean scoutauto --days-old 400--dry-run``` 

**Expected test outcome**:
- [ ] case found should be solved or archived before 400 days ago

**Review:**
- [x] code approved by @patrikgrenfeldt 
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
