### PR TITLE
Send new cli args to balsamic args for report generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,12 @@ Try to use the following format:
 ### Added
 ### Changed
 
-## [19.1.2]
+## [19.3.0]
+### Added
+- New options for balsamic report deliver to propagate delivery report data to Balsamic
+
+
+## [19.2.0]
 ### Added
 - Cases that decompression is started for will have the action set to "analyze"
 

--- a/cg/meta/workflow/balsamic.py
+++ b/cg/meta/workflow/balsamic.py
@@ -374,6 +374,8 @@ class BalsamicAnalysisAPI:
         }
 
     def build_sample_id_map_string(self, case_id: str) -> str:
+        """Creates sample info string for balsamic with format lims_id:tumor/normal:customer_sample_id"""
+
         tumor_sample_lims_id = self.get_tumor_sample_name(case_id=case_id)
         tumor_string = f"{tumor_sample_lims_id}:tumor:{self.store.sample(internal_id=tumor_sample_lims_id).name}"
         normal_sample_lims_id = self.get_normal_sample_name(case_id=case_id)
@@ -383,6 +385,8 @@ class BalsamicAnalysisAPI:
         return tumor_string
 
     def build_case_id_map_string(self, case_id: str) -> str:
+        """Creates case info string for balsamic with format panel_shortname:case_name:application_tag}"""
+
         case_obj: models.Family = self.store.family(case_id)
         capture_kit = self.lims_api.capture_kit(case_obj.links[0].sample.internal_id)
         if capture_kit:

--- a/cg/meta/workflow/balsamic.py
+++ b/cg/meta/workflow/balsamic.py
@@ -385,7 +385,7 @@ class BalsamicAnalysisAPI:
         return tumor_string
 
     def build_case_id_map_string(self, case_id: str) -> str:
-        """Creates case info string for balsamic with format panel_shortname:case_name:application_tag}"""
+        """Creates case info string for balsamic with format panel_shortname:case_name:application_tag"""
 
         case_obj: models.Family = self.store.family(case_id)
         capture_kit = self.lims_api.capture_kit(case_obj.links[0].sample.internal_id)
@@ -394,7 +394,7 @@ class BalsamicAnalysisAPI:
         elif self.get_application_type(case_obj.links[0]) == "wgs":
             panel_shortname = "Whole_Genome"
         else:
-            panel_shortname = "Undefined"
+            return None
         application_tag = (
             self.store.query(models.ApplicationVersion)
             .filter(models.ApplicationVersion.id == case_obj.links[0].sample.application_version_id)

--- a/cg/meta/workflow/balsamic.py
+++ b/cg/meta/workflow/balsamic.py
@@ -391,7 +391,12 @@ class BalsamicAnalysisAPI:
             panel_shortname = "Whole_Genome"
         else:
             panel_shortname = "Undefined"
-        application_tag = case_obj.links[0].sample.application.tag
+        application_tag = (
+            self.store.query(models.ApplicationVersion)
+            .filter(models.ApplicationVersion.id == case_obj.links[0].sample.application_version_id)
+            .first()
+            .application.tag
+        )
         return f"{panel_shortname}:{case_obj.name}:{application_tag}"
 
     @staticmethod

--- a/cg/meta/workflow/balsamic.py
+++ b/cg/meta/workflow/balsamic.py
@@ -384,7 +384,7 @@ class BalsamicAnalysisAPI:
             return ",".join([tumor_string, normal_string])
         return tumor_string
 
-    def build_case_id_map_string(self, case_id: str) -> str:
+    def build_case_id_map_string(self, case_id: str) -> Optional[str]:
         """Creates case info string for balsamic with format panel_shortname:case_name:application_tag"""
 
         case_obj: models.Family = self.store.family(case_id)
@@ -394,7 +394,7 @@ class BalsamicAnalysisAPI:
         elif self.get_application_type(case_obj.links[0]) == "wgs":
             panel_shortname = "Whole_Genome"
         else:
-            return None
+            return
         application_tag = (
             self.store.query(models.ApplicationVersion)
             .filter(models.ApplicationVersion.id == case_obj.links[0].sample.application_version_id)


### PR DESCRIPTION
This PR adds/fixes 

cg workflow balsamic report-deliver now passes new options to balsamic:
--sample-id-map lims_id:tumor/normal:customer_sample_id
--case-id-map panel_shortname:case_name:application_tag

### How to prepare for test
- [x] ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [x] do cg workflow balsamic report-deliver unitedbeagle
- [x] do cg workflow balsamic report-deliver moralgoat

### Expected test outcome
- [x] check that balsamic runs well with new args
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [x] code approved by
- [x] tests executed by
- [x] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [x] **MINOR** - when you add functionality in a backwards compatible manner

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
