### PR TITLE
Delivery-report: skip adding before including file

### DIFF
--- a/cg/cli/upload/delivery_report.py
+++ b/cg/cli/upload/delivery_report.py
@@ -117,8 +117,8 @@ def delivery_report(context, family_id, print_console, force_report):
         is_bundle_missing_delivery_report = number_of_delivery_reports == 0
 
         if is_bundle_missing_delivery_report:
-            file_obj = hk_api.add_file(
-                delivery_report_file.name, version_obj, delivery_report_tag_name
+            file_obj = hk_api.new_file(
+                delivery_report_file.name, tags=[delivery_report_tag_name]
             )
             hk_api.include_file(file_obj, version_obj)
             hk_api.add_commit(file_obj)


### PR DESCRIPTION
This PR fixes the problem that arises when the report is first added and THEN included in HK

**How to prepare for test**:
- [ ] ssh to hasta (depending on type of change)
- [ ] install on stage:
`bash servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`
- [ ] do housekeeper get CASE_ID -t delivery-report
- [ ] check that the delivery report is not created under the bundle-root

**How to test**:
- [ ] login to hasta 
- [ ] do cg upload delivery report CASE_ID
- [ ] do housekeeper get CASE_ID -t delivery-report

**Expected test outcome**:
- [ ] check that the delivery report is created under the bundle-version
- [ ] check that the delivery report is not created under the bundle-root
- [ ] Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
