### PR TITLE
create crunchy pending file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
+## 20.9.4
+### Fixed
+- Fix bug that pending path was not created 
+
 ## 20.9.3
 ### Fixed
 - Bug in automation of delivery report upload

--- a/cg/apps/crunchy/crunchy.py
+++ b/cg/apps/crunchy/crunchy.py
@@ -195,12 +195,22 @@ class CrunchyAPI:
 
         return True
 
+    @staticmethod
+    def create_pending_file(pending_path: Path, dry_run: bool) -> None:
+        LOG.info("Creating pending flag %s", pending_path)
+        if dry_run:
+            return
+        pending_path.touch(exist_ok=False)
+
     # These are the compression/decompression methods
     def fastq_to_spring(self, compression_obj: CompressionData, sample_id: str = "") -> int:
         """
         Compress FASTQ files into SPRING by sending to sbatch SLURM
 
         """
+        CrunchyAPI.create_pending_file(
+            pending_path=compression_obj.pending_path, dry_run=self.dry_run
+        )
         log_dir: Path = files.get_log_dir(compression_obj.spring_path)
         # Generate the error function
         error_function = FASTQ_TO_SPRING_ERROR.format(

--- a/cg/apps/crunchy/crunchy.py
+++ b/cg/apps/crunchy/crunchy.py
@@ -253,6 +253,9 @@ class CrunchyAPI:
         Decompress SPRING into FASTQ by submitting sbatch script to SLURM
 
         """
+        CrunchyAPI.create_pending_file(
+            pending_path=compression_obj.pending_path, dry_run=self.dry_run
+        )
         # Fetch the metadata information from a spring metadata file
         crunchy_metadata: CrunchyMetadata = files.get_crunchy_metadata(
             compression_obj.spring_metadata_path

--- a/tests/apps/crunchy/test_compress_fastq.py
+++ b/tests/apps/crunchy/test_compress_fastq.py
@@ -98,9 +98,10 @@ def test_fastq_to_spring_sbatch(
     log_path: Path = get_log_dir(spring_path)
     run_name: str = compression_object.run_name
     sbatch_path: Path = get_fastq_to_spring_sbatch_path(log_dir=log_path, run_name=run_name)
-
     # GIVEN that the sbatch file does not exist
     assert not sbatch_path.is_file()
+    # GIVEN that the pending path does not exist
+    assert compression_object.pending_exists() is False
 
     # WHEN calling fastq_to_spring on FASTQ files
     job_number: int = crunchy_api.fastq_to_spring(compression_obj=compression_object)
@@ -109,6 +110,8 @@ def test_fastq_to_spring_sbatch(
     assert sbatch_path.is_file()
     # THEN assert that correct job number was returned
     assert job_number == sbatch_job_number
+    # THEN assert that the pending path was created
+    assert compression_object.pending_exists() is True
 
 
 def test_spring_to_fastq(
@@ -126,9 +129,13 @@ def test_spring_to_fastq(
     assert spring_metadata_file.exists()
     mocker_submit_sbatch = mocker.patch.object(SlurmAPI, "submit_sbatch")
     crunchy_api = CrunchyAPI(crunchy_config_dict)
+    # GIVEN that the pending path does not exist
+    assert compression_object.pending_exists() is False
 
     # WHEN calling bam_to_cram method on bam-path
     crunchy_api.spring_to_fastq(compression_obj=compression_object)
 
     # THEN _submit_sbatch method is called
     mocker_submit_sbatch.assert_called()
+    # THEN assert that the pending path was created
+    assert compression_object.pending_exists() is True


### PR DESCRIPTION
## Description
This PR fixes a bug that the crunchy compress pending files was not created anymore. This bug was introduced when crunchy started to use the SlurmAPI to submit jobs.


### Expected test outcome
- [ ] check that crunchy jobs runs as expected
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [x] code approved by MM
- [x] "Merge and deploy" approved by MM
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


