### PR TITLE
Update api.py

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,6 +1,6 @@
 # Steps
 
-When all tests are ready and PR is approved follow these steps
+When all tests done and successful and PR is approved, follow these steps:
 
 1. Merge branch to master
 1. Bumpversion according to specifications, eg. `bumpversion <patch/minor/major>`
@@ -15,5 +15,5 @@ When all tests are ready and PR is approved follow these steps
     1.`up`
     1. `bash update-cg-prod.sh`
     1. make sure that installation was successful
-1. Take a screenshot and post as a comment on the PR. Screenshot should include environment and that it succeded
+1. Take a screenshot and post as a comment on the PR. Screenshot should include environment and that it succeeded
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -9,6 +9,7 @@ When all tests done and successful and PR is approved, follow these steps:
 1. Log into relevant serves with `ssh <hasta/clinical-db>`
 1. Deploy master to stage
     1.`us`
+    1. Request stage environment `paxa` and follow instructions
     1. `bash update-cg-stage.sh master`
     1. make sure that installation was successful
 1. Deploy master to stage

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,19 @@
+# Steps
+
+When all tests are ready and PR is approved follow these steps
+
+1. Merge branch to master
+1. Bumpversion according to specifications, eg. `bumpversion <patch/minor/major>`
+1. Push commit directly to master `git push`
+1. Push commit directly to master `git push --tag`
+1. Log into relevant serves with `ssh <hasta/clinical-db>`
+1. Deploy master to stage
+    1.`us`
+    1. `bash update-cg-stage.sh master`
+    1. make sure that installation was successful
+1. Deploy master to stage
+    1.`up`
+    1. `bash update-cg-prod.sh`
+    1. make sure that installation was successful
+1. Take a screenshot and post as a comment on the PR. Screenshot should include environment and that it succeded
+

--- a/cg/apps/lims/api.py
+++ b/cg/apps/lims/api.py
@@ -97,7 +97,7 @@ class LimsAPI(Lims, OrderHandler):
             return sample.udf.get("Received at")
         except:
             return None
-        
+
     def get_prepared_date(self, lims_id: str) -> dt.datetime:
         """Get the date when a sample was prepared in the lab."""
 

--- a/cg/apps/lims/api.py
+++ b/cg/apps/lims/api.py
@@ -42,9 +42,7 @@ class LimsAPI(Lims, OrderHandler):
 
     def __init__(self, config):
         lconf = config["lims"]
-        super(LimsAPI, self).__init__(
-            lconf["host"], lconf["username"], lconf["password"]
-        )
+        super(LimsAPI, self).__init__(lconf["host"], lconf["username"], lconf["password"])
 
     def sample(self, lims_id: str):
         """Fetch a sample from the LIMS database."""
@@ -54,9 +52,7 @@ class LimsAPI(Lims, OrderHandler):
 
     def samples_in_pools(self, pool_name, projectname):
         """Fetch all samples from a pool"""
-        return self.get_samples(
-            udf={"pool name": str(pool_name)}, projectname=projectname
-        )
+        return self.get_samples(udf={"pool name": str(pool_name)}, projectname=projectname)
 
     @staticmethod
     def _export_project(lims_project) -> dict:
@@ -64,9 +60,7 @@ class LimsAPI(Lims, OrderHandler):
         return {
             "id": lims_project.id,
             "name": lims_project.name,
-            "date": parse_date(lims_project.open_date)
-            if lims_project.open_date
-            else None,
+            "date": parse_date(lims_project.open_date) if lims_project.open_date else None,
         }
 
     def _export_sample(self, lims_sample):
@@ -83,9 +77,7 @@ class LimsAPI(Lims, OrderHandler):
             "mother": udfs.get("motherID"),
             "source": udfs.get("Source"),
             "status": udfs.get("Status"),
-            "panels": udfs.get("Gene List").split(";")
-            if udfs.get("Gene List")
-            else None,
+            "panels": udfs.get("Gene List").split(";") if udfs.get("Gene List") else None,
             "priority": udfs.get("priority"),
             "received": self.get_received_date(lims_sample.id),
             "application": udfs.get("Sequencing Analysis"),
@@ -178,9 +170,7 @@ class LimsAPI(Lims, OrderHandler):
         """Bypass to original method."""
         lims_samples = super(LimsAPI, self).get_samples(*args, **kwargs)
         if map_ids:
-            lims_map = {
-                lims_sample.name: lims_sample.id for lims_sample in lims_samples
-            }
+            lims_map = {lims_sample.name: lims_sample.id for lims_sample in lims_samples}
             return lims_map
 
         return lims_samples
@@ -189,9 +179,7 @@ class LimsAPI(Lims, OrderHandler):
         """Fetch information about a family of samples."""
         filters = {"customer": customer, "familyID": family}
         lims_samples = self.get_samples(udf=filters)
-        samples_data = [
-            self._export_sample(lims_sample) for lims_sample in lims_samples
-        ]
+        samples_data = [self._export_sample(lims_sample) for lims_sample in lims_samples]
         # get family level data
         family_data = {"family": family, "customer": customer, "samples": []}
         priorities = set()
@@ -229,12 +217,7 @@ class LimsAPI(Lims, OrderHandler):
                 yield lims_sample.id
 
     def update_sample(
-        self,
-        lims_id: str,
-        sex=None,
-        target_reads: int = None,
-        name: str = None,
-        **kwargs,
+        self, lims_id: str, sex=None, target_reads: int = None, name: str = None, **kwargs,
     ):
         """Update information about a sample."""
         lims_sample = Sample(self, id=lims_id)
@@ -251,8 +234,7 @@ class LimsAPI(Lims, OrderHandler):
         for key, value in kwargs.items():
             if not PROP2UDF.get(key):
                 raise LimsDataError(
-                    f"Unknown how to set {key} in LIMS since it is not defined in"
-                    f" {PROP2UDF}"
+                    f"Unknown how to set {key} in LIMS since it is not defined in" f" {PROP2UDF}"
                 )
             lims_sample.udf[PROP2UDF[key]] = value
 
@@ -331,9 +313,7 @@ class LimsAPI(Lims, OrderHandler):
         methods = []
 
         for process_name in step_names_udfs:
-            artifacts = self.get_artifacts(
-                process_type=process_name, samplelimsid=lims_id
-            )
+            artifacts = self.get_artifacts(process_type=process_name, samplelimsid=lims_id)
             if artifacts:
                 udf_key_number = step_names_udfs[process_name]["method_number"]
                 udf_key_version = step_names_udfs[process_name]["method_version"]

--- a/cg/apps/lims/api.py
+++ b/cg/apps/lims/api.py
@@ -42,7 +42,9 @@ class LimsAPI(Lims, OrderHandler):
 
     def __init__(self, config):
         lconf = config["lims"]
-        super(LimsAPI, self).__init__(lconf["host"], lconf["username"], lconf["password"])
+        super(LimsAPI, self).__init__(
+            lconf["host"], lconf["username"], lconf["password"]
+        )
 
     def sample(self, lims_id: str):
         """Fetch a sample from the LIMS database."""
@@ -52,7 +54,9 @@ class LimsAPI(Lims, OrderHandler):
 
     def samples_in_pools(self, pool_name, projectname):
         """Fetch all samples from a pool"""
-        return self.get_samples(udf={"pool name": str(pool_name)}, projectname=projectname)
+        return self.get_samples(
+            udf={"pool name": str(pool_name)}, projectname=projectname
+        )
 
     @staticmethod
     def _export_project(lims_project) -> dict:
@@ -60,7 +64,9 @@ class LimsAPI(Lims, OrderHandler):
         return {
             "id": lims_project.id,
             "name": lims_project.name,
-            "date": parse_date(lims_project.open_date) if lims_project.open_date else None,
+            "date": parse_date(lims_project.open_date)
+            if lims_project.open_date
+            else None,
         }
 
     def _export_sample(self, lims_sample):
@@ -77,7 +83,9 @@ class LimsAPI(Lims, OrderHandler):
             "mother": udfs.get("motherID"),
             "source": udfs.get("Source"),
             "status": udfs.get("Status"),
-            "panels": udfs.get("Gene List").split(";") if udfs.get("Gene List") else None,
+            "panels": udfs.get("Gene List").split(";")
+            if udfs.get("Gene List")
+            else None,
             "priority": udfs.get("priority"),
             "received": self.get_received_date(lims_sample.id),
             "application": udfs.get("Sequencing Analysis"),
@@ -100,36 +108,40 @@ class LimsAPI(Lims, OrderHandler):
 
         sample = Sample(self, id=lims_id)
         try:
-            return sample.udf.get("Received at")
+            date = sample.udf.get("Received at")
         except HTTPError:
-            return None
+            date = None
+        return date
 
     def get_prepared_date(self, lims_id: str) -> dt.datetime:
         """Get the date when a sample was prepared in the lab."""
 
         sample = Sample(self, id=lims_id)
         try:
-            return sample.udf.get("Library Prep Finished")
+            date = sample.udf.get("Library Prep Finished")
         except HTTPError:
-            return None
+            date = None
+        return date
 
     def get_delivery_date(self, lims_id: str) -> dt.date:
         """Get delivery date for a sample."""
 
         sample = Sample(self, id=lims_id)
         try:
-            return sample.udf.get("Delivered at")
+            date = sample.udf.get("Delivered at")
         except HTTPError:
-            return None
+            date = None
+        return date
 
     def get_sequenced_date(self, lims_id: str) -> dt.date:
         """Get the date when a sample was sequenced."""
 
         sample = Sample(self, id=lims_id)
         try:
-            return sample.udf.get("Sequencing Finished")
+            date = sample.udf.get("Sequencing Finished")
         except HTTPError:
-            return None
+            date = None
+        return date
 
     def capture_kit(self, lims_id: str) -> str:
         """Get capture kit for a LIMS sample."""
@@ -166,7 +178,9 @@ class LimsAPI(Lims, OrderHandler):
         """Bypass to original method."""
         lims_samples = super(LimsAPI, self).get_samples(*args, **kwargs)
         if map_ids:
-            lims_map = {lims_sample.name: lims_sample.id for lims_sample in lims_samples}
+            lims_map = {
+                lims_sample.name: lims_sample.id for lims_sample in lims_samples
+            }
             return lims_map
 
         return lims_samples
@@ -175,7 +189,9 @@ class LimsAPI(Lims, OrderHandler):
         """Fetch information about a family of samples."""
         filters = {"customer": customer, "familyID": family}
         lims_samples = self.get_samples(udf=filters)
-        samples_data = [self._export_sample(lims_sample) for lims_sample in lims_samples]
+        samples_data = [
+            self._export_sample(lims_sample) for lims_sample in lims_samples
+        ]
         # get family level data
         family_data = {"family": family, "customer": customer, "samples": []}
         priorities = set()
@@ -213,7 +229,12 @@ class LimsAPI(Lims, OrderHandler):
                 yield lims_sample.id
 
     def update_sample(
-        self, lims_id: str, sex=None, target_reads: int = None, name: str = None, **kwargs,
+        self,
+        lims_id: str,
+        sex=None,
+        target_reads: int = None,
+        name: str = None,
+        **kwargs,
     ):
         """Update information about a sample."""
         lims_sample = Sample(self, id=lims_id)
@@ -230,7 +251,8 @@ class LimsAPI(Lims, OrderHandler):
         for key, value in kwargs.items():
             if not PROP2UDF.get(key):
                 raise LimsDataError(
-                    f"Unknown how to set {key} in LIMS since it is not defined in" f" {PROP2UDF}"
+                    f"Unknown how to set {key} in LIMS since it is not defined in"
+                    f" {PROP2UDF}"
                 )
             lims_sample.udf[PROP2UDF[key]] = value
 
@@ -309,7 +331,9 @@ class LimsAPI(Lims, OrderHandler):
         methods = []
 
         for process_name in step_names_udfs:
-            artifacts = self.get_artifacts(process_type=process_name, samplelimsid=lims_id)
+            artifacts = self.get_artifacts(
+                process_type=process_name, samplelimsid=lims_id
+            )
             if artifacts:
                 udf_key_number = step_names_udfs[process_name]["method_number"]
                 udf_key_version = step_names_udfs[process_name]["method_version"]

--- a/cg/apps/lims/api.py
+++ b/cg/apps/lims/api.py
@@ -104,7 +104,7 @@ class LimsAPI(Lims, OrderHandler):
         sample = Sample(self, id=lims_id)
         try:
             return sample.udf.get("Library Prep Finished")
-        except:
+        except HTTPError:
             return None
 
     def get_delivery_date(self, lims_id: str) -> dt.date:
@@ -113,7 +113,7 @@ class LimsAPI(Lims, OrderHandler):
         sample = Sample(self, id=lims_id)
         try:
             return sample.udf.get("Delivered at")
-        except:
+        except HTTPError:
             return None
 
     def get_sequenced_date(self, lims_id: str) -> dt.date:
@@ -122,7 +122,7 @@ class LimsAPI(Lims, OrderHandler):
         sample = Sample(self, id=lims_id)
         try:
             return sample.udf.get("Sequencing Finished")
-        except:
+        except HTTPError:
             return None
 
     def capture_kit(self, lims_id: str) -> str:

--- a/cg/apps/lims/api.py
+++ b/cg/apps/lims/api.py
@@ -42,9 +42,7 @@ class LimsAPI(Lims, OrderHandler):
 
     def __init__(self, config):
         lconf = config["lims"]
-        super(LimsAPI, self).__init__(
-            lconf["host"], lconf["username"], lconf["password"]
-        )
+        super(LimsAPI, self).__init__(lconf["host"], lconf["username"], lconf["password"])
 
     def sample(self, lims_id: str):
         """Fetch a sample from the LIMS database."""
@@ -54,9 +52,7 @@ class LimsAPI(Lims, OrderHandler):
 
     def samples_in_pools(self, pool_name, projectname):
         """Fetch all samples from a pool"""
-        return self.get_samples(
-            udf={"pool name": str(pool_name)}, projectname=projectname
-        )
+        return self.get_samples(udf={"pool name": str(pool_name)}, projectname=projectname)
 
     @staticmethod
     def _export_project(lims_project) -> dict:
@@ -64,9 +60,7 @@ class LimsAPI(Lims, OrderHandler):
         return {
             "id": lims_project.id,
             "name": lims_project.name,
-            "date": parse_date(lims_project.open_date)
-            if lims_project.open_date
-            else None,
+            "date": parse_date(lims_project.open_date) if lims_project.open_date else None,
         }
 
     def _export_sample(self, lims_sample):
@@ -83,9 +77,7 @@ class LimsAPI(Lims, OrderHandler):
             "mother": udfs.get("motherID"),
             "source": udfs.get("Source"),
             "status": udfs.get("Status"),
-            "panels": udfs.get("Gene List").split(";")
-            if udfs.get("Gene List")
-            else None,
+            "panels": udfs.get("Gene List").split(";") if udfs.get("Gene List") else None,
             "priority": udfs.get("priority"),
             "received": self.get_received_date(lims_sample.id),
             "application": udfs.get("Sequencing Analysis"),
@@ -174,9 +166,7 @@ class LimsAPI(Lims, OrderHandler):
         """Bypass to original method."""
         lims_samples = super(LimsAPI, self).get_samples(*args, **kwargs)
         if map_ids:
-            lims_map = {
-                lims_sample.name: lims_sample.id for lims_sample in lims_samples
-            }
+            lims_map = {lims_sample.name: lims_sample.id for lims_sample in lims_samples}
             return lims_map
 
         return lims_samples
@@ -185,9 +175,7 @@ class LimsAPI(Lims, OrderHandler):
         """Fetch information about a family of samples."""
         filters = {"customer": customer, "familyID": family}
         lims_samples = self.get_samples(udf=filters)
-        samples_data = [
-            self._export_sample(lims_sample) for lims_sample in lims_samples
-        ]
+        samples_data = [self._export_sample(lims_sample) for lims_sample in lims_samples]
         # get family level data
         family_data = {"family": family, "customer": customer, "samples": []}
         priorities = set()
@@ -225,12 +213,7 @@ class LimsAPI(Lims, OrderHandler):
                 yield lims_sample.id
 
     def update_sample(
-        self,
-        lims_id: str,
-        sex=None,
-        target_reads: int = None,
-        name: str = None,
-        **kwargs,
+        self, lims_id: str, sex=None, target_reads: int = None, name: str = None, **kwargs,
     ):
         """Update information about a sample."""
         lims_sample = Sample(self, id=lims_id)
@@ -247,8 +230,7 @@ class LimsAPI(Lims, OrderHandler):
         for key, value in kwargs.items():
             if not PROP2UDF.get(key):
                 raise LimsDataError(
-                    f"Unknown how to set {key} in LIMS since it is not defined in"
-                    f" {PROP2UDF}"
+                    f"Unknown how to set {key} in LIMS since it is not defined in" f" {PROP2UDF}"
                 )
             lims_sample.udf[PROP2UDF[key]] = value
 
@@ -327,9 +309,7 @@ class LimsAPI(Lims, OrderHandler):
         methods = []
 
         for process_name in step_names_udfs:
-            artifacts = self.get_artifacts(
-                process_type=process_name, samplelimsid=lims_id
-            )
+            artifacts = self.get_artifacts(process_type=process_name, samplelimsid=lims_id)
             if artifacts:
                 udf_key_number = step_names_udfs[process_name]["method_number"]
                 udf_key_version = step_names_udfs[process_name]["method_version"]

--- a/cg/apps/lims/api.py
+++ b/cg/apps/lims/api.py
@@ -206,7 +206,7 @@ class LimsAPI(Lims, OrderHandler):
         return Process(self, id=process_id)
 
     @staticmethod
-    def process_samples(lims_process: Process) -> Generator[str]:
+    def process_samples(lims_process: Process) -> Generator[str, None, None]:
         """Retrieve LIMS input samples from a process."""
         for lims_artifact in lims_process.all_inputs():
             for lims_sample in lims_artifact.samples:

--- a/cg/apps/lims/api.py
+++ b/cg/apps/lims/api.py
@@ -95,7 +95,7 @@ class LimsAPI(Lims, OrderHandler):
         sample = Sample(self, id=lims_id)
         try:
             return sample.udf.get("Received at")
-        except:
+        except HTTPError:
             return None
 
     def get_prepared_date(self, lims_id: str) -> dt.datetime:

--- a/cg/apps/lims/api.py
+++ b/cg/apps/lims/api.py
@@ -42,7 +42,9 @@ class LimsAPI(Lims, OrderHandler):
 
     def __init__(self, config):
         lconf = config["lims"]
-        super(LimsAPI, self).__init__(lconf["host"], lconf["username"], lconf["password"])
+        super(LimsAPI, self).__init__(
+            lconf["host"], lconf["username"], lconf["password"]
+        )
 
     def sample(self, lims_id: str):
         """Fetch a sample from the LIMS database."""
@@ -52,7 +54,9 @@ class LimsAPI(Lims, OrderHandler):
 
     def samples_in_pools(self, pool_name, projectname):
         """Fetch all samples from a pool"""
-        return self.get_samples(udf={"pool name": str(pool_name)}, projectname=projectname)
+        return self.get_samples(
+            udf={"pool name": str(pool_name)}, projectname=projectname
+        )
 
     @staticmethod
     def _export_project(lims_project) -> dict:
@@ -60,7 +64,9 @@ class LimsAPI(Lims, OrderHandler):
         return {
             "id": lims_project.id,
             "name": lims_project.name,
-            "date": parse_date(lims_project.open_date) if lims_project.open_date else None,
+            "date": parse_date(lims_project.open_date)
+            if lims_project.open_date
+            else None,
         }
 
     def _export_sample(self, lims_sample):
@@ -77,7 +83,9 @@ class LimsAPI(Lims, OrderHandler):
             "mother": udfs.get("motherID"),
             "source": udfs.get("Source"),
             "status": udfs.get("Status"),
-            "panels": udfs.get("Gene List").split(";") if udfs.get("Gene List") else None,
+            "panels": udfs.get("Gene List").split(";")
+            if udfs.get("Gene List")
+            else None,
             "priority": udfs.get("priority"),
             "received": self.get_received_date(lims_sample.id),
             "application": udfs.get("Sequencing Analysis"),
@@ -95,7 +103,7 @@ class LimsAPI(Lims, OrderHandler):
         """Get data from a LIMS artifact."""
         return {"id": lims_artifact.id, "name": lims_artifact.name}
 
-    def get_received_date(self, lims_id: str) -> str:
+    def get_received_date(self, lims_id: str) -> dt.date:
         """Get the date when a sample was received."""
 
         sample = Sample(self, id=lims_id)
@@ -105,7 +113,7 @@ class LimsAPI(Lims, OrderHandler):
             date = None
         return date
 
-    def get_prepared_date(self, lims_id: str) -> dt.datetime:
+    def get_prepared_date(self, lims_id: str) -> dt.date:
         """Get the date when a sample was prepared in the lab."""
 
         sample = Sample(self, id=lims_id)
@@ -170,7 +178,9 @@ class LimsAPI(Lims, OrderHandler):
         """Bypass to original method."""
         lims_samples = super(LimsAPI, self).get_samples(*args, **kwargs)
         if map_ids:
-            lims_map = {lims_sample.name: lims_sample.id for lims_sample in lims_samples}
+            lims_map = {
+                lims_sample.name: lims_sample.id for lims_sample in lims_samples
+            }
             return lims_map
 
         return lims_samples
@@ -179,7 +189,9 @@ class LimsAPI(Lims, OrderHandler):
         """Fetch information about a family of samples."""
         filters = {"customer": customer, "familyID": family}
         lims_samples = self.get_samples(udf=filters)
-        samples_data = [self._export_sample(lims_sample) for lims_sample in lims_samples]
+        samples_data = [
+            self._export_sample(lims_sample) for lims_sample in lims_samples
+        ]
         # get family level data
         family_data = {"family": family, "customer": customer, "samples": []}
         priorities = set()
@@ -217,7 +229,12 @@ class LimsAPI(Lims, OrderHandler):
                 yield lims_sample.id
 
     def update_sample(
-        self, lims_id: str, sex=None, target_reads: int = None, name: str = None, **kwargs,
+        self,
+        lims_id: str,
+        sex=None,
+        target_reads: int = None,
+        name: str = None,
+        **kwargs,
     ):
         """Update information about a sample."""
         lims_sample = Sample(self, id=lims_id)
@@ -234,7 +251,8 @@ class LimsAPI(Lims, OrderHandler):
         for key, value in kwargs.items():
             if not PROP2UDF.get(key):
                 raise LimsDataError(
-                    f"Unknown how to set {key} in LIMS since it is not defined in" f" {PROP2UDF}"
+                    f"Unknown how to set {key} in LIMS since it is not defined in"
+                    f" {PROP2UDF}"
                 )
             lims_sample.udf[PROP2UDF[key]] = value
 
@@ -313,7 +331,9 @@ class LimsAPI(Lims, OrderHandler):
         methods = []
 
         for process_name in step_names_udfs:
-            artifacts = self.get_artifacts(process_type=process_name, samplelimsid=lims_id)
+            artifacts = self.get_artifacts(
+                process_type=process_name, samplelimsid=lims_id
+            )
             if artifacts:
                 udf_key_number = step_names_udfs[process_name]["method_number"]
                 udf_key_version = step_names_udfs[process_name]["method_version"]

--- a/cg/apps/lims/api.py
+++ b/cg/apps/lims/api.py
@@ -93,25 +93,37 @@ class LimsAPI(Lims, OrderHandler):
         """Get the date when a sample was received."""
 
         sample = Sample(self, id=lims_id)
-        return sample.udf.get("Received at") if sample else None
-
+        try:
+            return sample.udf.get("Received at")
+        except:
+            return None
+        
     def get_prepared_date(self, lims_id: str) -> dt.datetime:
         """Get the date when a sample was prepared in the lab."""
 
         sample = Sample(self, id=lims_id)
-        return sample.udf.get("Library Prep Finished") if sample else None
+        try:
+            return sample.udf.get("Library Prep Finished")
+        except:
+            return None
 
     def get_delivery_date(self, lims_id: str) -> dt.date:
         """Get delivery date for a sample."""
 
         sample = Sample(self, id=lims_id)
-        return sample.udf.get("Delivered at") if sample else None
+        try:
+            return sample.udf.get("Delivered at")
+        except:
+            return None
 
     def get_sequenced_date(self, lims_id: str) -> dt.date:
         """Get the date when a sample was sequenced."""
 
         sample = Sample(self, id=lims_id)
-        return sample.udf.get("Sequencing Finished") if sample else None
+        try:
+            return sample.udf.get("Sequencing Finished")
+        except:
+            return None
 
     def capture_kit(self, lims_id: str) -> str:
         """Get capture kit for a LIMS sample."""

--- a/tests/apps/lims/conftest.py
+++ b/tests/apps/lims/conftest.py
@@ -1,49 +1,39 @@
+"""Fixtures for lims tests"""
+
 import pytest
+
 from cg.apps.lims.api import LimsAPI
 
 
 class MockLims(LimsAPI):
+    """Mock parts of the lims api"""
 
     lims = None
 
     def __init__(self):
+        """Mock the init method"""
         self.lims = self
-        pass
-
-    _received_at = None
-    _delivered_at = None
 
     def get_prepmethod(self, lims_id: str) -> str:
-        pass
+        """Override the get_prepmethod"""
 
     def get_sequencingmethod(self, lims_id: str) -> str:
-        pass
+        """Override the get_sequencingmethod"""
 
     def get_deliverymethod(self, lims_id: str) -> str:
-        pass
-
-    def set_received_date(self, date):
-        self._received_at = date
-
-    def get_received_date(self, lims_id: str):
-        return self._received_at
-
-    def set_delivery_date(self, date):
-        self._delivered_at = date
-
-    def get_delivery_date(self, lims_id: str):
-        return self._delivered_at
+        """Override the get_deliverymethod"""
 
 
 @pytest.fixture(scope="function")
 def lims_api():
-
+    """Returns a Lims api mock"""
     _lims_api = MockLims()
     return _lims_api
 
 
 @pytest.fixture
 def skeleton_orderform_sample():
+    """Get the skeleton for a orderform"""
     return {
         "UDF/priority": "",
         "UDF/Sequencing Analysis": "",

--- a/tests/apps/lims/test_apps_lims_api.py
+++ b/tests/apps/lims/test_apps_lims_api.py
@@ -24,7 +24,7 @@ def test_get_received_date(lims_api, mocker):
 
 def test_get_received_date_no_sample(lims_api, mocker):
     """Test to get the received date when sample not exists"""
-    # GIVEN a lims api and a mocked sample that returns a received at date
+    # GIVEN a lims api and a mocked sample that raises exception when fething date
     mocked_sample = mocker.patch("cg.apps.lims.api.Sample")
     mock_instance = mocked_sample.return_value
     mock_instance.udf.get.side_effect = HTTPError()
@@ -33,7 +33,94 @@ def test_get_received_date_no_sample(lims_api, mocker):
     res = lims_api.get_received_date(123)
 
     # THEN assert that None is returned since a exception was raised
-    assert res == None
+    assert res is None
+
+
+def test_get_prepared_date(lims_api, mocker):
+    """Test to get the prepared date for an existing sample"""
+    # GIVEN a lims api and a mocked sample that returns a prepared at date
+    mocked_sample = mocker.patch("cg.apps.lims.api.Sample")
+    mock_instance = mocked_sample.return_value
+    date = dt.datetime.today()
+    mock_instance.udf = {"Library Prep Finished": date}
+
+    # WHEN fetching the date
+    res = lims_api.get_prepared_date(123)
+
+    # THEN asserrt the correct date is fetched
+    assert res == date
+
+
+def test_get_prepared_date_no_sample(lims_api, mocker):
+    """Test to get the prepared date when sample not exists"""
+    # GIVEN a lims api and a mocked sample that raises exception when fething date
+    mocked_sample = mocker.patch("cg.apps.lims.api.Sample")
+    mock_instance = mocked_sample.return_value
+    mock_instance.udf.get.side_effect = HTTPError()
+
+    # WHEN fetching the date
+    res = lims_api.get_prepared_date(123)
+
+    # THEN assert that None is returned since a exception was raised
+    assert res is None
+
+
+def test_get_delivery_date(lims_api, mocker):
+    """Test to get the delivery date for an existing sample"""
+    # GIVEN a lims api and a mocked sample that returns a delivery date
+    mocked_sample = mocker.patch("cg.apps.lims.api.Sample")
+    mock_instance = mocked_sample.return_value
+    date = dt.datetime.today()
+    mock_instance.udf = {"Delivered at": date}
+
+    # WHEN fetching the date
+    res = lims_api.get_delivery_date(123)
+
+    # THEN asserrt the correct date is fetched
+    assert res == date
+
+
+def test_get_delivery_date_no_sample(lims_api, mocker):
+    """Test to get the delivery date when sample not exists"""
+    # GIVEN a lims api and a mocked sample that raises exception when fething date
+    mocked_sample = mocker.patch("cg.apps.lims.api.Sample")
+    mock_instance = mocked_sample.return_value
+    mock_instance.udf.get.side_effect = HTTPError()
+
+    # WHEN fetching the date
+    res = lims_api.get_delivery_date(123)
+
+    # THEN assert that None is returned since a exception was raised
+    assert res is None
+
+
+def test_get_sequenced_date(lims_api, mocker):
+    """Test to get the sequenced date"""
+    # GIVEN a lims api and a mocked sample that returns a sequenced date
+    mocked_sample = mocker.patch("cg.apps.lims.api.Sample")
+    mock_instance = mocked_sample.return_value
+    date = dt.datetime.today()
+    mock_instance.udf = {"Sequencing Finished": date}
+
+    # WHEN fetching the date
+    res = lims_api.get_sequenced_date(123)
+
+    # THEN asserrt the correct date is fetched
+    assert res == date
+
+
+def test_get_sequenced_date_no_sample(lims_api, mocker):
+    """Test to get the sequenced date when sample not exists"""
+    # GIVEN a lims api and a mocked sample that raises exception when fething date
+    mocked_sample = mocker.patch("cg.apps.lims.api.Sample")
+    mock_instance = mocked_sample.return_value
+    mock_instance.udf.get.side_effect = HTTPError()
+
+    # WHEN fetching the date
+    res = lims_api.get_sequenced_date(123)
+
+    # THEN assert that None is returned since a exception was raised
+    assert res is None
 
 
 def test_get_processing_time_for_values(lims_api, mocker):

--- a/tests/apps/lims/test_apps_lims_api.py
+++ b/tests/apps/lims/test_apps_lims_api.py
@@ -1,7 +1,39 @@
 """Test the Lims api"""
 import datetime as dt
 
+from requests.exceptions import HTTPError
+
+import cg
 from cg.apps.lims.api import LimsAPI
+
+
+def test_get_received_date(lims_api, mocker):
+    """Test to get the received date"""
+    # GIVEN a lims api and a mocked sample that returns a received at date
+    mocked_sample = mocker.patch("cg.apps.lims.api.Sample")
+    mock_instance = mocked_sample.return_value
+    date = dt.datetime.today()
+    mock_instance.udf = {"Received at": date}
+
+    # WHEN fetching the date
+    res = lims_api.get_received_date(123)
+
+    # THEN asserrt the correct date is fetched
+    assert res == date
+
+
+def test_get_received_date_no_sample(lims_api, mocker):
+    """Test to get the received date when sample not exists"""
+    # GIVEN a lims api and a mocked sample that returns a received at date
+    mocked_sample = mocker.patch("cg.apps.lims.api.Sample")
+    mock_instance = mocked_sample.return_value
+    mock_instance.udf.get.side_effect = HTTPError()
+
+    # WHEN fetching the date
+    res = lims_api.get_received_date(123)
+
+    # THEN assert that None is returned since a exception was raised
+    assert res == None
 
 
 def test_get_processing_time_for_values(lims_api, mocker):

--- a/tests/apps/lims/test_apps_lims_api.py
+++ b/tests/apps/lims/test_apps_lims_api.py
@@ -1,38 +1,54 @@
+"""Test the Lims api"""
 import datetime as dt
 
+from cg.apps.lims.api import LimsAPI
 
-def test_get_processing_time_for_values(lims_api):
 
+def test_get_processing_time_for_values(lims_api, mocker):
+    """Test to get the processing time when there are some existing dates"""
     # GIVEN there is a received_at date and a delivered date
     date = dt.datetime.today()
-    lims_api.set_received_date(date)
-    lims_api.set_delivery_date(date)
+    # GIVEN that received and delivered date is the same
+    mocker.patch.object(LimsAPI, "get_received_date")
+    LimsAPI.get_received_date.return_value = date
 
-    # WHEN calling get_processing_time
+    mocker.patch.object(LimsAPI, "get_delivery_date")
+    LimsAPI.get_delivery_date.return_value = date
+
+    # WHEN fetching the processing time
     processing_time = lims_api.get_processing_time(123)
 
     # THEN return value is the delivered - received == 0 for same datetime
     assert processing_time == dt.timedelta(0)
 
 
-def test_get_processing_time_for_no_received_time(lims_api):
-
-    # GIVEN there is no received_at date and a delivered date
+def test_get_processing_time_for_no_received_time(lims_api, mocker):
+    """Test to get the processing time when there is not received time"""
+    # GIVEN there is no received_at date
+    mocker.patch.object(LimsAPI, "get_received_date")
+    LimsAPI.get_received_date.return_value = None
+    # GIVEN there is a delivery date
     date = dt.datetime.today()
-    lims_api.set_delivery_date(date)
+    mocker.patch.object(LimsAPI, "get_delivery_date")
+    LimsAPI.get_delivery_date.return_value = date
 
     # WHEN calling get_processing_time
     processing_time = lims_api.get_processing_time(123)
 
-    # THEN return value is none
+    # THEN return value should be none since one time is missing
     assert processing_time is None
 
 
-def test_get_processing_time_for_no_delivered_time(lims_api):
+def test_get_processing_time_for_no_delivered_time(lims_api, mocker):
+    """Test to get the processing time when there is not delivered time"""
 
     # GIVEN there is a received_at date and no delivered date
     date = dt.datetime.today()
-    lims_api.set_received_date(date)
+    mocker.patch.object(LimsAPI, "get_received_date")
+    LimsAPI.get_received_date.return_value = date
+
+    mocker.patch.object(LimsAPI, "get_delivery_date")
+    LimsAPI.get_delivery_date.return_value = None
 
     # WHEN calling get_processing_time
     processing_time = lims_api.get_processing_time(123)


### PR DESCRIPTION
This PR fixes an error when a lims id is missing

## Description

Sometimes the `lims_id` does not exist in lims. Then the sample will be created but sample.udf will give an error:

```
>>> s=Sample(lims, id='hoho')
>>> s.udf
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/mayabrandi/opt/genologics/genologics/descriptors.py", line 350, in __get__
    instance.get()
  File "/Users/mayabrandi/opt/genologics/genologics/entities.py", line 289, in get
    self.root = self.lims.get(self.uri)
  File "/Users/mayabrandi/opt/genologics/genologics/lims.py", line 90, in get
    return self.parse_response(r)
  File "/Users/mayabrandi/opt/genologics/genologics/lims.py", line 209, in parse_response
    self.validate_response(response, accept_status_codes)
  File "/Users/mayabrandi/opt/genologics/genologics/lims.py", line 202, in validate_response
    raise requests.exceptions.HTTPError(message)
requests.exceptions.HTTPError: 404: Sample not found: hoho
```

**How to prepare for test**:
- [x] ssh to hasta (depending on type of change)
- [x] install on stage:
`bash servers/resources/hasta.scilifelab.se/update-cg-stage.sh fix_date_functions`

**How to test**:
Run following commands
- [x] `us`
- [x] `cg transfer lims --status prepared --sample-id latelychoiceemu`

**Expected test outcome**:
- [x] no error

**Review:**
- [x] code approved by @moonso 
- [x] tests executed by @mayabrandi 
- [x] "Merge and deploy" approved by @moonso 
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
