### PR TITLE
Removes scout api from compress base command

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,11 @@
+name: Black
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: psf/black@stable

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -28,9 +28,6 @@ jobs:
       with:
         github_token: ${{ secrets.github_token }}
         auto_fix: true
-        # Enable linters
-        black: true
-        black_args: "--line-length 100"
         # stop the build if there are Python syntax errors or undefined names
         flake8: true
         flake8_args: "cg/ --count --select=E9,F63,F7,F82 --show-source --statistics"

--- a/cg/apps/crunchy/crunchy.py
+++ b/cg/apps/crunchy/crunchy.py
@@ -20,7 +20,8 @@ from cg.utils import Process
 from cg.utils.date import get_date_str
 
 from .models import CrunchyFileSchema
-from .sbatch import SBATCH_FASTQ_TO_SPRING, SBATCH_HEADER_TEMPLATE, SBATCH_SPRING_TO_FASTQ
+from .sbatch import (SBATCH_FASTQ_TO_SPRING, SBATCH_HEADER_TEMPLATE,
+                     SBATCH_SPRING_TO_FASTQ)
 
 LOG = logging.getLogger(__name__)
 
@@ -45,6 +46,7 @@ class CrunchyAPI:
 
     def set_dry_run(self, dry_run: bool) -> None:
         """Update dry run"""
+        LOG.info("Set dry run to %s", dry_run)
         self.dry_run = dry_run
 
     # Methods to check compression status
@@ -327,9 +329,12 @@ class CrunchyAPI:
 
     def _submit_sbatch(self, sbatch_content: str, sbatch_path: Path):
         """Submit SLURM job"""
+        LOG.info("Submit sbatch")
         if self.dry_run:
+            LOG.warning("HEJ")
             LOG.info("Would submit sbatch %s to slurm", sbatch_path)
             return
+        LOG.warning("DU")
         with open(sbatch_path, mode="w+t") as sbatch_file:
             sbatch_file.write(sbatch_content)
 
@@ -386,9 +391,7 @@ class CrunchyAPI:
 
     @staticmethod
     def _get_slurm_spring_to_fastq(
-        compression_obj: CompressionData,
-        checksum_first: str,
-        checksum_second: str,
+        compression_obj: CompressionData, checksum_first: str, checksum_second: str,
     ) -> str:
         """Create and return the body of a sbatch script that runs SPRING to FASTQ"""
         LOG.info("Generating SPRING to FASTQ sbatch body")

--- a/cg/apps/crunchy/crunchy.py
+++ b/cg/apps/crunchy/crunchy.py
@@ -330,10 +330,8 @@ class CrunchyAPI:
         """Submit SLURM job"""
         LOG.info("Submit sbatch")
         if self.dry_run:
-            LOG.warning("HEJ")
             LOG.info("Would submit sbatch %s to slurm", sbatch_path)
             return
-        LOG.warning("DU")
         with open(sbatch_path, mode="w+t") as sbatch_file:
             sbatch_file.write(sbatch_content)
 

--- a/cg/apps/crunchy/crunchy.py
+++ b/cg/apps/crunchy/crunchy.py
@@ -20,8 +20,7 @@ from cg.utils import Process
 from cg.utils.date import get_date_str
 
 from .models import CrunchyFileSchema
-from .sbatch import (SBATCH_FASTQ_TO_SPRING, SBATCH_HEADER_TEMPLATE,
-                     SBATCH_SPRING_TO_FASTQ)
+from .sbatch import SBATCH_FASTQ_TO_SPRING, SBATCH_HEADER_TEMPLATE, SBATCH_SPRING_TO_FASTQ
 
 LOG = logging.getLogger(__name__)
 
@@ -391,7 +390,9 @@ class CrunchyAPI:
 
     @staticmethod
     def _get_slurm_spring_to_fastq(
-        compression_obj: CompressionData, checksum_first: str, checksum_second: str,
+        compression_obj: CompressionData,
+        checksum_first: str,
+        checksum_second: str,
     ) -> str:
         """Create and return the body of a sbatch script that runs SPRING to FASTQ"""
         LOG.info("Generating SPRING to FASTQ sbatch body")

--- a/cg/cli/compress/base.py
+++ b/cg/cli/compress/base.py
@@ -3,7 +3,7 @@ import logging
 
 import click
 
-from cg.apps import crunchy, hk, scoutapi
+from cg.apps import crunchy, hk
 from cg.meta.compress import CompressAPI
 from cg.store import Store
 
@@ -19,10 +19,9 @@ def compress(context):
     context.obj["db"] = Store(context.obj.get("database"))
 
     hk_api = hk.HousekeeperAPI(context.obj)
-    scout_api = scoutapi.ScoutAPI(context.obj)
     crunchy_api = crunchy.CrunchyAPI(context.obj)
 
-    compress_api = CompressAPI(hk_api=hk_api, crunchy_api=crunchy_api, scout_api=scout_api)
+    compress_api = CompressAPI(hk_api=hk_api, crunchy_api=crunchy_api)
     context.obj["compress"] = compress_api
 
 
@@ -45,10 +44,9 @@ def decompress(context):
     context.obj["db"] = Store(context.obj.get("database"))
 
     hk_api = hk.HousekeeperAPI(context.obj)
-    scout_api = scoutapi.ScoutAPI(context.obj)
     crunchy_api = crunchy.CrunchyAPI(context.obj)
 
-    compress_api = CompressAPI(hk_api=hk_api, crunchy_api=crunchy_api, scout_api=scout_api)
+    compress_api = CompressAPI(hk_api=hk_api, crunchy_api=crunchy_api)
     context.obj["compress"] = compress_api
 
 

--- a/cg/meta/compress/compress.py
+++ b/cg/meta/compress/compress.py
@@ -18,10 +18,7 @@ class CompressAPI:
     """API for compressing BAM and FASTQ files"""
 
     def __init__(
-        self,
-        hk_api: hk.HousekeeperAPI,
-        crunchy_api: crunchy.CrunchyAPI,
-        dry_run: bool = False,
+        self, hk_api: hk.HousekeeperAPI, crunchy_api: crunchy.CrunchyAPI, dry_run: bool = False,
     ):
 
         self.hk_api = hk_api
@@ -31,7 +28,8 @@ class CompressAPI:
     def set_dry_run(self, dry_run: bool):
         """Update dry run"""
         self.dry_run = dry_run
-        self.crunchy_api.set_dry_run(dry_run)
+        if self.crunchy_api.dry_run is False:
+            self.crunchy_api.set_dry_run(dry_run)
 
     def get_latest_version(self, bundle_name: str) -> hk_models.Version:
         """Fetch the latest version of a hk bundle"""
@@ -171,8 +169,7 @@ class CompressAPI:
                 continue
 
             LOG.info(
-                "Adding decompressed FASTQ files to housekeeper for sample %s ",
-                sample_id,
+                "Adding decompressed FASTQ files to housekeeper for sample %s ", sample_id,
             )
 
             self.add_fastq_hk(

--- a/cg/meta/compress/compress.py
+++ b/cg/meta/compress/compress.py
@@ -18,7 +18,10 @@ class CompressAPI:
     """API for compressing BAM and FASTQ files"""
 
     def __init__(
-        self, hk_api: hk.HousekeeperAPI, crunchy_api: crunchy.CrunchyAPI, dry_run: bool = False,
+        self,
+        hk_api: hk.HousekeeperAPI,
+        crunchy_api: crunchy.CrunchyAPI,
+        dry_run: bool = False,
     ):
 
         self.hk_api = hk_api
@@ -169,7 +172,8 @@ class CompressAPI:
                 continue
 
             LOG.info(
-                "Adding decompressed FASTQ files to housekeeper for sample %s ", sample_id,
+                "Adding decompressed FASTQ files to housekeeper for sample %s ",
+                sample_id,
             )
 
             self.add_fastq_hk(

--- a/tests/cli/compress/conftest.py
+++ b/tests/cli/compress/conftest.py
@@ -84,7 +84,11 @@ class CaseInfo:
 
 @pytest.fixture(name="compress_case_info")
 def fixture_compress_case_info(
-    case_id, family_name, timestamp, later_timestamp, wgs_application_tag,
+    case_id,
+    family_name,
+    timestamp,
+    later_timestamp,
+    wgs_application_tag,
 ):
     """Returns a object with information about a case"""
     return CaseInfo(
@@ -113,7 +117,10 @@ def fixture_populated_compress_store(store, helpers, compress_case_info, analysi
 
 @pytest.fixture(name="populated_compress_multiple_store")
 def fixture_populated_compress_multiple_store(
-    store, helpers, compress_case_info, analysis_family,
+    store,
+    helpers,
+    compress_case_info,
+    analysis_family,
 ):
     """Return a store populated with multiple completed analysis"""
     case_id = compress_case_info.case_id

--- a/tests/cli/compress/conftest.py
+++ b/tests/cli/compress/conftest.py
@@ -2,6 +2,9 @@
 
 import pytest
 
+from cg.apps.crunchy import CrunchyAPI
+from cg.meta.compress import CompressAPI
+
 
 class MockCompressAPI:
     """Mock out necessary functions for running the compress CLI functions"""
@@ -35,6 +38,30 @@ def fixture_compress_api():
     return MockCompressAPI()
 
 
+@pytest.yield_fixture(scope="function", name="real_crunchy_api")
+def fixture_real_crunchy_api(crunchy_config_dict):
+    """crunchy api fixture"""
+    _api = CrunchyAPI(crunchy_config_dict)
+    _api.set_dry_run(True)
+    yield _api
+
+
+@pytest.fixture(name="real_compress_api")
+def fixture_real_compress_api(housekeeper_api, real_crunchy_api):
+    """Return a compress context"""
+    hk_api = housekeeper_api
+    _api = CompressAPI(crunchy_api=real_crunchy_api, hk_api=hk_api)
+    yield _api
+
+
+@pytest.fixture(scope="function", name="real_populated_compress_fastq_api")
+def fixture_real_populated_compress_fastq_api(real_compress_api, compress_hk_fastq_bundle, helpers):
+    """Populated compress api fixture"""
+    helpers.ensure_hk_bundle(real_compress_api.hk_api, compress_hk_fastq_bundle)
+
+    return real_compress_api
+
+
 @pytest.fixture(name="samples")
 def fixture_samples():
     """Return a list of sample ids"""
@@ -57,11 +84,7 @@ class CaseInfo:
 
 @pytest.fixture(name="compress_case_info")
 def fixture_compress_case_info(
-    case_id,
-    family_name,
-    timestamp,
-    later_timestamp,
-    wgs_application_tag,
+    case_id, family_name, timestamp, later_timestamp, wgs_application_tag,
 ):
     """Returns a object with information about a case"""
     return CaseInfo(
@@ -90,10 +113,7 @@ def fixture_populated_compress_store(store, helpers, compress_case_info, analysi
 
 @pytest.fixture(name="populated_compress_multiple_store")
 def fixture_populated_compress_multiple_store(
-    store,
-    helpers,
-    compress_case_info,
-    analysis_family,
+    store, helpers, compress_case_info, analysis_family,
 ):
     """Return a store populated with multiple completed analysis"""
     case_id = compress_case_info.case_id
@@ -133,8 +153,17 @@ def fixture_populated_multiple_compress_context(compress_api, populated_compress
 @pytest.fixture(name="populated_compress_context")
 def fixture_populated_compress_context(compress_api, populated_compress_store):
     """Return a compress context populated with a completed analysis"""
-    # Make sure that there is a family where anaylis is completer
+    # Make sure that there is a family where analysis is completed
     return {"compress": compress_api, "db": populated_compress_store}
+
+
+@pytest.fixture(name="real_populated_compress_context")
+def fixture_real_populated_compress_context(
+    real_populated_compress_fastq_api, populated_compress_store
+):
+    """Return a compress context populated with a completed analysis"""
+    # Make sure that there is a family where analysis is completed
+    return {"compress": real_populated_compress_fastq_api, "db": populated_compress_store}
 
 
 # Bundle fixtures

--- a/tests/cli/compress/test_cli_compress_fastq.py
+++ b/tests/cli/compress/test_cli_compress_fastq.py
@@ -33,7 +33,7 @@ def test_compress_fastq_cli_case_id_no_family(compress_context, cli_runner, case
     assert f"Could not find case {case_id}" in caplog.text
 
 
-def test_compress_fastq_cli_one_family(populated_compress_context, cli_runner, case_id, caplog):
+def test_compress_fastq_cli_one_family(populated_compress_context, cli_runner, caplog):
     """Test to run the compress command there is an existing family"""
     caplog.set_level(logging.DEBUG)
     # GIVEN a context with a family
@@ -43,7 +43,22 @@ def test_compress_fastq_cli_one_family(populated_compress_context, cli_runner, c
 
     # THEN assert the program exits since no cases where found
     assert res.exit_code == 0
-    # THEN assert it was communicated that no families where found
+    # THEN assert it was communicated that one family was compressed
+    assert f"Individuals in 1 (completed) cases where compressed" in caplog.text
+
+
+def test_real_compress_fastq_cli_one_family(
+    real_populated_compress_context, cli_runner, case_id, caplog
+):
+    """Test to run the compress command there is an existing family"""
+    caplog.set_level(logging.DEBUG)
+    # GIVEN a context with a family
+    # WHEN running the compress command
+    res = cli_runner.invoke(fastq_cmd, ["--case-id", case_id], obj=real_populated_compress_context)
+
+    # THEN assert the program exits with a non zero exit status
+    assert res.exit_code == 0
+    # THEN assert it was communicated that one family was compressed
     assert f"Individuals in 1 (completed) cases where compressed" in caplog.text
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """
     Conftest file for pytest fixtures
 """
+import copy
 import datetime as dt
 import logging
 import shutil
@@ -355,6 +356,51 @@ def fixture_hk_bundle_data(case_id, bed_file, timestamp):
     return data
 
 
+@pytest.fixture(scope="function", name="sample_hk_bundle_no_files")
+def fixture_sample_hk_bundle_no_files(sample, timestamp):
+    """Create a complete bundle mock for testing compression"""
+    hk_bundle_data = {
+        "name": sample,
+        "created": timestamp,
+        "expires": timestamp,
+        "files": [],
+    }
+
+    return hk_bundle_data
+
+
+@pytest.fixture(scope="function", name="case_hk_bundle_no_files")
+def fixture_case_hk_bundle_no_files(case_id, timestamp):
+    """Create a complete bundle mock for testing compression"""
+    hk_bundle_data = {
+        "name": case_id,
+        "created": timestamp,
+        "expires": timestamp,
+        "files": [],
+    }
+
+    return hk_bundle_data
+
+
+@pytest.fixture(scope="function", name="compress_hk_fastq_bundle")
+def fixture_compress_hk_fastq_bundle(compression_object, sample_hk_bundle_no_files):
+    """Create a complete bundle mock for testing compression
+
+    This bundle contains a pair of fastq files.
+    """
+    hk_bundle_data = copy.deepcopy(sample_hk_bundle_no_files)
+
+    first_fastq = compression_object.fastq_first
+    second_fastq = compression_object.fastq_second
+    for fastq_file in [first_fastq, second_fastq]:
+        fastq_file.touch()
+        fastq_file_info = {"path": str(fastq_file), "archive": False, "tags": ["fastq"]}
+
+        hk_bundle_data["files"].append(fastq_file_info)
+
+    return hk_bundle_data
+
+
 @pytest.yield_fixture(scope="function", name="housekeeper_api")
 def fixture_housekeeper_api(hk_config_dict):
     """Setup Housekeeper store."""
@@ -441,10 +487,7 @@ def fixture_customer_group() -> str:
 def fixture_customer_production(customer_group) -> dict:
     """Return a dictionary with infomation about the prod customer"""
     _cust = dict(
-        customer_id="cust000",
-        name="Production",
-        scout_access=True,
-        customer_group=customer_group,
+        customer_id="cust000", name="Production", scout_access=True, customer_group=customer_group,
     )
     return _cust
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -487,7 +487,10 @@ def fixture_customer_group() -> str:
 def fixture_customer_production(customer_group) -> dict:
     """Return a dictionary with infomation about the prod customer"""
     _cust = dict(
-        customer_id="cust000", name="Production", scout_access=True, customer_group=customer_group,
+        customer_id="cust000",
+        name="Production",
+        scout_access=True,
+        customer_group=customer_group,
     )
     return _cust
 

--- a/tests/meta/compress/conftest.py
+++ b/tests/meta/compress/conftest.py
@@ -119,14 +119,6 @@ def fixture_compress_api(real_crunchy_api, housekeeper_api):
     yield _api
 
 
-@pytest.fixture(scope="function", name="populated_compress_api")
-def fixture_populated_compress_api(compress_api, compress_hk_bam_bundle, helpers):
-    """Populated compress api fixture"""
-    helpers.ensure_hk_bundle(compress_api.hk_api, compress_hk_bam_bundle)
-
-    return compress_api
-
-
 @pytest.fixture(scope="function", name="populated_compress_fastq_api")
 def fixture_populated_compress_fastq_api(compress_api, compress_hk_fastq_bundle, helpers):
     """Populated compress api fixture"""
@@ -217,51 +209,6 @@ def fixture_fastq_files(fastq_paths):
 
 
 # Bundle fixtures
-
-
-@pytest.fixture(scope="function", name="sample_hk_bundle_no_files")
-def fixture_sample_hk_bundle_no_files(sample, timestamp):
-    """Create a complete bundle mock for testing compression"""
-    hk_bundle_data = {
-        "name": sample,
-        "created": timestamp,
-        "expires": timestamp,
-        "files": [],
-    }
-
-    return hk_bundle_data
-
-
-@pytest.fixture(scope="function", name="case_hk_bundle_no_files")
-def fixture_case_hk_bundle_no_files(case_id, timestamp):
-    """Create a complete bundle mock for testing compression"""
-    hk_bundle_data = {
-        "name": case_id,
-        "created": timestamp,
-        "expires": timestamp,
-        "files": [],
-    }
-
-    return hk_bundle_data
-
-
-@pytest.fixture(scope="function", name="compress_hk_fastq_bundle")
-def fixture_compress_hk_fastq_bundle(compression_object, sample_hk_bundle_no_files):
-    """Create a complete bundle mock for testing compression
-
-    This bundle contains a pair of fastq files.
-    """
-    hk_bundle_data = copy.deepcopy(sample_hk_bundle_no_files)
-
-    first_fastq = compression_object.fastq_first
-    second_fastq = compression_object.fastq_second
-    for fastq_file in [first_fastq, second_fastq]:
-        fastq_file.touch()
-        fastq_file_info = {"path": str(fastq_file), "archive": False, "tags": ["fastq"]}
-
-        hk_bundle_data["files"].append(fastq_file_info)
-
-    return hk_bundle_data
 
 
 @pytest.fixture(scope="function", name="decompress_hk_spring_bundle")


### PR DESCRIPTION
This PR fixes a bug where the scout api was used when instantiating the meta compress class. When bam compression was removed the scout api was not necessary anymore but it was still being used in the cli base class

### How to test

Unfortunately there is no way to test fastq compression on stage since we point to production fastq files ...

### Expected PR outcome
Fastq compression should now be possible

## Review
- [x] code approved by HS
- [x] "Merge and deploy" approved by MM
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
