### PR TITLE
fix failing microsalt store complete cronjob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
+## [15.0.4]
+### Fixed
+- fixed failing `cg microsalt store completed` cronjob
+
 ## [15.0.3]
 ### Fixed
 - Fixed path where microsalt deliverables files are located

--- a/cg/cli/workflow/microsalt/store.py
+++ b/cg/cli/workflow/microsalt/store.py
@@ -58,7 +58,7 @@ def analysis(context, config_stream):
 @click.pass_context
 def completed(context):
     """Store all completed analyses"""
-    microsalt_analysis_api = context.obj["analysis_api"]
+    microsalt_analysis_api = context.obj["microsalt_analysis_api"]
     exit_code = EXIT_SUCCESS
     for deliverables_file in microsalt_analysis_api.get_deliverables_to_store():
         try:


### PR DESCRIPTION
This PR fixes a wrong key in `context.obj`, see https://github.com/Clinical-Genomics/cg/pull/813 

### How to prepare for test
see PR https://github.com/Clinical-Genomics/cg/pull/813

### How to test
- [x] do `cg store microsalt completed`

### Expected test outcome
- [x] check that `cg store microsalt completed` doesn't error on ` KeyError: 'analysis_api'`
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [x] tests executed by @barrystokman 
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
