### PR TITLE
fixing bug. process_type argument can not be a string

### DIFF
--- a/cg/apps/lims/api.py
+++ b/cg/apps/lims/api.py
@@ -110,11 +110,9 @@ class LimsAPI(Lims, OrderHandler):
         step_names_udfs = MASTER_STEPS_UDFS["prepared_step"]
         prepared_dates = []
 
-        for process_type in step_names_udfs:
-            artifacts = self.get_artifacts(process_type=process_type, samplelimsid=lims_id)
-
-            for artifact in artifacts:
-                prepared_dates.append(parse_date(artifact.parent_process.date_run))
+        artifacts = self.get_artifacts(process_type=step_names_udfs, samplelimsid=lims_id)
+        for artifact in artifacts:
+            prepared_dates.append(parse_date(artifact.parent_process.date_run))
 
         if prepared_dates:
             sorted_dates = sorted(prepared_dates, reverse=True)


### PR DESCRIPTION
This fixes a bug. The process_type argument to the get_artifacts function requires a list. String was given. 

**How to prepare for test**:
- [ ] ssh to hasta 
- [ ] install on stage:
`bash servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

**How to test**:
- [ ] run `cg transfer lims --status prepared`

**Expected test outcome**:
- [ ] check that prepared date is added to this sample ACC6874A10
- [ ] Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
