### PR TITLE
remove unused flags from base command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
+## [14.0.1]
+
+### Fixed
+- Removed unused options form cg workflow balsamic base command
+
+
 
 ## [14.0.0]
 

--- a/cg/cli/workflow/balsamic/base.py
+++ b/cg/cli/workflow/balsamic/base.py
@@ -50,13 +50,8 @@ OPTION_PRIORITY = click.option(
 
 
 @click.group(invoke_without_command=True)
-@OPTION_ANALYSIS_TYPE
-@OPTION_PRIORITY
-@OPTION_PANEL_BED
-@OPTION_RUN_ANALYSIS
-@OPTION_DRY
 @click.pass_context
-def balsamic(context, priority, panel_bed, analysis_type, run_analysis, dry):
+def balsamic(context):
     """Cancer analysis workflow """
     if context.invoked_subcommand is None:
         click.echo(context.get_help())


### PR DESCRIPTION
This PR adds/fixes ...
- Removes flags (which had no function other than being displayed in a help message) from `cg workflow balsamic base` command 

### How to prepare for test
- [x] ssh to hasta (depending on type of change)
- [x] install on stage:
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [x] login to hasta atage
- [x] do cg workflow balsamic <..> --dry-run commands 

### Expected test outcome
- [x] check that functionality was not lost
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [x] code approved by MM, HFA
- [x] tests executed by MR
- [x] "Merge and deploy" approved by MR
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
