### PR TITLE
Fix: Store mip config

### DIFF
--- a/cg/constants.py
+++ b/cg/constants.py
@@ -1,12 +1,6 @@
 """Constans for cg"""
 
-PRIORITY_MAP = {
-    "research": 0,
-    "standard": 1,
-    "priority": 2,
-    "express": 3,
-    "clinical trials": 4,
-}
+PRIORITY_MAP = {"research": 0, "standard": 1, "priority": 2, "express": 3, "clinical trials": 4}
 REV_PRIORITY_MAP = {value: key for key, value in PRIORITY_MAP.items()}
 PRIORITY_OPTIONS = list(PRIORITY_MAP.keys())
 FAMILY_ACTIONS = ("analyze", "running", "hold")
@@ -67,11 +61,7 @@ FASTQ_SECOND_READ_SUFFIX = "R2_001.fastq.gz"
 SPRING_SUFFIX = ".spring"
 
 # tags for storing analyses in Housekeeper
-HK_TAGS = {
-    "wes": ["mip-dna", "wes"],
-    "wgs": ["mip-dna", "wgs"],
-    "wts": ["mip-rna"],
-}
+HK_TAGS = {"wes": ["mip-dna", "wes"], "wgs": ["mip-dna", "wgs"], "wts": ["mip-rna"]}
 
 # used to convert MIP tags derived from the deliverables to MIP standard tags and to check for
 # presence of mandatory files. Keys = tags found in deliverables, values = MIP standard tags and
@@ -82,7 +72,7 @@ MIP_DNA_TAGS = {
         "index_tags": ["cram-index"],
         "is_mandatory": False,
     },
-    tuple(["config"]): {"tags": ["mip-config"], "is_mandatory": True},
+    tuple(["config_analysis"]): {"tags": ["mip-config"], "is_mandatory": True},
     tuple(["sample_info"]): {"tags": ["sampleinfo"], "is_mandatory": True},
     tuple(["multiqc_ar", "html"]): {"tags": ["multiqc-html"], "is_mandatory": True},
     tuple(["multiqc_ar", "json"]): {"tags": ["multiqc-json"], "is_mandatory": True},
@@ -140,27 +130,27 @@ MIP_DNA_TAGS = {
 
 
 MIP_RNA_TAGS = {
-    tuple(["salmon_quant"]): {"tags": ["salmon-quant"], "is_mandatory": True,},
-    tuple(["star_fusion"]): {"tags": ["star-fusion"], "is_mandatory": True,},
+    tuple(["salmon_quant"]): {"tags": ["salmon-quant"], "is_mandatory": True},
+    tuple(["star_fusion"]): {"tags": ["star-fusion"], "is_mandatory": True},
     tuple(["arriba_ar", "arriba_report"]): {
         "tags": ["arriba-ar", "arriba-report"],
         "is_mandatory": True,
     },
-    tuple(["arriba_ar", "arriba_ar"]): {"tags": ["arriba-ar"], "is_mandatory": True,},
-    tuple(["stringtie_ar"]): {"tags": ["stringtie-ar"], "is_mandatory": True,},
-    tuple(["gffcompare_ar"]): {"tags": ["gffcompare-ar"], "is_mandatory": True,},
+    tuple(["arriba_ar", "arriba_ar"]): {"tags": ["arriba-ar"], "is_mandatory": True},
+    tuple(["stringtie_ar"]): {"tags": ["stringtie-ar"], "is_mandatory": True},
+    tuple(["gffcompare_ar"]): {"tags": ["gffcompare-ar"], "is_mandatory": True},
     tuple(["markduplicates"]): {
         "tags": ["cram"],
         "index_tags": ["cram-index"],
         "is_mandatory": True,
     },
-    tuple(["gatk_asereadcounter"]): {"tags": ["gatk-asereadcounter"], "is_mandatory": True,},
-    tuple(["bootstrapann"]): {"tags": ["bootstrapann"], "is_mandatory": True,},
-    tuple(["bcftools_merge"]): {"tags": ["bcftools-merge"], "is_mandatory": True,},
-    tuple(["varianteffectpredictor"]): {"tags": ["varianteffectpredictor"], "is_mandatory": True,},
-    tuple(["version_collect_ar"]): {"tags": ["version-collect-ar"], "is_mandatory": True,},
-    tuple(["multiqc_ar", "html"]): {"tags": ["multiqc-html"], "is_mandatory": True,},
-    tuple(["multiqc_ar", "json"]): {"tags": ["multiqc-json"], "is_mandatory": True,},
+    tuple(["gatk_asereadcounter"]): {"tags": ["gatk-asereadcounter"], "is_mandatory": True},
+    tuple(["bootstrapann"]): {"tags": ["bootstrapann"], "is_mandatory": True},
+    tuple(["bcftools_merge"]): {"tags": ["bcftools-merge"], "is_mandatory": True},
+    tuple(["varianteffectpredictor"]): {"tags": ["varianteffectpredictor"], "is_mandatory": True},
+    tuple(["version_collect_ar"]): {"tags": ["version-collect-ar"], "is_mandatory": True},
+    tuple(["multiqc_ar", "html"]): {"tags": ["multiqc-html"], "is_mandatory": True},
+    tuple(["multiqc_ar", "json"]): {"tags": ["multiqc-json"], "is_mandatory": True},
     tuple(["mip_analyse", "sample_info"]): {
         "tags": ["mip-analyse", "sample-info"],
         "is_mandatory": True,
@@ -169,19 +159,16 @@ MIP_RNA_TAGS = {
         "tags": ["mip-analyse", "reference-info"],
         "is_mandatory": True,
     },
-    tuple(["mip_analyse", "log"]): {"tags": ["mip-analyse", "log"], "is_mandatory": True,},
+    tuple(["mip_analyse", "log"]): {"tags": ["mip-analyse", "log"], "is_mandatory": True},
     tuple(["mip_analyse", "config_analysis"]): {
-        "tags": ["mip-analyse", "config-analysis"],
+        "tags": ["mip-analyse", "mip-config"],
         "is_mandatory": True,
     },
-    tuple(["mip_analyse", "pedigree"]): {
-        "tags": ["mip-analyse", "pedigree"],
-        "is_mandatory": True,
-    },
-    tuple(["mip_analyse", "config"]): {"tags": ["mip-analyse", "config"], "is_mandatory": True,},
+    tuple(["mip_analyse", "pedigree"]): {"tags": ["mip-analyse", "pedigree"], "is_mandatory": True},
+    tuple(["mip_analyse", "config"]): {"tags": ["mip-analyse", "config"], "is_mandatory": True},
     tuple(["mip_analyse", "pedigree_fam"]): {
         "tags": ["mip-analyse", "pedigree-fam"],
         "is_mandatory": True,
     },
-    tuple(["blobfish"]): {"tags": ["blobfish"], "is_mandatory": False,},
+    tuple(["blobfish"]): {"tags": ["blobfish"], "is_mandatory": False},
 }

--- a/cg/constants.py
+++ b/cg/constants.py
@@ -161,7 +161,7 @@ MIP_RNA_TAGS = {
     },
     tuple(["mip_analyse", "log"]): {"tags": ["mip-analyse", "log"], "is_mandatory": True},
     tuple(["mip_analyse", "config_analysis"]): {
-        "tags": ["mip-analyse", "mip-config"],
+        "tags": ["mip-analyse", "config-analysis"],
         "is_mandatory": True,
     },
     tuple(["mip_analyse", "pedigree"]): {"tags": ["mip-analyse", "pedigree"], "is_mandatory": True},


### PR DESCRIPTION
This PR adds/fixes:

- Points HK tag "mip-config" to MIPs "config_analysis" file like before and not the global mip config.

**How to prepare for test**:
- [x] ssh to hasta (depending on type of change)
- [x] install on stage:
`bash servers/resources/hasta.scilifelab.se/update-cg-stage.sh store_mip_config`

**How to test**:
- login to hasta
- `us`
- `housekeeper get -V -t mip-config vitalmouse`
- `housekeeper get -V -t config_analysis vitalmouse`
- `housekeeper delete bundle vitalmouse`
- Remove any existing analyses in status-db
1. `cg workflow mip-dna store analysis /home/proj/stage/rare-disease/cases/vitalmouse/analysis/vitalmouse_config.yaml`

**Expected test outcome**:
1.  Check that: The tag `mip-config` points to the MIP global config prior to removing and reloading bundle
1. Check that the reloaded bundle tag "mip-config" points to the MIP analysis config file


**Review:**
- [x] code approved by PG
- [x] tests executed by  HS
- [x] "Merge and deploy" approved by PG
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
