### PR TITLE
Update deliver analysis interface

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@ This PR adds/fixes ...
 ### How to prepare for test
 - [ ] ssh to relevant server (depending on type of change)
 - [ ] Use stage: `us`
-- [ ] paxa the environenmt: `paxa`
+- [ ] paxa the environment: `paxa`
 - [ ] install on stage (example for hasta):
 `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
+## [18.2]
+
+### Changed
+
+- Remove option to specify delivery path when delivering data
+
+### Fixed
+
+- Improved usage of `cg deliver analysis` command
+
 ## [18.1.5]
 
 ### Fixed

--- a/cg/cli/deliver/base.py
+++ b/cg/cli/deliver/base.py
@@ -25,24 +25,23 @@ def deliver(context):
 
 
 @click.command(name="analysis")
-@click.option("-c", "--case-id")
-@click.option("-t", "--ticket-id", type=int)
-@click.option("-d", "--delivery-type", type=click.Choice(PIPELINE_ANALYSIS_OPTIONS), required=True)
+@click.option("-c", "--case-id", help="Deliver the files for a specific case")
 @click.option(
-    "-i",
-    "--inbox",
-    help="customer inbox",
+    "-t", "--ticket-id", type=int, help="Deliver the files for ALL cases connected to a ticket"
 )
+@click.option("-d", "--delivery-type", type=click.Choice(PIPELINE_ANALYSIS_OPTIONS), required=True)
 @click.option("--dry-run", is_flag=True)
 @click.pass_context
-def deliver_analysis(
-    context, case_id: str, ticket_id: int, delivery_type: str, inbox: str, dry_run: bool
-):
-    """Deliver analysis files to customer inbox"""
+def deliver_analysis(context, case_id: str, ticket_id: int, delivery_type: str, dry_run: bool):
+    """Deliver analysis files to customer inbox
+
+    Files can be delivered either on case level or for all cases connected to a ticket.
+    Any of those needs to be specified.
+    """
     if not (case_id or ticket_id):
         LOG.info("Please provide a case-id or ticket-id")
         return
-    inbox = inbox or context.obj.get("delivery_path")
+    inbox = context.obj["delivery_path"]
     if not inbox:
         LOG.info("Please specify the root path for where files should be delivered")
         return

--- a/cg/cli/deliver/base.py
+++ b/cg/cli/deliver/base.py
@@ -41,7 +41,8 @@ def deliver_analysis(context, case_id: str, ticket_id: int, delivery_type: str, 
     if not (case_id or ticket_id):
         LOG.info("Please provide a case-id or ticket-id")
         return
-    inbox = context.obj["delivery_path"]
+
+    inbox = context.obj.get("delivery_path")
     if not inbox:
         LOG.info("Please specify the root path for where files should be delivered")
         return

--- a/tests/cli/deliver/test_run_deliver_cmd.py
+++ b/tests/cli/deliver/test_run_deliver_cmd.py
@@ -1,7 +1,6 @@
 """Tests for running the delivery command"""
 
 import logging
-
 from pathlib import Path
 
 from click.testing import CliRunner
@@ -148,7 +147,7 @@ def test_case_file_is_delivered(
     # WHEN running the deliver analysis command
     runner.invoke(
         deliver_analysis,
-        ["--case-id", case_id, "--delivery-type", "mip-dna", "--inbox", str(project_dir)],
+        ["--case-id", case_id, "--delivery-type", "mip-dna"],
         obj=populated_mip_context,
     )
 


### PR DESCRIPTION
This PR updates the deliver analysis interface with better description how delivery is done.
Also the `"-i", "--inbox"` option was removed since it was confusing that one could specify delivery path.

### How to prepare for test
- [x] ssh to hasta
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh better-cli-info`

### How to test
- [x] do `cg deliver analysis --dry-run -d balsamic -c unitedbeagle`

### Expected test outcome
- [x] check that the command works
- [x] Take a screenshot and attach or copy/paste the output.

![Screenshot 2021-01-15 at 11 52 15](https://user-images.githubusercontent.com/405278/104716372-2706d680-5728-11eb-808b-82bae0128287.png)


## Review
- [x] code approved by MR
- [x] tests executed by MM
- [x] "Merge and deploy" approved by MM
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **MINOR** - when you add functionality in a backwards compatible manner


