### PR TITLE
Fix(mip-json): Handle wells as customer sends them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ Try to use the following format:
 
 ### Changed
 
+## [NG.NG.NG]
+
+### Fixed
+
+- This PR fixes the problem handling wells in json orders without ":" as separator, e.g. A1 instead of A:1
+
 ## 16.15.1
 
 ### Fixed

--- a/cg/apps/lims/limsjson.py
+++ b/cg/apps/lims/limsjson.py
@@ -82,9 +82,16 @@ def expand_case(case_id: str, parsed_case: dict) -> dict:
     for raw_sample in samples:
         if raw_sample["panels"]:
             gene_panels.update(raw_sample["panels"])
+
         new_sample = {}
+        well_position_raw = raw_sample.get("well_position")
+        if well_position_raw:
+            new_sample["well_position"] = (
+                ":".join(well_position_raw) if ":" not in well_position_raw else well_position_raw
+            )
+
         for key, value in raw_sample.items():
-            if key not in ["panels"]:
+            if key not in ["panels", "well_position"]:
                 new_sample[key] = value
 
         new_case["samples"].append(new_sample)

--- a/tests/apps/lims/test_limsjson.py
+++ b/tests/apps/lims/test_limsjson.py
@@ -48,7 +48,6 @@ def test_parsing_mip_json(mip_json_order_to_submit: dict):
 
     # ... and collect relevant data about the families
     duo_family = data["items"][4]
-
     assert len(duo_family["samples"]) == 2
     assert duo_family["name"] == "F0018192"
     assert duo_family["priority"] == "standard"
@@ -58,7 +57,6 @@ def test_parsing_mip_json(mip_json_order_to_submit: dict):
     # ... and collect relevant info about the samples
     sibling_sample = duo_family["samples"][0]
     assert sibling_sample["name"] == "2020-16171-81"
-    assert sibling_sample["container"] == "Tube"
     assert sibling_sample["application"] == "WGSPCFC030"
     assert sibling_sample["sex"] == "female"
 
@@ -67,9 +65,9 @@ def test_parsing_mip_json(mip_json_order_to_submit: dict):
     # require-qc-ok on the family
     assert sibling_sample["source"] == "blood"
     assert sibling_sample.get("tumour") is None
-
+    assert sibling_sample["container"] == "96 well plate"
     assert sibling_sample["container_name"] == "2020-16171-81"
-    assert sibling_sample["well_position"] == ""
+    assert sibling_sample["well_position"] == "A:1"
 
     # panels on the family
     assert sibling_sample["status"] == "affected"

--- a/tests/fixtures/orders/mip-json.json
+++ b/tests/fixtures/orders/mip-json.json
@@ -133,9 +133,9 @@
       "application": "WGSPCFC030",
       "source": "blood",
       "status": "affected",
-      "container": "Tube",
+      "container":"96 well plate",
       "container_name": "2020-16171-81",
-      "well_position": "",
+      "well_position":"A1",
       "family_name": "F0018192",
       "panels": [
         "CTD"


### PR DESCRIPTION
This PR fixes the problem handling wells in json orders without ":" as separator, e.g. A1 instead of A:1

### How to prepare for test
- [x] ssh to clinical-db (depending on type of change)
- [x] install on stage:
`bash /home/proj/production/servers/resources/clinical-db.scilifelab.se/update-clinical-api-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [x] login to OP-stage
- [x] use json with wells without ":"

### Expected test outcome
- [x] check that the wells are picked up by the OP
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [x] code approved by PG
- [x] tests executed by PG
- [x] "Merge and deploy" approved by PG
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Deploy this branch
- [ ] Inform to lab, production and customer
