### PR TITLE
add deploy command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
+## [13.9]
+
+### Added
+- Deployment command
+- Functionality to deploy `shipping` with CG
+
+
 ## [13.8.0]
 ### Added
 - Functionality to change multiple families in one go, e.g. cg set families --sample-identifier ticket_number 123456 --priority research

--- a/cg/apps/shipping/__init__.py
+++ b/cg/apps/shipping/__init__.py
@@ -1,0 +1,1 @@
+from .shipping_api import ShippingAPI

--- a/cg/apps/shipping/shipping_api.py
+++ b/cg/apps/shipping/shipping_api.py
@@ -35,7 +35,7 @@ class ShippingAPI:
         if app_config:
             deploy_args.extend(["--app-config", str(app_config)])
         elif app_name:
-            deploy_args.append(app_name)
+            deploy_args.extend(["--tool-name", app_name])
         else:
             LOG.warning("Please specify what app to deploy")
             raise SyntaxError

--- a/cg/apps/shipping/shipping_api.py
+++ b/cg/apps/shipping/shipping_api.py
@@ -1,4 +1,4 @@
-"""API to the deployment tool shipping"""
+"""API to the deployment tool Shipping"""
 
 import logging
 from pathlib import Path
@@ -12,7 +12,7 @@ LOG = logging.getLogger(__name__)
 class ShippingAPI:
     """Class to communicate with the tool shipping
 
-    Shipping is used as a unified tool for deploying in the CG environment
+    Shipping is used as a unified tool for deploying in the Clinical Genomics environments
     """
 
     def __init__(self, config: Dict[str, str]):
@@ -37,7 +37,7 @@ class ShippingAPI:
         elif app_name:
             deploy_args.extend(["--tool-name", app_name])
         else:
-            LOG.warning("Please specify what app to deploy")
+            LOG.warning("Please specify what application to deploy")
             raise SyntaxError
         deploy_args.append("deploy")
         self.process.run_command(deploy_args, dry_run=self.dry_run)

--- a/cg/apps/shipping/shipping_api.py
+++ b/cg/apps/shipping/shipping_api.py
@@ -41,6 +41,8 @@ class ShippingAPI:
             raise SyntaxError
         deploy_args.append("deploy")
         self.process.run_command(deploy_args, dry_run=self.dry_run)
+        for line in self.process.stderr_lines():
+            LOG.info(line)
 
     def deploy_shipping(self):
         """Deploy the tool shipping

--- a/cg/apps/shipping/shipping_api.py
+++ b/cg/apps/shipping/shipping_api.py
@@ -48,5 +48,5 @@ class ShippingAPI:
         Deployment of shipping does not need any extra information since it is following the regular workflow
         with conda environments using standard names
         """
-        LOG.info("Deploying the shipping software on host")
+        LOG.info("Deploying the shipping software")
         self.deploy(app_name="shipping")

--- a/cg/apps/shipping/shipping_api.py
+++ b/cg/apps/shipping/shipping_api.py
@@ -1,0 +1,52 @@
+"""API to the deployment tool shipping"""
+
+import logging
+from pathlib import Path
+from typing import Dict
+
+from cg.utils import Process
+
+LOG = logging.getLogger(__name__)
+
+
+class ShippingAPI:
+    """Class to communicate with the tool shipping
+
+    Shipping is used as a unified tool for deploying in the CG environment
+    """
+
+    def __init__(self, config: Dict[str, str]):
+        self.config = config
+        self.host_config = config["host_config"]
+        self.binary_path = config["binary_path"]
+        self.process = Process(
+            binary=str(self.binary_path), config=self.host_config, config_parameter="--host-config"
+        )
+        self.dry_run = False
+
+    def set_dry_run(self, dry_run: bool) -> None:
+        """Update dry run"""
+        LOG.info("Set dry run to %s", dry_run)
+        self.dry_run = dry_run
+
+    def deploy(self, app_config: Path = None, app_name: str = None):
+        """Command to deploy a tool according to the specifications in the config files"""
+        deploy_args = []
+        if app_config:
+            deploy_args.extend(["--app-config", str(app_config)])
+        elif app_name:
+            deploy_args.append(app_name)
+        else:
+            LOG.warning("Please specify what app to deploy")
+            raise SyntaxError
+        deploy_args.append("deploy")
+        self.process.run_command(deploy_args, dry_run=self.dry_run)
+
+    def deploy_shipping(self):
+        """Deploy the tool shipping
+
+        Deployment of shipping does not need any extra information since it is following the regular workflow
+        with conda environments using standard names
+        """
+        LOG.info("Deploying the shipping software on host")
+        self.deploy(app_name="shipping")

--- a/cg/cli/base.py
+++ b/cg/cli/base.py
@@ -24,6 +24,7 @@ from .transfer import transfer
 from .upload import vogue as vogue_command
 from .upload.base import upload
 from .workflow.base import workflow as workflow_cmd
+from .deploy.base import deploy as deploy_cmd
 
 LOG = logging.getLogger(__name__)
 LEVELS = ["DEBUG", "INFO", "WARNING", "ERROR"]
@@ -82,4 +83,6 @@ base.add_command(transfer)
 base.add_command(upload)
 base.add_command(workflow_cmd)
 base.add_command(store_cmd)
+base.add_command(deploy_cmd)
+
 upload.add_command(vogue_command)

--- a/cg/cli/deploy/base.py
+++ b/cg/cli/deploy/base.py
@@ -1,0 +1,32 @@
+"""CLI for deploying tools with CG"""
+
+import logging
+
+import click
+
+from cg.apps.shipping import ShippingAPI
+
+LOG = logging.getLogger(__name__)
+
+
+@click.group()
+@click.option("--dry-run", is_flag=True)
+@click.pass_context
+def deploy(context, dry_run):
+    """Deploy tools with CG. Use --help to see what tools are available"""
+    LOG.info("Running CG DEPLOY")
+    shipping_api = ShippingAPI(context.obj["shipping"])
+    shipping_api.set_dry_run(dry_run)
+    context.obj["shipping_api"] = shipping_api
+
+
+@click.command(name="shipping")
+@click.pass_context
+def deploy_shipping_cmd(context):
+    """Deploy the shipping tool"""
+    LOG.info("Deploying shipping with CG")
+    shipping_api: ShippingAPI = context.obj["shipping_api"]
+    shipping_api.deploy_shipping()
+
+
+deploy.add_command(deploy_shipping_cmd)

--- a/tests/apps/shipping/conftest.py
+++ b/tests/apps/shipping/conftest.py
@@ -1,0 +1,29 @@
+"""Fixtures for the shipping api tests"""
+
+from typing import Dict
+from pathlib import Path
+import pytest
+
+from cg.apps.shipping import ShippingAPI
+
+
+@pytest.fixture(name="binary_path")
+def fixture_binary_path() -> Path:
+    return Path("path/to/shipping")
+
+
+@pytest.fixture(name="host_config")
+def fixture_host_config() -> Path:
+    return Path("path/to/host_config.yml")
+
+
+@pytest.fixture(name="shipping_configs")
+def fixture_shipping_configs(binary_path: Path, host_config: Path) -> Dict[str, str]:
+    return dict(host_config=str(host_config), binary_path=str(binary_path))
+
+
+@pytest.fixture(name="shipping_api")
+def fixture_shipping_api(shipping_configs: Dict[str, str]) -> ShippingAPI:
+    api = ShippingAPI(config=shipping_configs)
+    api.set_dry_run(dry_run=True)
+    return api

--- a/tests/apps/shipping/test_shipping.py
+++ b/tests/apps/shipping/test_shipping.py
@@ -1,0 +1,89 @@
+"""Tests for the shipping api"""
+import logging
+from pathlib import Path
+from typing import Dict
+
+import pytest
+
+from cg.apps.shipping import ShippingAPI
+
+
+def build_expected_output_string(
+    api: ShippingAPI, app_name: str = None, app_config: Path = None
+) -> str:
+    """Create a string that is expected to be logged when deploying with shipping"""
+    output = ["Running", "command", api.binary_path, "--host-config", api.host_config]
+    if app_name:
+        output.extend(["--tool-name", app_name])
+    if app_config:
+        output.extend(["--app-config", str(app_config)])
+    output.append("deploy")
+    return " ".join(output)
+
+
+def test_init_shipping_api(shipping_configs: Dict[str, str]):
+    """Test to initialize the shipping api"""
+    # GIVEN a config with some information about host file and binary
+    configs = shipping_configs
+
+    # WHEN initializing the api
+    api = ShippingAPI(config=configs)
+
+    # THEN assert that the base command is as expected
+    assert api.process.base_call == [
+        configs["binary_path"],
+        "--host-config",
+        configs["host_config"],
+    ]
+
+
+def test_shipping_api_deploy_tool_name(shipping_api: ShippingAPI, caplog):
+    """Test to run deploy with the shipping api with just a tool name"""
+    caplog.set_level(logging.DEBUG)
+    # GIVEN a shipping api and a dummy tool name
+    tool_name = "dummy"
+
+    # WHEN running the deploy method
+    shipping_api.deploy(app_name=tool_name)
+
+    # THEN assert that call to deploy was communicated
+    output_str = build_expected_output_string(api=shipping_api, app_name=tool_name)
+    assert output_str in caplog.text
+
+
+def test_shipping_api_deploy_app_config(shipping_api: ShippingAPI, caplog):
+    """Test to run deploy with the shipping api providing an app config"""
+    caplog.set_level(logging.DEBUG)
+    # GIVEN a shipping api and a dummy app config
+    app_config = Path("path/to/app_config.yml")
+
+    # WHEN running the deploy method
+    shipping_api.deploy(app_config=app_config)
+
+    # THEN assert that call to deploy was communicated
+    output_str = build_expected_output_string(api=shipping_api, app_config=app_config)
+
+    assert output_str in caplog.text
+
+
+def test_shipping_api_deploy_no_app_info(shipping_api: ShippingAPI):
+    """Test to run deploy with the shipping api without specifying the app"""
+    # GIVEN a shipping api
+
+    # WHEN running the deploy method without specifying any app
+    with pytest.raises(SyntaxError):
+        # THEN assert a SyntaxError is raised
+        shipping_api.deploy()
+
+
+def test_shipping_api_deploy_shipping(shipping_api: ShippingAPI, caplog):
+    """Test to run deploy with shipping itself"""
+    caplog.set_level(logging.DEBUG)
+    # GIVEN a shipping api
+
+    # WHEN running the deploy method shipping method
+    shipping_api.deploy_shipping()
+
+    # THEN assert that call to deploy was communicated
+    output_str = build_expected_output_string(api=shipping_api, app_name="shipping")
+    assert output_str in caplog.text

--- a/tests/cli/deploy/conftest.py
+++ b/tests/cli/deploy/conftest.py
@@ -1,0 +1,29 @@
+"""Fixtures for the shipping api tests"""
+
+from typing import Dict
+from pathlib import Path
+import pytest
+
+from cg.apps.shipping import ShippingAPI
+
+
+@pytest.fixture(name="binary_path")
+def fixture_binary_path() -> Path:
+    return Path("path/to/shipping")
+
+
+@pytest.fixture(name="host_config")
+def fixture_host_config() -> Path:
+    return Path("path/to/host_config.yml")
+
+
+@pytest.fixture(name="shipping_configs")
+def fixture_shipping_configs(binary_path: Path, host_config: Path) -> Dict[str, str]:
+    return dict(host_config=str(host_config), binary_path=str(binary_path))
+
+
+@pytest.fixture(name="shipping_api")
+def fixture_shipping_api(shipping_configs: Dict[str, str]) -> ShippingAPI:
+    api = ShippingAPI(config=shipping_configs)
+    api.set_dry_run(dry_run=True)
+    return api

--- a/tests/cli/deploy/conftest.py
+++ b/tests/cli/deploy/conftest.py
@@ -1,29 +1,7 @@
 """Fixtures for the shipping api tests"""
 
-from typing import Dict
-from pathlib import Path
-import pytest
-
-from cg.apps.shipping import ShippingAPI
-
-
-@pytest.fixture(name="binary_path")
-def fixture_binary_path() -> Path:
-    return Path("path/to/shipping")
-
-
-@pytest.fixture(name="host_config")
-def fixture_host_config() -> Path:
-    return Path("path/to/host_config.yml")
-
-
-@pytest.fixture(name="shipping_configs")
-def fixture_shipping_configs(binary_path: Path, host_config: Path) -> Dict[str, str]:
-    return dict(host_config=str(host_config), binary_path=str(binary_path))
-
-
-@pytest.fixture(name="shipping_api")
-def fixture_shipping_api(shipping_configs: Dict[str, str]) -> ShippingAPI:
-    api = ShippingAPI(config=shipping_configs)
-    api.set_dry_run(dry_run=True)
-    return api
+from tests.apps.shipping.conftest import (
+    fixture_shipping_configs,
+    fixture_binary_path,
+    fixture_host_config,
+)

--- a/tests/cli/deploy/test_deploy_command.py
+++ b/tests/cli/deploy/test_deploy_command.py
@@ -1,0 +1,22 @@
+"""Tests for running the deploy command"""
+
+import logging
+from typing import Dict
+from cg.cli.deploy.base import deploy
+
+from click.testing import CliRunner
+
+
+def test_running_deploy_shipping(shipping_configs: Dict[str, str], caplog):
+    """Test to deploy shipping with CG"""
+    caplog.set_level(logging.DEBUG)
+    # GIVEN a context with some shipping configs
+    context = dict(shipping=shipping_configs)
+    # GIVEN a cli runner
+    runner = CliRunner()
+
+    # WHEN running the deploy shipping command in dry run mode
+    result = runner.invoke(deploy, ["--dry-run", "shipping"], obj=context)
+
+    # THEN assert that the command exits without problems
+    assert result.exit_code == 0


### PR DESCRIPTION
This PR adds a deployment command to CG. In current form it is only possible to deploy the tool `shipping`, however we plan to add as many of the tools as possible here. Whenever we move a tool to use shipping we can delete the `upload-`-bash scripts for that tool

## Limitation

Only available on hasta at the moment due to problems in the environment setup on clinical-db

### How to prepare for test
- [x] ssh to hasta
- [x] install on stage:
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh add-deploy-command`
- [x] check that there is an older version of shipping installed `shipping` in conda environment `S_shipping`
![Skärmavbild 2020-10-14 kl  14 56 00](https://user-images.githubusercontent.com/405278/95991693-61ad5a00-0e2d-11eb-996e-43ef5d46d419.png)


### How to test
- [x] run command `cg deploy --dry-run shipping` and check that the output looks ok
- [x] run command `cg deploy shipping`

### Expected test outcome
- [x] Make sure that shipping was updated (deployed) in `S_shipping`
- [x] Take a screenshot and attach or copy/paste the output.
![Skärmavbild 2020-10-14 kl  14 57 49](https://user-images.githubusercontent.com/405278/95991908-a2a56e80-0e2d-11eb-8e79-09971d548a2f.png)


## Review
- [x] code approved by MR
- [x] tests executed by MM
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **MINOR** - when you add functionality in a backwards compatible manner

