### PR TITLE
Stop compressing validation cases on hasta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,17 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
-## 18.7.0
+## [18.7.1]
+
+### Fixed
+
+- clean_fastq command now also skips validation cases when cleaning fastq files
+
+## [18.7.0]
 
 ### Added customer name in order tickets
 
-## 18.6.1
+## [18.6.1]
 
 ### Fixed
 

--- a/cg/cli/compress/fastq.py
+++ b/cg/cli/compress/fastq.py
@@ -12,68 +12,11 @@ from .helpers import (
     update_compress_api,
 )
 from cg.store.get.cases import ready_for_spring_compression
+from cg.constants.compression import CASES_TO_IGNORE
 
 LOG = logging.getLogger(__name__)
 
 # There is a list of problematic cases that we should skip
-PROBLEMATIC_CASES = [
-    "causalmite",
-    "deepcub",
-    "expertalien",
-    "fluenteagle",
-    "grandkoi",
-    "lovingmayfly",
-    "loyalegret",
-    "modernbee",
-    "proudcollie",
-    "richalien",
-    "suremako",
-    "wisestork",
-]
-
-# List of cases used for validation that we should skip
-VALIDATION_CASES = [
-    "bosssponge",
-    "busycolt",
-    "casualgannet",
-    "cleanshrimp",
-    "daringpony",
-    "easybeetle",
-    "epicasp",
-    "firstfawn",
-    "fleetjay",
-    "gamedeer",
-    "gladthrush",
-    "helpedfilly",
-    "hotskink",
-    "hotviper",
-    "intentcorgi",
-    "intentmayfly",
-    "keencalf",
-    "keenviper",
-    "lightprawn",
-    "livingox",
-    "meetpossum",
-    "mintbaboon",
-    "mintyeti",
-    "moralgoat",
-    "onemite",
-    "proeagle",
-    "propercoral",
-    "pumpedcat",
-    "rightmacaw",
-    "safeguinea",
-    "sharpparrot",
-    "sharppigeon",
-    "strongbison",
-    "strongman",
-    "topsrhino",
-    "unitedbeagle",
-    "usablemarten",
-    "vitalmouse",
-]
-
-CASES_TO_IGNORE = PROBLEMATIC_CASES + VALIDATION_CASES
 
 
 @click.command("fastq")

--- a/cg/cli/compress/fastq.py
+++ b/cg/cli/compress/fastq.py
@@ -110,6 +110,8 @@ def clean_fastq(context, case_id, days_back, dry_run):
 
     cleaned_inds = 0
     for case_obj in cases:
+        if case_obj.internal_id in CASES_TO_IGNORE:
+            continue
         samples = get_fastq_individuals(store=store, case_id=case_obj.internal_id)
         for sample_id in samples:
             res = compress_api.clean_fastq(sample_id)

--- a/cg/constants/compression.py
+++ b/cg/constants/compression.py
@@ -10,3 +10,62 @@ SPRING_SUFFIX = ".spring"
 FASTQ_DELTA = 21
 # Get the fastq delta in datetime format
 FASTQ_DATETIME_DELTA = datetime.timedelta(days=FASTQ_DELTA)
+
+PROBLEMATIC_CASES = [
+    "causalmite",
+    "deepcub",
+    "expertalien",
+    "fluenteagle",
+    "grandkoi",
+    "lovingmayfly",
+    "loyalegret",
+    "modernbee",
+    "proudcollie",
+    "richalien",
+    "suremako",
+    "wisestork",
+]
+
+# List of cases used for validation that we should skip
+VALIDATION_CASES = [
+    "bosssponge",
+    "busycolt",
+    "casualgannet",
+    "cleanshrimp",
+    "daringpony",
+    "easybeetle",
+    "epicasp",
+    "firstfawn",
+    "fleetjay",
+    "gamedeer",
+    "gladthrush",
+    "helpedfilly",
+    "hotskink",
+    "hotviper",
+    "intentcorgi",
+    "intentmayfly",
+    "keencalf",
+    "keenviper",
+    "lightprawn",
+    "livingox",
+    "meetpossum",
+    "mintbaboon",
+    "mintyeti",
+    "moralgoat",
+    "onemite",
+    "proeagle",
+    "propercoral",
+    "pumpedcat",
+    "rightmacaw",
+    "safeguinea",
+    "sharpparrot",
+    "sharppigeon",
+    "strongbison",
+    "strongman",
+    "topsrhino",
+    "unitedbeagle",
+    "usablemarten",
+    "vitalmouse",
+]
+
+CASES_TO_IGNORE = PROBLEMATIC_CASES + VALIDATION_CASES


### PR DESCRIPTION
This PR adds/fixes ...

-Fix: skip cases on ignore list when cleaning fastq. This should solve the problem that fastq files of validation cases end up compressed again

## Testing
- Not applicable

## Review
- [x] code approved by MM
- [x] "Merge and deploy" approved by MR
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Deploy this branch
