### PR TITLE
set bait set udf

### DIFF
--- a/cg/apps/lims/constants.py
+++ b/cg/apps/lims/constants.py
@@ -47,10 +47,7 @@ MASTER_STEPS_UDFS = {
         "Aggregate QC (Library Validation) (RNA) v2",
         "Aggregate QC (Library Validation)",
     },
-    "delivery_step": {
-        "CG002 - Delivery": "Date delivered",
-        "Delivery v1": "Date delivered",
-    },
+    "delivery_step": {"CG002 - Delivery": "Date delivered", "Delivery v1": "Date delivered"},
     "sequenced_step": {
         "CG002 - Illumina Sequencing (HiSeq X)": "Finish Date",
         "CG002 - Illumina Sequencing (Illumina SBS)": "Finish Date",
@@ -101,13 +98,8 @@ MASTER_STEPS_UDFS = {
             "method_number": "Method Document",
             "method_version": "Method Version",
         },
-        "Delivery v1": {
-            "method_number": "Method Document",
-            "method_version": "Method Version",
-        },
+        "Delivery v1": {"method_number": "Method Document", "method_version": "Method Version"},
     },
 }
 
-PROCESSES = {
-    "sequenced_date": "AUTOMATED - NovaSeq Run",
-}
+PROCESSES = {"sequenced_date": "AUTOMATED - NovaSeq Run"}

--- a/cg/apps/lims/constants.py
+++ b/cg/apps/lims/constants.py
@@ -1,5 +1,6 @@
 PROP2UDF = {
     "application": "Sequencing Analysis",
+    "bait_set": "Bait Set",
     "capture_kit": "Capture Library version",
     "comment": "Comment",
     "concentration": "Concentration (nM)",


### PR DESCRIPTION
This PR adds possibility to set bait set in lims

**How to prepare for test**:
- [x] ssh to hasta
- [x] us
- [x] install on stage:
`bash servers/resources/hasta.scilifelab.se/update-cg-stage.sh feat/set-bait-set`

**How to test**:
1. Run: `cg workflow mip-dna config-case -d usablestud`
1. Run: `cg set sample BIL2299A1 -kv bait_set agilent_sureselect_cre_11.1`
1. Run: `cg set sample BIL2299A2 -kv bait_set agilent_sureselect_cre_11.1`
1. Run: `cg set sample BIL2299A3 -kv bait_set agilent_sureselect_cre_11.1`
1. Run: `cg workflow mip-dna config-case -d usablestud`

**Expected test outcome**:
- [x]  cg workflow mip-dna config-case -d usablestud` should fail with a LIMS error
- [x] Check in lims that the expected value was set for the samples
- [x]  cg workflow mip-dna config-case -d usablestud` should print a config since the lims bait set is set for each sample

**Review:**
- [x] code approved by @henrikstranneheim 
- [x] tests executed by @henrikstranneheim 
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
