### PR TITLE
Assure a version is found for bundle

### DIFF
--- a/cg/cli/clean.py
+++ b/cg/cli/clean.py
@@ -146,9 +146,10 @@ def hk_past_files(context, case_id, tags, yes, dry_run):
         cases = context.obj["db"].families()
     for case in cases:
         case_id = case.internal_id
-        last_version = context.obj["hk"].last_version(bundle=case_id)
-        if not last_version:
+        bundle = context.obj["hk"].bundle(case_id)
+        if not bundle:
             continue
+        last_version = context.obj["hk"].last_version(bundle=case_id)
         last_version_file_paths = [
             Path(hk_file.full_path)
             for hk_file in context.obj["hk"].get_files(

--- a/cg/cli/clean.py
+++ b/cg/cli/clean.py
@@ -151,7 +151,9 @@ def hk_past_files(context, case_id, tags, yes, dry_run):
             continue
         last_version_file_paths = [
             Path(hk_file.full_path)
-            for hk_file in context.obj["hk"].get_files(bundle=case_id, version=last_version.id)
+            for hk_file in context.obj["hk"].get_files(
+                bundle=case_id, tags=None, version=last_version.id
+            )
         ]
         LOG.info("Searching %s bundle for outdated files", case_id)
         hk_files = []

--- a/cg/cli/clean.py
+++ b/cg/cli/clean.py
@@ -147,6 +147,8 @@ def hk_past_files(context, case_id, tags, yes, dry_run):
     for case in cases:
         case_id = case.internal_id
         last_version = context.obj["hk"].last_version(bundle=case_id)
+        if not last_version:
+            continue
         last_version_file_paths = [
             Path(hk_file.full_path)
             for hk_file in context.obj["hk"].get_files(bundle=case_id, version=last_version.id)


### PR DESCRIPTION
This PR fixes the `cg clean hk-past-files` command so that it does not throw an exception when a hk bundle is not found for a case.

**How to prepare for test**:
- [x] ssh to hasta
- [x] install on stage:
`bash servers/resources/hasta.scilifelab.se/update-cg-stage.sh clean-old-hk-fix`

**How to test**:
- [x] login to hasta
- [x] do `us`
- [x] do `cg clean hk-past-files --dry-run --yes -t cram -t cram-index -t bam -t bam-index`

**Expected test outcome**:
- [x] check that command does not throw an exception

![Screen Shot 2020-03-27 at 15 48 36](https://user-images.githubusercontent.com/42931633/77768303-94833280-7042-11ea-9619-5fee7be1eae2.png)


**Review:**
- [ ] code approved by
- [x] tests executed by @adrosenbaum 
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
