### PR TITLE
continue loop if last version not found

### DIFF
--- a/cg/cli/clean.py
+++ b/cg/cli/clean.py
@@ -146,9 +146,6 @@ def hk_past_files(context, case_id, tags, yes, dry_run):
         cases = context.obj["db"].families()
     for case in cases:
         case_id = case.internal_id
-        bundle = context.obj["hk"].bundle(case_id)
-        if not bundle:
-            continue
         last_version = context.obj["hk"].last_version(bundle=case_id)
         if not last_version:
             continue

--- a/cg/cli/clean.py
+++ b/cg/cli/clean.py
@@ -150,6 +150,8 @@ def hk_past_files(context, case_id, tags, yes, dry_run):
         if not bundle:
             continue
         last_version = context.obj["hk"].last_version(bundle=case_id)
+        if not last_version:
+            continue
         last_version_file_paths = [
             Path(hk_file.full_path)
             for hk_file in context.obj["hk"].get_files(


### PR DESCRIPTION
This PR fixes so that if a bundle without a `last_version` is found, the hk clean up command does not throw an exception.
**How to prepare for test**:

**How to test**:
- [x]  us
- [x] cg clean hk-past-files --dry-run --yes -t cram -t cram-index -t bam -t bam-index

**Expected test outcome**:
- [x] no errors 
![image](https://user-images.githubusercontent.com/6697636/77892000-29b83e00-7272-11ea-98b1-18bea2fd2fbd.png)

**Review:**
- [x] code approved by @patrikgrenfeldt 
- [x] tests executed by @patrikgrenfeldt 
- [x] "Merge and deploy" approved by @patrikgrenfeldt 
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
