### PR TITLE
Fix dry run flag in automatic decompression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Please add a new candidate release at the top after changing the latest one. Fee
 
 Try to use the following format:
 
+## [x.x.x]
+### Added
+### Changed
+### Fixed
+
+## [19.5.3]
+### Fixed
+- Fix dry run flag when resolving decompression state
+
 ## [19.5.2]
 ### Fixed
 - fix container name when publishing branch builds on dockerhub

--- a/cg/cli/workflow/mip_dna/base.py
+++ b/cg/cli/workflow/mip_dna/base.py
@@ -282,7 +282,8 @@ def resolve_compression(context: click.Context, case_id: str, dry_run: bool):
             case_obj.internal_id, dry_run
         )
         if decompression_all_samples_started:
-            dna_api.set_statusdb_action(case_id=case_id, action="analyze")
+            if not dry_run:
+                dna_api.set_statusdb_action(case_id=case_id, action="analyze")
             LOG.info(
                 "The analysis for %s could not start, started decompression instead",
                 case_obj.internal_id,

--- a/cg/meta/workflow/prepare_fastq.py
+++ b/cg/meta/workflow/prepare_fastq.py
@@ -48,10 +48,10 @@ class PrepareFastqAPI:
     def is_spring_decompression_running(self, case_id: str) -> bool:
         """Check if case is being decompressed"""
         compression_objects = self.get_compression_objects(case_id=case_id)
-        for compression_object in compression_objects:
-            if self.crunchy_api.is_compression_pending(compression_object):
-                return True
-        return False
+        return any(
+            self.crunchy_api.is_compression_pending(compression_object)
+            for compression_object in compression_objects
+        )
 
     def start_spring_decompression(self, case_id: str, dry_run: bool) -> bool:
         """Starts spring decompression"""


### PR DESCRIPTION
This PR adds/fixes ...
Starting decompression automatically with dry run no longer marks the case for re-analysis

## Review
- [x ] code approved by MR
- [x] "Merge and deploy" approved by MR
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [x] Deploy this branch
