### PR TITLE
Fix revert balsamic default behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,19 +13,23 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
-## 20.9.4
+## [20.9.5]
+### Fixed
+- Balsamic crontab start-available auto-disables balsamic dry run
+
+## [20.9.4]
 ### Fixed
 - Fix bug that pending path was not created 
 
-## 20.9.3
+## [20.9.3]
 ### Fixed
 - Bug in automation of delivery report upload
 
-## 20.9.2
+## [20.9.2]
 ### Fixed
 - Bug when updating crunchy metadata files
 
-## 20.9.1
+## [20.9.1]
 ### Fixed
 - Bug preventing MicroSALT to start automatically
 

--- a/cg/cli/workflow/balsamic/base.py
+++ b/cg/cli/workflow/balsamic/base.py
@@ -110,7 +110,7 @@ def run(
             priority=priority,
             dry_run=dry_run,
         )
-        if dry_run:
+        if dry_run or not run_analysis:
             return
         analysis_api.add_pending_trailblazer_analysis(case_id=case_id)
         analysis_api.set_statusdb_action(case_id=case_id, action="running")
@@ -219,7 +219,7 @@ def start_available(context: click.Context, dry_run: bool = False):
     exit_code: int = EXIT_SUCCESS
     for case_obj in analysis_api.get_cases_to_analyze():
         try:
-            context.invoke(start, case_id=case_obj.internal_id, dry_run=dry_run)
+            context.invoke(start, case_id=case_obj.internal_id, dry_run=dry_run, run_analysis=True)
         except CgError as error:
             LOG.error(error.message)
             exit_code = EXIT_FAIL


### PR DESCRIPTION
## Description
*This PR adds/fixes ...*
Fixes bug where after refactor the dry-run flag was not automatically disabled in balsamic crontab command

### How to prepare for test
- [x] ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [x] do cg workflow balsamic start bosssponge -r

### Expected test outcome
- [ ] check that case starts and is monitored by tb
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
