### PR TITLE
CG to always disable mutect in BALSAMIC for WES 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
+
+## [13.11.0]
+
+### Changed
+- Balsamic always skips mutect when application is WES
+- SPRING compression is set to run on oldest families first
+
+### Fixed
+- Format print statements
+
 ## [13.10.1]
 
 ### Fixed

--- a/cg/apps/balsamic/api.py
+++ b/cg/apps/balsamic/api.py
@@ -67,6 +67,7 @@ class BalsamicAPI:
                 "--qos": arguments.get("priority", self.qos),
                 "--sample-config": arguments.get("sample_config"),
                 "--analysis-type": arguments.get("analysis_type"),
+                "--disable-variant-caller": arguments.get("disable_variant_caller"),
             }
         )
         parameters = command + options + run_analysis

--- a/cg/cli/deploy/base.py
+++ b/cg/cli/deploy/base.py
@@ -15,7 +15,6 @@ LOG = logging.getLogger(__name__)
 def deploy(context, dry_run):
     """Deploy tools with CG. Use --help to see what tools are available"""
     LOG.info("Running CG DEPLOY")
-    print(context.obj)
     shipping_api = ShippingAPI(context.obj["shipping"])
     shipping_api.set_dry_run(dry_run)
     context.obj["shipping_api"] = shipping_api

--- a/cg/cli/workflow/balsamic/base.py
+++ b/cg/cli/workflow/balsamic/base.py
@@ -127,6 +127,9 @@ def run(context, analysis_type, run_analysis, priority, case_id, dry):
             "sample_config": balsamic_analysis_api.get_config_path(
                 case_id=case_id, check_exists=True
             ),
+            "disable_variant_caller": "mutect"
+            if balsamic_analysis_api.check_application_type_wes(case_id=case_id)
+            else None,  # Tell Balsamic to disable mutect for WES analyses.
         }
         balsamic_analysis_api.balsamic_api.run_analysis(
             arguments=arguments, run_analysis=run_analysis, dry=dry

--- a/cg/meta/workflow/balsamic.py
+++ b/cg/meta/workflow/balsamic.py
@@ -335,7 +335,7 @@ class BalsamicAnalysisAPI:
             )
         LOG.info("")
 
-    def get_sample_params(self, case_id: str, panel_bed: str) -> dict:
+    def get_sample_params(self, case_id: str, panel_bed: Optional[str]) -> dict:
 
         """Returns a dictionary of attributes for each sample in given family,
         where SAMPLE ID is used as key"""
@@ -351,7 +351,17 @@ class BalsamicAnalysisAPI:
         self.print_sample_params(case_id=case_id, sample_data=sample_data)
         return sample_data
 
-    def resolve_target_bed(self, panel_bed, link_object: models.FamilySample) -> Optional[str]:
+    def check_application_type_wes(self, case_id: str) -> bool:
+        """Checks if any of the samples in case have application type WES"""
+        for link_object in self.get_balsamic_sample_objects(case_id=case_id):
+            sample_application_type = self.get_application_type(link_object)
+            if str(sample_application_type).lower() == "wes":
+                return True
+        return False
+
+    def resolve_target_bed(
+        self, panel_bed: Optional[str], link_object: models.FamilySample
+    ) -> Optional[str]:
         if panel_bed:
             return panel_bed
         if self.get_application_type(link_object) not in self.__BALSAMIC_BED_APPLICATIONS:

--- a/cg/store/api/status.py
+++ b/cg/store/api/status.py
@@ -99,10 +99,8 @@ class StatusHandler(BaseHandler):
         families_query = (
             self.Family.query.outerjoin(models.Analysis)
             .join(models.Family.links, models.FamilySample.sample)
-            .filter(or_(models.Sample.is_external, models.Sample.sequenced_at.isnot(None)))
             .filter(models.Sample.data_analysis.ilike(f"%{pipeline}%"))
             .filter(models.Family.action == "running")
-            .order_by(models.Family.priority.desc(), models.Family.ordered_at)
         )
         return list(families_query)[:limit]
 

--- a/cg/store/get/cases.py
+++ b/cg/store/get/cases.py
@@ -11,7 +11,9 @@ from cg.store.api import Store
 def analysis_completed(store: Store) -> Query:
     """Return cases where analysis is finished"""
     cases = store.Family.query.join(models.Analysis)
-    return cases.filter(models.Analysis.completed_at.isnot(None))
+    return cases.filter(models.Analysis.completed_at.isnot(None)).order_by(
+        models.Family.created_at.asc()
+    )
 
 
 def ready_for_spring_compresssion(store: Store) -> Iterator[models.Family]:

--- a/tests/cli/workflow/balsamic/conftest.py
+++ b/tests/cli/workflow/balsamic/conftest.py
@@ -192,6 +192,7 @@ def balsamic_housekeeper(housekeeper_api, helpers, balsamic_mock_fastq_files: li
         "sample_case_wgs_paired_two_normal_normal1_error",
         "sample_case_wgs_paired_two_normal_normal2_error",
         "sample_case_wes_panel_error",
+        "sample_case_wes_tumor",
     ]
 
     for sample in samples:
@@ -304,6 +305,11 @@ def balsamic_lims(server_config: dict) -> MockLimsAPI:
         internal_id="mixed_sample_case_mixed_bed_paired_normal_error",
         capture_kit="BalsamicBed2",
     )
+    balsamic_lims.add_capture_kit(
+        internal_id="sample_case_wes_tumor",
+        capture_kit="BalsamicBed2",
+    )
+
     balsamic_lims.add_capture_kit(
         internal_id="mip_sample_case_wgs_single_tumor",
         capture_kit=None,
@@ -679,6 +685,22 @@ def balsamic_store(base_store: Store, balsamic_dir: Path, helpers) -> Store:
         family=case_wgs_paired_two_normal_error,
         sample=sample_case_wgs_paired_two_normal_normal2_error,
     )
+
+    # Create WES case with 1 tumor sample
+    case_wes_tumor = helpers.add_family(
+        _store,
+        internal_id="balsamic_case_wes_tumor",
+        family_id="balsamic_case_wes_tumor",
+    )
+    sample_case_wes_tumor = helpers.add_sample(
+        _store,
+        internal_id="sample_case_wes_tumor",
+        is_tumour=True,
+        application_tag="WESA",
+        application_type="wes",
+        data_analysis="balsamic",
+    )
+    helpers.add_relationship(_store, family=case_wes_tumor, sample=sample_case_wes_tumor)
 
     # Create ERROR case for WES when no panel is found
     case_wes_panel_error = helpers.add_family(

--- a/tests/cli/workflow/balsamic/test_run.py
+++ b/tests/cli/workflow/balsamic/test_run.py
@@ -158,3 +158,21 @@ def test_priority_clinical(cli_runner, balsamic_context: dict, caplog):
     # THEN dry-print should include the the option-value
     assert "--qos" in caplog.text
     assert option_value in caplog.text
+
+
+def test_run_wes_application(cli_runner, balsamic_context: dict, caplog):
+    """Test command with case_id that has WES application set in statusdb"""
+    caplog.set_level(logging.INFO)
+    # GIVEN valid case-id
+    case_id = "balsamic_case_wes_tumor"
+    # WHEN ensuring case config exists where it should be stored
+    Path.mkdir(
+        Path(balsamic_context["BalsamicAnalysisAPI"].get_config_path(case_id)).parent, exist_ok=True
+    )
+    Path(balsamic_context["BalsamicAnalysisAPI"].get_config_path(case_id)).touch(exist_ok=True)
+    # WHEN dry running with option specified
+    result = cli_runner.invoke(run, [case_id, "--dry-run"], obj=balsamic_context)
+    # THEN command should execute successfully
+    assert result.exit_code == EXIT_SUCCESS
+    # THEN dry-print should show option disabling mutect in balsamic
+    assert "--disable-variant-caller mutect" in caplog.text


### PR DESCRIPTION
This PR adds/fixes ...
When running BALSAMIC on WES samples, mutect tends to time out and clog the prod slurm queue.
This PR adds a check that will always be performed when running analysis. If analysis type is WES, it will append 
"--disable-variant-caller mutect" to command string when calling balsamic

Bonus: Sort families in SPRING compression by date created
Bonus2: fix deploy cli print

### How to prepare for test
- [ ] ssh to hasta (depending on type of change)
- [ ] install on stage:
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`
- [ ] ssh to clinical-db (depending on type of change)
- [ ] install on stage:
`bash /home/proj/production/servers/resources/clinical-db.scilifelab.se/update-clinical-api-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] login to hasta
- [ ] do cg workflow balsamic start [wes case id] --dry-run

### Expected test outcome
- [ ] check that option is included
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
