### PR TITLE
Adds tests for cleaning fastq files

### DIFF
--- a/cg/apps/crunchy/crunchy.py
+++ b/cg/apps/crunchy/crunchy.py
@@ -12,26 +12,15 @@ from typing import List
 
 from marshmallow import ValidationError
 
-from cg.constants import (
-    BAM_INDEX_SUFFIX,
-    BAM_SUFFIX,
-    CRAM_INDEX_SUFFIX,
-    CRAM_SUFFIX,
-    FASTQ_DELTA,
-    FASTQ_FIRST_READ_SUFFIX,
-    FASTQ_SECOND_READ_SUFFIX,
-    SPRING_SUFFIX,
-)
+from cg.constants import (BAM_INDEX_SUFFIX, BAM_SUFFIX, CRAM_INDEX_SUFFIX,
+                          CRAM_SUFFIX, FASTQ_DELTA, FASTQ_FIRST_READ_SUFFIX,
+                          FASTQ_SECOND_READ_SUFFIX, SPRING_SUFFIX)
 from cg.utils import Process
 from cg.utils.date import get_date_str
 
 from .models import CrunchyFileSchema
-from .sbatch import (
-    SBATCH_BAM_TO_CRAM,
-    SBATCH_FASTQ_TO_SPRING,
-    SBATCH_HEADER_TEMPLATE,
-    SBATCH_SPRING_TO_FASTQ,
-)
+from .sbatch import (SBATCH_BAM_TO_CRAM, SBATCH_FASTQ_TO_SPRING,
+                     SBATCH_HEADER_TEMPLATE, SBATCH_SPRING_TO_FASTQ)
 
 LOG = logging.getLogger(__name__)
 
@@ -209,10 +198,12 @@ class CrunchyAPI:
     # Methods to check compression status
     def is_compression_pending(self, file_path: Path) -> bool:
         """Check if compression/decompression has started but not finished"""
+        LOG.info("Check if compression/decompression is pending for %s", file_path)
         pending_path = self.get_pending_path(file_path)
         if pending_path.exists():
             LOG.info("Compression/decompression is pending for %s", file_path)
             return True
+        LOG.info("Compression/decompression is not running")
         return False
 
     def is_compression_possible(self, file_path: Path) -> bool:
@@ -283,12 +274,14 @@ class CrunchyAPI:
         if not spring_path.exists():
             LOG.info("No SPRING file for %s", fastq_file)
             return False
+        LOG.info("SPRING file found")
 
         flag_path = self.get_flag_path(file_path=spring_path)
         LOG.info("Check if SPRING metadata file %s exists", flag_path)
         if not flag_path.exists():
             LOG.info("No %s file for %s. Compression not ready", FLAG_PATH_SUFFIX, fastq_file)
             return False
+        LOG.info("SPRING metadata file found")
 
         if self.is_compression_pending(spring_path):
             return False

--- a/cg/apps/crunchy/crunchy.py
+++ b/cg/apps/crunchy/crunchy.py
@@ -12,15 +12,26 @@ from typing import List
 
 from marshmallow import ValidationError
 
-from cg.constants import (BAM_INDEX_SUFFIX, BAM_SUFFIX, CRAM_INDEX_SUFFIX,
-                          CRAM_SUFFIX, FASTQ_DELTA, FASTQ_FIRST_READ_SUFFIX,
-                          FASTQ_SECOND_READ_SUFFIX, SPRING_SUFFIX)
+from cg.constants import (
+    BAM_INDEX_SUFFIX,
+    BAM_SUFFIX,
+    CRAM_INDEX_SUFFIX,
+    CRAM_SUFFIX,
+    FASTQ_DELTA,
+    FASTQ_FIRST_READ_SUFFIX,
+    FASTQ_SECOND_READ_SUFFIX,
+    SPRING_SUFFIX,
+)
 from cg.utils import Process
 from cg.utils.date import get_date_str
 
 from .models import CrunchyFileSchema
-from .sbatch import (SBATCH_BAM_TO_CRAM, SBATCH_FASTQ_TO_SPRING,
-                     SBATCH_HEADER_TEMPLATE, SBATCH_SPRING_TO_FASTQ)
+from .sbatch import (
+    SBATCH_BAM_TO_CRAM,
+    SBATCH_FASTQ_TO_SPRING,
+    SBATCH_HEADER_TEMPLATE,
+    SBATCH_SPRING_TO_FASTQ,
+)
 
 LOG = logging.getLogger(__name__)
 

--- a/tests/meta/compress/conftest.py
+++ b/tests/meta/compress/conftest.py
@@ -1,5 +1,6 @@
 """Fixtures for compress api tests"""
 import copy
+import json
 import os
 from pathlib import Path
 
@@ -9,6 +10,81 @@ from cg.apps.crunchy import CrunchyAPI
 from cg.constants import FASTQ_FIRST_READ_SUFFIX, FASTQ_SECOND_READ_SUFFIX
 from cg.meta.compress import CompressAPI
 from tests.mocks.hk_mock import MockFile
+
+
+class CompressionData:
+    """Class to hold some data files"""
+
+    def __init__(self, **kwargs):
+        self.spring_path = kwargs["spring_path"]
+        self.spring_metadata_path = kwargs["spring_metadata_path"]
+        self.fastq_first = kwargs["fastq_first"]
+        self.fastq_second = kwargs["fastq_second"]
+
+    @property
+    def spring_file(self):
+        """Return the path to an existing spring file"""
+        self.spring_path.touch()
+        return self.spring_path
+
+    @property
+    def spring_metadata_file(self):
+        """Return the path to an existing spring metadata file"""
+
+        def _spring_metadata(fastq_first, fastq_second, spring_path):
+            """Return metada information"""
+            metadata = [
+                {
+                    "path": str(fastq_first.resolve()),
+                    "file": "first_read",
+                    "checksum": "checksum_first_read",
+                    "algorithm": "sha256",
+                },
+                {
+                    "path": str(fastq_second.resolve()),
+                    "file": "second_read",
+                    "checksum": "checksum_second_read",
+                    "algorithm": "sha256",
+                },
+                {"path": str(spring_path.resolve()), "file": "spring"},
+            ]
+            return metadata
+
+        spring_metadata = _spring_metadata(self.fastq_first, self.fastq_second, self.spring_path)
+        with open(self.spring_metadata_path, "w") as outfile:
+            outfile.write(json.dumps(spring_metadata))
+
+        return self.spring_metadata_path
+
+    @property
+    def fastq_first_file(self):
+        """Return the path to an existing spring metadata file"""
+        self.fastq_first.touch()
+        return self.fastq_first
+
+    @property
+    def fastq_second_file(self):
+        """Return the path to an existing fastq file"""
+        self.fastq_second.touch()
+        return self.fastq_second
+
+
+@pytest.yield_fixture(scope="function", name="compression_files")
+def fixture_compression_files(spring_path, spring_metadata_path, fastq_paths):
+    """Return a small class with compression files"""
+    return CompressionData(
+        spring_path=spring_path,
+        spring_metadata_path=spring_metadata_path,
+        fastq_first=fastq_paths["fastq_first_path"],
+        fastq_second=fastq_paths["fastq_second_path"],
+    )
+
+
+@pytest.yield_fixture(scope="function", name="real_crunchy_api")
+def fixture_real_crunchy_api(crunchy_config_dict):
+    """crunchy api fixture"""
+
+    yield CrunchyAPI(crunchy_config_dict)
 
 
 @pytest.yield_fixture(scope="function", name="compress_api")
@@ -109,6 +185,12 @@ def fixture_bam_flag_path(bam_path) -> Path:
 def fixture_spring_path(fastq_paths) -> Path:
     """Return the path to a non existing spring file"""
     return CrunchyAPI.get_spring_path_from_fastq(fastq=fastq_paths["fastq_first_path"])
+
+
+@pytest.fixture(scope="function", name="spring_metadata_path")
+def fixture_spring_metadata_path(spring_path) -> Path:
+    """Return the path to a non existing spring metadata file"""
+    return CrunchyAPI.get_flag_path(file_path=spring_path)
 
 
 @pytest.fixture(scope="function", name="fastq_flag_path")

--- a/tests/mocks/crunchy.py
+++ b/tests/mocks/crunchy.py
@@ -117,7 +117,7 @@ class MockCrunchyAPI(CrunchyAPI):
 
         return self._bam_compression_done.get(bam_path, self._compression_done_all)
 
-    def is_spring_compression_done(self, fastq_first: Path, fastq_second: Path) -> bool:
+    def is_spring_compression_done(self, fastq_file: Path) -> bool:
         """Check if spring compression if finished"""
         return self._compression_done_all
 


### PR DESCRIPTION
This PR adds some tests to the functionality to clean compressed fastq files

**How to prepare for test**:
Tests are automated

**Expected test outcome**:
All automated tests should pass

**Review:**
- [x] code approved by @barrystokman 
- [x] tests executed by @moonso
- [x] "Merge and deploy" approved by @barrystokman 
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
