### PR TITLE
Change concentration type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
+## [20.3.1]
+
+### Changed
+- Set concentration and concentration sample to str in json orderform sample since this is expected in frontend
+
 ## [20.3.0]
 ### Changed
 - Refactored AnalysisAPI anf FastHandler classes into one class

--- a/cg/models/orders/json_sample.py
+++ b/cg/models/orders/json_sample.py
@@ -1,13 +1,14 @@
 from typing import List, Optional
 
-from pydantic import Field, constr, validator
-
 from cg.constants import DataDelivery, Pipeline
 from cg.models.orders.sample_base import OrderSample
+from pydantic import Field, constr, validator
 
 
 class JsonSample(OrderSample):
     case_id: str = Field(None, alias="family_name")
+    concentration: Optional[str]
+    concentration_sample: Optional[str]
     data_analysis: Pipeline = Pipeline.MIP_DNA
     data_delivery: DataDelivery = DataDelivery.SCOUT
     index: Optional[str]

--- a/cg/models/orders/sample_base.py
+++ b/cg/models/orders/sample_base.py
@@ -1,9 +1,8 @@
 from enum import Enum
 from typing import List, Optional
 
-from pydantic import BaseModel, constr
-
 from cg.constants import DataDelivery, Pipeline
+from pydantic import BaseModel, constr
 
 
 class SexEnum(str, Enum):
@@ -64,7 +63,7 @@ class OrderSample(BaseModel):
     formalin_fixation_time: Optional[int]
     from_sample: Optional[str]
     index: str
-    index_number: Optional[int]
+    index_number: Optional[str]
     index_sequence: Optional[str]
     internal_id: Optional[str]
     mother: Optional[str]


### PR DESCRIPTION
## Description
This PR fixes a problem that the frontend (cgweb) expects concentration to be a string for samples

### Expected outcome
- [x] check that it should be possible to upload a NIPT orderform
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [x] Tested by PG
- [x] code approved by PG
- [x] "Merge and deploy" approved by MM
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


