### PR TITLE
Add help on -kv choices

### DIFF
--- a/cg/cli/set.py
+++ b/cg/cli/set.py
@@ -132,7 +132,7 @@ def show_set_sample_help(sample_obj: models.Sample = "None"):
     click.echo(f"To set apptag use '{OPTION_SHORT_KEY_VALUE} application_version [APPTAG]")
     click.echo(f"To set customer use '{OPTION_SHORT_KEY_VALUE} customer [CUSTOMER]")
     show_option_help(option_long=OPTION_LONG_SKIP_LIMS, option_help=HELP_SKIP_LIMS)
-    show_option_help(OPTION_SHORT_KEY_VALUE, OPTION_LONG_KEY_VALUE, HELP_YES)
+    show_option_help(OPTION_SHORT_YES, OPTION_LONG_YES, HELP_YES)
 
 
 def show_option_help(option_short: str = None, option_long: str = None, option_help: str = None):

--- a/cg/cli/set.py
+++ b/cg/cli/set.py
@@ -138,7 +138,7 @@ def list_changeable_sample_attributes(sample_obj: models.Sample = None, skip_lis
 
 def show_set_sample_help(sample_obj: models.Sample = "None"):
     """Show help for the set sample command"""
-    show_option_help(option_long=OPTION_LONG_SKIP_LIMS, option_help=HELP_SKIP_LIMS)
+    show_option_help(long_name=OPTION_LONG_SKIP_LIMS, help_text=HELP_SKIP_LIMS)
     show_option_help(OPTION_SHORT_YES, OPTION_LONG_YES, HELP_YES)
     show_option_help(OPTION_SHORT_KEY_VALUE, OPTION_LONG_KEY_VALUE, HELP_KEY_VALUE)
     list_changeable_sample_attributes(sample_obj, skip_list=NOT_CHANGABLE_SAMPLE_ATTRIBUTES)
@@ -146,21 +146,21 @@ def show_set_sample_help(sample_obj: models.Sample = "None"):
     click.echo(f"To set customer use '{OPTION_SHORT_KEY_VALUE} customer [CUSTOMER]")
 
 
-def show_option_help(option_short: str = None, option_long: str = None, option_help: str = None):
-    """Shop help for one option"""
+def show_option_help(short_name: str = None, long_name: str = None, help_text: str = None):
+    """Show help for one option"""
     help_message = f"Use "
 
-    if option_short:
-        help_message += f"'{option_short}'"
+    if short_name:
+        help_message += f"'{short_name}'"
 
-    if option_short and option_long:
+    if short_name and long_name:
         help_message += " or "
 
-    if option_long:
-        help_message += f"'{option_long}'"
+    if long_name:
+        help_message += f"'{long_name}'"
 
-    if option_help:
-        help_message += f": {option_help}"
+    if help_text:
+        help_message += f": {help_text}"
 
     click.echo(help_message)
 

--- a/cg/cli/set.py
+++ b/cg/cli/set.py
@@ -152,8 +152,9 @@ def list_changeable_sample_attributes(
 def show_set_sample_help(sample_obj: models.Sample = "None"):
     """Show help for the set sample command"""
     show_option_help(long_name=OPTION_LONG_SKIP_LIMS, help_text=HELP_SKIP_LIMS)
-    show_option_help(OPTION_SHORT_YES, OPTION_LONG_YES, HELP_YES)
-    show_option_help(OPTION_SHORT_KEY_VALUE, OPTION_LONG_KEY_VALUE, HELP_KEY_VALUE)
+    show_option_help(short_name=OPTION_SHORT_YES, long_name=OPTION_LONG_YES, help_text=HELP_YES)
+    show_option_help(short_name=OPTION_SHORT_KEY_VALUE, long_name=OPTION_LONG_KEY_VALUE,
+                     help_text=HELP_KEY_VALUE)
     list_changeable_sample_attributes(sample_obj, skip_attributes=NOT_CHANGABLE_SAMPLE_ATTRIBUTES)
     click.echo(f"To set apptag use '{OPTION_SHORT_KEY_VALUE} application_version [APPTAG]")
     click.echo(f"To set customer use '{OPTION_SHORT_KEY_VALUE} customer [CUSTOMER]")

--- a/cg/cli/set.py
+++ b/cg/cli/set.py
@@ -89,6 +89,7 @@ def family(context, action, priority, panels, family_id):
 @click.option("-y", "--yes", is_flag=True, help="Answer yes on all confirmations")
 @click.pass_context
 def samples(context, identifiers, kwargs, skip_lims, yes):
+    """Set values on many samples at the same time"""
     identifier_args = {}
     for identifier_name, identifier_value in identifiers:
         identifier_args[identifier_name] = identifier_value
@@ -125,6 +126,7 @@ def list_changable_sample_attributes(sample_obj: models.Sample = None, skip_list
 
 
 def show_set_sample_help(sample_obj: models.Sample = "None"):
+    """Show help for the set sample command"""
     show_option_help(OPTION_SHORT_KEY_VALUE, OPTION_LONG_KEY_VALUE, HELP_KEY_VALUE)
     list_changable_sample_attributes(sample_obj, skip_list=NOT_CHANGABLE_SAMPLE_ATTRIBUTES)
     click.echo(f"To set apptag use '{OPTION_SHORT_KEY_VALUE} application_version [APPTAG]")
@@ -134,6 +136,7 @@ def show_set_sample_help(sample_obj: models.Sample = "None"):
 
 
 def show_option_help(option_short: str = None, option_long: str = None, option_help: str = None):
+    """Shop help for one option"""
     help_message = f"Use "
 
     if option_short:
@@ -224,6 +227,7 @@ def sample(context, sample_id, kwargs, skip_lims, yes, help):
 
 
 def _generate_comment(what, old_value, new_value):
+    """Generate a comment that can be used in the comment field to describe updated value"""
     return f"\n{what} changed from " f"{str(old_value)} to " f"{str(new_value)}."
 
 

--- a/cg/cli/set.py
+++ b/cg/cli/set.py
@@ -131,8 +131,9 @@ def is_private_attribute(key):
     return key.startswith("_")
 
 
-def list_changeable_sample_attributes(sample_obj: models.Sample = None, skip_attributes: list() =
-None):
+def list_changeable_sample_attributes(
+    sample_obj: models.Sample = None, skip_attributes: list() = None
+):
     """List changeable attributes on sample and its current value"""
 
     sample_attributes = models.Sample.__dict__.keys()

--- a/cg/cli/set.py
+++ b/cg/cli/set.py
@@ -133,7 +133,7 @@ def is_private_attribute(key):
 
 def list_changeable_sample_attributes(sample_obj: models.Sample = None, skip_attributes: list() =
 None):
-    """ list changeable attributes on sample and its current value"""
+    """List changeable attributes on sample and its current value"""
 
     sample_attributes = models.Sample.__dict__.keys()
     for attribute in sample_attributes:

--- a/cg/cli/set.py
+++ b/cg/cli/set.py
@@ -133,16 +133,17 @@ def is_private_attribute(key):
 
 def list_changeable_sample_attributes(sample_obj: models.Sample = None, skip_attributes: list() =
 None):
-    """ list changeable attributes on sample """
-    keys = sample_obj.__dict__.keys() if sample_obj else models.Sample.__dict__.keys()
-    for key in keys:
-        if is_locked_attribute_on_sample(key, skip_attributes):
+    """ list changeable attributes on sample and its current value"""
+
+    sample_attributes = models.Sample.__dict__.keys()
+    for attribute in sample_attributes:
+        if is_locked_attribute_on_sample(attribute, skip_attributes):
             continue
 
-        message = key
+        message = attribute
 
         if sample_obj:
-            message += f": {sample_obj.__dict__.get(key)}"
+            message += f": {sample_obj.__dict__.get(attribute)}"
 
         click.echo(message)
 

--- a/cg/cli/set.py
+++ b/cg/cli/set.py
@@ -17,10 +17,20 @@ OPTION_LONG_SKIP_LIMS = "--skip-lims"
 OPTION_LONG_YES = "--yes"
 OPTION_SHORT_KEY_VALUE = "-kv"
 OPTION_SHORT_YES = "-y"
-NOT_CHANGABLE_SAMPLE_ATTRIBUTES = ["application_version_id", "customer_id", "deliveries",
-                                   "flowcells", "id",
-                                   "internal_id", "invoice", "invoice_id", "is_external", "links",
-                                   "state", "to_dict"]
+NOT_CHANGABLE_SAMPLE_ATTRIBUTES = [
+    "application_version_id",
+    "customer_id",
+    "deliveries",
+    "flowcells",
+    "id",
+    "internal_id",
+    "invoice",
+    "invoice_id",
+    "is_external",
+    "links",
+    "state",
+    "to_dict",
+]
 
 
 @click.group("set")
@@ -224,8 +234,9 @@ def sample(context, sample_id, kwargs, skip_lims, yes, help):
                 context.obj["lims"].update_sample(lims_id=sample_id, **{key: value})
                 click.echo(click.style(f"Set LIMS/{key} to {value}", fg="blue"))
             except LimsDataError as err:
-                click.echo(click.style(f"Failed to set LIMS/{key} to {value}, {err.message}",
-                                       fg="red"))
+                click.echo(
+                    click.style(f"Failed to set LIMS/{key} to {value}, {err.message}", fg="red")
+                )
 
 
 def _generate_comment(what, old_value, new_value):

--- a/cg/cli/set.py
+++ b/cg/cli/set.py
@@ -153,8 +153,9 @@ def show_set_sample_help(sample_obj: models.Sample = "None"):
     """Show help for the set sample command"""
     show_option_help(long_name=OPTION_LONG_SKIP_LIMS, help_text=HELP_SKIP_LIMS)
     show_option_help(short_name=OPTION_SHORT_YES, long_name=OPTION_LONG_YES, help_text=HELP_YES)
-    show_option_help(short_name=OPTION_SHORT_KEY_VALUE, long_name=OPTION_LONG_KEY_VALUE,
-                     help_text=HELP_KEY_VALUE)
+    show_option_help(
+        short_name=OPTION_SHORT_KEY_VALUE, long_name=OPTION_LONG_KEY_VALUE, help_text=HELP_KEY_VALUE
+    )
     list_changeable_sample_attributes(sample_obj, skip_attributes=NOT_CHANGABLE_SAMPLE_ATTRIBUTES)
     click.echo(f"To set apptag use '{OPTION_SHORT_KEY_VALUE} application_version [APPTAG]")
     click.echo(f"To set customer use '{OPTION_SHORT_KEY_VALUE} customer [CUSTOMER]")

--- a/cg/cli/set.py
+++ b/cg/cli/set.py
@@ -121,8 +121,8 @@ def samples(context, identifiers, kwargs, skip_lims, yes):
         )
 
 
-def list_changable_sample_attributes(sample_obj: models.Sample = None, skip_list: list() = None):
-    """ list changable attributes on sample """
+def list_changeable_sample_attributes(sample_obj: models.Sample = None, skip_list: list() = None):
+    """ list changeable attributes on sample """
     keys = sample_obj.__dict__.keys() if sample_obj else models.Sample.__dict__.keys()
     for key in keys:
         if key.startswith("__") or key.startswith("_") or key in skip_list:
@@ -141,7 +141,7 @@ def show_set_sample_help(sample_obj: models.Sample = "None"):
     show_option_help(option_long=OPTION_LONG_SKIP_LIMS, option_help=HELP_SKIP_LIMS)
     show_option_help(OPTION_SHORT_YES, OPTION_LONG_YES, HELP_YES)
     show_option_help(OPTION_SHORT_KEY_VALUE, OPTION_LONG_KEY_VALUE, HELP_KEY_VALUE)
-    list_changable_sample_attributes(sample_obj, skip_list=NOT_CHANGABLE_SAMPLE_ATTRIBUTES)
+    list_changeable_sample_attributes(sample_obj, skip_list=NOT_CHANGABLE_SAMPLE_ATTRIBUTES)
     click.echo(f"To set apptag use '{OPTION_SHORT_KEY_VALUE} application_version [APPTAG]")
     click.echo(f"To set customer use '{OPTION_SHORT_KEY_VALUE} customer [CUSTOMER]")
 

--- a/cg/cli/set.py
+++ b/cg/cli/set.py
@@ -128,12 +128,12 @@ def list_changable_sample_attributes(sample_obj: models.Sample = None, skip_list
 
 def show_set_sample_help(sample_obj: models.Sample = "None"):
     """Show help for the set sample command"""
+    show_option_help(option_long=OPTION_LONG_SKIP_LIMS, option_help=HELP_SKIP_LIMS)
+    show_option_help(OPTION_SHORT_YES, OPTION_LONG_YES, HELP_YES)
     show_option_help(OPTION_SHORT_KEY_VALUE, OPTION_LONG_KEY_VALUE, HELP_KEY_VALUE)
     list_changable_sample_attributes(sample_obj, skip_list=NOT_CHANGABLE_SAMPLE_ATTRIBUTES)
     click.echo(f"To set apptag use '{OPTION_SHORT_KEY_VALUE} application_version [APPTAG]")
     click.echo(f"To set customer use '{OPTION_SHORT_KEY_VALUE} customer [CUSTOMER]")
-    show_option_help(option_long=OPTION_LONG_SKIP_LIMS, option_help=HELP_SKIP_LIMS)
-    show_option_help(OPTION_SHORT_YES, OPTION_LONG_YES, HELP_YES)
 
 
 def show_option_help(option_short: str = None, option_long: str = None, option_help: str = None):

--- a/tests/cli/set/test_sample.py
+++ b/tests/cli/set/test_sample.py
@@ -42,11 +42,7 @@ def test_help_without_sample(cli_runner, base_context, base_store: Store, helper
     # GIVEN a database with no sample
 
     # WHEN setting sample but asking for help
-    result = cli_runner.invoke(
-        sample,
-        ["--help"],
-        obj=base_context,
-    )
+    result = cli_runner.invoke(sample, ["--help"], obj=base_context)
 
     # THEN it should fail on not having a sample as argument
     assert result.exit_code != SUCCESS
@@ -66,11 +62,7 @@ def test_help_with_sample(cli_runner, base_context, base_store: Store, helpers):
     sample_obj = helpers.add_sample(base_store, gender="female")
 
     # WHEN setting sample but skipping lims
-    result = cli_runner.invoke(
-        sample,
-        [sample_obj.internal_id, "--help"],
-        obj=base_context,
-    )
+    result = cli_runner.invoke(sample, [sample_obj.internal_id, "--help"], obj=base_context)
 
     # THEN it should not fail on not having a sample as argument
     assert result.exit_code == SUCCESS
@@ -135,9 +127,7 @@ def test_invalid_customer(cli_runner, base_context, base_store: Store, helpers):
 
     # WHEN calling set sample with an invalid customer
     result = cli_runner.invoke(
-        sample,
-        [sample_id, "-kv", "customer", customer_id, "-y", "--skip-lims"],
-        obj=base_context,
+        sample, [sample_id, "-kv", "customer", customer_id, "-y", "--skip-lims"], obj=base_context
     )
 
     # THEN then it should error about missing customer instead of setting the value
@@ -153,9 +143,7 @@ def test_customer(cli_runner, base_context, base_store: Store, helpers):
 
     # WHEN calling set sample with a valid customer
     result = cli_runner.invoke(
-        sample,
-        [sample_id, "-kv", "customer", customer_id, "-y", "--skip-lims"],
-        obj=base_context,
+        sample, [sample_id, "-kv", "customer", customer_id, "-y", "--skip-lims"], obj=base_context
     )
 
     # THEN then it should set the customer of the sample
@@ -169,9 +157,7 @@ def test_invalid_downsampled_to(cli_runner, base_context):
 
     # WHEN calling set sample with an invalid value of downsampled to
     result = cli_runner.invoke(
-        sample,
-        ["dummy_sample_id", "-kv", "downsampled_to", downsampled_to, "-y"],
-        obj=base_context,
+        sample, ["dummy_sample_id", "-kv", "downsampled_to", downsampled_to, "-y"], obj=base_context
     )
 
     # THEN wrong data type
@@ -186,9 +172,7 @@ def test_downsampled_to(cli_runner, base_context, base_store: Store, helpers):
 
     # WHEN calling set sample with a valid value of downsampled to
     result = cli_runner.invoke(
-        sample,
-        [sample_id, "-kv", "downsampled_to", downsampled_to, "-y"],
-        obj=base_context,
+        sample, [sample_id, "-kv", "downsampled_to", downsampled_to, "-y"], obj=base_context
     )
 
     # THEN then the value should have been set on the sample

--- a/tests/cli/set/test_sample.py
+++ b/tests/cli/set/test_sample.py
@@ -38,6 +38,55 @@ def test_skip_lims(cli_runner, base_context, base_store: Store, helpers):
     assert base_context["lims"].get_updated_sample_value() != new_value
 
 
+def test_help_without_sample(cli_runner, base_context, base_store: Store, helpers):
+    # GIVEN a database with no sample
+
+    # WHEN setting sample but asking for help
+    result = cli_runner.invoke(
+        sample,
+        ["--help"],
+        obj=base_context,
+    )
+
+    # THEN it should fail on not having a sample as argument
+    assert result.exit_code != SUCCESS
+
+    # THEN the flags should have been mentioned in the output
+    assert "-kv" in result.output
+    assert "--skip-lims" in result.output
+    assert "-y" in result.output
+
+    # THEN the name property should have been mentioned
+    assert "name" in result.output
+
+
+def test_help_with_sample(cli_runner, base_context, base_store: Store, helpers):
+    # GIVEN a database with a sample
+
+    sample_obj = helpers.add_sample(base_store, gender="female")
+
+    # WHEN setting sample but skipping lims
+    result = cli_runner.invoke(
+        sample,
+        [sample_obj.internal_id, "--help"],
+        obj=base_context,
+    )
+
+    # THEN it should not fail on not having a sample as argument
+    assert result.exit_code == SUCCESS
+
+    # THEN the flags should have been mentioned in the output
+    assert "-kv" in result.output
+    assert "--skip-lims" in result.output
+    assert "-y" in result.output
+
+    # THEN the name property should have been mentioned
+    assert "name" in result.output
+
+    # THEN the name value should have been mentioned
+    assert sample_obj.name in result.output
+
+
 @pytest.mark.parametrize("key", ["name", "capture_kit"])
 def test_set_sample(cli_runner, base_context, base_store: Store, key, helpers):
     # GIVEN a database with a sample


### PR DESCRIPTION
This PR adds help message for cg set sample containing all changeable attributes

### How to prepare for test
- [x] ssh to hasta (depending on type of change)
- [x] install on stage:
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test generic help
- [x] login to hasta
- [x] do us
- [x] do cg set sample --help

### Expected test outcome
- [x] check that you get help on which attributes can be changed 
- [x] and the flags -kv, --skip-lims and --yes

### How to test sample specific help
- [x] login to hasta
- [x] do us
- [x] do cg set sample [SAMPLE-ID] --help

### Expected test outcome
- [x] check that you get help on which attributes can be changed  
- [x] check that the sample attributes are listed  
- [x] and the flags -kv, --skip-lims and --yes

- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [x] tests executed by PG
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
