### PR TITLE
Fix AnalysisApi init in Upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 Please add a new candidate release at the top after changing the latest one. Feel free to copy paste from the "squash and commit" box that gets generated when creating PRs
+## [12.3.1]
+
+### Fixed
+ 
+- Fixed bug where AnalysisAPI in cg upload auto was not updated to recent class changes
 
 ## [12.3.0]
 

--- a/cg/cli/upload/base.py
+++ b/cg/cli/upload/base.py
@@ -91,12 +91,16 @@ def upload(context, family_id, force_restart):
     )
     context.obj["scout_api"] = scoutapi.ScoutAPI(context.obj)
     context.obj["analysis_api"] = AnalysisAPI(
-        context.obj,
-        hk_api=context.obj["housekeeper_api"],
-        scout_api=context.obj["scout_api"],
-        tb_api=context.obj["tb_api"],
-        lims_api=context.obj["lims_api"],
+        db=Store(context.obj["database"]),
+        hk_api=hk.HousekeeperAPI(context.obj),
+        tb_api=tb.TrailblazerAPI(context.obj),
+        scout_api=scoutapi.ScoutAPI(context.obj),
+        lims_api=lims.LimsAPI(context.obj),
         deliver_api=context.obj["deliver_api"],
+        script=context.obj["mip-rd-dna"]["script"],
+        pipeline=context.obj["mip-rd-dna"]["pipeline"],
+        conda_env=context.obj["mip-rd-dna"]["conda_env"],
+        root=context.obj["mip-rd-dna"]["root"],
     )
     context.obj["report_api"] = ReportAPI(
         store=context.obj["status"],


### PR DESCRIPTION
Fixes bug where cg upload was not properly updated to AnalysisApi changes
There are no other imports of AnalysisApi where this should be an issue

### How to prepare for test
- [x] ssh to hasta
- [x] install on stage:
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh fix/update-analysis-upload`

### How to test
- [x] login to hasta
- [x] do `us && cg upload auto --pipeline mip`
- [x] upload should execute successfully

### Expected test outcome
- [x] check that upload functionality works for MIP ✅ 

## Review
- [x] code approved by HS
- [x] tests executed by HS
- [x] "Merge and deploy" approved by HS
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
