### PR TITLE
Load Scout from CLI

### DIFF
--- a/cg/meta/upload/scoutapi.py
+++ b/cg/meta/upload/scoutapi.py
@@ -76,7 +76,7 @@ class UploadScoutAPI:
             }
             yield sample
 
-    def generate_config(self, analysis_obj: models.Analysis) -> dict:
+    def generate_config(self, analysis_obj: models.Analysis, rank_score_threshold: int = 5) -> dict:
         """Fetch data about an analysis to load Scout."""
         analysis_date = analysis_obj.started_at or analysis_obj.completed_at
         hk_version = self.housekeeper.version(analysis_obj.family.internal_id, analysis_date)
@@ -86,6 +86,7 @@ class UploadScoutAPI:
             "default_gene_panels": analysis_obj.family.panels,
             "family": analysis_obj.family.internal_id,
             "family_name": analysis_obj.family.name,
+            "rank_score_threshold": rank_score_threshold,
             "gene_panels": self.analysis.convert_panels(
                 analysis_obj.family.customer.internal_id, analysis_obj.family.panels
             ),


### PR DESCRIPTION
This PR changes the behaviour so that CG uses scout cli when uploading cases instead of importing code directly from Scout

### How to prepare for test
- [ ] ssh to hasta (depending on type of change)
- [ ] install on stage:
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh use-cli-scout-load`

### How to test
- [ ] use stage us
- [ ] upload a case `cg load case vitalmouse`

### Expected test outcome
- [ ] check that the case was uploaded to scout
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **MINOR** - when you add functionality in a backwards compatible manner
