### PR TITLE
Fix: Make samples of pools non-invoicable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Try to use the following format:
 ## [NG.NG.NG]
 
 ### Fixed
+- FLUFFY now have a validation schema and can be submitted in the Order Portal again
 - Samples of pools are now marked not to be invoiced, only the pool is invoiced
 
 ## [18.10.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
+## [NG.NG.NG]
+
+### Fixed
+- Samples of pools are now marked not to be invoiced, only the pool is invoiced
+
 ## [18.10.1]
 
 ### Added

--- a/cg/meta/orders/api.py
+++ b/cg/meta/orders/api.py
@@ -173,8 +173,15 @@ class OrdersAPI(LimsHandler, StatusHandler):
             message += f", {customer_name} ({customer_id})"
         return message
 
+    def _submit_fluffy(self, order: dict) -> dict:
+        """Submit a batch of ready made libraries for FLUFFY analysis."""
+        return self._submit_pools(order)
+
     def _submit_rml(self, order: dict) -> dict:
-        """Submit a batch of ready made libraries."""
+        """Submit a batch of ready made libraries for sequencing."""
+        return self._submit_pools(order)
+
+    def _submit_pools(self, order):
         status_data = self.pools_to_status(order)
         project_data, lims_map = self.process_lims(order, order["samples"])
         samples = [sample for pool in status_data["pools"] for sample in pool["samples"]]

--- a/cg/meta/orders/schema.py
+++ b/cg/meta/orders/schema.py
@@ -16,7 +16,7 @@ from cg.utils.StrEnum import StrEnum
 class OrderType(StrEnum):
     BALSAMIC: str = str(Pipeline.BALSAMIC)
     EXTERNAL: str = "external"
-    FASTQ: str = "fastq"
+    FASTQ: str = str(Pipeline.FASTQ)
     FLUFFY: str = str(Pipeline.FLUFFY)
     METAGENOME: str = "metagenome"
     MICROSALT: str = str(Pipeline.MICROSALT)
@@ -337,6 +337,7 @@ ORDER_SCHEMES = {
     ),
     OrderType.FASTQ: Scheme({**BASE_PROJECT, "samples": ListValidator(FASTQ_SAMPLE, min_items=1)}),
     OrderType.RML: Scheme({**BASE_PROJECT, "samples": ListValidator(RML_SAMPLE, min_items=1)}),
+    OrderType.FLUFFY: Scheme({**BASE_PROJECT, "samples": ListValidator(RML_SAMPLE, min_items=1)}),
     OrderType.MICROSALT: Scheme(
         {**BASE_PROJECT, "samples": ListValidator(MICROSALT_SAMPLE, min_items=1)}
     ),

--- a/cg/meta/orders/status.py
+++ b/cg/meta/orders/status.py
@@ -486,6 +486,7 @@ class StatusHandler:
                     customer=customer_obj,
                     internal_id=sample.get("internal_id"),
                     name=sample["name"],
+                    no_invoice=True,
                     order=order,
                     ordered=ordered,
                     priority=sample["priority"],

--- a/tests/meta/orders/test_meta_orders_status.py
+++ b/tests/meta/orders/test_meta_orders_status.py
@@ -97,7 +97,6 @@ def test_families_to_status(mip_order_to_submit):
 
 
 def test_store_rml(orders_api, base_store, rml_status_data):
-
     # GIVEN a basic store with no samples and a rml order
     assert base_store.pools(customer=None).count() == 0
     assert base_store.families(customer=None).count() == 0
@@ -132,9 +131,13 @@ def test_store_rml(orders_api, base_store, rml_status_data):
     assert new_case.data_analysis == str(Pipeline.FLUFFY)
     assert new_case.data_delivery == str(DataDelivery.NIPT_VIEWER)
 
+    # and that the pool is set for invoicing but not the samples of the pool
+    assert not new_pool.no_invoice
+    for link in new_case.links:
+        assert link.sample.no_invoice
+
 
 def test_store_rml_bad_apptag(orders_api, base_store, rml_status_data):
-
     # GIVEN a basic store with no samples and a rml order
     assert base_store.pools(customer=None).count() == 0
 
@@ -220,7 +223,6 @@ def test_store_samples_bad_apptag(orders_api, base_store, fastq_status_data):
 
 
 def test_store_microbial_samples(orders_api, base_store, microbial_status_data):
-
     # GIVEN a basic store with no samples and a microbial order and one Organism
     assert base_store.samples().count() == 0
     assert base_store.families().count() == 0
@@ -248,7 +250,6 @@ def test_store_microbial_samples(orders_api, base_store, microbial_status_data):
 
 
 def test_store_microbial_case_data_analysis_stored(orders_api, base_store, microbial_status_data):
-
     # GIVEN a basic store with no samples and a microbial order and one Organism
     assert base_store.samples().count() == 0
     assert base_store.families().count() == 0
@@ -275,7 +276,6 @@ def test_store_microbial_case_data_analysis_stored(orders_api, base_store, micro
 
 
 def test_store_microbial_samples_bad_apptag(orders_api, microbial_status_data):
-
     # GIVEN a basic store missing the application on the samples
 
     for sample in microbial_status_data["samples"]:
@@ -297,7 +297,6 @@ def test_store_microbial_samples_bad_apptag(orders_api, microbial_status_data):
 
 
 def test_store_microbial_sample_priority(orders_api, base_store, microbial_status_data):
-
     # GIVEN a basic store with no samples
     assert base_store.samples().count() == 0
 
@@ -411,7 +410,6 @@ def test_store_families_bad_apptag(orders_api, base_store, mip_status_data):
 
 
 def test_store_external(orders_api, base_store, external_status_data):
-
     # GIVEN a basic store with no samples or nothing in it + external order
     assert base_store.samples().first() is None
     assert base_store.families().first() is None
@@ -451,7 +449,6 @@ def test_store_external(orders_api, base_store, external_status_data):
 
 
 def test_store_external_bad_apptag(orders_api, base_store, external_status_data):
-
     # GIVEN a basic store with no samples or nothing in it + external order
     assert base_store.samples().first() is None
     assert base_store.families().first() is None
@@ -473,7 +470,6 @@ def test_store_external_bad_apptag(orders_api, base_store, external_status_data)
 
 
 def test_store_metagenome_samples(orders_api, base_store, metagenome_status_data):
-
     # GIVEN a basic store with no samples and a metagenome order
     assert base_store.samples().count() == 0
 
@@ -492,7 +488,6 @@ def test_store_metagenome_samples(orders_api, base_store, metagenome_status_data
 
 
 def test_store_metagenome_samples(orders_api, base_store, metagenome_status_data):
-
     # GIVEN a basic store with no samples and a metagenome order
     assert base_store.samples().count() == 0
 
@@ -510,7 +505,6 @@ def test_store_metagenome_samples(orders_api, base_store, metagenome_status_data
 
 
 def test_store_metagenome_samples_bad_apptag(orders_api, base_store, metagenome_status_data):
-
     # GIVEN a basic store with no samples and a metagenome order
     assert base_store.samples().count() == 0
 
@@ -530,7 +524,6 @@ def test_store_metagenome_samples_bad_apptag(orders_api, base_store, metagenome_
 
 
 def test_store_cancer_samples(orders_api, base_store, balsamic_status_data):
-
     # GIVEN a basic store with no samples and a cancer order
     assert base_store.samples().first() is None
     assert base_store.families().first() is None


### PR DESCRIPTION
This PR fixes 
- so that samples created for pools defaults to non-invoicable in order to not double invoice pools
- so that FLUFFY pools can be handled as RML when submitted
- so that FLUFFY pools are validated by the same schema as RML

### How to prepare for test
- [x] ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [x] do submit an RML order in OP

### Expected test outcome
- [x] check that the pool has no_invoice == False and the samples has no_invoice == True
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [x] code approved by MM
- [x] tests executed by
- [x] "Merge and deploy" approved by PG
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Deploy this branch
- [ ] Inform to VW, AZ, production, lab
