### PR TITLE
Remove check of analysisrunstatus in MIP store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
+## [13.17.0]
+
+
+### Changed
+- Workflow mip-dna store no longer needs analysisrunstatus to be completed to attempt storing bundle
+
+
 ## [13.16.2]
 
 ### Fixed

--- a/cg/meta/store/mip.py
+++ b/cg/meta/store/mip.py
@@ -16,9 +16,6 @@ def add_mip_analysis(config_stream):
     sampleinfo_raw = ruamel.yaml.safe_load(Path(config_data["sampleinfo_path"]).open())
     sampleinfo_data = parse_sampleinfo(sampleinfo_raw)
 
-    if sampleinfo_data["is_finished"] is False:
-        raise AnalysisNotFinishedError("analysis not finished")
-
     deliverables_raw = ruamel.yaml.safe_load(Path(config_raw["store_file"]).open())
     new_bundle = store_base.build_bundle(config_data, sampleinfo_data, deliverables_raw)
 

--- a/tests/meta/store/test_cg_meta_store_mip.py
+++ b/tests/meta/store/test_cg_meta_store_mip.py
@@ -43,31 +43,6 @@ def test_add_mip_analysis_finished(
     assert result == mock_build_bundle(config_data_rna, sampleinfo_data, rna_deliverables_raw)
 
 
-@mock.patch("cg.meta.store.mip.parse_sampleinfo")
-@mock.patch("cg.meta.store.mip.parse_config")
-def test_add_mip_analysis_not_finished(
-    mock_parse_config, mock_parse_sample, config_stream, config_data_rna, sampleinfo_data
-):
-    """
-    tests the function add_mip_analysis when passing a config file of an unfinished RNA analysis
-    """
-    # GIVEN a MIP RNA analysis configuration file
-
-    mip_rna_config = config_stream["rna_config_store"]
-    mock_parse_config.return_value = config_data_rna
-    sampleinfo_data["is_finished"] = False
-    mock_parse_sample.return_value = sampleinfo_data
-
-    # WHEN  gathering information from the MIP RNA analysis to store and the analysis is not
-    # finished
-
-    with pytest.raises(AnalysisNotFinishedError) as exc_info:
-        store_mip.add_mip_analysis(mip_rna_config)
-
-    # THEN the correct exception should be raised
-    assert exc_info.value.message == "analysis not finished"
-
-
 def test_parse_config(snapshot: Snapshot, config_raw: dict):
     """
     tests the function parse_config against a snapshot


### PR DESCRIPTION
This PR adds/fixes ...
Removes requirement of finished analysis in mip config when storing

### How to prepare for test
- [x] ssh to hasta (depending on type of change)
- [x] install on stage:
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [x] do cg workflow mip-dna store

### Expected test outcome
- [x] check that files with analysisrunstatus == failed are stored if finished in Trailblazer
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [x] tests executed by MR
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [x] **MINOR** - when you add functionality in a backwards compatible manner
