### PR TITLE
get from udf bait set instead of capture library version

### DIFF
--- a/cg/apps/lims/api.py
+++ b/cg/apps/lims/api.py
@@ -170,7 +170,7 @@ class LimsAPI(Lims, OrderHandler):
         capture_kits = set()
 
         lims_sample = Sample(self, id=lims_id)
-        capture_kit = lims_sample.udf.get("Capture Library version")
+        capture_kit = lims_sample.udf.get("Bait Set")
 
         if capture_kit and capture_kit != "NA":
             return capture_kit


### PR DESCRIPTION
This PR modifes how cg gets the target bed file for analysis for mip rd dna:
- From lims for application_type: "tga", "wes"
- From constant for application type: "wgs"
- For "tga", "wes", a lims capture kit must be set or cg will raise an exception

**How to prepare for test**:
- [x] ssh to hasta
- [x] Install on stage:
`bash /home/proj/stage/servers/resources/hasta.scilifelab.se/update-cg-stage.sh  fix/use-bait-set-as-capture-kit`

**How to test**:
1. Run wes case: `cg workflow mip-dna config-case bossghoul --dry`
1. Run wgs case:`cg workflow mip-dna config-case justhusky --dry`
1. Run wes case: `cg workflow mip-dna config-case strongbison --dry`
1. Run wes case: `cg workflow mip-dna config-case livingcaiman --dry`
1. Run panel case: `cg workflow mip-dna config-case sureemu --dry`

**Expected test outcome**:
1. Check that the capture kit is `twistexomerefseq_9.1_hg19_design.bed` for sample: ACC6390A1  
1. Check that the samples has capture kit: `twistexomerefseq_9.1_hg19_design.bed` 
1. Check that the strongbison get a LIMS ERROR since it does not have a "Bait set" in lims-stage
1. Check that livincaiman has capture kit: `twistexomerefseq_9.1_hg19_design.bed`
1. Check that sureemu has capture kit: `gmcksolid_4.1_hg19_design.bed`


**Review:**
- [x] code approved by @henrikstranneheim 
- [x] tests executed by @henrikstranneheim 
- [x] "Merge and deploy" approved by @patrikgrenfeldt 
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
