### PR TITLE
Fix/create delivery reportonly for latest analysis

### DIFF
--- a/cg/store/api/status.py
+++ b/cg/store/api/status.py
@@ -1,10 +1,10 @@
 from datetime import datetime, timedelta
 from typing import List
-from sqlalchemy import or_, and_
 
 from cg.constants import PRIORITY_MAP
 from cg.store import models
 from cg.store.api.base import BaseHandler
+from sqlalchemy import or_, and_, func
 
 
 class StatusHandler(BaseHandler):

--- a/tests/store/api/test_analyses_to_delivery_report.py
+++ b/tests/store/api/test_analyses_to_delivery_report.py
@@ -4,12 +4,12 @@ from datetime import datetime, timedelta
 from cg.store import Store
 
 
-def test_analyses_to_delivery_report_missing(analysis_store: Store, helpers):
+def test_missing(analysis_store: Store, helpers):
     """Tests that analyses that are completed but lacks delivery report are returned"""
 
     # GIVEN an analysis that is delivered but has no delivery report
     timestamp = datetime.now()
-    analysis = helpers.add_analysis(analysis_store, completed_at=timestamp, uploaded_at=timestamp)
+    analysis = helpers.add_analysis(analysis_store, started_at=timestamp, uploaded_at=timestamp)
     sample = helpers.add_sample(analysis_store, delivered_at=timestamp)
     analysis_store.relate_sample(family=analysis.family, sample=sample, status="unknown")
     assert sample.delivered_at is not None
@@ -22,7 +22,7 @@ def test_analyses_to_delivery_report_missing(analysis_store: Store, helpers):
     assert analysis in analyses
 
 
-def test_analyses_to_delivery_report_outdated(analysis_store, helpers):
+def test_outdated(analysis_store, helpers):
     """Tests that analyses that have a delivery report but is older than the delivery are
     returned"""
 
@@ -31,7 +31,7 @@ def test_analyses_to_delivery_report_outdated(analysis_store, helpers):
     delivery_timestamp = timestamp - timedelta(days=1)
     analysis = helpers.add_analysis(
         analysis_store,
-        completed_at=timestamp,
+        started_at=timestamp,
         uploaded_at=timestamp,
         delivery_reported_at=delivery_timestamp,
     )
@@ -42,3 +42,35 @@ def test_analyses_to_delivery_report_outdated(analysis_store, helpers):
 
     # THEN this analyse should be returned
     assert analysis in analyses
+
+
+def test_multiple_analyses(analysis_store, helpers):
+    """Tests that analyses that are not latest are not returned"""
+
+    # GIVEN an analysis that is not delivery reported but there exists a newer analysis
+    timestamp = datetime.now()
+    family = helpers.add_family(analysis_store)
+    analysis_oldest = helpers.add_analysis(
+        analysis_store,
+        family=family,
+        started_at=timestamp - timedelta(days=1),
+        uploaded_at=timestamp - timedelta(days=1),
+        delivery_reported_at=None,
+    )
+    analysis_store.add_commit(analysis_oldest)
+    analysis_newest = helpers.add_analysis(
+        analysis_store,
+        family=family,
+        started_at=timestamp,
+        uploaded_at=timestamp,
+        delivery_reported_at=None,
+    )
+    sample = helpers.add_sample(analysis_store, delivered_at=timestamp)
+    analysis_store.relate_sample(family=analysis_oldest.family, sample=sample, status="unknown")
+
+    # WHEN calling the analyses_to_delivery_report
+    analyses = analysis_store.analyses_to_delivery_report().all()
+
+    # THEN only the newest analysis should be returned
+    assert analysis_newest in analyses
+    assert analysis_oldest not in analyses

--- a/tests/store/api/test_analyses_to_delivery_report.py
+++ b/tests/store/api/test_analyses_to_delivery_report.py
@@ -42,35 +42,3 @@ def test_outdated(analysis_store, helpers):
 
     # THEN this analyse should be returned
     assert analysis in analyses
-
-
-def test_multiple_analyses(analysis_store, helpers):
-    """Tests that analyses that are not latest are not returned"""
-
-    # GIVEN an analysis that is not delivery reported but there exists a newer analysis
-    timestamp = datetime.now()
-    family = helpers.add_family(analysis_store)
-    analysis_oldest = helpers.add_analysis(
-        analysis_store,
-        family=family,
-        started_at=timestamp - timedelta(days=1),
-        uploaded_at=timestamp - timedelta(days=1),
-        delivery_reported_at=None,
-    )
-    analysis_store.add_commit(analysis_oldest)
-    analysis_newest = helpers.add_analysis(
-        analysis_store,
-        family=family,
-        started_at=timestamp,
-        uploaded_at=timestamp,
-        delivery_reported_at=None,
-    )
-    sample = helpers.add_sample(analysis_store, delivered_at=timestamp)
-    analysis_store.relate_sample(family=analysis_oldest.family, sample=sample, status="unknown")
-
-    # WHEN calling the analyses_to_delivery_report
-    analyses = analysis_store.analyses_to_delivery_report().all()
-
-    # THEN only the newest analysis should be returned
-    assert analysis_newest in analyses
-    assert analysis_oldest not in analyses

--- a/tests/store/api/test_store_api_status.py
+++ b/tests/store/api/test_store_api_status.py
@@ -1,5 +1,5 @@
 """Tests the status part of the cg.store.api"""
-from datetime import datetime
+from datetime import datetime, timedelta
 
 
 def test_samples_to_receive_external(sample_store, helpers):
@@ -118,6 +118,39 @@ def test_case_not_in_observations_to_upload(sample_store):
 
     # THEN the case should not be in the returned collection
     assert analysis.family not in observations_to_upload
+
+
+def test_multiple_analyses(analysis_store, helpers):
+    """Tests that analyses that are not latest are not returned"""
+
+    # GIVEN an analysis that is not delivery reported but there exists a newer analysis
+    timestamp = datetime.now()
+    family = helpers.add_family(analysis_store)
+    analysis_oldest = helpers.add_analysis(
+        analysis_store,
+        family=family,
+        started_at=timestamp - timedelta(days=1),
+        uploaded_at=timestamp - timedelta(days=1),
+        delivery_reported_at=None,
+    )
+    analysis_store.add_commit(analysis_oldest)
+    analysis_newest = helpers.add_analysis(
+        analysis_store,
+        family=family,
+        started_at=timestamp,
+        uploaded_at=timestamp,
+        delivery_reported_at=None,
+    )
+    sample = helpers.add_sample(analysis_store, delivered_at=timestamp)
+    analysis_store.relate_sample(family=analysis_oldest.family, sample=sample, status="unknown")
+
+    # WHEN calling the analyses_to_delivery_report
+    analyses = analysis_store.latest_analyses().all()
+
+    # THEN only the newest analysis should be returned
+    assert analysis_newest in analyses
+    assert analysis_oldest not in analyses
+
 
 
 def ensure_customer(store, customer_id="cust_test"):

--- a/tests/store/api/test_store_api_status.py
+++ b/tests/store/api/test_store_api_status.py
@@ -152,7 +152,6 @@ def test_multiple_analyses(analysis_store, helpers):
     assert analysis_oldest not in analyses
 
 
-
 def ensure_customer(store, customer_id="cust_test"):
     """utility function to return existing or create customer for tests"""
     customer_group = store.customer_group("dummy_group")

--- a/tests/store_helpers.py
+++ b/tests/store_helpers.py
@@ -141,6 +141,7 @@ class StoreHelpers:
         self,
         store: Store,
         family: models.Family = None,
+        started_at: datetime = None,
         completed_at: datetime = None,
         uploaded_at: datetime = None,
         upload_started: datetime = None,
@@ -157,6 +158,8 @@ class StoreHelpers:
 
         analysis = store.add_analysis(pipeline=pipeline, version=pipeline_version)
 
+        if started_at:
+            analysis.started_at = started_at
         if completed_at:
             analysis.completed_at = completed_at
         if uploaded_at:
@@ -290,7 +293,7 @@ class StoreHelpers:
         )
 
         family_obj = self.add_family(
-            store, family_obj=family_obj, customer_id=customer_obj.internal_id,
+            store, family_obj=family_obj, customer_id=customer_obj.internal_id
         )
 
         app_tag = app_tag or "WGTPCFC030"


### PR DESCRIPTION
This PR fixes the problem that arises when there are multiple analyses for one case that lacks a delivery report. Resolves #660 

**How to prepare for test**:
- [x] ssh to hasta (depending on type of change)
- [x] install on stage:
`bash servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

**How to test**:
- [x] login to hasta
- [x] do us
- [x] cg upload delivery-report 

**Expected test outcome**:
- [x] check that stillpython is not included in the proposed cases
- [x] Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @moonso 
- [x] tests executed by PG
- [x] "Merge and deploy" approved by PG
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
