### PR TITLE
Fix(OP): Avoid RML case name clash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
+## [NG.NG.NG]
+
+### Fixed
+
+- Fix bug with name clash for created case when submitting RML-orders via Orderportal
+
 ## 18.6.0
 
 ### Added

--- a/cg/meta/orders/status.py
+++ b/cg/meta/orders/status.py
@@ -452,12 +452,14 @@ class StatusHandler:
                 application_version = self.status.current_application_version(pool["application"])
                 if application_version is None:
                     raise OrderError(f"Invalid application: {pool['application']}")
-            case_obj = self.status.find_family(customer=customer_obj, name=ticket)
+
+            case_name = f"{ticket}-{pool['name']}"
+            case_obj = self.status.find_family(customer=customer_obj, name=case_name)
 
             if not case_obj:
                 case_obj = self.status.add_family(
                     data_analysis=Pipeline(pool["data_analysis"]),
-                    name=ticket,
+                    name=case_name,
                     panels=None,
                 )
                 case_obj.customer = customer_obj

--- a/cg/meta/orders/status.py
+++ b/cg/meta/orders/status.py
@@ -457,7 +457,7 @@ class StatusHandler:
             if not case_obj:
                 case_obj = self.status.add_family(
                     data_analysis=Pipeline(pool["data_analysis"]),
-                    name=pool["name"],
+                    name=ticket,
                     panels=None,
                 )
                 case_obj.customer = customer_obj

--- a/documentation/orderportal/README.md
+++ b/documentation/orderportal/README.md
@@ -1,0 +1,6 @@
+# Orderportal
+
+## RML
+
+For each pool in the RML order a case is created with the name of the used ticket and the pool-name.
+Each sample in the order gets a sample in statusDB and is connected to the pool case.

--- a/tests/meta/orders/test_meta_orders_status.py
+++ b/tests/meta/orders/test_meta_orders_status.py
@@ -111,8 +111,7 @@ def test_store_rml(orders_api, base_store, rml_status_data):
     # THEN it should update the database with new pools
     assert len(new_pools) == 2
 
-    assert base_store.pools(customer=None).count() == 2
-    assert base_store.families(customer=None).count() == 2
+    assert base_store.pools(customer=None).count() == base_store.families(customer=None).count()
     assert base_store.samples(customer=None).count() == 4
     new_pool = base_store.pools(customer=None).first()
 


### PR DESCRIPTION
This PR fixes the name clash that occurs for RML-samples

### How to prepare for test
- [x] ssh to clinical-db
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [x] do submit an rml-order for a customer connecting to an existing order (e.g #111111)
- [x] do submit the same rml-order for same customer connecting to another order (e.g #222222)

### Expected test outcome
- [x] check that both orders submit OK
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [x] code approved by MR
- [x] tests executed by PG
- [x] "Merge and deploy" approved by PG
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [x] Document in repo
- [ ] Deploy this branch
- [ ] Inform to lab and production
