### PR TITLE
Missing prep method

### DIFF
--- a/cg/apps/lims/constants.py
+++ b/cg/apps/lims/constants.py
@@ -64,6 +64,10 @@ MASTER_STEPS_UDFS = {
             "method_number": "Method document",
             "method_version": "Method document version",
         },
+        "End repair Size selection A-tailing and Adapter ligation (TruSeq PCR-free DNA)": {
+            "method_number": "Method document",
+            "method_version": "Method document version",
+        },
         "obsolete_CG002 - Hybridize Library  (SS XT)": {
             "method_number": "Method document",
             "method_version": "Method document versio",

--- a/cg/apps/lims/constants.py
+++ b/cg/apps/lims/constants.py
@@ -86,6 +86,10 @@ MASTER_STEPS_UDFS = {
             "method_number": "Method Document 1",
             "method_version": "Document 1 Version",
         },
+        "Define Run Format and Calculate Volumes (Nova Seq)": {
+            "method_number": "Method",
+            "method_version": "Version",
+        },
     },
     "delivery_method_step": {
         "CG002 - Delivery": {


### PR DESCRIPTION
Prep method and sequencing method are missing in some delivery reports. Below is an example. 

![Screenshot 2020-03-11 at 11 33 36](https://user-images.githubusercontent.com/1306333/76507993-fe4dea80-644d-11ea-8a70-62822a0b03b3.png)

This PR should solve the problem. I want to test the change by running 

`cg upload delivery-report maindrum -p`


The command gives this error:

![Skärmavbild 2020-03-17 kl  09 18 19](https://user-images.githubusercontent.com/1306333/76835983-53b04000-6830-11ea-9f8a-838b264ec103.png)



**How to prepare for test**:
- [x] ssh to clinical-db and become hiseq.clinical user:
then run the folowing to copy the housekeeper database from prod to stage:
bash /home/proj/stage/servers/resources/clinical-db.scilifelab.se/dbcopy-prod-to-stage.sh housekeeper
- [x] ssh to hasta 
- [x] install on stage:
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh update_constants`
activate stage: `usestage`
- [x] change the lims host to "https://clinical-lims.scilifelab.se" in 
/home/proj/stage/servers/config/hasta.scilifelab.se/cg-stage.yaml

**How to test**:
run `cg upload delivery-report maindrum -p`

**Expected test outcome**:
Sequencing and prep methods should be given for the two samples from 2020. 

**Review:**
- [x] code approved by @henrikstranneheim 
- [x] tests executed by @mayabrandi 
- [x] "Merge and deploy" approved by @barrystokman 
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
