### PR TITLE
Accept False as a valid value

### DIFF
--- a/cg/meta/report/report_validator.py
+++ b/cg/meta/report/report_validator.py
@@ -72,7 +72,7 @@ class ReportValidator:
     def _collect_missing_attributes(self, subscriptable, keys):
         """Gathers all attributes that should exist"""
         for key in keys:
-            if not subscriptable[key]:
+            if subscriptable.get(key) is None:
                 self._attributes_missing_values.append(key)
 
     def _check_required_sample_attributes_for_all(self, sample):


### PR DESCRIPTION
This PR fixes the problem creating delivery reports when applications has been used that does not have accreditation

**How to prepare for test**:
- [x] ssh to hasta (depending on type of change)
- [x] install on stage:
`bash servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

**How to test**:
- [x] login to hasta
- [x] do us
- [x] mkdir -p /home/proj/stage/housekeeper-bundles/casualskink/2020-04-20
- [x] cp /home/proj/production/housekeeper-bundles/casualskink/2020-04-20/*.yaml /home/proj/stage/housekeeper-bundles/casualskink/2020-04-20
- [x] cg -c ../cg_stage.yaml --log-level=DEBUG upload delivery-report casualskink --force --print | grep missing

**Expected test outcome**:
- [x] check that accredited is not listed as missing field
- [x] Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @moonso 
- [x] tests executed by PG
- [x] "Merge and deploy" approved by PG
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
