### PR TITLE
string to subprocess call

### DIFF
--- a/cg/apps/gt.py
+++ b/cg/apps/gt.py
@@ -48,7 +48,7 @@ class GenotypeAPI(Manager):
     def export_sample(self, days: int = 0) -> str:
         """Export sample info."""
         trending_call = self.base_call[:]
-        trending_call.extend(["export-sample", "-d", days])
+        trending_call.extend(["export-sample", "-d", str(days)])
         try:
             LOG.info("Running Genotype API to get data.")
             LOG.debug(trending_call)
@@ -65,7 +65,7 @@ class GenotypeAPI(Manager):
     def export_sample_analysis(self, days: int = 0) -> str:
         """Export analysis."""
         trending_call = self.base_call[:]
-        trending_call.extend(["export-sample-analysis", "-d", days])
+        trending_call.extend(["export-sample-analysis", "-d", str(days)])
         try:
             LOG.info("Running Genotype API to get data.")
             LOG.debug(trending_call)

--- a/tests/apps/gt/test_gt_api.py
+++ b/tests/apps/gt/test_gt_api.py
@@ -28,7 +28,7 @@ def test_export_sample(genotypeapi, mocker):
     """Test that get_trending calls the genotype API with correct command."""
 
     # GIVEN a genotypeapi api and argument days
-    days = "20"
+    days = 20
 
     # WHEN running get_trending
     mocker.patch.object(subprocess, "check_output")
@@ -52,3 +52,5 @@ def test_export_sample_no_output(genotypeapi, mocker):
     # THEN assert CaseNotFoundError
     with pytest.raises(CaseNotFoundError):
         genotypeapi.export_sample(days="")
+
+

--- a/tests/apps/gt/test_gt_api.py
+++ b/tests/apps/gt/test_gt_api.py
@@ -52,5 +52,3 @@ def test_export_sample_no_output(genotypeapi, mocker):
     # THEN assert CaseNotFoundError
     with pytest.raises(CaseNotFoundError):
         genotypeapi.export_sample(days="")
-
-

--- a/tests/apps/gt/test_gt_api.py
+++ b/tests/apps/gt/test_gt_api.py
@@ -35,7 +35,7 @@ def test_export_sample(genotypeapi, mocker):
     genotypeapi.export_sample(days=days)
 
     # THEN assert subprocess is running the GenotypeAPI with correct command
-    call = ["gtdb", "--config", "config/path", "export-sample", "-d", days]
+    call = ["gtdb", "--config", "config/path", "export-sample", "-d", str(days)]
     subprocess.check_output.assert_called_with(call)
 
 


### PR DESCRIPTION
This PR fixes a small bug subrocess command requires str, not int

**How to prepare for test**:
- [x] ssh to hasta (depending on type of change)
- [x] install on stage:
`bash servers/resources/hasta.scilifelab.se/update-cg-stage.sh int2str`

**How to test**:
- [x] run: `cg upload vogue genotype -d 1`

**Expected test outcome**:
- [x] check that you get no errors. Data should be loaded to database if avalible

**Review:**
- [x] code approved by @moonso 
- [x] tests executed by @mayabrandi 
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
