### PR TITLE
create pending flag outside batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Please add a new candidate release at the top after changing the latest one. Fee
 
 ### Changed
 
+## [12.1.6]
+### Fixed
+- Create crunchy pending path outside batch script
+
+
 ## [12.1.5]
 ### Fixed
 - support current orderform RML-1604:9 again

--- a/cg/apps/crunchy/crunchy.py
+++ b/cg/apps/crunchy/crunchy.py
@@ -399,6 +399,7 @@ class CrunchyAPI:
             fastq_second=compression_obj.fastq_second,
             spring_path=compression_obj.spring_path,
             flag_path=compression_obj.spring_metadata_path,
+            pending_path=compression_obj.pending_path,
             tmp_dir=tmp_dir_path,
         )
 
@@ -419,6 +420,7 @@ class CrunchyAPI:
             spring_path=compression_obj.spring_path,
             fastq_first=compression_obj.fastq_first,
             fastq_second=compression_obj.fastq_second,
+            pending_path=compression_obj.pending_path,
             checksum_first=checksum_first,
             checksum_second=checksum_second,
             tmp_dir=tmp_dir_path,

--- a/cg/apps/crunchy/sbatch.py
+++ b/cg/apps/crunchy/sbatch.py
@@ -38,7 +38,6 @@ error() {{
 
 trap error ERR
 
-touch {pending_path}
 mkdir -p {tmp_dir}
 crunchy -t 12 --tmp-dir {tmp_dir} compress fastq -f {fastq_first} -s {fastq_second} \
 -o {spring_path} --check-integrity --metadata-file
@@ -69,7 +68,6 @@ error() {{
 
 trap error ERR
 
-touch {pending_path}
 mkdir -p {tmp_dir}
 crunchy -t 12 --tmp-dir {tmp_dir} decompress spring {spring_path} -f {fastq_first} -s \
 {fastq_second} --first-checksum {checksum_first} --second-checksum {checksum_second}


### PR DESCRIPTION
This PR fixes a problem that when two processes of fastq compression was launched at the same time the processes would fail. This was due to the fact that the crunchy pending flag was created in the batch script. This PR solves this by creating the pending flag in the crunchy API instead of the batch script.

### Expected test outcome
- [ ] Two fastq compressions started at the same time should not be possible

## Review
- [x] code approved by PG
- [x] "Merge and deploy" approved by @moonso
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
