### PR TITLE
Deploy Genotype with CG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
+## [13.10]
+
+### Added
+- Functionality to deploy `genotype` with CG on hasta
+
 ## [13.9]
 
 ### Added

--- a/cg/apps/shipping/shipping_api.py
+++ b/cg/apps/shipping/shipping_api.py
@@ -29,35 +29,16 @@ class ShippingAPI:
         LOG.info("Set dry run to %s", dry_run)
         self.dry_run = dry_run
 
-    def deploy(self, app_config: Path = None, app_name: str = None):
+    def deploy(self, app_name: str, app_config: Path = None):
         """Command to deploy a tool according to the specifications in the config files"""
+        LOG.info("Deploying the %s software", app_name)
         deploy_args = []
         if app_config:
             deploy_args.extend(["--app-config", str(app_config)])
-        elif app_name:
-            deploy_args.extend(["--tool-name", app_name])
         else:
-            LOG.warning("Please specify what application to deploy")
-            raise SyntaxError
+            deploy_args.extend(["--tool-name", app_name])
+
         deploy_args.append("deploy")
         self.process.run_command(deploy_args, dry_run=self.dry_run)
         for line in self.process.stderr_lines():
             LOG.info(line)
-
-    def deploy_shipping(self):
-        """Deploy the tool shipping
-
-        Deployment of shipping does not need any extra information since it is following the regular workflow
-        with conda environments using standard names
-        """
-        LOG.info("Deploying the shipping software")
-        self.deploy(app_name="shipping")
-
-    def deploy_genotype(self):
-        """Deploy the tool genotype
-
-        Deployment of genotype does not need any extra information since it is following the regular workflow
-        with conda environments using standard names and pip
-        """
-        LOG.info("Deploying the genotype software")
-        self.deploy(app_name="genotype")

--- a/cg/apps/shipping/shipping_api.py
+++ b/cg/apps/shipping/shipping_api.py
@@ -52,3 +52,12 @@ class ShippingAPI:
         """
         LOG.info("Deploying the shipping software")
         self.deploy(app_name="shipping")
+
+    def deploy_genotype(self):
+        """Deploy the tool genotype
+
+        Deployment of genotype does not need any extra information since it is following the regular workflow
+        with conda environments using standard names and pip
+        """
+        LOG.info("Deploying the genotype software")
+        self.deploy(app_name="genotype")

--- a/cg/cli/deploy/base.py
+++ b/cg/cli/deploy/base.py
@@ -26,7 +26,7 @@ def deploy_shipping_cmd(context):
     """Deploy the shipping tool"""
     LOG.info("Deploying shipping with CG")
     shipping_api: ShippingAPI = context.obj["shipping_api"]
-    shipping_api.deploy_shipping()
+    shipping_api.deploy(app_name="shipping")
 
 
 @click.command(name="genotype")
@@ -35,7 +35,7 @@ def deploy_genotype_cmd(context):
     """Deploy the shipping tool"""
     LOG.info("Deploying genotype with CG")
     shipping_api: ShippingAPI = context.obj["shipping_api"]
-    shipping_api.deploy_genotype()
+    shipping_api.deploy(app_name="genotype")
 
 
 deploy.add_command(deploy_shipping_cmd)

--- a/cg/cli/deploy/base.py
+++ b/cg/cli/deploy/base.py
@@ -29,4 +29,14 @@ def deploy_shipping_cmd(context):
     shipping_api.deploy_shipping()
 
 
+@click.command(name="genotype")
+@click.pass_context
+def deploy_genotype_cmd(context):
+    """Deploy the shipping tool"""
+    LOG.info("Deploying genotype with CG")
+    shipping_api: ShippingAPI = context.obj["shipping_api"]
+    shipping_api.deploy_genotype()
+
+
 deploy.add_command(deploy_shipping_cmd)
+deploy.add_command(deploy_genotype_cmd)

--- a/cg/cli/deploy/base.py
+++ b/cg/cli/deploy/base.py
@@ -15,6 +15,7 @@ LOG = logging.getLogger(__name__)
 def deploy(context, dry_run):
     """Deploy tools with CG. Use --help to see what tools are available"""
     LOG.info("Running CG DEPLOY")
+    print(context.obj)
     shipping_api = ShippingAPI(context.obj["shipping"])
     shipping_api.set_dry_run(dry_run)
     context.obj["shipping_api"] = shipping_api

--- a/tests/apps/shipping/test_shipping.py
+++ b/tests/apps/shipping/test_shipping.py
@@ -87,3 +87,16 @@ def test_shipping_api_deploy_shipping(shipping_api: ShippingAPI, caplog):
     # THEN assert that call to deploy was communicated
     output_str = build_expected_output_string(api=shipping_api, app_name="shipping")
     assert output_str in caplog.text
+
+
+def test_shipping_api_deploy_genotype(shipping_api: ShippingAPI, caplog):
+    """Test to run deploy with genotype"""
+    caplog.set_level(logging.DEBUG)
+    # GIVEN a shipping api
+
+    # WHEN running the deploy method shipping method
+    shipping_api.deploy_genotype()
+
+    # THEN assert that call to deploy was communicated
+    output_str = build_expected_output_string(api=shipping_api, app_name="genotype")
+    assert output_str in caplog.text

--- a/tests/apps/shipping/test_shipping.py
+++ b/tests/apps/shipping/test_shipping.py
@@ -56,9 +56,10 @@ def test_shipping_api_deploy_app_config(shipping_api: ShippingAPI, caplog):
     caplog.set_level(logging.DEBUG)
     # GIVEN a shipping api and a dummy app config
     app_config = Path("path/to/app_config.yml")
+    app_name = "myapp"
 
     # WHEN running the deploy method
-    shipping_api.deploy(app_config=app_config)
+    shipping_api.deploy(app_name=app_name, app_config=app_config)
 
     # THEN assert that call to deploy was communicated
     output_str = build_expected_output_string(api=shipping_api, app_config=app_config)
@@ -66,26 +67,18 @@ def test_shipping_api_deploy_app_config(shipping_api: ShippingAPI, caplog):
     assert output_str in caplog.text
 
 
-def test_shipping_api_deploy_no_app_info(shipping_api: ShippingAPI):
-    """Test to run deploy with the shipping api without specifying the app"""
-    # GIVEN a shipping api
-
-    # WHEN running the deploy method without specifying any app
-    with pytest.raises(SyntaxError):
-        # THEN assert a SyntaxError is raised
-        shipping_api.deploy()
-
-
 def test_shipping_api_deploy_shipping(shipping_api: ShippingAPI, caplog):
     """Test to run deploy with shipping itself"""
     caplog.set_level(logging.DEBUG)
     # GIVEN a shipping api
+    # GIVEN a shipping app name
+    app_name = "shipping"
 
     # WHEN running the deploy method shipping method
-    shipping_api.deploy_shipping()
+    shipping_api.deploy(app_name=app_name)
 
     # THEN assert that call to deploy was communicated
-    output_str = build_expected_output_string(api=shipping_api, app_name="shipping")
+    output_str = build_expected_output_string(api=shipping_api, app_name=app_name)
     assert output_str in caplog.text
 
 
@@ -93,10 +86,12 @@ def test_shipping_api_deploy_genotype(shipping_api: ShippingAPI, caplog):
     """Test to run deploy with genotype"""
     caplog.set_level(logging.DEBUG)
     # GIVEN a shipping api
+    # GIVEN a genotype app name
+    app_name = "genotype"
 
     # WHEN running the deploy method shipping method
-    shipping_api.deploy_genotype()
+    shipping_api.deploy(app_name=app_name)
 
     # THEN assert that call to deploy was communicated
-    output_str = build_expected_output_string(api=shipping_api, app_name="genotype")
+    output_str = build_expected_output_string(api=shipping_api, app_name=app_name)
     assert output_str in caplog.text

--- a/tests/cli/deploy/test_deploy_command.py
+++ b/tests/cli/deploy/test_deploy_command.py
@@ -22,7 +22,7 @@ def test_running_deploy_shipping(shipping_configs: Dict[str, str], caplog):
     assert result.exit_code == 0
 
 
-def test_running_deploy_shipping(shipping_configs: Dict[str, str], caplog):
+def test_running_deploy_genotype(shipping_configs: Dict[str, str], caplog):
     """Test to deploy genotype with CG"""
     caplog.set_level(logging.DEBUG)
     # GIVEN a context with some shipping configs

--- a/tests/cli/deploy/test_deploy_command.py
+++ b/tests/cli/deploy/test_deploy_command.py
@@ -20,3 +20,18 @@ def test_running_deploy_shipping(shipping_configs: Dict[str, str], caplog):
 
     # THEN assert that the command exits without problems
     assert result.exit_code == 0
+
+
+def test_running_deploy_shipping(shipping_configs: Dict[str, str], caplog):
+    """Test to deploy genotype with CG"""
+    caplog.set_level(logging.DEBUG)
+    # GIVEN a context with some shipping configs
+    context = dict(shipping=shipping_configs)
+    # GIVEN a cli runner
+    runner = CliRunner()
+
+    # WHEN running the deploy genotype command in dry run mode
+    result = runner.invoke(deploy, ["--dry-run", "genotype"], obj=context)
+
+    # THEN assert that the command exits without problems
+    assert result.exit_code == 0


### PR DESCRIPTION
This PR adds the functionality to deploy the tool `genotype` with CG on hasta. Since `genotype` has been decoupled from CG it lives in the conda environments `S_genotype` and `P_genotype`. CG will now deploy this tool with the command `cg deploy genotype` by using shipping.

When this PR is merged it is possible to remove the bash update scripts for genotype on hasta from the servers repo :cake: :candle: :cake:

### How to prepare for test
- [x] ssh to hasta (depending on type of change)
- [x] install on stage:
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh deploy-genotype`
- [x] Check that an old version of genotype is installed in `S_genotype`
![Skärmavbild 2020-10-15 kl  11 05 18](https://user-images.githubusercontent.com/405278/96102014-52361b80-0ed6-11eb-84f2-cc080f3c7563.png)


### How to test
- [x] Run the command `cg deploy --dry-run genotype` and check that the output looks fine
- [x] Deploy genotype stage by running `cg deploy genotype`

### Expected test outcome
- [x] check that the newest version of genotype was deployed in `S_genotype`
- [x] Take a screenshot and attach or copy/paste the output.
![Skärmavbild 2020-10-15 kl  12 28 47](https://user-images.githubusercontent.com/405278/96111797-fd989d80-0ee1-11eb-896b-a7c327bb7980.png)

## After merging

- [ ] Repeat the procedure for `P_genotype` (by running the commands from production env)
- [ ] Check that the deployment was logged in the log file
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [x] code approved by MR
- [x] tests executed by MM
- [x] "Merge and deploy" approved by MM
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **MINOR** - when you add functionality in a backwards compatible manner

