### PR TITLE
Adds two problematic cases to skip list

### DIFF
--- a/cg/cli/compress/fastq.py
+++ b/cg/cli/compress/fastq.py
@@ -6,12 +6,8 @@ import click
 
 from cg.exc import CaseNotFoundError
 
-from .helpers import (
-    correct_spring_paths,
-    get_fastq_cases,
-    get_fastq_individuals,
-    update_compress_api,
-)
+from .helpers import (correct_spring_paths, get_fastq_cases,
+                      get_fastq_individuals, update_compress_api)
 
 LOG = logging.getLogger(__name__)
 
@@ -26,6 +22,8 @@ PROBLEMATIC_CASES = [
     "causalmite",
     "proudcollie",
     "loyalegret",
+    "grandkoi",
+    "fluenteagle",
 ]
 
 

--- a/cg/cli/compress/fastq.py
+++ b/cg/cli/compress/fastq.py
@@ -6,8 +6,12 @@ import click
 
 from cg.exc import CaseNotFoundError
 
-from .helpers import (correct_spring_paths, get_fastq_cases,
-                      get_fastq_individuals, update_compress_api)
+from .helpers import (
+    correct_spring_paths,
+    get_fastq_cases,
+    get_fastq_individuals,
+    update_compress_api,
+)
 
 LOG = logging.getLogger(__name__)
 


### PR DESCRIPTION
This PR adds two more cases two the list of cases that should be skipped when compressing fastq files.

### Expected outcome
The problematic cases should be skipped when running spring compression

## Review
- [x] code approved by @moonso 
- [x] "Merge and deploy" approved by @moonso
Thanks for filling in who performed the code review

### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
