### PR TITLE
Adjusting for new vogue config

### DIFF
--- a/cg/apps/vogue.py
+++ b/cg/apps/vogue.py
@@ -17,8 +17,9 @@ class VogueAPI:
 
     def __init__(self, config: dict):
         super(VogueAPI, self).__init__()
+        self.vogue_config = config["vogue"]["config_path"]
         self.vogue_binary = config["vogue"]["binary_path"]
-        self.process = Process(binary=self.vogue_binary)
+        self.process = Process(binary=self.vogue_binary, config=self.vogue_config)
 
     def load_genotype_data(self, genotype_dict: dict):
         """Load genotype data from a dict."""

--- a/tests/apps/vogue/conftest.py
+++ b/tests/apps/vogue/conftest.py
@@ -5,7 +5,7 @@
 import pytest
 from cg.apps.vogue import VogueAPI
 
-CONFIG = {"vogue": {"binary_path": "gtdb", "config_path": "vogue_config"}}
+CONFIG = {"vogue": {"binary_path": "/path/to/vogue", "config_path": "vogue_config"}}
 
 
 @pytest.fixture(scope="function")

--- a/tests/apps/vogue/conftest.py
+++ b/tests/apps/vogue/conftest.py
@@ -5,7 +5,7 @@
 import pytest
 from cg.apps.vogue import VogueAPI
 
-CONFIG = {"vogue": {"binary_path": "gtdb"}}
+CONFIG = {"vogue": {"binary_path": "gtdb", "config_path": "vogue_config"}}
 
 
 @pytest.fixture(scope="function")

--- a/tests/meta/upload/vogue/conftest.py
+++ b/tests/meta/upload/vogue/conftest.py
@@ -14,17 +14,11 @@ GTCONFIG = {
         "binary_path": "/path/to/genotype_path",
     }
 }
-VOGUECONFIG = {
-    "vogue": {"binary_path": "/path/to/vogue_path", "config_path": "vogue_config"}
-}
+VOGUECONFIG = {"vogue": {"binary_path": "/path/to/vogue_path", "config_path": "vogue_config"}}
 
-GENOTYPE_RETURN_SAMPLE = (
-    b'{"ACC5346A3": {"status":"pass"}, "SIB903A19": {"status":"pass"}}'
-)
+GENOTYPE_RETURN_SAMPLE = b'{"ACC5346A3": {"status":"pass"}, "SIB903A19": {"status":"pass"}}'
 
-GENOTYPE_RETURN_SAMPLE_ANALYSIS = (
-    b'{"ACC5346A3": {"snp": {}}, "SIB903A19": {"snp": {}}}'
-)
+GENOTYPE_RETURN_SAMPLE_ANALYSIS = b'{"ACC5346A3": {"snp": {}}, "SIB903A19": {"snp": {}}}'
 
 
 @pytest.fixture(scope="function")

--- a/tests/meta/upload/vogue/conftest.py
+++ b/tests/meta/upload/vogue/conftest.py
@@ -14,7 +14,7 @@ GTCONFIG = {
         "binary_path": "/path/to/genotype_path",
     }
 }
-VOGUECONFIG = {"vogue": {"binary_path": "/path/to/vogue_path"}}
+VOGUECONFIG = {"vogue": {"binary_path": "/path/to/vogue_path", "config_path": "vogue_config"}}
 
 GENOTYPE_RETURN_SAMPLE = (
     b'{"ACC5346A3": {"status":"pass"}, "SIB903A19": {"status":"pass"}}'

--- a/tests/meta/upload/vogue/conftest.py
+++ b/tests/meta/upload/vogue/conftest.py
@@ -14,7 +14,9 @@ GTCONFIG = {
         "binary_path": "/path/to/genotype_path",
     }
 }
-VOGUECONFIG = {"vogue": {"binary_path": "/path/to/vogue_path", "config_path": "vogue_config"}}
+VOGUECONFIG = {
+    "vogue": {"binary_path": "/path/to/vogue_path", "config_path": "vogue_config"}
+}
 
 GENOTYPE_RETURN_SAMPLE = (
     b'{"ACC5346A3": {"status":"pass"}, "SIB903A19": {"status":"pass"}}'


### PR DESCRIPTION
This PR addjusts cg to run vogue with config. 

**How to prepare for test**:
On hasta

1.  cd /home/proj/stage/servers/resources/hasta.scilifelab.se

2. bash update-servers-stage.sh vogue_alias

3. bash update-cg-stage.sh vogue_config

4. bash update-vogue-stage.sh master

5. run:

```
usestage
cg upload vogue genotype -d 300
```

**Expected test outcome**:
Something like this:
```
----------------- UPLOAD ----------------------
----------------- TRENDING -----------------------
----------------- GENOTYPE -----------------------
vogue output: INFO:vogue.adapter.plugin:Use database vogue-stage.
vogue output: INFO:vogue.load.genotype:Trying to build json
vogue output: INFO:vogue.adapter.plugin:No updates for sample ADM1464A1.
...
```

**Review:**
- [X] code approved by @barrystokman 
- [x] tests executed by MB
- [x] "Merge and deploy" approved by @barrystokman 
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
