### PR TITLE
Add posibility to give case-id as argument when setting values on multiple samples by the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,18 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
+## [13.5.0]
+
+
+### Added
+- Possibility to give case-id as argument when setting values on multiple samples by the CLI
+
 
 ## [13.4.1]
 
 
 ### Fixed
--Updated changelog with correct release version
+- Updated changelog with correct release version
 
 
 ## [13.4.0]

--- a/cg/cli/set.py
+++ b/cg/cli/set.py
@@ -98,27 +98,73 @@ def family(context, action, priority, panels, family_id):
 )
 @click.option("--skip-lims", is_flag=True, help="Skip setting value in LIMS")
 @click.option("-y", "--yes", is_flag=True, help="Answer yes on all confirmations")
+@click.argument("case_id", required=False)
 @click.pass_context
-def samples(context, identifiers, kwargs, skip_lims, yes):
+def samples(
+    context: click.Context,
+    identifiers: click.Tuple([str, str]),
+    kwargs: click.Tuple([str, str]),
+    skip_lims: bool,
+    yes: bool,
+    case_id: str,
+):
     """Set values on many samples at the same time"""
-    identifier_args = {}
-    for identifier_name, identifier_value in identifiers:
-        identifier_args[identifier_name] = identifier_value
+    store = context.obj["status"]
+    sample_objs = _get_samples(case_id, identifiers, store)
 
-    samples_objs = context.obj["status"].samples_by_ids(**identifier_args)
+    if not sample_objs:
+        click.echo(click.style(fg="red", text="No samples to alter!"))
+        context.abort()
 
     click.echo("Would alter samples:")
 
-    for sample_obj in samples_objs:
+    for sample_obj in sample_objs:
         click.echo(f"{sample_obj}")
 
     if not (yes or click.confirm(CONFIRM)):
         context.abort()
 
-    for sample_obj in samples_objs:
+    for sample_obj in sample_objs:
         context.invoke(
             sample, sample_id=sample_obj.internal_id, kwargs=kwargs, yes=yes, skip_lims=skip_lims
         )
+
+
+def _get_samples(
+    case_id: str, identifiers: click.Tuple([str, str]), store: Store
+) -> [models.Sample]:
+    """Get samples that match both case_id and identifiers if given"""
+    samples_by_case_id = None
+    samples_by_id = None
+
+    if case_id:
+        samples_by_case_id = _get_samples_by_case_id(case_id, store)
+
+    if identifiers:
+        samples_by_id = _get_samples_by_identifiers(identifiers, store)
+
+    if case_id and identifiers:
+        sample_objs = set(set(samples_by_case_id) & set(samples_by_id))
+    else:
+        sample_objs = samples_by_case_id or samples_by_id
+
+    return sample_objs
+
+
+def _get_samples_by_identifiers(
+    identifiers: click.Tuple([str, str]), store: Store
+) -> models.Sample:
+    """Get samples matched by given set of identifiers"""
+    identifier_args = {}
+    for identifier_name, identifier_value in identifiers:
+        identifier_args[identifier_name] = identifier_value
+    return store.samples_by_ids(**identifier_args)
+
+
+def _get_samples_by_case_id(case_id: str, store: Store) -> [models.Sample]:
+    """Get samples on a given case-id"""
+    case = store.family(internal_id=case_id)
+    return [link.sample for link in case.links] if case else []
 
 
 def is_locked_attribute_on_sample(key, skip_attributes):
@@ -131,9 +177,7 @@ def is_private_attribute(key):
     return key.startswith("_")
 
 
-def list_changeable_sample_attributes(
-    sample_obj: models.Sample = None, skip_attributes: list() = None
-):
+def list_changeable_sample_attributes(sample_obj: models.Sample = None, skip_attributes: [] = None):
     """List changeable attributes on sample and its current value"""
 
     sample_attributes = models.Sample.__dict__.keys()

--- a/cg/cli/set.py
+++ b/cg/cli/set.py
@@ -193,8 +193,9 @@ def list_changeable_sample_attributes(sample_obj: models.Sample = None, skip_att
         click.echo(message)
 
 
-def show_set_sample_help(sample_obj: models.Sample = "None"):
+def show_set_sample_help(sample_obj: models.Sample = "None") -> None:
     """Show help for the set sample command"""
+    click.echo("sample_id: optional, internal_id of sample to set value on")
     show_option_help(long_name=OPTION_LONG_SKIP_LIMS, help_text=HELP_SKIP_LIMS)
     show_option_help(short_name=OPTION_SHORT_YES, long_name=OPTION_LONG_YES, help_text=HELP_YES)
     show_option_help(

--- a/tests/cli/set/test_samples.py
+++ b/tests/cli/set/test_samples.py
@@ -1,0 +1,138 @@
+"""Test methods for cg/cli/set/samples"""
+import pytest
+
+from cg.cli.set import samples
+from cg.store import Store
+
+SUCCESS = 0
+
+
+@pytest.mark.parametrize("identifier_key", ["name", "internal_id"])
+def test_set_samples_by_identifiers(
+    cli_runner, base_context, base_store: Store, identifier_key, helpers
+):
+    # GIVEN a database with a sample
+    sample_obj = helpers.add_sample(base_store)
+    identifier_value = getattr(sample_obj, identifier_key)
+
+    # WHEN calling set samples with valid identifiers
+    result = cli_runner.invoke(
+        samples, ["-id", identifier_key, identifier_value, "-y", "--skip-lims"], obj=base_context
+    )
+
+    # THEN it should name the sample to be changed
+    assert result.exit_code == SUCCESS
+    assert sample_obj.internal_id in result.output
+    assert sample_obj.name in result.output
+
+
+def test_set_samples_by_invalid_identifier(cli_runner, base_context, base_store: Store, helpers):
+    # GIVEN a database with a sample that belongs to a case
+    sample_obj = helpers.add_sample(base_store)
+
+    # WHEN calling set samples with an identifier not existing on sample
+    bad_identifier = "bad_identifier"
+    assert not hasattr(sample_obj, bad_identifier)
+    result = cli_runner.invoke(
+        samples, ["-id", bad_identifier, "any_value", "-y", "--skip-lims"], obj=base_context
+    )
+
+    # THEN it should fail and not name the sample to be changed
+    assert sample_obj.internal_id not in result.output
+    assert sample_obj.name not in result.output
+    assert result.exit_code != SUCCESS
+
+
+def test_set_samples_by_case_id(cli_runner, base_context, base_store: Store, helpers):
+    # GIVEN a database with a sample that belongs to a case
+    case_obj = helpers.add_family(store=base_store)
+    sample_obj = helpers.add_sample(base_store)
+    helpers.add_relationship(store=base_store, family=case_obj, sample=sample_obj)
+
+    # WHEN calling set samples with case_id
+    result = cli_runner.invoke(
+        samples, [case_obj.internal_id, "-y", "--skip-lims"], obj=base_context
+    )
+
+    # THEN it should name the sample to be changed
+    assert result.exit_code == SUCCESS
+    assert sample_obj.internal_id in result.output
+    assert sample_obj.name in result.output
+
+
+def test_set_samples_by_invalid_case_id(cli_runner, base_context, base_store: Store, helpers):
+    # GIVEN a database with a sample that belongs to a case
+    sample_obj = helpers.add_sample(base_store)
+
+    # WHEN calling set samples with an identifier not existing on sample
+    non_existing_case = "not_a_case"
+    assert not base_store.family(non_existing_case)
+    result = cli_runner.invoke(samples, [non_existing_case, "-y", "--skip-lims"], obj=base_context)
+
+    # THEN it should fail and not name the sample to be changed
+    assert result.exit_code != SUCCESS
+    assert sample_obj.internal_id not in result.output
+    assert sample_obj.name not in result.output
+
+
+def test_set_samples_by_valid_case_id_and_valid_identifier(
+    cli_runner, base_context, base_store: Store, helpers
+):
+    # GIVEN a database with a sample that belongs to a case
+    case_obj = helpers.add_family(store=base_store)
+    sample_obj = helpers.add_sample(base_store)
+    helpers.add_relationship(store=base_store, family=case_obj, sample=sample_obj)
+
+    # WHEN calling set samples with case_id for sample and valid identifier for sample
+    result = cli_runner.invoke(
+        samples,
+        [case_obj.internal_id, "-id", "internal_id", sample_obj.internal_id, "-y", "--skip-lims"],
+        obj=base_context,
+    )
+
+    # THEN it should name the sample to be changed
+    assert sample_obj.internal_id in result.output
+    assert sample_obj.name in result.output
+    assert result.exit_code == SUCCESS
+
+
+def test_set_samples_by_invalid_case_id_and_valid_identifier(
+    cli_runner, base_context, base_store: Store, helpers
+):
+    # GIVEN a database with a sample that belongs to a case
+    case_obj = helpers.add_family(store=base_store)
+    sample_obj = helpers.add_sample(base_store)
+    helpers.add_relationship(store=base_store, family=case_obj, sample=sample_obj)
+
+    # WHEN calling set samples with bad case_id for sample and valid identifier for sample
+    result = cli_runner.invoke(
+        samples,
+        ["wrong_caseid", "-id", "internal_id", sample_obj.internal_id, "-y", "--skip-lims"],
+        obj=base_context,
+    )
+
+    # THEN it should not name the sample to be changed
+    assert sample_obj.internal_id not in result.output
+    assert sample_obj.name not in result.output
+    assert result.exit_code != SUCCESS
+
+
+def test_set_samples_by_valid_case_id_and_invalid_identifier(
+    cli_runner, base_context, base_store: Store, helpers
+):
+    # GIVEN a database with a sample that belongs to a case
+    case_obj = helpers.add_family(store=base_store)
+    sample_obj = helpers.add_sample(base_store)
+    helpers.add_relationship(store=base_store, family=case_obj, sample=sample_obj)
+
+    # WHEN calling set samples with valid case_id for sample and wrong valid identifier for sample
+    result = cli_runner.invoke(
+        samples,
+        [case_obj.internal_id, "-id", "internal_id", "wrong_internal_id", "-y", "--skip-lims"],
+        obj=base_context,
+    )
+
+    # THEN it should not name the sample to be changed
+    assert sample_obj.internal_id not in result.output
+    assert sample_obj.name not in result.output
+    assert result.exit_code != SUCCESS


### PR DESCRIPTION
This PR adds posibility to give case-id as argument when setting values on multiple samples by the CLI

### How to prepare for test
- [x] ssh to hasta (depending on type of change)
- [x] install on stage:
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [x] login to hasta
- [x] do us
- [x] do cg set samples [CASE-ID] -kv data_analysis fluffy

### Expected test outcome
- [x] check that data_analysis was set to fluffy for the given case
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [x] code approved by MM
- [x] tests executed by PG
- [x] "Merge and deploy" approved by PG
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
