### PR TITLE
Fix/OP Accept missing data analysis in customers mip json

### DIFF
--- a/cg/apps/lims/limsjson.py
+++ b/cg/apps/lims/limsjson.py
@@ -19,7 +19,7 @@ OPTIONAL_KEYS = (
 def get_project_type(samples: [dict]) -> str:
     """Determine the project type."""
 
-    data_analyses = set(sample["data_analysis"].lower() for sample in samples)
+    data_analyses = set(sample.get("data_analysis", "mip-dna").lower() for sample in samples)
 
     if len(data_analyses) != 1:
         raise OrderFormError(f"mixed 'Data Analysis' types: {', '.join(data_analyses)}")
@@ -43,7 +43,7 @@ def parse_json(indata: dict) -> dict:
         raise OrderFormError("orderform doesn't contain any samples")
 
     project_type = get_project_type(parsed_samples)
-    customer_id = indata.get("customer")
+    customer_id = indata.get("customer").lower()
     comment = indata.get("comment")
 
     if project_type in CASE_PROJECT_TYPES:
@@ -73,7 +73,7 @@ def expand_case(case_id: str, parsed_case: dict) -> dict:
     require_qcoks = set(raw_sample["require_qcok"] for raw_sample in samples)
     new_case["require_qcok"] = True in require_qcoks
 
-    priorities = set(raw_sample["priority"] for raw_sample in samples)
+    priorities = set(raw_sample["priority"].lower() for raw_sample in samples)
     if len(priorities) != 1:
         raise OrderFormError(f"multiple values for 'Priority' for case: {case_id}")
     new_case["priority"] = priorities.pop()

--- a/cg/meta/orders/schema.py
+++ b/cg/meta/orders/schema.py
@@ -96,6 +96,7 @@ MIP_SAMPLE = {
     # customer
     "data_analysis": str,
     "data_delivery": OptionalNone(TypeValidatorNone(str)),
+    "age_at_sampling": OptionalNone(TypeValidatorNone(str)),
     "application": str,
     "family_name": validators.RegexValidator(NAME_PATTERN),
     "sex": OptionalNone(validators.Any(SEX_OPTIONS)),

--- a/tests/apps/lims/test_limsjson.py
+++ b/tests/apps/lims/test_limsjson.py
@@ -33,49 +33,48 @@ def test_parsing_rml_json(rml_order_to_submit: dict) -> None:
     assert sample_data["concentration_sample"] == "6"
 
 
-def test_parsing_mip_json(mip_order_to_submit: dict):
+def test_parsing_mip_json(mip_json_order_to_submit: dict):
 
     # GIVEN an order form for a Scout order with samples, 1 trio, in a plate
 
     # WHEN parsing the order form
-    data = limsjson.parse_json(mip_order_to_submit)
+    data = limsjson.parse_json(mip_json_order_to_submit)
 
     # THEN it should detect the type of project
     assert data["project_type"] == "mip-dna"
-    assert data["customer"] == "cust000"
+    assert data["customer"] == "Cust000"
 
     # ... and it should find and group all samples in families
-    assert len(data["items"]) == 2
+    assert len(data["items"]) == 7
 
     # ... and collect relevant data about the families
-    trio_family = data["items"][0]
+    duo_family = data["items"][4]
 
-    assert len(trio_family["samples"]) == 3
-    assert trio_family["name"] == "family1"
-    assert trio_family["priority"] == "standard"
-    assert set(trio_family["panels"]) == set(["IEM"])
-    assert trio_family["require_qcok"] is True
+    assert len(duo_family["samples"]) == 2
+    assert duo_family["name"] == "F0018192"
+    assert duo_family["priority"] == "Standard"
+    assert set(duo_family["panels"]) == set(["CTD"])
+    assert duo_family["require_qcok"] is False
 
     # ... and collect relevant info about the samples
-    proband_sample = trio_family["samples"][0]
-    assert proband_sample["name"] == "sample1"
-    assert proband_sample["container"] == "96 well plate"
-    assert proband_sample["data_analysis"] == "mip-dna"
-    assert proband_sample["application"] == "WGTPCFC030"
-    assert proband_sample["sex"] == "female"
+    sibling_sample = duo_family["samples"][0]
+    assert sibling_sample["name"] == "2020-16171-81"
+    assert sibling_sample["container"] == "Tube"
+    assert sibling_sample["application"] == "WGSPCFC030"
+    assert sibling_sample["sex"] == "female"
 
     # family-id on the family
     # customer on the order (data)
     # require-qc-ok on the family
-    assert proband_sample["source"] == "tissue (fresh frozen)"
-    assert proband_sample["tumour"] is True
+    assert sibling_sample["source"] == "blood"
+    assert sibling_sample.get("tumour") is None
 
-    assert proband_sample["container_name"] == "CMMS"
-    assert proband_sample["well_position"] == "A:1"
+    assert sibling_sample["container_name"] == "2020-16171-81"
+    assert sibling_sample["well_position"] == ""
 
     # panels on the family
-    assert proband_sample["status"] == "affected"
-    assert proband_sample["mother"] == "sample2"
-    assert proband_sample["father"] == "sample3"
-    assert proband_sample["quantity"] == "220"
-    assert proband_sample["comment"] == "comment"
+    assert sibling_sample["status"] == "affected"
+    assert sibling_sample["mother"] == ""
+    assert sibling_sample["father"] == ""
+    assert sibling_sample["quantity"] == ""
+    assert sibling_sample["comment"] == "F0018192-0 Data finns 2019-19202 duo med bror "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -322,7 +322,6 @@ def mip_json_order_to_submit() -> dict:
     return json.load(open("tests/fixtures/orders/mip-json.json"))
 
 
-
 @pytest.fixture
 def mip_rna_order_to_submit() -> dict:
     """Load an example rna order."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -317,6 +317,13 @@ def mip_order_to_submit() -> dict:
 
 
 @pytest.fixture
+def mip_json_order_to_submit() -> dict:
+    """Load an example json scout order."""
+    return json.load(open("tests/fixtures/orders/mip-json.json"))
+
+
+
+@pytest.fixture
 def mip_rna_order_to_submit() -> dict:
     """Load an example rna order."""
     return json.load(open("tests/fixtures/orders/mip_rna.json"))

--- a/tests/fixtures/orders/mip-json.json
+++ b/tests/fixtures/orders/mip-json.json
@@ -1,0 +1,247 @@
+{
+  "name": "Testorder",
+  "customer": "Cust000",
+  "comment": "",
+  "samples": [
+    {
+      "name": "2020-12345-67",
+      "father": "",
+      "mother": "",
+      "sex": "male",
+      "age_at_sampling": "46.14648",
+      "quantity": "",
+      "application": "WGSPCFC030",
+      "source": "other",
+      "status": "affected",
+      "container": "Tube",
+      "container_name": "2020-12345-67",
+      "well_position": "",
+      "family_name": "F0034567",
+      "panels": [
+        "OMIM-AUTO"
+      ],
+      "require_qcok": false,
+      "priority": "Standard",
+      "comment": "Data finns F0034567-8 2020-45678",
+      "synopsis": [
+        ""
+      ],
+      "phenotype_terms": [
+        ""
+      ],
+      "cohorts": [
+        ""
+      ]
+    },
+    {
+      "name": "2020-56789-10",
+      "father": "",
+      "mother": "",
+      "sex": "female",
+      "age_at_sampling": "67.89101",
+      "quantity": "",
+      "application": "WGSPCFC030",
+      "source": "blood",
+      "status": "affected",
+      "container": "Tube",
+      "container_name": "2020-56789-10",
+      "well_position": "",
+      "family_name": "F0067891",
+      "panels": [
+        "OMIM-AUTO"
+      ],
+      "require_qcok": false,
+      "priority": "Standard",
+      "comment": "Data finns F0067891-0 2020-78910",
+      "synopsis": [
+        ""
+      ],
+      "phenotype_terms": [
+        ""
+      ],
+      "cohorts": [
+        ""
+      ]
+    },
+    {
+      "name": "2020-89101-11",
+      "father": "",
+      "mother": "",
+      "sex": "female",
+      "age_at_sampling": "9.10111",
+      "quantity": "",
+      "application": "WGSPCFC030",
+      "source": "blood",
+      "status": "affected",
+      "container": "Tube",
+      "container_name": "2020-89101-11",
+      "well_position": "",
+      "family_name": "F0010111",
+      "panels": [
+        "OMIM-AUTO"
+      ],
+      "require_qcok": false,
+      "priority": "Standard",
+      "comment": "Data finns F0010111-2 2020-11121",
+      "synopsis": [
+        ""
+      ],
+      "phenotype_terms": [
+        ""
+      ],
+      "cohorts": [
+        ""
+      ]
+    },
+    {
+      "name": "2020-12131-41",
+      "father": "",
+      "mother": "",
+      "sex": "male",
+      "age_at_sampling": "1.31415",
+      "quantity": "",
+      "application": "WGSPCFC030",
+      "source": "other",
+      "status": "affected",
+      "container": "Tube",
+      "container_name": "2020-12131-41",
+      "well_position": "",
+      "family_name": "F0014151",
+      "panels": [
+        "OMIM-AUTO"
+      ],
+      "require_qcok": false,
+      "priority": "Standard",
+      "comment": "Data finns F0014151-6 2020-15161",
+      "synopsis": [
+        ""
+      ],
+      "phenotype_terms": [
+        ""
+      ],
+      "cohorts": [
+        ""
+      ]
+    },
+    {
+      "name": "2020-16171-81",
+      "father": "",
+      "mother": "",
+      "sex": "female",
+      "age_at_sampling": "17.18192",
+      "quantity": "",
+      "application": "WGSPCFC030",
+      "source": "blood",
+      "status": "affected",
+      "container": "Tube",
+      "container_name": "2020-16171-81",
+      "well_position": "",
+      "family_name": "F0018192",
+      "panels": [
+        "CTD"
+      ],
+      "require_qcok": false,
+      "priority": "Standard",
+      "comment": "F0018192-0 Data finns 2019-19202 duo med bror ",
+      "synopsis": [
+        ""
+      ],
+      "phenotype_terms": [
+        ""
+      ],
+      "cohorts": [
+        ""
+      ]
+    },
+    {
+      "name": "2020-20212-22",
+      "father": "",
+      "mother": "",
+      "sex": "male",
+      "age_at_sampling": "21.22232",
+      "quantity": "",
+      "application": "WGSPCFC030",
+      "source": "blood",
+      "status": "affected",
+      "container": "Tube",
+      "container_name": "2020-20212-23",
+      "well_position": "",
+      "family_name": "F0018192",
+      "panels": [
+        "CTD"
+      ],
+      "require_qcok": false,
+      "priority": "Standard",
+      "comment": "F0018192-0 Data finns 2018-19202 duo med syster",
+      "synopsis": [
+        ""
+      ],
+      "phenotype_terms": [
+        ""
+      ],
+      "cohorts": [
+        ""
+      ]
+    },
+    {
+      "name": "2020-20212-22",
+      "father": "",
+      "mother": "",
+      "sex": "male",
+      "age_at_sampling": "2.12223",
+      "quantity": "",
+      "application": "WGSPCFC030",
+      "source": "other",
+      "status": "affected",
+      "container": "Tube",
+      "container_name": "2020-20212-22",
+      "well_position": "",
+      "family_name": "F0022232",
+      "panels": [
+        "OMIM-AUTO"
+      ],
+      "require_qcok": false,
+      "priority": "Priority",
+      "comment": "Data finns 23242-I-5A",
+      "synopsis": [
+        ""
+      ],
+      "phenotype_terms": [
+        ""
+      ],
+      "cohorts": [
+        ""
+      ]
+    },
+    {
+      "name": "2020-24252-62",
+      "father": "",
+      "mother": "",
+      "sex": "male",
+      "age_at_sampling": "2.52627",
+      "quantity": "",
+      "application": "WGSPCFC030",
+      "source": "other",
+      "status": "affected",
+      "container": "Tube",
+      "container_name": "2020-24252-62",
+      "well_position": "",
+      "family_name": "F0002627",
+      "panels": [
+        "OMIM-AUTO"
+      ],
+      "require_qcok": false,
+      "priority": "Standard",
+      "comment": "Data trio finns F0002627-2 272-8-2A",
+      "synopsis": [
+        ""
+      ],
+      "phenotype_terms": [
+        ""
+      ],
+      "cohorts": [
+        ""
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR fixes the problem handling mip-json without specified data_analysis 

### How to prepare for test
- [x] ssh to clinical-db (depending on type of change)
- [x] install on stage:
`bash /home/proj/production/servers/resources/clinical-db.scilifelab.se/update-clinical-api-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [x] login to OP-stage
- [x] submit an actual customer mip-json

### Expected test outcome
- [x] check that the order is accepted
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [x] code approved by MR
- [x] tests executed by PG
- [x] "Merge and deploy" approved by PG
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Deploy this branch
- [ ] Inform to production, lab
