### PR TITLE
feat(delivery_report): Do not genererate delivery report for analysis…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
+## [13.2.1]
+
+### Changed
+- Exclude analysis older than hasta in production (2017-09-27) from delivery report generation
+
 ## [13.2.0]
 
 ### Changed

--- a/cg/store/api/status.py
+++ b/cg/store/api/status.py
@@ -4,8 +4,11 @@ from typing import List
 from cg.constants import PRIORITY_MAP
 from cg.store import models
 from cg.store.api.base import BaseHandler
+from cg.utils.date import get_date
 from sqlalchemy import or_, and_, func
 from sqlalchemy.orm import Query
+
+HASTA_IN_PRODUCTION = get_date("2017-09-27")
 
 
 class StatusHandler(BaseHandler):
@@ -602,6 +605,7 @@ class StatusHandler(BaseHandler):
 
         analyses_query = (
             analyses_query.filter(models.Analysis.uploaded_at)
+            .filter(HASTA_IN_PRODUCTION < models.Analysis.started_at)
             .join(models.Family, models.Family.links, models.FamilySample.sample)
             .filter(
                 or_(

--- a/tests/store/api/status/test_analyses_to_delivery_report.py
+++ b/tests/store/api/status/test_analyses_to_delivery_report.py
@@ -50,16 +50,25 @@ def test_outdated_analysis(analysis_store, helpers):
 
     # GIVEN an analysis that is older than Hasta
     timestamp_old_analysis = get_date("2017-09-26")
+
+    # GIVEN a delivery report created at date which is older than the upload date to trigger delivery report generation
     timestamp = datetime.now()
-    delivery_timestamp = timestamp - timedelta(days=1)
+    delivery_reported_at_timestamp = timestamp - timedelta(days=1)
+
+    # GIVEN a store to add analysis to
     analysis = helpers.add_analysis(
         analysis_store,
         started_at=timestamp_old_analysis,
         uploaded_at=timestamp,
-        delivery_reported_at=delivery_timestamp,
+        delivery_reported_at=delivery_reported_at_timestamp,
     )
+
+    # GIVEN samples which has been delivered
     sample = helpers.add_sample(analysis_store, delivered_at=timestamp, data_analysis="mip")
+
+    # GIVEN a store sample family relation
     analysis_store.relate_sample(family=analysis.family, sample=sample, status="unknown")
+
     # WHEN calling the analyses_to_delivery_report
     analyses = analysis_store.analyses_to_delivery_report(pipeline="mip").all()
 


### PR DESCRIPTION
This PR adds/fixes:

- Skips generating a delivery report for analyses with a started_at date prior to 2017-09-27 (when statusDB was initilized on Hasta)

### How to prepare for test
- [x] ssh to hasta

### How to test
- [x] login to hasta
- [x] do `us`
1. `cg upload delivery-reports -p`
- [x] install on stage:
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh skip_delivery_report_prior_to_hasta_2`
1. `cg upload delivery-reports -p`

### Expected test outcome
1.  check that more cases than betterbison and freeelf are included in the delivery report generation ✅ 
1. check taht only betterbison and freeelf are included in the delivery report generation ✅ 
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [x] tests executed by HS
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
