### PR TITLE
Change MIP store condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
+## [13.18.0]
+
+
+### Changed
+- Changed condition for which cases should be stored in CG. This fixes a bug where cg would try to store cases which already have been stored due to mismatch in timestamp stored in Trailblazer and Housekeeper
+
 ## [13.17.2]
 
 ### Changed

--- a/cg/cli/workflow/mip/store.py
+++ b/cg/cli/workflow/mip/store.py
@@ -104,12 +104,6 @@ def completed(context):
     for case_obj in mip_api.db.cases_to_store(pipeline="mip"):
         analysis_obj = mip_api.tb.get_latest_analysis(case_id=case_obj.internal_id)
         if analysis_obj.status == "completed":
-            existing_record = mip_api.hk.version(analysis_obj.family, analysis_obj.started_at)
-            if existing_record:
-                LOG.info(
-                    "analysis already stored: %s - %s", analysis_obj.family, analysis_obj.started_at
-                )
-                continue
             LOG.info(f"storing family: {analysis_obj.family}")
             with Path(
                 mip_api.get_case_config_path(case_id=analysis_obj.family)

--- a/cg/cli/workflow/mip/store.py
+++ b/cg/cli/workflow/mip/store.py
@@ -104,11 +104,12 @@ def completed(context):
     for case_obj in mip_api.db.cases_to_store(pipeline="mip"):
         analysis_obj = mip_api.tb.get_latest_analysis(case_id=case_obj.internal_id)
         if analysis_obj.status != "completed":
+
             continue
         LOG.info(f"storing family: {analysis_obj.family}")
         with Path(
-                mip_api.get_case_config_path(case_id=analysis_obj.family)
-            ).open() as config_stream:
+            mip_api.get_case_config_path(case_id=analysis_obj.family)
+        ).open() as config_stream:
             try:
                 context.invoke(analysis, config_stream=config_stream)
             except (Exception, click.Abort):

--- a/cg/cli/workflow/mip/store.py
+++ b/cg/cli/workflow/mip/store.py
@@ -104,7 +104,6 @@ def completed(context):
     for case_obj in mip_api.db.cases_to_store(pipeline="mip"):
         analysis_obj = mip_api.tb.get_latest_analysis(case_id=case_obj.internal_id)
         if analysis_obj.status != "completed":
-
             continue
         LOG.info(f"storing family: {analysis_obj.family}")
         with Path(

--- a/cg/cli/workflow/mip/store.py
+++ b/cg/cli/workflow/mip/store.py
@@ -101,19 +101,23 @@ def completed(context):
     mip_api = context.obj["mip_api"]
 
     exit_code = EXIT_SUCCESS
-    for analysis_obj in mip_api.tb.analyses(status="completed", deleted=False, data_analysis="mip"):
-        existing_record = mip_api.hk.version(analysis_obj.family, analysis_obj.started_at)
-        if existing_record:
-            LOG.info("analysis stored: %s - %s", analysis_obj.family, analysis_obj.started_at)
-            continue
-        LOG.info(f"storing family: {analysis_obj.family}")
-        with Path(
-            mip_api.get_case_config_path(case_id=analysis_obj.family)
-        ).open() as config_stream:
-            try:
-                context.invoke(analysis, config_stream=config_stream)
-            except (Exception, click.Abort):
-                LOG.error("case storage failed: %s", analysis_obj.family, exc_info=True)
-                exit_code = EXIT_FAIL
+    for case_obj in mip_api.db.cases_to_store(pipeline="mip"):
+        analysis_obj = mip_api.tb.get_latest_analysis(case_id=case_obj.internal_id)
+        if analysis_obj.status == "completed":
+            existing_record = mip_api.hk.version(analysis_obj.family, analysis_obj.started_at)
+            if existing_record:
+                LOG.info(
+                    "analysis already stored: %s - %s", analysis_obj.family, analysis_obj.started_at
+                )
+                continue
+            LOG.info(f"storing family: {analysis_obj.family}")
+            with Path(
+                mip_api.get_case_config_path(case_id=analysis_obj.family)
+            ).open() as config_stream:
+                try:
+                    context.invoke(analysis, config_stream=config_stream)
+                except (Exception, click.Abort):
+                    LOG.error("case storage failed: %s", analysis_obj.family, exc_info=True)
+                    exit_code = EXIT_FAIL
     if exit_code:
         raise click.Abort

--- a/tests/cli/workflow/mip/test_cli_mip_store.py
+++ b/tests/cli/workflow/mip/test_cli_mip_store.py
@@ -57,37 +57,44 @@ def test_store_analysis(
 
 
 def test_store_completed_good_cases(
-    cli_runner: CliRunner, mip_store_context: dict, mip_case_ids: dict, mip_configs, caplog
+    cli_runner: CliRunner, mip_store_context: dict, mip_case_ids: dict, mip_configs, helpers, caplog
 ):
     """Test if store completed stores function"""
 
     with caplog.at_level("INFO"):
         trailblazer_api = mip_store_context["trailblazer_api"]
-        trailblazer_api.ensure_analyses_response(
-            [
-                TrailblazerAnalysis.parse_obj(
-                    {
-                        "id": 1,
-                        "family": "yellowhog",
-                        "config_path": mip_configs["yellowhog"].as_posix(),
-                    }
-                ),
-                TrailblazerAnalysis.parse_obj(
-                    {
-                        "id": 2,
-                        "family": "bluezebra",
-                        "config_path": mip_configs["bluezebra"].as_posix(),
-                    }
-                ),
-                TrailblazerAnalysis.parse_obj(
-                    {
-                        "id": 3,
-                        "family": "purplesnail",
-                        "config_path": mip_configs["purplesnail"].as_posix(),
-                    }
-                ),
-            ]
-        )
+        analyses = [
+            {
+                "id": 1,
+                "family": "yellowhog",
+                "config_path": mip_configs["yellowhog"].as_posix(),
+                "status": "completed",
+            },
+            {
+                "id": 2,
+                "family": "bluezebra",
+                "config_path": mip_configs["bluezebra"].as_posix(),
+                "status": "completed",
+            },
+            {
+                "id": 3,
+                "family": "purplesnail",
+                "config_path": mip_configs["purplesnail"].as_posix(),
+                "status": "completed",
+            },
+        ]
+        for analysis in analyses:
+            trailblazer_api.ensure_get_latest_analysis_response(analysis_dict=analysis)
+
+        status_db = mip_store_context["status_db"]
+        for case_id in ["yellowhog", "bluezebra", "purplesnail"]:
+            case_obj = status_db.family(case_id)
+            if case_obj:
+                case_obj.action = "running"
+                status_db.commit()
+            else:
+                helpers.add_family(store=status_db, internal_id=case_id, action="running")
+
         # WHEN we run store all completed cases
         result = cli_runner.invoke(completed, obj=mip_store_context)
         # THEN some cases should be added and some should fail

--- a/tests/mocks/tb_mock.py
+++ b/tests/mocks/tb_mock.py
@@ -1,6 +1,11 @@
+from cg.apps.tb.models import TrailblazerAnalysis
+from typing import Optional
+
+
 class MockTB:
     def __init__(self):
         self.analyses_response = []
+        self.get_latest_analysis_response = {}
 
     def is_latest_analysis_ongoing(self, *args, **kwargs) -> bool:
         return False
@@ -14,11 +19,21 @@ class MockTB:
     def add_commit(self, *args, **kwargs) -> None:
         return None
 
-    def has_latest_analysis_started(self, *args, **kwargs):
+    def has_latest_analysis_started(self, *args, **kwargs) -> bool:
         return False
 
-    def analyses(self, *args, **kwargs):
+    def analyses(self, *args, **kwargs) -> list:
         return self.analyses_response
 
-    def ensure_analyses_response(self, analyses_list):
-        self.analyses_response = analyses_list
+    def get_latest_analysis(self, case_id: str) -> Optional[TrailblazerAnalysis]:
+        return self.get_latest_analysis_response.get(case_id)
+
+    def ensure_analyses_response(self, analyses_list: list) -> None:
+        self.analyses_response = [
+            TrailblazerAnalysis.parse_obj(analysis) for analysis in analyses_list
+        ]
+
+    def ensure_get_latest_analysis_response(self, analysis_dict: dict) -> None:
+        self.get_latest_analysis_response[analysis_dict["family"]] = TrailblazerAnalysis.parse_obj(
+            analysis_dict
+        )

--- a/tests/store_helpers.py
+++ b/tests/store_helpers.py
@@ -271,6 +271,7 @@ class StoreHelpers:
         self,
         store: Store,
         family_id: str = "family_test",
+        action: str = None,
         data_analysis: str = "mip",
         internal_id: str = None,
         customer_id: str = "cust000",
@@ -291,9 +292,12 @@ class StoreHelpers:
 
         if not family_obj:
             family_obj = store.add_family(
-                data_analysis=data_analysis, name=family_id, panels=panels
+                data_analysis=data_analysis,
+                name=family_id,
+                panels=panels,
             )
-
+        if action:
+            family_obj.action = action
         if internal_id:
             family_obj.internal_id = internal_id
 


### PR DESCRIPTION
This PR adds/fixes ...
-Changes condition for which cases should be stored in CG. This fixes a bug where cg would try to store cases which already have been stored due to mismatch in timestamp stored in Trailblazer and Housekeeper

### How to prepare for test
- [x] ssh to hasta (depending on type of change)
- [x] install on stage:
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [x] login to hasta and us
- [x] do cg workflow mip-dna store completed
- [x] do cg workflow mip-dna store completed again and see which cases are being stored

### Expected test outcome
- [x] check that same analyses arent stored again when the command runs a second time
- [x] Solemnly swear that it worked since the log is too large to print

## Review
- [ ] code approved by
- [x] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
