### PR TITLE
different tmp path

### DIFF
--- a/cg/apps/crunchy/crunchy.py
+++ b/cg/apps/crunchy/crunchy.py
@@ -361,10 +361,10 @@ class CrunchyAPI:
         return sbatch_header
 
     @staticmethod
-    def _get_tmp_dir(prefix: str, suffix: str) -> str:
+    def _get_tmp_dir(prefix: str, suffix: str, base: str = None) -> str:
         """Create a temporary directory and return the path to it"""
 
-        with tempfile.TemporaryDirectory(prefix=prefix, suffix=suffix) as dir_name:
+        with tempfile.TemporaryDirectory(prefix=prefix, suffix=suffix, dir=base) as dir_name:
             tmp_dir_path = dir_name
 
         LOG.info("Created temporary dir %s", tmp_dir_path)
@@ -374,7 +374,9 @@ class CrunchyAPI:
     def _get_slurm_fastq_to_spring(compression_obj: CompressionData) -> str:
         """Create and return the body of a sbatch script that runs FASTQ to SPRING"""
         LOG.info("Generating FASTQ to SPRING sbatch body")
-        tmp_dir_path = CrunchyAPI._get_tmp_dir(prefix="spring_", suffix="_compress")
+        tmp_dir_path = CrunchyAPI._get_tmp_dir(
+            prefix="spring_", suffix="_compress", base=compression_obj.analysis_dir
+        )
         sbatch_body = SBATCH_FASTQ_TO_SPRING.format(
             fastq_first=compression_obj.fastq_first,
             fastq_second=compression_obj.fastq_second,
@@ -388,13 +390,13 @@ class CrunchyAPI:
 
     @staticmethod
     def _get_slurm_spring_to_fastq(
-        compression_obj: CompressionData,
-        checksum_first: str,
-        checksum_second: str,
+        compression_obj: CompressionData, checksum_first: str, checksum_second: str,
     ) -> str:
         """Create and return the body of a sbatch script that runs SPRING to FASTQ"""
         LOG.info("Generating SPRING to FASTQ sbatch body")
-        tmp_dir_path = CrunchyAPI._get_tmp_dir(prefix="spring_", suffix="_decompress")
+        tmp_dir_path = CrunchyAPI._get_tmp_dir(
+            prefix="spring_", suffix="_decompress", base=compression_obj.analysis_dir
+        )
         sbatch_body = SBATCH_SPRING_TO_FASTQ.format(
             spring_path=compression_obj.spring_path,
             fastq_first=compression_obj.fastq_first,

--- a/cg/models/compression_data.py
+++ b/cg/models/compression_data.py
@@ -37,6 +37,11 @@ class CompressionData:
         return self.stub.with_suffix(".json")
 
     @property
+    def analysis_dir(self) -> Path:
+        """Return the path to folder where analysis is"""
+        return self.stub.resolve().parent
+
+    @property
     def fastq_first(self) -> Path:
         """Return the path to the first read in pair"""
         return Path(self.stub_string + FASTQ_FIRST_READ_SUFFIX)

--- a/tests/apps/crunchy/test_crunchy.py
+++ b/tests/apps/crunchy/test_crunchy.py
@@ -1,8 +1,26 @@
 """Tests for CrunchyAPI"""
 import json
 import logging
+from pathlib import Path
 
 from cg.apps.crunchy import CrunchyAPI
+
+
+def test_get_tmp_path_correct_place(crunchy_config_dict, project_dir):
+    """Test to get the path to a temporary directory"""
+    # GIVEN a crunchy API
+    crunchy_api = CrunchyAPI(crunchy_config_dict)
+    prefix = "spring_"
+    suffix = "fastq_"
+
+    # WHEN creating a tmpdir path
+    tmp_dir = crunchy_api._get_tmp_dir(prefix=prefix, suffix=suffix, base=str(project_dir))
+
+    # THEN assert that the path is correct
+    assert isinstance(tmp_dir, str)
+    tmp_dir_path = Path(tmp_dir)
+    # THEN assert the dir is in the correct place
+    assert tmp_dir_path.parent == project_dir
 
 
 def test_set_dry_run(crunchy_config_dict):


### PR DESCRIPTION
This PR fixes so that the tmp directories are written to the analysis dir when running compression/decompression with SPRING


### How to test
- [x] tests are automated


## Review
- [ ] code approved by
- [x] "Merge and deploy" approved by MM
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
