### PR TITLE
remove fastq balsamic delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
+## [18.7.2]
+
+### Changed
+
+- Skip deliver fastq files when delivering balsamic analysis
+
 ## [18.7.1]
 
 ### Fixed

--- a/cg/constants/delivery.py
+++ b/cg/constants/delivery.py
@@ -36,7 +36,6 @@ BALSAMIC_ANALYSIS_SAMPLE_TAGS = [
     {"cram-index", "tumor"},
     {"bam"},
     {"bam-index"},
-    {"fastq"},
 ]
 
 BALSAMIC_QC_CASE_TAGS = [


### PR DESCRIPTION
This PR changes so that no fastq files will be delivered when delivering balsamic analysis results

## Review
- [x] code approved by MR
- [x] "Merge and deploy" approved by MM
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


