### PR TITLE
Adds a problematic case to skip list

### DIFF
--- a/cg/cli/compress/fastq.py
+++ b/cg/cli/compress/fastq.py
@@ -6,7 +6,8 @@ import click
 
 from cg.exc import CaseNotFoundError
 
-from .helpers import get_fastq_cases, get_fastq_individuals, update_compress_api
+from .helpers import (get_fastq_cases, get_fastq_individuals,
+                      update_compress_api)
 
 LOG = logging.getLogger(__name__)
 
@@ -20,6 +21,7 @@ PROBLEMATIC_CASES = [
     "deepcub",
     "causalmite",
     "proudcollie",
+    "loyalegret",
 ]
 
 

--- a/cg/cli/compress/fastq.py
+++ b/cg/cli/compress/fastq.py
@@ -6,8 +6,7 @@ import click
 
 from cg.exc import CaseNotFoundError
 
-from .helpers import (get_fastq_cases, get_fastq_individuals,
-                      update_compress_api)
+from .helpers import get_fastq_cases, get_fastq_individuals, update_compress_api
 
 LOG = logging.getLogger(__name__)
 


### PR DESCRIPTION
This PR adds a case (**loyalegret**) that has some problems during fastq compression. Since it is vacation times we will skip this for now and investigate further when there is more time.


**Expected outcome**:
- [x] one more case will be skipped when searching for cases to compress

**Review:**
- [x] "Merge and deploy" approved by @barrystokman 
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
