### PR TITLE
Fix bug that broke automation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
+## [13.10.1]
+
+### Fixed
+- Repaired automation query for storing Balsamic cases in Housekeeper 
+
 ## [13.10]
 
 ### Added

--- a/cg/meta/workflow/balsamic.py
+++ b/cg/meta/workflow/balsamic.py
@@ -460,6 +460,6 @@ class BalsamicAnalysisAPI:
         cases_to_store = []
         for case_object in self.store.cases_to_store(pipeline="balsamic"):
             case_id = case_object.internal_id
-            if Path(self.get_deliverables_file_path(case_id=case_id)).exists():
+            if Path(self.get_analysis_finish_path(case_id=case_id)).exists():
                 cases_to_store.append(case_id)
         return cases_to_store


### PR DESCRIPTION
This PR adds/fixes ...
Some time ago a clause was added which prevented Balsamic cases from being stored in HK
This happened because we intended to make Balsamic create its own deliverables at the end of the workflow. The query then would check if Balsamic created deliverables before storing. However, this was not implemented, so there should have been a different condition in place in order to store cases in Housekeeper (for now)
This PR changes the condition.

### How to prepare for test
- [x] ssh to hasta (depending on type of change)
- [x] install on stage:
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`
- [x] ssh to clinical-db (depending on type of change)
- [x] install on stage:
`bash /home/proj/production/servers/resources/clinical-db.scilifelab.se/update-clinical-api-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [x] run cg workflow balsamic store-available 

### Expected test outcome
- [x] check that finished cases are being stored in HK

## Review
- [x] code approved by MR
- [x] tests executed by MR
- [x] "Merge and deploy" approved by MR

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
