### PR TITLE
feat(refactor): Use case id as positional arg in linking command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
+## [20.0.0]
+
+### Changed
+- cg workflow mip-rna link command to take case as positional arg
+
 ## [19.5.4]
 
 ### Changed

--- a/cg/cli/workflow/mip_dna/base.py
+++ b/cg/cli/workflow/mip_dna/base.py
@@ -114,7 +114,7 @@ def ensure_flowcells_ondisk(context: click.Context, case_id: str):
 @ARGUMENT_CASE_ID
 @click.pass_context
 def link(context: click.Context, case_id: str):
-    """Link FASTQ files for a sample_id"""
+    """Link FASTQ files for all samples in a case"""
     dna_api: MipAnalysisAPI = context.obj["dna_api"]
     case_obj: models.Family = dna_api.db.family(case_id)
     link_objs: List[models.FamilySample] = case_obj.links

--- a/cg/cli/workflow/mip_rna/base.py
+++ b/cg/cli/workflow/mip_rna/base.py
@@ -1,6 +1,7 @@
 """ Add CLI support to start MIP rare disease RNA"""
 
 import logging
+from typing import List
 
 import click
 
@@ -9,14 +10,15 @@ from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.apps.lims import LimsAPI
 from cg.apps.scout.scoutapi import ScoutAPI
 from cg.apps.tb import TrailblazerAPI
-from cg.cli.workflow.get_links import get_links
 from cg.cli.workflow.mip.store import store as store_cmd
 from cg.constants import Pipeline
 from cg.meta.workflow.mip import MipAnalysisAPI
-from cg.store import Store
+from cg.store import Store, models
 from cg.store.utils import case_exists
 
 LOG = logging.getLogger(__name__)
+
+ARGUMENT_CASE_ID = click.argument("case_id", required=True, type=str)
 
 
 @click.group("mip-rna")
@@ -43,13 +45,13 @@ def mip_rna(context: click.Context):
 
 
 @mip_rna.command()
-@click.option("-c", "--case", "case_id", help="link all samples for a case")
-@click.argument("sample_id", required=False)
+@ARGUMENT_CASE_ID
 @click.pass_context
-def link(context: click.Context, case_id: str, sample_id: str):
-    """Link FASTQ files for a sample_id"""
-    rna_api = context.obj["rna_api"]
-    link_objs = get_links(rna_api.db, case_id, sample_id)
+def link(context: click.Context, case_id: str):
+    """Link FASTQ files for all samples in a case"""
+    rna_api: MipAnalysisAPI = context.obj["rna_api"]
+    case_obj: models.Family = rna_api.db.family(case_id)
+    link_objs: List[models.FamilySample] = case_obj.links
 
     for link_obj in link_objs:
         LOG.info(
@@ -70,7 +72,7 @@ def link(context: click.Context, case_id: str, sample_id: str):
 @click.option("--mip-dry-run", "mip_dry_run", is_flag=True, help="Run MIP in dry-run mode")
 @click.option("-p", "--priority", type=click.Choice(["low", "normal", "high"]))
 @click.option("-sw", "--start-with", help="start mip from this program.")
-@click.argument("case_id")
+@ARGUMENT_CASE_ID
 @click.pass_context
 def run(
     context: click.Context,
@@ -126,7 +128,7 @@ def run(
 
 @mip_rna.command("config-case")
 @click.option("-d", "--dry-run", "dry_run", is_flag=True, help="Print pedigree config to console")
-@click.argument("case_id")
+@ARGUMENT_CASE_ID
 @click.pass_context
 def config_case(context: click.Context, case_id: str, dry_run: bool = False):
     """Generate a pedigree config for the case"""

--- a/tests/cli/workflow/mip/test_cli_mip_rna_link.py
+++ b/tests/cli/workflow/mip/test_cli_mip_rna_link.py
@@ -12,7 +12,7 @@ def test_cg_workflow_mip_rna_link(cli_runner, caplog, case_id, rna_mip_context):
     # GIVEN a store with a RNA case with wts application
 
     # WHEN we run a case in dry run mode
-    result = cli_runner.invoke(link, ["-c", case_id], obj=rna_mip_context)
+    result = cli_runner.invoke(link, [case_id], obj=rna_mip_context)
 
     # THEN the command should be printed
     assert result.exit_code == 0


### PR DESCRIPTION
This PR adds/fixes:
- Use case id as positional arg in linking command
- Standardise mip-dna link and mip-rna link by removing sample id option
- Do not use sub get_links but use same calls as in mip-dna
- Fix mip-dna link help text

### How to prepare for test
- [x] ssh to relevant server hasta
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh fix-mip-link`

### How to test
- [x] do: ` cg workflow mip-rna link sharpparrot`

### Expected test outcome
- [x] check that the fastq files for sample ACC5963A2 are linked to the case sharpparrot
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [x] code approved by MR
- [x] tests executed by HS
- [x] "Merge and deploy" approved by MR, HS
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [x] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [x] There is no current documentation in place for RNA data analysis workflow in production (this will be done as part of the rna-results-in-scout project) 

