### PR TITLE
fix failing mutacc cronjob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
+## [20.1.3]
+### Changed
+- Genes are optional when exporting scout variants
 
 ## [20.1.2]
 ### Changed

--- a/cg/apps/scout/scout_export.py
+++ b/cg/apps/scout/scout_export.py
@@ -1,9 +1,10 @@
 """Schemas for scout serialisation"""
 
-from typing import List, Optional
-from typing_extensions import Literal
-from pydantic import BaseModel, Field, validator
 from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, Field, validator
+from typing_extensions import Literal
 
 
 class Individual(BaseModel):
@@ -92,5 +93,5 @@ class Variant(BaseModel):
     rank_score: int
     category: str
     sub_category: str
-    genes: List[Gene]
+    genes: Optional[List[Gene]]
     samples: List[Genotype]


### PR DESCRIPTION
## Description
This PR fixes a problem that CG crashed when exporting variants from Scout without genes


### Expected test outcome
- [ ] cronjob `/home/proj/production/servers/resources/hasta.scilifelab.se/crontabs/mutacc-process.sh` should not crash
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [x] code approved by MR
- [x] tests executed by crontab
- [x] "Merge and deploy" approved by MM
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

