### PR TITLE
Lims dates: Remove faulty error message code

### DIFF
--- a/cg/apps/lims/api.py
+++ b/cg/apps/lims/api.py
@@ -404,14 +404,9 @@ class LimsAPI(Lims, OrderHandler):
                 all_artifacts.append(artifact)
 
         if all_artifacts and not dates:
-            udfs = " ,".join(set(step_names_udfs.values()))
-            process_ids = " ,".join(set(processes))
             LOG.warning(
-                "Did not find date for sample %s. Searched for udfs: %s. Searched in "
-                "processes: %s.",
-                lims_id,
-                udfs,
-                process_ids,
+                "Did not find expected date for sample: %s",
+                lims_id
             )
         return dates
 


### PR DESCRIPTION
This PR removes the broken code when creating error message when fetching dates  from lims

**How to prepare for test**:
- [ ] ssh to hasta (depending on type of change)
- [ ] install on stage:
`bash servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`
- [ ] ssh to clinical-db (depending on type of change)
- [ ] install on stage:
`bash servers/resources/clinical-db.scilifelab.se/update-clinical-api-stage.sh [THIS-BRANCH-NAME]`

**How to test**:
- [ ] login to ...
- [ ] do ...

**Expected test outcome**:
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
