### PR TITLE
add condition fo check if target bed supplied

### DIFF
--- a/cg/cli/workflow/balsamic/base.py
+++ b/cg/cli/workflow/balsamic/base.py
@@ -13,7 +13,7 @@ from cg.apps.balsamic.fastq import FastqHandler
 from cg.cli.workflow.balsamic.store import store as store_cmd
 from cg.cli.workflow.balsamic.deliver import deliver as deliver_cmd, CASE_TAGS, SAMPLE_TAGS
 from cg.cli.workflow.get_links import get_links
-from cg.exc import LimsDataError, BalsamicStartError, CgError
+from cg.exc import LimsDataError, BalsamicStartError
 from cg.meta.deliver import DeliverAPI
 from cg.meta.workflow.base import get_target_bed_from_lims
 from cg.meta.workflow.balsamic import AnalysisAPI

--- a/cg/cli/workflow/balsamic/base.py
+++ b/cg/cli/workflow/balsamic/base.py
@@ -13,7 +13,7 @@ from cg.apps.balsamic.fastq import FastqHandler
 from cg.cli.workflow.balsamic.store import store as store_cmd
 from cg.cli.workflow.balsamic.deliver import deliver as deliver_cmd, CASE_TAGS, SAMPLE_TAGS
 from cg.cli.workflow.get_links import get_links
-from cg.exc import LimsDataError, BalsamicStartError
+from cg.exc import LimsDataError, BalsamicStartError, CgError
 from cg.meta.deliver import DeliverAPI
 from cg.meta.workflow.base import get_target_bed_from_lims
 from cg.meta.workflow.balsamic import AnalysisAPI
@@ -190,10 +190,11 @@ def config_case(
         else:
             normal_paths.add(concatenated_paths[1])
 
-        target_bed_filename = get_target_bed_from_lims(
-            context.obj["lims_api"], context.obj["db"], link_obj.sample.internal_id
-        )
-        target_beds.add(target_bed_filename)
+        if not target_bed:
+            target_bed_filename = get_target_bed_from_lims(
+                context.obj["lims_api"], context.obj["db"], link_obj.sample.internal_id
+            )
+            target_beds.add(target_bed_filename)
 
     if len(application_types) != 1:
         raise BalsamicStartError(


### PR DESCRIPTION
This PR fixes the orblem supplying target bed at command line when starting balsamic

**How to prepare for test**:
- [x] ssh to hasta (depending on type of change)
- [x] install on stage:
`bash servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

**How to test**:
- [x] login to hasta
- [x] cg --log-level=DEBUG workflow balsamic config-case --target-bed /home/proj/production/cancer/reference/panel/gmcksolid_4.1_hg19_design.bed usablecod -d

**Expected test outcome**:
- [x] check that the bed is the supplied one and not fetched from LIMS
- [x] Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @patrikgrenfeldt 
- [x] tests executed by @patrikgrenfeldt 
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
