### PR TITLE
Fix the deliverables path in MicrosaltAnalysisAPI to be non-optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,13 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
-## 18.5.0
+## [18.5.1]
+
+### Fixed
+
+- Fix bug with microsalt deliverables path where it only returns the path only if it exists. This caused errors in some cases when submitting to Trailblazer
+
+## [18.5.0]
 
 ### Added
 - Added MHT to gene panel master-list

--- a/cg/cli/workflow/microsalt/base.py
+++ b/cg/cli/workflow/microsalt/base.py
@@ -170,8 +170,12 @@ def run(
     microsalt_analysis_api.set_statusdb_action(case_id=case_id, action="running")
     try:
         microsalt_analysis_api.submit_trailblazer_analysis(case_id=case_id)
-    except Exception:
-        LOG.warning("Trailblazer warning: Could not track analysis progress for case %s!", case_id)
+    except Exception as e:
+        LOG.warning(
+            "Trailblazer warning: Could not track analysis progress for case %s! %s",
+            case_id,
+            e.__class__.__name__,
+        )
 
 
 @microsalt.command()

--- a/cg/meta/workflow/microsalt.py
+++ b/cg/meta/workflow/microsalt.py
@@ -89,7 +89,7 @@ class MicrosaltAnalysisAPI:
             self.root_dir, "results", "reports", "trailblazer", f"{order_id}_slurm_ids.yaml"
         )
 
-    def get_deliverables_file_path(self, case_id: str) -> Optional[Path]:
+    def get_deliverables_file_path(self, case_id: str) -> Path:
         """Returns a path where the microSALT deliverables file for the order_id should be
         located"""
         case_obj: models.Family = self.db.family(case_id)
@@ -103,7 +103,7 @@ class MicrosaltAnalysisAPI:
         )
         if deliverables_file_path.exists():
             LOG.info("Found deliverables file %s", deliverables_file_path)
-            return deliverables_file_path
+        return deliverables_file_path
 
     @staticmethod
     def generate_fastq_name(
@@ -385,7 +385,7 @@ class MicrosaltAnalysisAPI:
         """Gather information from microSALT analysis to store."""
 
         deliverables_path = self.get_deliverables_file_path(case_id=case_id)
-        if not deliverables_path:
+        if not deliverables_path.exists():
             LOG.warning(
                 "Deliverables file not found for %s, analysis may not be finished yet", case_id
             )


### PR DESCRIPTION
This PR adds/fixes:

- Fix bug with microsalt deliverables path where it only returns the path only if it exists. This caused errors in some cases when submitting to Trailblazer

### How to prepare for test
- [x] ssh to hasta
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [x] do cg workflow microsalt run aboveprawn

### Expected test outcome
- [x] check that analysis starts
- [x] Take a screenshot and attach or copy/paste the output.

```
cg workflow microsalt run aboveprawn
Running command source activate S_microSALT; /home/proj/bin/conda/envs/S_microSALT/bin/microSALT analyse /home/proj/stage/microbial/queries/aboveprawn.json --input /home/proj/stage/microbial/fastq/aboveprawn
Action running set for case aboveprawn
```
![image](https://user-images.githubusercontent.com/35531751/105189825-a7b54080-5b35-11eb-8f82-b005067b1733.png)


## Review
- [x] code approved by MR
- [x] tests executed by MR
- [x] "Merge and deploy" approved by MR
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Deploy this branch

