### PR TITLE
refactor, change balsamic command for store 

### DIFF
--- a/cg/cli/workflow/balsamic/store.py
+++ b/cg/cli/workflow/balsamic/store.py
@@ -93,7 +93,7 @@ def generate_deliverables_file(context, dry, config_path, case_id):
         config_path = Path.joinpath(root_dir, case_id, case_id + ".json")
 
     # Call Balsamic
-    command_str = f" plugins deliver" f" --sample-config {config_path}'"
+    command_str = f" report deliver" f" --sample-config {config_path}'"
 
     command = [f"bash -c 'source activate {conda_env}; balsamic"]
     command.extend(command_str.split(" "))

--- a/tests/cli/workflow/balsamic/store/test_generate_deliverables_file.py
+++ b/tests/cli/workflow/balsamic/store/test_generate_deliverables_file.py
@@ -31,7 +31,7 @@ def test_dry(cli_runner, balsamic_context, balsamic_case):
 
     # THEN command should print the balsamic command-string to generate the deliverables fils
     assert result.exit_code == EXIT_SUCCESS
-    assert "plugins deliver" in result.output
+    assert "report deliver" in result.output
     assert case_id in result.output
 
 
@@ -47,7 +47,7 @@ def test_without_file(cli_runner, balsamic_context, balsamic_case):
 
     # THEN we should get a message that the deliverables file was created
     assert result.exit_code == EXIT_SUCCESS
-    assert "plugins deliver" in result.output
+    assert "report deliver" in result.output
     assert "--sample-config" in result.output
     assert ".json" in result.output
 


### PR DESCRIPTION
This PR updates balsamic's command to reflect release `4.2.2` : https://balsamic.readthedocs.io/en/v4.2.2/modules.html#balsamic-report-deliver

**How to prepare for test**:

- [X] ssh to hasta (depending on type of change)
- [ ] ~install on stage:~
`bash servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`
- [ ] ~ssh to clinical-db (depending on type of change)~
- [ ] ~install on stage:~
`bash servers/resources/clinical-db.scilifelab.se/update-clinical-api-stage.sh [THIS-BRANCH-NAME]`

**How to test**:
- [X] `cg --config ~/repos/servers/config/hasta.scilifelab.se/cg-stage.yaml workflow balsamic store generate-deliverables-file firmshiner --dry-run`

**Expected test outcome**:
- [X] check that it print `balsamic report deliver`
- [X] Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [X] tests executed by @hassanfa
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
