### PR TITLE
allow missing volume for rerun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,15 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
+## [NG.NG.NG]
+
+### Added
+- Allow existing trio-samples to be re-run as single samples 
+
 ## [18.10.0]
 
 ### Added
- - Support for delivery type in the Order Portal
+- Support for delivery type in the Order Portal
 
 ## [18.9.1]
 

--- a/cg/meta/orders/schema.py
+++ b/cg/meta/orders/schema.py
@@ -106,7 +106,7 @@ MIP_SAMPLE = {
     "source": OptionalNone(TypeValidatorNone(str)),
     "priority": OptionalNone(validators.Any(PRIORITY_OPTIONS)),
     "require_qcok": bool,
-    "volume": str,
+    "volume": OptionalNone(TypeValidatorNone(str)),
     "container": OptionalNone(validators.Any(CONTAINER_OPTIONS)),
     # "required if plate for new samples"
     "container_name": OptionalNone(TypeValidatorNone(str)),


### PR DESCRIPTION
This PR fixes the faulty requirement of volume for existing samples

### How to prepare for test
- [x] ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [x] do crate an mip-order in the order-portal
- [x] try to submit it without volume

### Expected test outcome
- [x] check that the order submits
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [x] code approved by MR
- [x] tests executed by PG
- [x] "Merge and deploy" approved by PG
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [x] Deploy this branch
- [x] Inform to production
