### PR TITLE
Only create reports for mip

### DIFF
--- a/cg/store/api/status.py
+++ b/cg/store/api/status.py
@@ -573,6 +573,11 @@ class StatusHandler(BaseHandler):
             self.Analysis.query.filter(models.Analysis.uploaded_at)
             .join(models.Family, models.Family.links, models.FamilySample.sample)
             .filter(
+                or_(
+                    models.Sample.data_analysis.is_(None), models.Sample.data_analysis != "Balsamic"
+                )
+            )
+            .filter(
                 models.Sample.delivered_at.isnot(None),
                 or_(
                     models.Analysis.delivery_report_created_at.is_(None),


### PR DESCRIPTION
This PR fixes the problem that comes when we try to create reports for non mip samples

**How to prepare for test**:
- [x] ssh to hasta (depending on type of change)
- [x] install on stage:
`bash servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

**How to test exclusion of balsamic **:
- [x] login to hasta
- [x] us
- [x] set data_analysis to "Balsamic" on all samples
- [x] cg upload delivery-reports

**Expected test outcome**:
- [x] check that no cases are processed

**How to test inclusion of mip 1 **:
- [x] login to hasta
- [x] us
- [x] set data_analysis to "mip" on all samples
- [x] cg upload delivery-reports

**Expected test outcome**:
- [x] check that cases are processed


**How to test inclusion of mip 2 (empty data_analysis) **:
- [x] login to hasta
- [x] us
- [x] set data_analysis to "" on all samples
- [x] cg upload delivery-reports

**Expected test outcome**:
- [x] check that cases are processed


- [x] Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @henrikstranneheim 
- [x] tests executed by @patrikgrenfeldt 
- [x] "Merge and deploy" approved by @barrystokman 
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
