### PR TITLE
adding load reagent label to cli

### DIFF
--- a/cg/apps/vogue.py
+++ b/cg/apps/vogue.py
@@ -60,6 +60,16 @@ class VogueAPI:
         for line in self.process.stderr_lines():
             LOG.info("vogue output: %s", line)
 
+    def load_reagent_labels(self, days):
+        """Running vogue load reagent_labels."""
+
+        load_call = ["load", "reagent_labels", "-d", days]
+        self.process.run_command(load_call)
+
+        # Execute command and print its stdout+stderr as it executes
+        for line in self.process.stderr_lines():
+            LOG.info("vogue output: %s", line)
+
     def load_bioinfo_raw(self, load_bioinfo_inputs):
         """Running vogue load bioinfo raw."""
 

--- a/cg/apps/vogue.py
+++ b/cg/apps/vogue.py
@@ -40,30 +40,30 @@ class VogueAPI:
         for line in self.process.stderr_lines():
             LOG.info("vogue output: %s", line)
 
-    def load_samples(self, days):
+    def load_samples(self, days: int) -> None:
         """Running vogue load samples."""
 
-        load_call = ["load", "sample", "-d", days]
+        load_call = ["load", "sample", "-d", str(days)]
         self.process.run_command(load_call)
 
         # Execute command and print its stdout+stderr as it executes
         for line in self.process.stderr_lines():
             LOG.info("vogue output: %s", line)
 
-    def load_flowcells(self, days):
+    def load_flowcells(self, days: int) -> None:
         """Running vogue load flowcells."""
 
-        load_call = ["load", "flowcell", "-d", days]
+        load_call = ["load", "flowcell", "-d", str(days)]
         self.process.run_command(load_call)
 
         # Execute command and print its stdout+stderr as it executes
         for line in self.process.stderr_lines():
             LOG.info("vogue output: %s", line)
 
-    def load_reagent_labels(self, days) -> None:
+    def load_reagent_labels(self, days: int) -> None:
         """Running vogue load reagent_labels."""
 
-        load_call = ["load", "reagent_labels", "-d", days]
+        load_call = ["load", "reagent_labels", "-d", str(days)]
         self.process.run_command(load_call)
 
         # Execute command and print its stdout+stderr as it executes

--- a/cg/apps/vogue.py
+++ b/cg/apps/vogue.py
@@ -60,7 +60,7 @@ class VogueAPI:
         for line in self.process.stderr_lines():
             LOG.info("vogue output: %s", line)
 
-    def load_reagent_labels(self, days: int) -> None:
+    def load_reagent_labels(self, days) -> None:
         """Running vogue load reagent_labels."""
 
         load_call = ["load", "reagent_labels", "-d", days]

--- a/cg/cli/upload/vogue.py
+++ b/cg/cli/upload/vogue.py
@@ -82,6 +82,19 @@ def samples(context, days: int):
     context.obj["vogue_upload_api"].load_samples(days=days)
 
 
+@vogue.command("reagent-labels", short_help="Getting reagent_label data from lims.")
+@click.option(
+    "-d", "--days", required="True", help="load X days old sampels from lims to vogue",
+)
+@click.pass_context
+def reagent_labels(context, days: int):
+    """Loading reagent_labels from lims to the trending database"""
+
+    click.echo(click.style("----------------- SAMPLES -----------------------"))
+
+    context.obj["vogue_upload_api"].load_reagent_labels(days=days)
+
+
 @vogue.command("bioinfo", short_help="Load bioinfo results into vogue")
 @click.option(
     "-c",

--- a/cg/cli/upload/vogue.py
+++ b/cg/cli/upload/vogue.py
@@ -84,7 +84,7 @@ def samples(context, days: int):
 
 @vogue.command("reagent-labels", short_help="Getting reagent_label data from lims.")
 @click.option(
-    "-d", "--days", required=True, type=int, help="load X days old sampels from lims to vogue",
+    "-d", "--days", required=True, help="load X days old sampels from lims to vogue",
 )
 @click.pass_context
 def reagent_labels(context, days: int):

--- a/cg/cli/upload/vogue.py
+++ b/cg/cli/upload/vogue.py
@@ -84,15 +84,15 @@ def samples(context, days: int):
 
 @vogue.command("reagent-labels", short_help="Getting reagent_label data from lims.")
 @click.option(
-    "-d", "--days", required="True", help="load X days old sampels from lims to vogue",
+    "-d", "--days", required=True, type=int, help="load X days old sampels from lims to vogue",
 )
 @click.pass_context
 def reagent_labels(context, days: int):
     """Loading reagent_labels from lims to the trending database"""
 
-    click.echo(click.style("----------------- SAMPLES -----------------------"))
+    LOG.info("----------------- REAGENT LABELS -----------------------")
 
-    context.obj["vogue_upload_api"].load_reagent_labels(days=days)
+    context.obj["vogue_api"].load_reagent_labels(days=days)
 
 
 @vogue.command("bioinfo", short_help="Load bioinfo results into vogue")

--- a/cg/cli/upload/vogue.py
+++ b/cg/cli/upload/vogue.py
@@ -35,7 +35,7 @@ def vogue(context):
 
 @vogue.command("genotype", short_help="Getting genotype data from the genotype database.")
 @click.option(
-    "-d", "--days", required="True", help="load X days old sampels from genotype to vogue",
+    "-d", "--days", type=int, required="True", help="load X days old sampels from genotype to vogue",
 )
 @click.pass_context
 def genotype(context, days: int):
@@ -58,7 +58,7 @@ def apptags(context):
 
 @vogue.command("flowcells", short_help="Getting flowcell data from the lims.")
 @click.option(
-    "-d", "--days", required="True", help="load X days old runs from lims to vogue",
+    "-d", "--days", type=int, required="True", help="load X days old runs from lims to vogue",
 )
 @click.pass_context
 def flowcells(context, days: int):
@@ -71,7 +71,7 @@ def flowcells(context, days: int):
 
 @vogue.command("samples", short_help="Getting sample data from lims.")
 @click.option(
-    "-d", "--days", required="True", help="load X days old sampels from lims to vogue",
+    "-d", "--days", type=int, required="True", help="load X days old sampels from lims to vogue",
 )
 @click.pass_context
 def samples(context, days: int):
@@ -84,7 +84,7 @@ def samples(context, days: int):
 
 @vogue.command("reagent-labels", short_help="Getting reagent_label data from lims.")
 @click.option(
-    "-d", "--days", required=True, help="load X days old sampels from lims to vogue",
+    "-d", "--days", type=int, required=True, help="load X days old sampels from lims to vogue",
 )
 @click.pass_context
 def reagent_labels(context, days: int):

--- a/cg/cli/upload/vogue.py
+++ b/cg/cli/upload/vogue.py
@@ -35,7 +35,11 @@ def vogue(context):
 
 @vogue.command("genotype", short_help="Getting genotype data from the genotype database.")
 @click.option(
-    "-d", "--days", type=int, required="True", help="load X days old sampels from genotype to vogue",
+    "-d",
+    "--days",
+    type=int,
+    required="True",
+    help="load X days old sampels from genotype to vogue",
 )
 @click.pass_context
 def genotype(context, days: int):

--- a/cg/cli/upload/vogue.py
+++ b/cg/cli/upload/vogue.py
@@ -64,9 +64,9 @@ def apptags(context):
 def flowcells(context, days: int):
     """Loading runs from lims to the trending database"""
 
-    click.echo(click.style("----------------- FLOWCELLS -----------------------"))
+    LOG.info("----------------- FLOWCELLS -----------------------")
 
-    context.obj["vogue_upload_api"].load_flowcells(days=days)
+    context.obj["vogue_api"].load_flowcells(days=days)
 
 
 @vogue.command("samples", short_help="Getting sample data from lims.")
@@ -77,9 +77,9 @@ def flowcells(context, days: int):
 def samples(context, days: int):
     """Loading samples from lims to the trending database"""
 
-    click.echo(click.style("----------------- SAMPLES -----------------------"))
+    LOG.info("----------------- SAMPLES -----------------------")
 
-    context.obj["vogue_upload_api"].load_samples(days=days)
+    context.obj["vogue_api"].load_samples(days=days)
 
 
 @vogue.command("reagent-labels", short_help="Getting reagent_label data from lims.")

--- a/cg/meta/upload/vogue.py
+++ b/cg/meta/upload/vogue.py
@@ -48,6 +48,11 @@ class UploadVogueAPI:
 
         self.vogue_api.load_flowcells(days=days)
 
+    def load_reagent_labels(self, days):
+        """Loading reagent_labels from lims into the trending database"""
+
+        self.vogue_api.load_reagent_labels(days=days)
+
     def load_bioinfo_raw(self, load_bioinfo_inputs):
         """Running vogue load bioinfo raw."""
 

--- a/cg/meta/upload/vogue.py
+++ b/cg/meta/upload/vogue.py
@@ -15,7 +15,7 @@ class UploadVogueAPI:
         self.vogue_api = vogue_api
         self.store = store
 
-    def load_genotype(self, days) -> None:
+    def load_genotype(self, days: int) -> None:
         """Loading genotype data from the genotype database into the trending database"""
         samples = self.genotype_api.export_sample(days=days)
         samples = json.loads(samples)

--- a/cg/meta/upload/vogue.py
+++ b/cg/meta/upload/vogue.py
@@ -38,21 +38,6 @@ class UploadVogueAPI:
 
         self.vogue_api.load_apptags(apptags_for_vogue)
 
-    def load_samples(self, days: int) -> None:
-        """Loading samples from lims into the trending database"""
-
-        self.vogue_api.load_samples(days=days)
-
-    def load_flowcells(self, days: int) -> None:
-        """Loading flowcells from lims into the trending database"""
-
-        self.vogue_api.load_flowcells(days=days)
-
-    def load_reagent_labels(self, days: int) -> None:
-        """Loading reagent_labels from lims into the trending database"""
-
-        self.vogue_api.load_reagent_labels(days=days)
-
     def load_bioinfo_raw(self, load_bioinfo_inputs):
         """Running vogue load bioinfo raw."""
 

--- a/cg/meta/upload/vogue.py
+++ b/cg/meta/upload/vogue.py
@@ -15,7 +15,7 @@ class UploadVogueAPI:
         self.vogue_api = vogue_api
         self.store = store
 
-    def load_genotype(self, days: int) -> None:
+    def load_genotype(self, days) -> None:
         """Loading genotype data from the genotype database into the trending database"""
         samples = self.genotype_api.export_sample(days=days)
         samples = json.loads(samples)

--- a/tests/apps/vogue/conftest.py
+++ b/tests/apps/vogue/conftest.py
@@ -51,7 +51,7 @@ class MockProcess:
         self._stderr = ""
 
     def run_command(self, command: list):
-        self._stderr = " ".join([str(item) for item in command])
+        self._stderr = " ".join(command)
 
     def stderr_lines(self):
         return self._stderr.split("\n")

--- a/tests/apps/vogue/conftest.py
+++ b/tests/apps/vogue/conftest.py
@@ -19,7 +19,7 @@ def vogue_config():
     return _config
 
 
-@pytest.fixture(scope="function", name='vogue_api')
+@pytest.fixture(scope="function", name="vogue_api")
 def fixture_vogue_api(process):
     """
         vogue API fixture
@@ -39,7 +39,7 @@ def genotype_dict():
     return "{}"
 
 
-@pytest.fixture(scope="function", name='process')
+@pytest.fixture(scope="function", name="process")
 def fixture_process():
     """"""
 
@@ -47,12 +47,11 @@ def fixture_process():
 
 
 class MockProcess:
-
     def __init__(self):
-        self._stderr = ''
+        self._stderr = ""
 
     def run_command(self, command: list):
-        self._stderr = ' '.join([str(item) for item in command])
+        self._stderr = " ".join([str(item) for item in command])
 
     def stderr_lines(self):
-        return self._stderr.split('\n')
+        return self._stderr.split("\n")

--- a/tests/apps/vogue/conftest.py
+++ b/tests/apps/vogue/conftest.py
@@ -19,13 +19,14 @@ def vogue_config():
     return _config
 
 
-@pytest.fixture(scope="function")
-def vogueapi():
+@pytest.fixture(scope="function", name='vogue_api')
+def fixture_vogue_api(process):
     """
         vogue API fixture
     """
 
     _vogue_api = VogueAPI(CONFIG)
+    _vogue_api.process = process
     return _vogue_api
 
 
@@ -36,3 +37,22 @@ def genotype_dict():
     """
 
     return "{}"
+
+
+@pytest.fixture(scope="function", name='process')
+def fixture_process():
+    """"""
+
+    return MockProcess()
+
+
+class MockProcess:
+
+    def __init__(self):
+        self._stderr = ''
+
+    def run_command(self, command: list):
+        self._stderr = ' '.join([str(item) for item in command])
+
+    def stderr_lines(self):
+        return self._stderr.split('\n')

--- a/tests/apps/vogue/test_vogue_api.py
+++ b/tests/apps/vogue/test_vogue_api.py
@@ -155,33 +155,33 @@ def test_load_bioinfo_process(vogue_config, caplog):
 
 def test_vogue_load_reagent_labels(vogue_api, caplog):
     caplog.set_level(logging.DEBUG)
-    #GIVEN a vogue api 
+    # GIVEN a vogue api
 
-    #WHEN running vogue load reagent_label with some days as argument
-    vogue_api.load_reagent_labels(days = 1)
-    
-    #THEN assert vogue output is comunicated
-    assert 'vogue output' in caplog.text
+    # WHEN running vogue load reagent_label with some days as argument
+    vogue_api.load_reagent_labels(days=1)
+
+    # THEN assert vogue output is comunicated
+    assert "vogue output" in caplog.text
 
 
 def test_vogue_load_samples(vogue_api, caplog):
     caplog.set_level(logging.DEBUG)
-    
-    #GIVEN a vogue api 
 
-    #WHEN running vogue load samples with some days as argument
-    vogue_api.load_samples(days = 1)
-    
-    #THEN assert vogue output is comunicated
-    assert 'vogue output' in caplog.text
+    # GIVEN a vogue api
+
+    # WHEN running vogue load samples with some days as argument
+    vogue_api.load_samples(days=1)
+
+    # THEN assert vogue output is comunicated
+    assert "vogue output" in caplog.text
+
 
 def test_vogue_load_flowcells(vogue_api, caplog):
     caplog.set_level(logging.DEBUG)
-    #GIVEN a vogue api 
+    # GIVEN a vogue api
 
-    #WHEN running vogue load flowcells with some days as argument
-    vogue_api.load_flowcells(days = 1)
-    
-    #THEN assert vogue output is comunicated
-    assert 'vogue output' in caplog.text
+    # WHEN running vogue load flowcells with some days as argument
+    vogue_api.load_flowcells(days=1)
 
+    # THEN assert vogue output is comunicated
+    assert "vogue output" in caplog.text

--- a/tests/apps/vogue/test_vogue_api.py
+++ b/tests/apps/vogue/test_vogue_api.py
@@ -157,9 +157,30 @@ def test_vogue_load_reagent_labels(vogue_api, caplog):
     caplog.set_level(logging.DEBUG)
     #GIVEN a vogue api 
 
-    
     #WHEN running vogue load reagent_label with some days as argument
     vogue_api.load_reagent_labels(days = 1)
+    
+    #THEN assert vogue output is comunicated
+    assert 'vogue output' in caplog.text
+
+
+def test_vogue_load_samples(vogue_api, caplog):
+    caplog.set_level(logging.DEBUG)
+    
+    #GIVEN a vogue api 
+
+    #WHEN running vogue load samples with some days as argument
+    vogue_api.load_samples(days = 1)
+    
+    #THEN assert vogue output is comunicated
+    assert 'vogue output' in caplog.text
+
+def test_vogue_load_flowcells(vogue_api, caplog):
+    caplog.set_level(logging.DEBUG)
+    #GIVEN a vogue api 
+
+    #WHEN running vogue load flowcells with some days as argument
+    vogue_api.load_flowcells(days = 1)
     
     #THEN assert vogue output is comunicated
     assert 'vogue output' in caplog.text

--- a/tests/apps/vogue/test_vogue_api.py
+++ b/tests/apps/vogue/test_vogue_api.py
@@ -151,3 +151,16 @@ def test_load_bioinfo_process(vogue_config, caplog):
 
         # THEN assert that command is in log output
         assert load_bioinfo_process_call_command in caplog.text
+
+
+def test_vogue_load_reagent_labels(vogue_api, caplog):
+    caplog.set_level(logging.DEBUG)
+    #GIVEN a vogue api 
+
+    
+    #WHEN running vogue load reagent_label with some days as argument
+    vogue_api.load_reagent_labels(days = 1)
+    
+    #THEN assert vogue output is comunicated
+    assert 'vogue output' in caplog.text
+

--- a/tests/cli/upload/conftest.py
+++ b/tests/cli/upload/conftest.py
@@ -101,6 +101,12 @@ class MockVogueApi:
     def load_reagent_labels(self, days: int):
         """docstring for upload"""
 
+    def load_samples(self, days: int):
+        """docstring for upload"""
+
+    def load_flowcells(self, days: int):
+        """docstring for upload"""
+
 
 class MockAnalysisApi(AnalysisAPI):
     def __init__(self):

--- a/tests/cli/upload/conftest.py
+++ b/tests/cli/upload/conftest.py
@@ -49,6 +49,12 @@ def fixture_base_cli_context(analysis_store: Store, housekeeper_api, upload_scou
     }
 
 
+@pytest.fixture(scope="function", name="vogue_context")
+def fixture_vogue_cli_context(vogue_api) -> dict:
+    """context to use in cli"""
+
+    return {'vogue_api' : vogue_api}
+
 @pytest.fixture(scope="function", name="upload_scout_api")
 def fixture_upload_scout_api(housekeeper_api):
     """Return a upload scout api"""
@@ -56,6 +62,14 @@ def fixture_upload_scout_api(housekeeper_api):
     api.housekeeper = housekeeper_api
 
     return api
+
+
+@pytest.fixture(scope="function", name="vogue_api")
+def fixture_vogue_api():
+    """Return a MockVogueApi"""
+
+    return MockVogueApi()
+
 
 
 class MockTB(TrailblazerAPI):
@@ -77,6 +91,15 @@ class MockScoutApi(ScoutAPI):
     def upload(self, scout_config, force=False):
         """docstring for upload"""
         LOG.info("Case loaded successfully to Scout")
+
+
+class MockVogueApi:
+    def __init__(self):
+        """docstring for __init__"""
+        pass
+
+    def load_reagent_labels(self, days: int):
+        """docstring for upload"""
 
 
 class MockAnalysisApi(AnalysisAPI):
@@ -141,3 +164,4 @@ class MockLims:
             if sample["id"] == sample_id:
                 return sample
         return None
+

--- a/tests/cli/upload/conftest.py
+++ b/tests/cli/upload/conftest.py
@@ -111,7 +111,6 @@ class MockVogueApi:
 class MockAnalysisApi(AnalysisAPI):
     def __init__(self):
         """docstring for __init__"""
-        pass
 
     def get_latest_metadata(self, internal_id):
         """docstring for upload"""

--- a/tests/cli/upload/test_cli_upload_vogue.py
+++ b/tests/cli/upload/test_cli_upload_vogue.py
@@ -1,0 +1,34 @@
+""" Test cg.cli.upload.vogue module """
+
+from cg.cli.upload.vogue import reagent_labels
+import logging
+
+def test_cli_upload_vogue_reagent_labes(vogue_context, cli_runner, caplog):
+    """"""
+
+    # GIVEN a vogue api 
+    caplog.set_level(logging.DEBUG)
+
+    # WHEN running vogue load reagent_labels with the days argument
+    result = cli_runner.invoke(reagent_labels, ['-d', 1], obj=vogue_context)
+    
+
+    # THEN assert that the correct information was communicated
+    assert 'REAGENT LABELS' in caplog.text
+    # THEN assert that the program exits without errors
+    assert result.exit_code==0
+
+
+def test_cli_upload_vogue_reagent_labes_no_days(vogue_context, cli_runner):
+    """"""
+    
+    # GIVEN a vogue api 
+
+    # WHEN running vogue load reagent_labels without the days argument
+    result = cli_runner.invoke(reagent_labels, [], obj=vogue_context)
+    
+
+    # THEN assert that the program exits with a non zero exit code
+    assert result.exit_code!=0
+    
+

--- a/tests/cli/upload/test_cli_upload_vogue.py
+++ b/tests/cli/upload/test_cli_upload_vogue.py
@@ -1,10 +1,10 @@
 """ Test cg.cli.upload.vogue module """
 
-from cg.cli.upload.vogue import reagent_labels
+from cg.cli.upload.vogue import reagent_labels, samples, flowcells
 import logging
 
 def test_cli_upload_vogue_reagent_labes(vogue_context, cli_runner, caplog):
-    """"""
+    """Testing cli for upload vogue reagent_labels with correct argument"""
 
     # GIVEN a vogue api 
     caplog.set_level(logging.DEBUG)
@@ -20,12 +20,69 @@ def test_cli_upload_vogue_reagent_labes(vogue_context, cli_runner, caplog):
 
 
 def test_cli_upload_vogue_reagent_labes_no_days(vogue_context, cli_runner):
-    """"""
+    """Testing cli for upload vogue reagent_labels with wrong argument"""
     
     # GIVEN a vogue api 
 
     # WHEN running vogue load reagent_labels without the days argument
     result = cli_runner.invoke(reagent_labels, [], obj=vogue_context)
+    
+
+    # THEN assert that the program exits with a non zero exit code
+    assert result.exit_code!=0
+
+
+def test_cli_upload_vogue_samples(vogue_context, cli_runner, caplog):
+    """Testing cli for upload vogue samples with correct argument"""
+
+    # GIVEN a vogue api 
+    caplog.set_level(logging.DEBUG)
+
+    # WHEN running vogue load samples with the days argument
+    result = cli_runner.invoke(samples, ['-d', 1], obj=vogue_context)
+    
+
+    # THEN assert that the correct information was communicated
+    assert 'SAMPLES' in caplog.text
+    # THEN assert that the program exits without errors
+    assert result.exit_code==0
+
+
+def test_cli_upload_vogue_samples_no_days(vogue_context, cli_runner):
+    """Testing cli for upload vogue samples with wrong argument"""
+    
+    # GIVEN a vogue api 
+
+    # WHEN running vogue load samples without the days argument
+    result = cli_runner.invoke(samples, [], obj=vogue_context)
+    
+
+    # THEN assert that the program exits with a non zero exit code
+    assert result.exit_code!=0
+
+def test_cli_upload_vogue_flowcells(vogue_context, cli_runner, caplog):
+    """Testing cli for upload vogue flowcells with correct argument"""
+
+    # GIVEN a vogue api 
+    caplog.set_level(logging.DEBUG)
+
+    # WHEN running vogue load flowcells with the days argument
+    result = cli_runner.invoke(flowcells, ['-d', 1], obj=vogue_context)
+    
+
+    # THEN assert that the correct information was communicated
+    assert 'FLOWCELLS' in caplog.text
+    # THEN assert that the program exits without errors
+    assert result.exit_code==0
+
+
+def test_cli_upload_vogue_flowcells_no_days(vogue_context, cli_runner):
+    """Testing cli for upload vogue flowcells with wrong argument"""
+    
+    # GIVEN a vogue api 
+
+    # WHEN running vogue load flowcells without the days argument
+    result = cli_runner.invoke(flowcells, [], obj=vogue_context)
     
 
     # THEN assert that the program exits with a non zero exit code

--- a/tests/cli/upload/test_cli_upload_vogue.py
+++ b/tests/cli/upload/test_cli_upload_vogue.py
@@ -28,63 +28,58 @@ def test_cli_upload_vogue_reagent_labes_no_days(vogue_context, cli_runner):
     result = cli_runner.invoke(reagent_labels, [], obj=vogue_context)
 
     # THEN assert that the program exits with a non zero exit code
-    assert result.exit_code!=0
+    assert result.exit_code != 0
 
 
 def test_cli_upload_vogue_samples(vogue_context, cli_runner, caplog):
     """Testing cli for upload vogue samples with correct argument"""
 
-    # GIVEN a vogue api 
+    # GIVEN a vogue api
     caplog.set_level(logging.DEBUG)
 
     # WHEN running vogue load samples with the days argument
-    result = cli_runner.invoke(samples, ['-d', 1], obj=vogue_context)
-    
+    result = cli_runner.invoke(samples, ["-d", 1], obj=vogue_context)
 
     # THEN assert that the correct information was communicated
-    assert 'SAMPLES' in caplog.text
+    assert "SAMPLES" in caplog.text
     # THEN assert that the program exits without errors
-    assert result.exit_code==0
+    assert result.exit_code == 0
 
 
 def test_cli_upload_vogue_samples_no_days(vogue_context, cli_runner):
     """Testing cli for upload vogue samples with wrong argument"""
-    
-    # GIVEN a vogue api 
+
+    # GIVEN a vogue api
 
     # WHEN running vogue load samples without the days argument
     result = cli_runner.invoke(samples, [], obj=vogue_context)
-    
 
     # THEN assert that the program exits with a non zero exit code
-    assert result.exit_code!=0
+    assert result.exit_code != 0
+
 
 def test_cli_upload_vogue_flowcells(vogue_context, cli_runner, caplog):
     """Testing cli for upload vogue flowcells with correct argument"""
 
-    # GIVEN a vogue api 
+    # GIVEN a vogue api
     caplog.set_level(logging.DEBUG)
 
     # WHEN running vogue load flowcells with the days argument
-    result = cli_runner.invoke(flowcells, ['-d', 1], obj=vogue_context)
-    
+    result = cli_runner.invoke(flowcells, ["-d", 1], obj=vogue_context)
 
     # THEN assert that the correct information was communicated
-    assert 'FLOWCELLS' in caplog.text
+    assert "FLOWCELLS" in caplog.text
     # THEN assert that the program exits without errors
-    assert result.exit_code==0
+    assert result.exit_code == 0
 
 
 def test_cli_upload_vogue_flowcells_no_days(vogue_context, cli_runner):
     """Testing cli for upload vogue flowcells with wrong argument"""
-    
-    # GIVEN a vogue api 
+
+    # GIVEN a vogue api
 
     # WHEN running vogue load flowcells without the days argument
     result = cli_runner.invoke(flowcells, [], obj=vogue_context)
-    
 
     # THEN assert that the program exits with a non zero exit code
-    assert result.exit_code!=0
-    
-
+    assert result.exit_code != 0


### PR DESCRIPTION
This PR adds `upload vogue reagent-labels` to the cli. 

**How to prepare for test**:
- [x] ssh to hasta 
- [x] install on stage:
`bash servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`
`bash servers/resources/hasta.scilifelab.se/update-vogue-stage.sh v1.1.5`

**How to test**:
- [x] Run:

`cg upload vogue reagent-labels -d 1`

**Expected test outcome**:
- [x] check that the data is being loaded to the database.

**Review:**
- [x] code approved by @moonso 
- [x] tests executed by @mayabrandi 
- [x] "Merge and deploy" approved by @moonso 
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
