### PR TITLE
Fix microsalt start available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,19 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
+## [NG.NG.NG]
+### Fixed
+- Bug preventing MicroSALT to start automatically
 
-## [20.8.0]
+## [20.9.0]
 ### Added
 - SlurmAPI to handle all communication with slurm from cg
 
-## [20.7.1]
+## [20.8.0]
+### Added
+- Support for creating delivery reports for analyses that are not the latest ones
+
+## [20.8.1]
 ### Changed
 - Deletes unused files .gitlint, housekeeper, status, status_db
 
@@ -233,11 +240,6 @@ Try to use the following format:
 
 ### Added
 - Allow existing trio-samples to be re-run as single samples 
-
-## [20.8.0]
-
-### Added
-- Support for creating delivery reports for analyses that are not the latest ones
 
 ## [18.10.0]
 

--- a/cg/cli/workflow/microsalt/base.py
+++ b/cg/cli/workflow/microsalt/base.py
@@ -195,7 +195,7 @@ def start_available(context: click.Context, dry_run: bool = False):
     exit_code: int = EXIT_SUCCESS
     for case_obj in analysis_api.get_cases_to_analyze():
         try:
-            context.invoke(start, case_id=case_obj.internal_id, dry_run=dry_run)
+            context.invoke(start, unique_id=case_obj.internal_id, dry_run=dry_run)
         except CgError as error:
             LOG.error(error.message)
             exit_code = EXIT_FAIL


### PR DESCRIPTION
## Description
*This PR fixes a bug that prevents MicroSALT dfrom starting automatically*

### How to prepare for test
- [x] ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [x] do run cg workflow microsalt start-available

### Expected test outcome
- [x] check that there are no complaints on wrong argument sent to the start function
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [x] code approved by BS
- [x] tests executed by PG
- [x] "Merge and deploy" approved by PG
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [x] Document in changelog
- [ ] Deploy this branch
- [ ] Inform to HS and production
