### PR TITLE
Better tmp dir and cleaning

### DIFF
--- a/cg/apps/crunchy/crunchy.py
+++ b/cg/apps/crunchy/crunchy.py
@@ -7,34 +7,21 @@
 import datetime
 import json
 import logging
-import os
 import tempfile
 from pathlib import Path
 from typing import List
 
 from marshmallow import ValidationError
 
-from cg.constants import (
-    BAM_INDEX_SUFFIX,
-    BAM_SUFFIX,
-    CRAM_INDEX_SUFFIX,
-    CRAM_SUFFIX,
-    FASTQ_DELTA,
-    FASTQ_FIRST_READ_SUFFIX,
-    FASTQ_SECOND_READ_SUFFIX,
-    SPRING_SUFFIX,
-    TMP_DIR,
-)
+from cg.constants import (BAM_INDEX_SUFFIX, BAM_SUFFIX, CRAM_INDEX_SUFFIX,
+                          CRAM_SUFFIX, FASTQ_DELTA, FASTQ_FIRST_READ_SUFFIX,
+                          FASTQ_SECOND_READ_SUFFIX, SPRING_SUFFIX)
 from cg.utils import Process
 from cg.utils.date import get_date_str
 
 from .models import CrunchyFileSchema
-from .sbatch import (
-    SBATCH_BAM_TO_CRAM,
-    SBATCH_FASTQ_TO_SPRING,
-    SBATCH_HEADER_TEMPLATE,
-    SBATCH_SPRING_TO_FASTQ,
-)
+from .sbatch import (SBATCH_BAM_TO_CRAM, SBATCH_FASTQ_TO_SPRING,
+                     SBATCH_HEADER_TEMPLATE, SBATCH_SPRING_TO_FASTQ)
 
 LOG = logging.getLogger(__name__)
 
@@ -469,22 +456,11 @@ class CrunchyAPI:
         return sbatch_header
 
     @staticmethod
-    def _get_tmp_dir(prefix: str, suffix: str, base: str) -> str:
+    def _get_tmp_dir(prefix: str, suffix: str) -> str:
         """Create a temporary directory and return the path to it"""
 
-        LOG.info("Check if possible to create tmp dir with base %s", base)
-        if not os.path.exists(base):
-            LOG.warning("Not allowed to create tmp dir")
-            base = None
-        elif not os.access(base, os.W_OK):
-            LOG.warning("Could not find temp path")
-            base = None
-        if base:
-            with tempfile.TemporaryDirectory(dir=base, prefix=prefix, suffix=suffix) as dir_name:
-                tmp_dir_path = dir_name
-        else:
-            with tempfile.TemporaryDirectory(prefix=prefix, suffix=suffix) as dir_name:
-                tmp_dir_path = dir_name
+        with tempfile.TemporaryDirectory(prefix=prefix, suffix=suffix) as dir_name:
+            tmp_dir_path = dir_name
 
         LOG.info("Created temporary dir %s", tmp_dir_path)
         return tmp_dir_path
@@ -514,7 +490,7 @@ class CrunchyAPI:
     ) -> str:
         """Create and return the body of a sbatch script that runs FASTQ to SPRING"""
         LOG.info("Generating fastq to spring sbatch body")
-        tmp_dir_path = CrunchyAPI._get_tmp_dir(prefix="spring_", suffix="_compress", base=TMP_DIR)
+        tmp_dir_path = CrunchyAPI._get_tmp_dir(prefix="spring_", suffix="_compress")
         sbatch_body = SBATCH_FASTQ_TO_SPRING.format(
             fastq_first=fastq_first_path,
             fastq_second=fastq_second_path,
@@ -537,7 +513,7 @@ class CrunchyAPI:
     ) -> str:
         """Create and return the body of a sbatch script that runs SPRING to FASTQ"""
         LOG.info("Generating spring to fastq sbatch body")
-        tmp_dir_path = CrunchyAPI._get_tmp_dir(prefix="spring_", suffix="_decompress", base=TMP_DIR)
+        tmp_dir_path = CrunchyAPI._get_tmp_dir(prefix="spring_", suffix="_decompress")
         sbatch_body = SBATCH_SPRING_TO_FASTQ.format(
             spring_path=spring_path,
             fastq_first=fastq_first_path,

--- a/cg/apps/crunchy/crunchy.py
+++ b/cg/apps/crunchy/crunchy.py
@@ -13,15 +13,26 @@ from typing import List
 
 from marshmallow import ValidationError
 
-from cg.constants import (BAM_INDEX_SUFFIX, BAM_SUFFIX, CRAM_INDEX_SUFFIX,
-                          CRAM_SUFFIX, FASTQ_DELTA, FASTQ_FIRST_READ_SUFFIX,
-                          FASTQ_SECOND_READ_SUFFIX, SPRING_SUFFIX)
+from cg.constants import (
+    BAM_INDEX_SUFFIX,
+    BAM_SUFFIX,
+    CRAM_INDEX_SUFFIX,
+    CRAM_SUFFIX,
+    FASTQ_DELTA,
+    FASTQ_FIRST_READ_SUFFIX,
+    FASTQ_SECOND_READ_SUFFIX,
+    SPRING_SUFFIX,
+)
 from cg.utils import Process
 from cg.utils.date import get_date_str
 
 from .models import CrunchyFileSchema
-from .sbatch import (SBATCH_BAM_TO_CRAM, SBATCH_FASTQ_TO_SPRING,
-                     SBATCH_HEADER_TEMPLATE, SBATCH_SPRING_TO_FASTQ)
+from .sbatch import (
+    SBATCH_BAM_TO_CRAM,
+    SBATCH_FASTQ_TO_SPRING,
+    SBATCH_HEADER_TEMPLATE,
+    SBATCH_SPRING_TO_FASTQ,
+)
 
 LOG = logging.getLogger(__name__)
 

--- a/cg/apps/crunchy/crunchy.py
+++ b/cg/apps/crunchy/crunchy.py
@@ -88,12 +88,14 @@ class CrunchyAPI:
         sbatch_path = self.get_sbatch_path(log_dir, "bam", self.get_run_name(bam_path))
         self._submit_sbatch(sbatch_content=sbatch_content, sbatch_path=sbatch_path)
 
-    def fastq_to_spring(self, fastq_first: Path, fastq_second: Path):
+    def fastq_to_spring(self, fastq_first: Path, fastq_second: Path, sample_id: str = ""):
         """
             Compress FASTQ files into SPRING by sending to sbatch SLURM
         """
         spring_path = self.get_spring_path_from_fastq(fastq=fastq_first)
-        job_name = str(fastq_first.name).replace(FASTQ_FIRST_READ_SUFFIX, "_fastq_to_spring")
+        job_name = "_".join(
+            [sample_id, str(fastq_first.name).replace(FASTQ_FIRST_READ_SUFFIX, "_fastq_to_spring")]
+        )
         flag_path = self.get_flag_path(file_path=spring_path)
         pending_path = self.get_pending_path(file_path=spring_path)
         LOG.info("Use pending path: %s", pending_path)
@@ -113,7 +115,7 @@ class CrunchyAPI:
         sbatch_content = "\n".join([sbatch_header, sbatch_body])
         self._submit_sbatch(sbatch_content=sbatch_content, sbatch_path=sbatch_path)
 
-    def spring_to_fastq(self, spring_path: Path):
+    def spring_to_fastq(self, spring_path: Path, sample_id: str = ""):
         """
             Decompress SPRING into fastq by sending to sbatch SLURM
         """
@@ -123,7 +125,12 @@ class CrunchyAPI:
 
         fastq_first_path = Path(files_info["fastq_first"]["path"])
 
-        job_name = str(fastq_first_path.name).replace(FASTQ_FIRST_READ_SUFFIX, "_spring_to_fastq")
+        job_name = "_".join(
+            [
+                sample_id,
+                str(fastq_first_path.name).replace(FASTQ_FIRST_READ_SUFFIX, "_spring_to_fastq"),
+            ]
+        )
         pending_path = self.get_pending_path(file_path=spring_path)
         LOG.info("Use pending path: %s", pending_path)
         log_dir = self.get_log_dir(spring_path)

--- a/cg/cli/compress/fastq.py
+++ b/cg/cli/compress/fastq.py
@@ -6,7 +6,8 @@ import click
 
 from cg.exc import CaseNotFoundError
 
-from .helpers import get_fastq_cases, get_fastq_individuals, update_compress_api
+from .helpers import (get_fastq_cases, get_fastq_individuals,
+                      update_compress_api)
 
 LOG = logging.getLogger(__name__)
 
@@ -50,7 +51,9 @@ def fastq_cmd(context, case_id, number_of_conversions, ntasks, mem, dry_run):
             case_conversion_count += 1
 
     LOG.info(
-        "%s Individuals in %s cases where compressed", ind_conversion_count, case_conversion_count
+        "%s Individuals in %s (completed) cases where compressed",
+        ind_conversion_count,
+        case_conversion_count,
     )
 
 

--- a/cg/cli/compress/fastq.py
+++ b/cg/cli/compress/fastq.py
@@ -6,8 +6,7 @@ import click
 
 from cg.exc import CaseNotFoundError
 
-from .helpers import (get_fastq_cases, get_fastq_individuals,
-                      update_compress_api)
+from .helpers import get_fastq_cases, get_fastq_individuals, update_compress_api
 
 LOG = logging.getLogger(__name__)
 

--- a/cg/cli/compress/fastq.py
+++ b/cg/cli/compress/fastq.py
@@ -6,7 +6,8 @@ import click
 
 from cg.exc import CaseNotFoundError
 
-from .helpers import get_fastq_cases, get_fastq_individuals, update_compress_api
+from .helpers import (get_fastq_cases, get_fastq_individuals,
+                      update_compress_api)
 
 LOG = logging.getLogger(__name__)
 
@@ -38,7 +39,7 @@ def fastq_cmd(context, case_id, number_of_conversions, ntasks, mem, dry_run):
         if case_conversion_count >= number_of_conversions:
             break
 
-        LOG.info("\n\nSearching for FASTQ files in case %s", case.internal_id)
+        LOG.info("Searching for FASTQ files in case %s", case.internal_id)
         for link_obj in case.links:
             sample_id = link_obj.sample.internal_id
             case_converted = compress_api.compress_fastq(sample_id)

--- a/cg/meta/compress/compress.py
+++ b/cg/meta/compress/compress.py
@@ -98,14 +98,16 @@ class CompressAPI:
         if not sample_fastq_dict:
             return False
 
+        all_ok = True
         for run in sample_fastq_dict:
             LOG.info("Check if compression possible for run %s", run)
             fastq_first = sample_fastq_dict[run]["fastq_first_file"]["path"]
             fastq_second = sample_fastq_dict[run]["fastq_second_file"]["path"]
 
             if not self.crunchy_api.is_compression_possible(fastq_first):
-                LOG.warning("FASTQ to SPRING not possible for %s", sample_id)
-                return False
+                LOG.warning("FASTQ to SPRING not possible for %s, run %s", sample_id, run)
+                all_ok = False
+                continue
 
             LOG.info(
                 "Compressing %s and %s for sample %s into SPRING format",
@@ -115,7 +117,7 @@ class CompressAPI:
             )
             self.crunchy_api.fastq_to_spring(fastq_first=fastq_first, fastq_second=fastq_second)
 
-        return True
+        return all_ok
 
     def decompress_spring(self, sample_id: str):
         """Decompress SPRING archive for a sample

--- a/cg/meta/compress/compress.py
+++ b/cg/meta/compress/compress.py
@@ -115,7 +115,9 @@ class CompressAPI:
                 fastq_second,
                 sample_id,
             )
-            self.crunchy_api.fastq_to_spring(fastq_first=fastq_first, fastq_second=fastq_second)
+            self.crunchy_api.fastq_to_spring(
+                fastq_first=fastq_first, fastq_second=fastq_second, sample_id=sample_id
+            )
 
         return all_ok
 
@@ -140,7 +142,7 @@ class CompressAPI:
                 "Decompressing %s to FASTQ format for sample %s ", spring_path, sample_id,
             )
 
-            self.crunchy_api.spring_to_fastq(spring_path)
+            self.crunchy_api.spring_to_fastq(spring_path, sample_id=sample_id)
             spring_metadata_path = self.crunchy_api.get_flag_path(spring_path)
             self.crunchy_api.update_metadata_date(spring_metadata_path)
 

--- a/cg/meta/compress/compress.py
+++ b/cg/meta/compress/compress.py
@@ -89,7 +89,7 @@ class CompressAPI:
 
     def compress_fastq(self, sample_id: str) -> bool:
         """Compress the fastq files for a individual"""
-        LOG.info("\nCheck if FASTQ compression is possible for %s", sample_id)
+        LOG.info("Check if FASTQ compression is possible for %s", sample_id)
         version_obj = self.get_latest_version(sample_id)
         if not version_obj:
             return False
@@ -99,7 +99,7 @@ class CompressAPI:
             return False
 
         for run in sample_fastq_dict:
-            LOG.info("\nCheck if compression possible for run %s", run)
+            LOG.info("Check if compression possible for run %s", run)
             fastq_first = sample_fastq_dict[run]["fastq_first_file"]["path"]
             fastq_second = sample_fastq_dict[run]["fastq_second_file"]["path"]
 

--- a/cg/meta/compress/compress.py
+++ b/cg/meta/compress/compress.py
@@ -195,7 +195,7 @@ class CompressAPI:
         This means removing compressed fastq files and update housekeeper to point to the new spring
         file and its metadata file
         """
-        LOG.info("\nClean FASTQ files for %s", sample_id)
+        LOG.info("Clean FASTQ files for %s", sample_id)
         version_obj = self.get_latest_version(sample_id)
         if not version_obj:
             return False
@@ -204,15 +204,17 @@ class CompressAPI:
         if not sample_fastq_dict:
             return False
 
+        all_cleaned = True
         for run in sample_fastq_dict:
             fastq_first = sample_fastq_dict[run]["fastq_first_file"]["path"]
             fastq_second = sample_fastq_dict[run]["fastq_second_file"]["path"]
 
             if not self.crunchy_api.is_spring_compression_done(fastq_first):
-                LOG.info("Fastq compression not done: %s", sample_id)
-                return False
+                LOG.info("Fastq compression not done for sample %s, run %s", sample_id, run)
+                all_cleaned = False
+                continue
 
-            LOG.info("Fastq compression done for: %s!!", sample_id)
+            LOG.info("FASTQ compression done for sample %s, run %s!!", sample_id, run)
 
             fastq_first_hk = sample_fastq_dict[run]["fastq_first_file"]["hk_file"]
             fastq_second_hk = sample_fastq_dict[run]["fastq_second_file"]["hk_file"]
@@ -223,8 +225,9 @@ class CompressAPI:
 
             self.remove_fastq(fastq_first=fastq_first, fastq_second=fastq_second)
 
-        LOG.info("\nFASTQ files cleaned for %s!!", sample_id)
-        return True
+        if all_cleaned:
+            LOG.info("All FASTQ files cleaned for %s!!", sample_id)
+        return all_cleaned
 
     def add_decompressed_fastq(self, sample_id) -> bool:
         """Adds unpacked fastq files to housekeeper"""

--- a/cg/meta/compress/files.py
+++ b/cg/meta/compress/files.py
@@ -8,13 +8,8 @@ from typing import Dict, List, Tuple
 from housekeeper.store import models as hk_models
 
 from cg.apps.crunchy import CrunchyAPI
-from cg.constants import (
-    BAM_SUFFIX,
-    FASTQ_FIRST_READ_SUFFIX,
-    FASTQ_SECOND_READ_SUFFIX,
-    HK_BAM_TAGS,
-    HK_FASTQ_TAGS,
-)
+from cg.constants import (BAM_SUFFIX, FASTQ_FIRST_READ_SUFFIX,
+                          FASTQ_SECOND_READ_SUFFIX, HK_BAM_TAGS, HK_FASTQ_TAGS)
 
 LOG = logging.getLogger(__name__)
 
@@ -186,6 +181,7 @@ def get_fastq_runs(fastq_files: List[Path]) -> Dict[str, list]:
         if not run_name:
             continue
         if run_name not in fastq_runs:
+            LOG.info("Found run %s", run_name)
             fastq_runs[run_name] = []
         fastq_runs[run_name].append(fastq_file)
 
@@ -208,14 +204,16 @@ def get_fastq_files(sample_id: str, version_obj: hk_models.Version) -> Dict[str,
 
         sorted_fastqs = sort_fastqs(fastq_files=fastq_runs[run])
         if not sorted_fastqs:
-            LOG.info("Could not sort FASTQ files for %s", sample_id)
+            LOG.info("Skipping run %s", run)
             continue
+
         fastq_first = {"path": sorted_fastqs[0], "hk_file": hk_files_dict[sorted_fastqs[0]]}
         fastq_second = {"path": sorted_fastqs[1], "hk_file": hk_files_dict[sorted_fastqs[1]]}
         fastq_dict[run] = {
             "fastq_first_file": fastq_first,
             "fastq_second_file": fastq_second,
         }
+
     return fastq_dict
 
 

--- a/cg/meta/compress/files.py
+++ b/cg/meta/compress/files.py
@@ -8,8 +8,13 @@ from typing import Dict, List, Tuple
 from housekeeper.store import models as hk_models
 
 from cg.apps.crunchy import CrunchyAPI
-from cg.constants import (BAM_SUFFIX, FASTQ_FIRST_READ_SUFFIX,
-                          FASTQ_SECOND_READ_SUFFIX, HK_BAM_TAGS, HK_FASTQ_TAGS)
+from cg.constants import (
+    BAM_SUFFIX,
+    FASTQ_FIRST_READ_SUFFIX,
+    FASTQ_SECOND_READ_SUFFIX,
+    HK_BAM_TAGS,
+    HK_FASTQ_TAGS,
+)
 
 LOG = logging.getLogger(__name__)
 

--- a/tests/cli/compress/test_cli_compress_fastq.py
+++ b/tests/cli/compress/test_cli_compress_fastq.py
@@ -16,7 +16,7 @@ def test_compress_fastq_cli_no_family(compress_context, cli_runner, caplog):
     # THEN assert the program exits since no cases where found
     assert res.exit_code == 0
     # THEN assert it was communicated that no families where found
-    assert "Individuals in 0 cases where compressed" in caplog.text
+    assert "Individuals in 0 (completed) cases where compressed" in caplog.text
 
 
 def test_compress_fastq_cli_case_id_no_family(compress_context, cli_runner, case_id, caplog):
@@ -44,7 +44,7 @@ def test_compress_fastq_cli_one_family(populated_compress_context, cli_runner, c
     # THEN assert the program exits since no cases where found
     assert res.exit_code == 0
     # THEN assert it was communicated that no families where found
-    assert f"Individuals in 1 cases where compressed" in caplog.text
+    assert f"Individuals in 1 (completed) cases where compressed" in caplog.text
 
 
 def test_compress_fastq_cli_case_id(populated_compress_context, cli_runner, case_id, caplog):
@@ -58,7 +58,7 @@ def test_compress_fastq_cli_case_id(populated_compress_context, cli_runner, case
     # THEN assert the program exits since no cases where found
     assert res.exit_code == 0
     # THEN assert it was communicated that no families where found
-    assert f"Individuals in 1 cases where compressed" in caplog.text
+    assert f"Individuals in 1 (completed) cases where compressed" in caplog.text
 
 
 def test_compress_fastq_cli_multiple_family(
@@ -77,7 +77,7 @@ def test_compress_fastq_cli_multiple_family(
     # THEN assert the program exits since no cases where found
     assert res.exit_code == 0
     # THEN assert it was communicated that no families where found
-    assert f"Individuals in {nr_cases} cases where compressed" in caplog.text
+    assert f"Individuals in {nr_cases} (completed) cases where compressed" in caplog.text
 
 
 def test_compress_fastq_cli_multiple_set_limit(
@@ -97,4 +97,4 @@ def test_compress_fastq_cli_multiple_set_limit(
     # THEN assert the program exits since no cases where found
     assert res.exit_code == 0
     # THEN assert it was communicated no more than the limited number of cases was compressed
-    assert f"Individuals in {limit} cases where compressed" in caplog.text
+    assert f"Individuals in {limit} (completed) cases where compressed" in caplog.text


### PR DESCRIPTION
This PR fixes an issue with creating tmp dirs from the nodes when running cg compress fastq.
The tmp dir will now be created under the user, attempt to create tmp dirs under `/home/proj/production/rare-disease/temp-dir/` did not work for some reason.

Also now cleaning and compression will be performed on run level, not sample level. Each sample can have multiple runs. Before compression and cleaning was stopped if one run was failing for some reason.

**How to prepare for test**:
- [x] ssh to hasta
- [x] use stage `us`
- [x] install on stage:
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh better-tmp-dir`

**How to test**:
Try the functionality on a problematic case like `modernbee` with dry run
- [ ] `cg compress fastq --case-id modernbee --dry-run`
- [ ] `cg compress clean fastq --case-id modernbee --dry-run`

**Expected test outcome**:
- [ ] check that the log message is showing the intended behaviour

**Review:**
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

**This [version](https://semver.org/) is a**
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
