### PR TITLE
Adds @Mropat as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @patrikgrenfeldt @barrystokman @moonso
+*       @patrikgrenfeldt @barrystokman @moonso @Mropat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 Please add a new candidate release at the top after changing the latest one. Feel free to copy paste from the "squash and commit" box that gets generated when creating PRs
+
+Try to use the follwing format:
+
+## [x.x.x]
+
+### Added
+
+### Changed
+
+### Fixed
+
+
+## [12.3.5]
+
+### Added
+- Added @Mropat as codeowner
+
 ## [12.3.4]
 
 ### Fixed


### PR DESCRIPTION
This PR adds @Mropat as codeowner to CG.

### Why?

Maria is doing heavy development in CG and are really into the ideas and structure of CG.

## Review
- [x] code approved by @moonso 
- [x] "Merge and deploy" approved by @moonso 
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
