### PR TITLE
Analyses to upload

### DIFF
--- a/cg/cli/upload/base.py
+++ b/cg/cli/upload/base.py
@@ -141,14 +141,15 @@ def upload(context, family_id, force_restart):
 
 
 @upload.command()
+@click.option("--pipeline", type=str, help="Limit to specific pipeline")
 @click.pass_context
-def auto(context):
+def auto(context: click.Context, pipeline: str = None):
     """Upload all completed analyses."""
 
     click.echo(click.style("----------------- AUTO ------------------------"))
 
     exit_code = 0
-    for analysis_obj in context.obj["status"].analyses_to_upload():
+    for analysis_obj in context.obj["status"].analyses_to_upload(pipeline=pipeline):
 
         if analysis_obj.family.analyses[0].uploaded_at is not None:
             LOG.warning(

--- a/cg/store/api/status.py
+++ b/cg/store/api/status.py
@@ -533,7 +533,7 @@ class StatusHandler(BaseHandler):
         """Return True if all samples are external or sequenced inhouse."""
         return all((link.sample.sequenced_at or link.sample.is_external) for link in links)
 
-    def analyses_to_upload(self, pipeline: str = None):
+    def analyses_to_upload(self, pipeline: str = None) -> List[models.Analysis]:
         """Fetch analyses that haven't been uploaded."""
         records = self.Analysis.query.filter(
             models.Analysis.completed_at != None, models.Analysis.uploaded_at == None

--- a/cg/store/api/status.py
+++ b/cg/store/api/status.py
@@ -533,11 +533,15 @@ class StatusHandler(BaseHandler):
         """Return True if all samples are external or sequenced inhouse."""
         return all((link.sample.sequenced_at or link.sample.is_external) for link in links)
 
-    def analyses_to_upload(self):
+    def analyses_to_upload(self, pipeline: str = None):
         """Fetch analyses that haven't been uploaded."""
         records = self.Analysis.query.filter(
             models.Analysis.completed_at != None, models.Analysis.uploaded_at == None
         )
+
+        if pipeline:
+            records = records.filter(models.Analysis.pipeline.ilike(f"%{pipeline}%"))
+
         return records
 
     def analyses_to_clean(self, pipeline: str = None):

--- a/tests/cli/upload/test_cli_upload_auto.py
+++ b/tests/cli/upload/test_cli_upload_auto.py
@@ -4,7 +4,9 @@ import logging
 from cg.cli.upload.base import auto
 
 
-def test_upload_auto_with_pipeline_as_argument(base_context, cli_runner, caplog, helpers, sample_store, timestamp):
+def test_upload_auto_with_pipeline_as_argument(
+    base_context, cli_runner, caplog, helpers, sample_store, timestamp
+):
     """Test upload auto"""
     # GIVEN a store with a MIP analysis
     helpers.add_analysis(store=sample_store, completed_at=timestamp, pipeline="MIP")

--- a/tests/cli/upload/test_cli_upload_auto.py
+++ b/tests/cli/upload/test_cli_upload_auto.py
@@ -1,0 +1,18 @@
+"""Test the cli for uploading using auto"""
+import logging
+
+from cg.cli.upload.base import auto
+
+
+def test_upload_auto(base_context, cli_runner, caplog, helpers, sample_store, timestamp):
+    """Test upload auto"""
+    # GIVEN a analysis to upload
+    helpers.add_analysis(store=sample_store, completed_at=timestamp, pipeline="MIP")
+
+    # WHEN trying to upload case
+    caplog.set_level(logging.INFO)
+    cli_runner.invoke(auto, ["--pipeline", "MIP"], obj=base_context)
+
+    # THEN communicate this to user
+    with caplog.at_level(logging.INFO):
+        assert "uploading family" in caplog.text

--- a/tests/cli/upload/test_cli_upload_auto.py
+++ b/tests/cli/upload/test_cli_upload_auto.py
@@ -4,15 +4,15 @@ import logging
 from cg.cli.upload.base import auto
 
 
-def test_upload_auto(base_context, cli_runner, caplog, helpers, sample_store, timestamp):
+def test_upload_auto_with_pipeline_as_argument(base_context, cli_runner, caplog, helpers, sample_store, timestamp):
     """Test upload auto"""
-    # GIVEN a analysis to upload
+    # GIVEN a store with a MIP analysis
     helpers.add_analysis(store=sample_store, completed_at=timestamp, pipeline="MIP")
 
-    # WHEN trying to upload case
+    # WHEN uploading all analysis from pipeline MIP
     caplog.set_level(logging.INFO)
     cli_runner.invoke(auto, ["--pipeline", "MIP"], obj=base_context)
 
-    # THEN communicate this to user
+    # THEN assert that the MIP analysis was successfully uploaded
     with caplog.at_level(logging.INFO):
         assert "uploading family" in caplog.text

--- a/tests/store/api/test_store_api_status.py
+++ b/tests/store/api/test_store_api_status.py
@@ -152,7 +152,7 @@ def test_analyses_to_upload_when_existing_pipeline(helpers, sample_store, timest
     # WHEN uploading without a pipeline specified
     records = [analysis_obj for analysis_obj in sample_store.analyses_to_upload(pipeline=None)]
 
-    # THEN at least one analysis object should be returned
+    # THEN one analysis object should be returned
     assert len(records) == 1
 
 
@@ -170,6 +170,18 @@ def test_analyses_to_upload_when_filtering_with_pipeline(helpers, sample_store, 
     for analysis_obj in records:
         # THEN pipeline should be MIP in the analysis object
         assert analysis_obj.pipeline == "MIP"
+
+
+def test_analyses_to_upload_with_pipeline_and_no_complete_at(helpers, sample_store, timestamp):
+    """Test analyses to upload to when exisiting pipeline and using it in filtering"""
+    # GIVEN a case with completed analysis
+    helpers.add_analysis(store=sample_store, pipeline="MIP")
+
+    # WHEN uploading without a pipeline specified
+    records = [analysis_obj for analysis_obj in sample_store.analyses_to_upload(pipeline="MIP")]
+
+    # THEN no analysis object should be returned
+    assert len(records) == 0
 
 
 def test_analyses_to_upload_when_filtering_with_missing_pipeline(helpers, sample_store, timestamp):

--- a/tests/store/api/test_store_api_status.py
+++ b/tests/store/api/test_store_api_status.py
@@ -120,6 +120,70 @@ def test_case_not_in_observations_to_upload(sample_store):
     assert analysis.family not in observations_to_upload
 
 
+def test_analyses_to_upload_when_not_completed_at(helpers, sample_store):
+    """Test analyses to upload with no completed_at date"""
+    # GIVEN a case with completed analysis
+    helpers.add_analysis(store=sample_store)
+
+    # WHEN no analyses are completed
+    records = [analysis_obj for analysis_obj in sample_store.analyses_to_upload()]
+
+    # THEN no analysis object should be returned
+    assert len(records) == 0
+
+
+def test_analyses_to_upload_when_no_pipeline(helpers, sample_store, timestamp):
+    """Test analyses to upload with no pipeline specified"""
+    # GIVEN a case with completed analysis
+    helpers.add_analysis(store=sample_store, completed_at=timestamp)
+
+    # WHEN uploading without a pipeline specified
+    records = [analysis_obj for analysis_obj in sample_store.analyses_to_upload(pipeline=None)]
+
+    # THEN one analysis object should be returned
+    assert len(records) == 1
+
+
+def test_analyses_to_upload_when_existing_pipeline(helpers, sample_store, timestamp):
+    """Test analyses to upload to when exisiting pipeline"""
+    # GIVEN a case with completed analysis
+    helpers.add_analysis(store=sample_store, completed_at=timestamp, pipeline="MIP")
+
+    # WHEN uploading without a pipeline specified
+    records = [analysis_obj for analysis_obj in sample_store.analyses_to_upload(pipeline=None)]
+
+    # THEN at least one analysis object should be returned
+    assert len(records) == 1
+
+
+def test_analyses_to_upload_when_filtering_with_pipeline(helpers, sample_store, timestamp):
+    """Test analyses to upload to when exisiting pipeline and using it in filtering"""
+    # GIVEN a case with completed analysis
+    helpers.add_analysis(store=sample_store, completed_at=timestamp, pipeline="MIP")
+
+    # WHEN uploading without a pipeline specified
+    records = [analysis_obj for analysis_obj in sample_store.analyses_to_upload(pipeline="MIP")]
+
+    # THEN at least one analysis object should be returned
+    assert len(records) == 1
+
+    for analysis_obj in records:
+        # THEN pipeline should be MIP in the analysis object
+        assert analysis_obj.pipeline == "MIP"
+
+
+def test_analyses_to_upload_when_filtering_with_missing_pipeline(helpers, sample_store, timestamp):
+    """Test analyses to upload to when missing pipeline and using it in filtering"""
+    # GIVEN a case with completed analysis
+    helpers.add_analysis(store=sample_store, completed_at=timestamp, pipeline="missing_pipeline")
+
+    # WHEN uploading without a pipeline specified
+    records = [analysis_obj for analysis_obj in sample_store.analyses_to_upload(pipeline="MIP")]
+
+    # THEN no analysis object should be returned
+    assert len(records) == 0
+
+
 def test_multiple_analyses(analysis_store, helpers):
     """Tests that analyses that are not latest are not returned"""
 
@@ -219,7 +283,7 @@ def ensure_application_version(disk_store, application_tag="dummy_tag"):
     application = disk_store.application(tag=application_tag)
     if not application:
         application = disk_store.add_application(
-            tag=application_tag, category="wgs", description="dummy_description", percent_kth=80,
+            tag=application_tag, category="wgs", description="dummy_description", percent_kth=80
         )
         disk_store.add_commit(application)
 

--- a/tests/store/api/test_store_api_status.py
+++ b/tests/store/api/test_store_api_status.py
@@ -122,19 +122,19 @@ def test_case_not_in_observations_to_upload(helpers, sample_store):
 
 def test_analyses_to_upload_when_not_completed_at(helpers, sample_store):
     """Test analyses to upload with no completed_at date"""
-    # GIVEN a case with completed analysis
+    # GIVEN a store with an analysis without a completed_at date
     helpers.add_analysis(store=sample_store)
 
-    # WHEN no analyses are completed
+    # WHEN fetching all analyses that are ready for upload
     records = [analysis_obj for analysis_obj in sample_store.analyses_to_upload()]
 
-    # THEN no analysis object should be returned
+    # THEN no analysis object should be returned since they did not have a completed_at entry
     assert len(records) == 0
 
 
 def test_analyses_to_upload_when_no_pipeline(helpers, sample_store, timestamp):
     """Test analyses to upload with no pipeline specified"""
-    # GIVEN a case with completed analysis
+    # GIVEN a store with one analysis
     helpers.add_analysis(store=sample_store, completed_at=timestamp)
 
     # WHEN uploading without a pipeline specified

--- a/tests/store/api/test_store_api_status.py
+++ b/tests/store/api/test_store_api_status.py
@@ -174,22 +174,22 @@ def test_analyses_to_upload_with_pipeline_and_no_complete_at(helpers, sample_sto
     # GIVEN a store with an analysis that is analysed with MIP but does not have a completed_at entry
     helpers.add_analysis(store=sample_store, pipeline="MIP")
 
-    # WHEN uploading without a pipeline specified
+    # WHEN fetching all analyses that are ready for upload and analysed by MIP
     records = [analysis_obj for analysis_obj in sample_store.analyses_to_upload(pipeline="MIP")]
 
-    # THEN no analysis object should be returned
+    # THEN no analysis object should be returned since they where not completed
     assert len(records) == 0
 
 
 def test_analyses_to_upload_when_filtering_with_missing_pipeline(helpers, sample_store, timestamp):
     """Test analyses to upload to when missing pipeline and using it in filtering"""
-    # GIVEN a case with completed analysis
+    # GIVEN a store with an analysis that has been analysed with "missing_pipeline"
     helpers.add_analysis(store=sample_store, completed_at=timestamp, pipeline="missing_pipeline")
 
-    # WHEN uploading without a pipeline specified
+    # WHEN fetching all analyses that was analysed with MIP
     records = [analysis_obj for analysis_obj in sample_store.analyses_to_upload(pipeline="MIP")]
 
-    # THEN no analysis object should be returned
+    # THEN no analysis object should be returned since there where no MIP analyses
     assert len(records) == 0
 
 

--- a/tests/store/api/test_store_api_status.py
+++ b/tests/store/api/test_store_api_status.py
@@ -137,7 +137,7 @@ def test_analyses_to_upload_when_no_pipeline(helpers, sample_store, timestamp):
     # GIVEN a store with one analysis
     helpers.add_analysis(store=sample_store, completed_at=timestamp)
 
-    # WHEN uploading without a pipeline specified
+    # WHEN fetching all analysis that are ready for upload without specifying pipeline
     records = [analysis_obj for analysis_obj in sample_store.analyses_to_upload(pipeline=None)]
 
     # THEN one analysis object should be returned

--- a/tests/store/api/test_store_api_status.py
+++ b/tests/store/api/test_store_api_status.py
@@ -52,9 +52,9 @@ def test_samples_to_sequence(sample_store):
             assert sample.reads > 0
 
 
-def test_case_in_uploaded_observations(sample_store):
+def test_case_in_uploaded_observations(helpers, sample_store):
     # GIVEN a case with observations that has been uploaded to loqusdb
-    analysis = add_analysis(store=sample_store)
+    analysis = helpers.add_analysis(store=sample_store)
 
     sample = add_sample(sample_store, uploaded_to_loqus=True)
     sample_store.relate_sample(analysis.family, sample, "unknown")
@@ -69,9 +69,9 @@ def test_case_in_uploaded_observations(sample_store):
     assert analysis.family in uploaded_observations
 
 
-def test_case_not_in_uploaded_observations(sample_store):
+def test_case_not_in_uploaded_observations(helpers, sample_store):
     # GIVEN a case with observations that has not been uploaded to loqusdb
-    analysis = add_analysis(store=sample_store)
+    analysis = helpers.add_analysis(store=sample_store)
 
     sample = add_sample(sample_store)
     sample_store.relate_sample(analysis.family, sample, "unknown")
@@ -86,9 +86,9 @@ def test_case_not_in_uploaded_observations(sample_store):
     assert analysis.family not in uploaded_observations
 
 
-def test_case_in_observations_to_upload(sample_store):
+def test_case_in_observations_to_upload(helpers, sample_store):
     # GIVEN a case with completed analysis and samples w/o loqus_id
-    analysis = add_analysis(store=sample_store)
+    analysis = helpers.add_analysis(store=sample_store)
 
     sample = add_sample(sample_store)
     sample_store.relate_sample(analysis.family, sample, "unknown")
@@ -103,9 +103,9 @@ def test_case_in_observations_to_upload(sample_store):
     assert analysis.family in observations_to_upload
 
 
-def test_case_not_in_observations_to_upload(sample_store):
+def test_case_not_in_observations_to_upload(helpers, sample_store):
     # GIVEN a case with completed analysis and samples w loqus_id
-    analysis = add_analysis(store=sample_store)
+    analysis = helpers.add_analysis(store=sample_store)
 
     sample = add_sample(sample_store, uploaded_to_loqus=True)
     sample_store.relate_sample(analysis.family, sample, "unknown")
@@ -250,32 +250,6 @@ def ensure_panel(store, panel_id="panel_test", customer_id="cust_test"):
         )
         store.add_commit(panel)
     return panel
-
-
-def add_family(store, family_id="family_test", customer_id="cust_test"):
-    """utility function to add a family to use in tests"""
-    panel = ensure_panel(store)
-    customer = ensure_customer(store, customer_id)
-    family = store.add_family(name=family_id, panels=panel.name)
-    family.customer = customer
-    store.add_commit(family)
-    return family
-
-
-def add_analysis(store, family=None, completed_at=None):
-    """Utility function to add an analysis for tests"""
-
-    if not family:
-        family = add_family(store)
-
-    analysis = store.add_analysis(pipeline="", version="")
-
-    if completed_at:
-        analysis.completed_at = completed_at
-
-    analysis.family = family
-    store.add_commit(analysis)
-    return analysis
 
 
 def ensure_application_version(disk_store, application_tag="dummy_tag"):

--- a/tests/store/api/test_store_api_status.py
+++ b/tests/store/api/test_store_api_status.py
@@ -56,7 +56,7 @@ def test_case_in_uploaded_observations(helpers, sample_store):
     # GIVEN a case with observations that has been uploaded to loqusdb
     analysis = helpers.add_analysis(store=sample_store)
 
-    sample = add_sample(sample_store, uploaded_to_loqus=True)
+    sample = helpers.add_sample(sample_store, loqus_id="uploaded_to_loqus")
     sample_store.relate_sample(analysis.family, sample, "unknown")
     assert analysis.family.analyses
     for link in analysis.family.links:
@@ -73,7 +73,7 @@ def test_case_not_in_uploaded_observations(helpers, sample_store):
     # GIVEN a case with observations that has not been uploaded to loqusdb
     analysis = helpers.add_analysis(store=sample_store)
 
-    sample = add_sample(sample_store)
+    sample = helpers.add_sample(sample_store)
     sample_store.relate_sample(analysis.family, sample, "unknown")
     assert analysis.family.analyses
     for link in analysis.family.links:
@@ -90,7 +90,7 @@ def test_case_in_observations_to_upload(helpers, sample_store):
     # GIVEN a case with completed analysis and samples w/o loqus_id
     analysis = helpers.add_analysis(store=sample_store)
 
-    sample = add_sample(sample_store)
+    sample = helpers.add_sample(sample_store)
     sample_store.relate_sample(analysis.family, sample, "unknown")
     assert analysis.family.analyses
     for link in analysis.family.links:
@@ -107,7 +107,7 @@ def test_case_not_in_observations_to_upload(helpers, sample_store):
     # GIVEN a case with completed analysis and samples w loqus_id
     analysis = helpers.add_analysis(store=sample_store)
 
-    sample = add_sample(sample_store, uploaded_to_loqus=True)
+    sample = helpers.add_sample(sample_store, loqus_id="uploaded_to_loqus")
     sample_store.relate_sample(analysis.family, sample, "unknown")
     assert analysis.family.analyses
     for link in analysis.family.links:
@@ -226,70 +226,3 @@ def test_multiple_analyses(analysis_store, helpers):
     # THEN only the newest analysis should be returned
     assert analysis_newest in analyses
     assert analysis_oldest not in analyses
-
-
-def ensure_customer(store, customer_id="cust_test"):
-    """utility function to return existing or create customer for tests"""
-    customer_group = store.customer_group("dummy_group")
-    if not customer_group:
-        customer_group = store.add_customer_group("dummy_group", "dummy group")
-
-        customer = store.add_customer(
-            internal_id=customer_id,
-            name="Test Customer",
-            scout_access=False,
-            customer_group=customer_group,
-            invoice_address="dummy_address",
-            invoice_reference="dummy_reference",
-        )
-        store.add_commit(customer)
-    customer = store.customer(customer_id)
-    return customer
-
-
-def ensure_panel(store, panel_id="panel_test", customer_id="cust_test"):
-    """utility function to add a panel to use in tests"""
-    customer = ensure_customer(store, customer_id)
-    panel = store.panel(panel_id)
-    if not panel:
-        panel = store.add_panel(
-            customer=customer,
-            name=panel_id,
-            abbrev=panel_id,
-            version=1.0,
-            date=datetime.now(),
-            genes=1,
-        )
-        store.add_commit(panel)
-    return panel
-
-
-def ensure_application_version(disk_store, application_tag="dummy_tag"):
-    """utility function to return existing or create application version for tests"""
-    application = disk_store.application(tag=application_tag)
-    if not application:
-        application = disk_store.add_application(
-            tag=application_tag, category="wgs", description="dummy_description", percent_kth=80
-        )
-        disk_store.add_commit(application)
-
-    prices = {"standard": 10, "priority": 20, "express": 30, "research": 5}
-    version = disk_store.application_version(application, 1)
-    if not version:
-        version = disk_store.add_version(application, 1, valid_from=datetime.now(), prices=prices)
-
-        disk_store.add_commit(version)
-    return version
-
-
-def add_sample(store, sample_name="sample_test", uploaded_to_loqus=None):
-    """utility function to add a sample to use in tests"""
-    customer = ensure_customer(store)
-    application_version_id = ensure_application_version(store).id
-    sample = store.add_sample(name=sample_name, sex="unknown")
-    sample.application_version_id = application_version_id
-    sample.customer = customer
-    if uploaded_to_loqus:
-        sample.loqusdb_id = uploaded_to_loqus
-    store.add_commit(sample)
-    return sample

--- a/tests/store/api/test_store_api_status.py
+++ b/tests/store/api/test_store_api_status.py
@@ -146,10 +146,10 @@ def test_analyses_to_upload_when_no_pipeline(helpers, sample_store, timestamp):
 
 def test_analyses_to_upload_when_existing_pipeline(helpers, sample_store, timestamp):
     """Test analyses to upload to when exisiting pipeline"""
-    # GIVEN a case with completed analysis
+    # GIVEN a store with an analysis that has been run with MIP
     helpers.add_analysis(store=sample_store, completed_at=timestamp, pipeline="MIP")
 
-    # WHEN uploading without a pipeline specified
+    # WHEN fetching all analyses that are ready for upload and analysed with MIP
     records = [analysis_obj for analysis_obj in sample_store.analyses_to_upload(pipeline=None)]
 
     # THEN one analysis object should be returned
@@ -158,14 +158,11 @@ def test_analyses_to_upload_when_existing_pipeline(helpers, sample_store, timest
 
 def test_analyses_to_upload_when_filtering_with_pipeline(helpers, sample_store, timestamp):
     """Test analyses to upload to when exisiting pipeline and using it in filtering"""
-    # GIVEN a case with completed analysis
+    # GIVEN a store with an analysis that is analysed with MIP
     helpers.add_analysis(store=sample_store, completed_at=timestamp, pipeline="MIP")
 
-    # WHEN uploading without a pipeline specified
+    # WHEN fetching all pipelines that are analysed with MIP
     records = [analysis_obj for analysis_obj in sample_store.analyses_to_upload(pipeline="MIP")]
-
-    # THEN at least one analysis object should be returned
-    assert len(records) == 1
 
     for analysis_obj in records:
         # THEN pipeline should be MIP in the analysis object
@@ -174,7 +171,7 @@ def test_analyses_to_upload_when_filtering_with_pipeline(helpers, sample_store, 
 
 def test_analyses_to_upload_with_pipeline_and_no_complete_at(helpers, sample_store, timestamp):
     """Test analyses to upload to when exisiting pipeline and using it in filtering"""
-    # GIVEN a case with completed analysis
+    # GIVEN a store with an analysis that is analysed with MIP but does not have a completed_at entry
     helpers.add_analysis(store=sample_store, pipeline="MIP")
 
     # WHEN uploading without a pipeline specified

--- a/tests/store/api/test_store_api_status.py
+++ b/tests/store/api/test_store_api_status.py
@@ -144,8 +144,8 @@ def test_analyses_to_upload_when_no_pipeline(helpers, sample_store, timestamp):
     assert len(records) == 1
 
 
-def test_analyses_to_upload_when_existing_pipeline(helpers, sample_store, timestamp):
-    """Test analyses to upload to when exisiting pipeline"""
+def test_analyses_to_upload_when_analysis_has_pipeline(helpers, sample_store, timestamp):
+    """Test analyses to upload to when existing pipeline"""
     # GIVEN a store with an analysis that has been run with MIP
     helpers.add_analysis(store=sample_store, completed_at=timestamp, pipeline="MIP")
 
@@ -157,7 +157,7 @@ def test_analyses_to_upload_when_existing_pipeline(helpers, sample_store, timest
 
 
 def test_analyses_to_upload_when_filtering_with_pipeline(helpers, sample_store, timestamp):
-    """Test analyses to upload to when exisiting pipeline and using it in filtering"""
+    """Test analyses to upload to when existing pipeline and using it in filtering"""
     # GIVEN a store with an analysis that is analysed with MIP
     helpers.add_analysis(store=sample_store, completed_at=timestamp, pipeline="MIP")
 
@@ -170,7 +170,7 @@ def test_analyses_to_upload_when_filtering_with_pipeline(helpers, sample_store, 
 
 
 def test_analyses_to_upload_with_pipeline_and_no_complete_at(helpers, sample_store, timestamp):
-    """Test analyses to upload to when exisiting pipeline and using it in filtering"""
+    """Test analyses to upload to when existing pipeline and using it in filtering"""
     # GIVEN a store with an analysis that is analysed with MIP but does not have a completed_at entry
     helpers.add_analysis(store=sample_store, pipeline="MIP")
 

--- a/tests/store_helpers.py
+++ b/tests/store_helpers.py
@@ -197,6 +197,7 @@ class StoreHelpers:
         application_type: str = "tgs",
         customer_name: str = None,
         reads: int = None,
+        loqus_id: str = None,
         **kwargs,
     ) -> models.Sample:
         """Utility function to add a sample to use in tests"""
@@ -224,20 +225,19 @@ class StoreHelpers:
         # print("is_external: %s" % is_external)
         sample.is_external = is_external
 
+        if loqus_id:
+            sample.loqusdb_id = loqus_id
+
         if kwargs.get("delivered_at"):
-            # print("Adding delivered_at")
             sample.delivered_at = kwargs["delivered_at"]
 
         if kwargs.get("received_at"):
-            # print("Adding received_at")
             sample.received_at = kwargs["received_at"]
 
         if kwargs.get("prepared_at"):
-            # print("Adding prepared")
             sample.received_at = kwargs["prepared_at"]
 
         if kwargs.get("flowcell"):
-            # print("Adding flowcell")
             sample.flowcells.append(kwargs["flowcell"])
 
         store.add_commit(sample)


### PR DESCRIPTION
This PR adds/fixes:

- Adds a pipeline filter to cli upload auto
- Adds test and refactor tests

### How to prepare for test
- [x] ssh to hasta
- [x] install on stage:
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh analyses_to_upload`

### How to test
- [x] login to hasta
- [x] do us
1. do `cg upload auto --help` ✅ 
1. do `cg upload auto --pipeline not_really_a_pipeline` ✅ 
1. do `cg upload auto` ✅ 
1. do `cg upload auto --pipeline MIP` ✅ 
1. do `cg upload auto --pipeline balsamic` ✅ 

### Expected test outcome
1. check that there is a new pipeline option
1. Should exit without uploading anything
1. Case onemite should be uploaded and already uploaded MIP cases should be skipped
1. Case amusedkrill should be in the output and already be uploaded, among several other cases
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [x] code approved by @patrikgrenfeldt 
- [x] tests executed by @henrikstranneheim 
- [x] "Merge and deploy" approved by @patrikgrenfeldt 
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

*Implement*
- [ ] Together with https://github.com/Clinical-Genomics/servers/pull/388