### PR TITLE
Feat/vogue upload micro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,13 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
-## 18.6.0
+## [18.7.0]
+
+### Added
+- cg workflow microsalt upload-analysis-vogue [case_id] to upload specific analysis
+- cg workflow microsalt upload-latest-analyses-vogue to upload all latest analyses what haven't been uploaded
+
+## [18.6.0]
 
 ### Added
 

--- a/cg/apps/vogue.py
+++ b/cg/apps/vogue.py
@@ -21,7 +21,7 @@ class VogueAPI:
         self.vogue_binary = config["vogue"]["binary_path"]
         self.process = Process(binary=self.vogue_binary, config=self.vogue_config)
 
-    def load_genotype_data(self, genotype_dict: dict):
+    def load_genotype_data(self, genotype_dict: dict) -> None:
         """Load genotype data from a dict."""
 
         load_call = ["load", "genotype", "-s", json.dumps(genotype_dict)]
@@ -31,7 +31,7 @@ class VogueAPI:
         for line in self.process.stderr_lines():
             LOG.info("vogue output: %s", line)
 
-    def load_apptags(self, apptag_list: list):
+    def load_apptags(self, apptag_list: list) -> None:
         """Add observations from a VCF."""
         load_call = ["load", "apptag", json.dumps(apptag_list)]
         self.process.run_command(parameters=load_call)
@@ -70,7 +70,7 @@ class VogueAPI:
         for line in self.process.stderr_lines():
             LOG.info("vogue output: %s", line)
 
-    def load_bioinfo_raw(self, load_bioinfo_inputs):
+    def load_bioinfo_raw(self, load_bioinfo_inputs: dict) -> None:
         """Running vogue load bioinfo raw."""
 
         load_bioinfo_raw_call = [
@@ -95,7 +95,7 @@ class VogueAPI:
 
         self.process.run_command(parameters=load_bioinfo_raw_call)
 
-    def load_bioinfo_process(self, load_bioinfo_inputs, cleanup_flag):
+    def load_bioinfo_process(self, load_bioinfo_inputs: dict, cleanup_flag: bool) -> None:
         """Running load bioinfo process."""
 
         load_bioinfo_process_call = [
@@ -119,7 +119,7 @@ class VogueAPI:
 
         self.process.run_command(parameters=load_bioinfo_process_call)
 
-    def load_bioinfo_sample(self, load_bioinfo_inputs):
+    def load_bioinfo_sample(self, load_bioinfo_inputs: dict) -> None:
         """Running load bioinfo sample."""
 
         load_bioinfo_sample_call = [

--- a/cg/cli/upload/vogue.py
+++ b/cg/cli/upload/vogue.py
@@ -236,9 +236,7 @@ def _get_samples(store: Store, case_name: str) -> str:
     """
 
     link_objs = get_links(store, case_name)
-    sample_ids = set()
-    for link_obj in link_objs:
-        sample_ids.add(link_obj.sample.internal_id)
+    sample_ids = {link_obj.sample.internal_id for link_obj in link_objs}
     return ",".join(sample_ids)
 
 

--- a/cg/cli/workflow/microsalt/base.py
+++ b/cg/cli/workflow/microsalt/base.py
@@ -291,6 +291,8 @@ def upload_analysis_vogue(context: click.Context, unique_id: str, dry_run: bool)
             samples_string,
             microsalt_version,
         )
+        return
+
     analysis_result_file = microsalt_analysis_api.hk.get_files(
         bundle=unique_id, tags=["vogue"]
     ).first()

--- a/cg/cli/workflow/microsalt/base.py
+++ b/cg/cli/workflow/microsalt/base.py
@@ -273,6 +273,7 @@ def start_available(context: click.Context, dry_run: bool) -> None:
 @ARGUMENT_UNIQUE_IDENTIFIER
 @click.pass_context
 def upload_analysis_vogue(context: click.Context, unique_id: str, dry_run: bool) -> None:
+    """Upload the trending report for latest analysis of given case_id to Vogue"""
 
     vogue_api = VogueAPI(context.obj)
     microsalt_analysis_api: MicrosaltAnalysisAPI = context.obj["microsalt_analysis_api"]
@@ -321,6 +322,7 @@ def upload_analysis_vogue(context: click.Context, unique_id: str, dry_run: bool)
 @OPTION_DRY_RUN
 @click.pass_context
 def upload_vogue_latest(context: click.Context, dry_run: bool) -> None:
+    """Upload the trending reports for all un-uploaded latest analyses to Vogue"""
 
     EXIT_CODE: int = EXIT_SUCCESS
     microsalt_analysis_api: MicrosaltAnalysisAPI = context.obj["microsalt_analysis_api"]

--- a/cg/cli/workflow/microsalt/base.py
+++ b/cg/cli/workflow/microsalt/base.py
@@ -325,7 +325,7 @@ def upload_vogue_latest(context: click.Context, dry_run: bool) -> None:
     latest_analyses = list(
         microsalt_analysis_api.db.latest_analyses()
         .filter(models.Analysis.pipeline == Pipeline.MICROSALT)
-        .filter(models.Analysis.uploaded_at is None)
+        .filter(models.Analysis.uploaded_at.is_(None))
     )
     for analysis in latest_analyses:
         unique_id = analysis.family.internal_id

--- a/cg/cli/workflow/microsalt/base.py
+++ b/cg/cli/workflow/microsalt/base.py
@@ -300,7 +300,7 @@ def upload_analysis_vogue(context: click.Context, unique_id: str, dry_run: bool)
 
     vogue_load_args = {
         "samples": samples_string,
-        "analysis_result_file": analysis_result_file.path,
+        "analysis_result_file": analysis_result_file.full_path,
         "analysis_case_name": unique_id,
         "analysis_type": "microsalt",
         "analysis_workflow_name": "microsalt",

--- a/cg/cli/workflow/microsalt/base.py
+++ b/cg/cli/workflow/microsalt/base.py
@@ -300,7 +300,7 @@ def upload_analysis_vogue(context: click.Context, unique_id: str, dry_run: bool)
 
     vogue_load_args = {
         "samples": samples_string,
-        "analysis_result_file": analysis_result_file,
+        "analysis_result_file": analysis_result_file.path,
         "analysis_case_name": unique_id,
         "analysis_type": "microsalt",
         "analysis_workflow_name": "microsalt",

--- a/cg/constants/compression.py
+++ b/cg/constants/compression.py
@@ -28,6 +28,7 @@ PROBLEMATIC_CASES = [
 
 # List of cases used for validation that we should skip
 VALIDATION_CASES = [
+    "bigdrum",
     "bosssponge",
     "busycolt",
     "casualgannet",
@@ -48,6 +49,7 @@ VALIDATION_CASES = [
     "keenviper",
     "lightprawn",
     "livingox",
+    "luckyhog",
     "meetpossum",
     "mintbaboon",
     "mintyeti",

--- a/cg/meta/upload/vogue.py
+++ b/cg/meta/upload/vogue.py
@@ -32,9 +32,9 @@ class UploadVogueAPI:
     def load_apptags(self) -> None:
         """Loading application tags from statusdb into the trending database"""
         apptags = self.store.applications()
-        apptags_for_vogue = []
-        for tag in apptags.all():
-            apptags_for_vogue.append({"tag": tag.tag, "prep_category": tag.prep_category})
+        apptags_for_vogue = [
+            {"tag": tag.tag, "prep_category": tag.prep_category} for tag in apptags.all()
+        ]
 
         self.vogue_api.load_apptags(apptags_for_vogue)
 

--- a/cg/meta/workflow/microsalt.py
+++ b/cg/meta/workflow/microsalt.py
@@ -459,7 +459,7 @@ class MicrosaltAnalysisAPI:
     def get_microsalt_version(self):
         try:
             self.process.run_command(["--version"])
-            return self.process.stdout_lines().split()[-1]
+            return list(self.process.stdout_lines())[0].split()[-1]
         except CalledProcessError:
             LOG.warning("Could not retrieve microsalt version!")
             return "0.0.0"

--- a/cg/meta/workflow/microsalt.py
+++ b/cg/meta/workflow/microsalt.py
@@ -11,6 +11,7 @@ import os
 import re
 from datetime import datetime
 from pathlib import Path
+from subprocess import CalledProcessError
 from typing import Any, Dict, List, Optional
 
 import click
@@ -420,6 +421,7 @@ class MicrosaltAnalysisAPI:
 
         new_analysis: models.Analysis = self.db.add_analysis(
             pipeline=Pipeline.MICROSALT,
+            version=self.get_microsalt_version(),
             started_at=analysis_date,
             completed_at=datetime.now(),
             primary=(len(case_obj.analyses) == 0),
@@ -453,3 +455,11 @@ class MicrosaltAnalysisAPI:
             priority=self.get_priority(case_id),
             data_analysis=Pipeline.MICROSALT,
         )
+
+    def get_microsalt_version(self):
+        try:
+            self.process.run_command(["--version"])
+            return self.process.stdout_lines().split()[-1]
+        except CalledProcessError:
+            LOG.warning("Could not retrieve microsalt version!")
+            return "0.0.0"

--- a/cg/meta/workflow/microsalt.py
+++ b/cg/meta/workflow/microsalt.py
@@ -456,7 +456,7 @@ class MicrosaltAnalysisAPI:
             data_analysis=Pipeline.MICROSALT,
         )
 
-    def get_microsalt_version(self):
+    def get_microsalt_version(self) -> str:
         try:
             self.process.run_command(["--version"])
             return list(self.process.stdout_lines())[0].split()[-1]


### PR DESCRIPTION
This PR adds/fixes ...
Upload microsalt results to Vogue
Added:
`cg workflow microsalt upload-analysis-vogue <case_id>` 
Uploads latest trending data from latest analysis for given case
`cg workflow microsalt upload-latest-analyses-vogue`
Uploads latest trending data from latest analyses for all cases where un-uploaded microbial analysis trending data exists

TODOs:
Tests will be added shortly (if needed)

### How to prepare for test
- [x] ssh to hasta
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [x] do `cg workflow microsalt upload-analysis-vogue bigdrum`
- [x] do `cg workflow microsalt upload-latest-analyses-vogue --dry-run`

### Expected test outcome
- [x] check that  `upload-analysis-vogue` command executes successfully
- [x] check that `upload-latest-analyses-vogue` command finds latest analyses and informes what it would have uploaded 
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [x] code approved by @mayabrandi 
- [x] tests executed by MR
- [x] "Merge and deploy" approved by MR
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [x] **MINOR** - when you add functionality in a backwards compatible manner

## Implementation Plan
- [ ] Document in Atlas when we're allowed to add things to Atlas again
- [ ] Deploy this branch
- [ ] Inform @hassanfa and production about trended vogue data from microsalt
- [ ] Create cronjob for automatic upload of microsalt to vogue
