### PR TITLE
Fix cg upload auto --pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Try to use the following format:
 
 ### Fixed
 
+## [16.0.6]
+
+### Fixed
+- 'cg upload auto --pipeline' to accept 'mip-dna' as pipeline 
+
 ## [16.0.5]
 
 ### Fixed

--- a/cg/utils/click/EnumChoice.py
+++ b/cg/utils/click/EnumChoice.py
@@ -11,12 +11,16 @@ class EnumChoice(click.Choice):
     """ class to use when the click option is an Enum """
 
     def __init__(self, enum, case_sensitive=False, use_value=True):
-        if use_value and isinstance(enum, tuple):
-            choices = (_.value for _ in enum)
-        elif isinstance(enum, tuple):
-            choices = (_.name for _ in enum)
+        if isinstance(enum, tuple):
+            if use_value:
+                choices = (_.value for _ in enum)
+            else:
+                choices = (_.name for _ in enum)
         elif isinstance(enum, EnumMeta):
-            choices = enum.__members__
+            if use_value:
+                choices = enum
+            else:
+                choices = enum.__members__
         else:
             raise TypeError("`enum` must be `tuple` or `Enum`")
 
@@ -25,6 +29,7 @@ class EnumChoice(click.Choice):
 
         self.__enum = enum
         self.__case_sensitive = case_sensitive
+        self.__use_value = use_value
 
         super().__init__(list(sorted(set(choices))))
 
@@ -34,10 +39,16 @@ class EnumChoice(click.Choice):
 
         value = super().convert(value, param, ctx)
 
-        if not self.__case_sensitive:
-            return next(_ for _ in self.__enum if _.name.lower() == value.lower())
+        if self.__use_value:
+            if not self.__case_sensitive:
+                return next(_ for _ in self.__enum if _.value.lower() == value.lower())
+            else:
+                return next(_ for _ in self.__enum if _.value == value)
         else:
-            return next(_ for _ in self.__enum if _.name == value)
+            if not self.__case_sensitive:
+                return next(_ for _ in self.__enum if _.name.lower() == value.lower())
+            else:
+                return next(_ for _ in self.__enum if _.name == value)
 
     def get_metavar(self, param):
         word = self.__enum.__name__

--- a/tests/cli/upload/test_cli_upload_auto.py
+++ b/tests/cli/upload/test_cli_upload_auto.py
@@ -10,13 +10,12 @@ def test_upload_auto_with_pipeline_as_argument(
 ):
     """Test upload auto"""
     # GIVEN a store with a MIP analysis
-    pipeline = Pipeline.BALSAMIC
+    pipeline = Pipeline.MIP_DNA
     helpers.add_analysis(store=sample_store, completed_at=timestamp, pipeline=pipeline)
 
     # WHEN uploading all analysis from pipeline MIP
     caplog.set_level(logging.INFO)
-    cli_runner.invoke(auto, ["--pipeline", str(pipeline)], obj=base_context, catch_exceptions=False)
+    cli_runner.invoke(auto, ["--pipeline", "mip-dna"], obj=base_context)
 
     # THEN assert that the MIP analysis was successfully uploaded
-    with caplog.at_level(logging.INFO):
-        assert "Uploading family" in caplog.text
+    assert "Uploading family" in caplog.text

--- a/tests/cli/workflow/microsalt/test_microsalt_run.py
+++ b/tests/cli/workflow/microsalt/test_microsalt_run.py
@@ -27,9 +27,7 @@ def test_dry_arguments(
     caplog.set_level(logging.INFO)
 
     # WHEN dry running without anything specified
-    result = cli_runner.invoke(
-        run, ["--dry-run", microbial_ticket], obj=base_context, catch_exceptions=False
-    )
+    result = cli_runner.invoke(run, ["--dry-run", microbial_ticket], obj=base_context)
 
     # THEN command should mention missing arguments
     assert result.exit_code == EXIT_SUCCESS

--- a/tests/cli/workflow/mip/test_cli_mip_store.py
+++ b/tests/cli/workflow/mip/test_cli_mip_store.py
@@ -48,9 +48,7 @@ def test_store_analysis(
 
     with caplog.at_level("INFO"):
         # WHEN we run store on a config
-        result = cli_runner.invoke(
-            analysis, [str(mip_configs["yellowhog"])], obj=mip_store_context, catch_exceptions=False
-        )
+        result = cli_runner.invoke(analysis, [str(mip_configs["yellowhog"])], obj=mip_store_context)
         # THEN we should store the files in housekeeper
         assert "new bundle added: yellowhog" in caplog.text
         assert "Included files in Housekeeper" in caplog.text


### PR DESCRIPTION
This PR fixes cg upload auto to use '-' in pipelines instead of '_'

### How to prepare for test
- [x] ssh to hasta (depending on type of change)
- [x] install on stage:
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [x] login to hasta
- [x] do us
- [x] do cg upload auto --pipeline mip-dna

### Expected test outcome
- [x] check that mip-dna was accepted as pipeline value
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [x] code approved by PG
- [x] tests executed by PG
- [x] "Merge and deploy" approved by PG
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Deploy this branch
- [ ] Inform to production
