### PR TITLE
Use coverage_qc_report when uploading balsamic cases to scout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
+## [20.9.6]
+### Fixed
+- Use `coverage_qc_report` instead of `delivery_report` when uploading balsamic cases to scout
+
 ## [20.9.5]
 ### Fixed
 - Balsamic crontab start-available auto-disables balsamic dry run

--- a/cg/meta/upload/scout/balsamic_config_builder.py
+++ b/cg/meta/upload/scout/balsamic_config_builder.py
@@ -33,6 +33,13 @@ class BalsamicConfigBuilder(ScoutConfigBuilder):
     def include_sample_files(self, config_sample: ScoutBalsamicIndividual):
         LOG.info("Including BALSAMIC specific sample level files")
 
+    def include_delivery_report(self) -> None:
+        LOG.info("Include coverage qc report to case")
+        print(self.case_tags.delivery_report)
+        self.load_config.coverage_qc_report = self.fetch_file_from_hk(
+            self.case_tags.delivery_report
+        )
+
     def build_config_sample(self, db_sample: models.FamilySample) -> ScoutBalsamicIndividual:
         """Build a sample with balsamic specific information"""
         config_sample = ScoutBalsamicIndividual()

--- a/cg/meta/upload/scout/balsamic_config_builder.py
+++ b/cg/meta/upload/scout/balsamic_config_builder.py
@@ -35,7 +35,6 @@ class BalsamicConfigBuilder(ScoutConfigBuilder):
 
     def include_delivery_report(self) -> None:
         LOG.info("Include coverage qc report to case")
-        print(self.case_tags.delivery_report)
         self.load_config.coverage_qc_report = self.fetch_file_from_hk(
             self.case_tags.delivery_report
         )

--- a/cg/meta/upload/scout/scout_load_config.py
+++ b/cg/meta/upload/scout/scout_load_config.py
@@ -77,6 +77,7 @@ class ScoutLoadConfig(BaseModel):
     samples: List[ScoutIndividual] = []
 
     delivery_report: Optional[str] = None
+    coverage_qc_report: Optional[str] = None
     cnv_report: Optional[str] = None
     multiqc: Optional[str] = None
     track: Literal["rare", "cancer"] = "rare"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # database
 Alchy
-SQLAlchemy
+SQLAlchemy<1.4
 
 # cli
 Click<7.0

--- a/tests/meta/upload/scout/conftest.py
+++ b/tests/meta/upload/scout/conftest.py
@@ -7,14 +7,6 @@ from pathlib import Path
 from typing import List
 
 import pytest
-
-# Mocks
-from tests.mocks.hk_mock import MockHousekeeperAPI
-from tests.mocks.limsmock import MockLimsAPI
-from tests.mocks.madeline import MockMadelineAPI
-from tests.mocks.scout import MockScoutAPI
-from tests.store_helpers import StoreHelpers
-
 from cg.constants import Pipeline
 from cg.meta.upload.scout.balsamic_config_builder import BalsamicConfigBuilder
 from cg.meta.upload.scout.mip_config_builder import MipConfigBuilder
@@ -22,6 +14,13 @@ from cg.meta.upload.scout.scout_load_config import MipLoadConfig
 from cg.meta.upload.scout.scoutapi import UploadScoutAPI
 from cg.store import Store, models
 from housekeeper.store import models as hk_models
+
+# Mocks
+from tests.mocks.hk_mock import MockHousekeeperAPI
+from tests.mocks.limsmock import MockLimsAPI
+from tests.mocks.madeline import MockMadelineAPI
+from tests.mocks.scout import MockScoutAPI
+from tests.store_helpers import StoreHelpers
 
 LOG = logging.getLogger(__name__)
 
@@ -141,7 +140,7 @@ def fixture_balsamic_analysis_hk_bundle_data(
     case_id: str, timestamp: datetime, balsamic_panel_analysis_dir: Path, sample_id: str
 ) -> dict:
     """Get some bundle data for housekeeper"""
-    data = {
+    return {
         "name": case_id,
         "created": timestamp,
         "expires": timestamp,
@@ -161,9 +160,13 @@ def fixture_balsamic_analysis_hk_bundle_data(
                 "archive": False,
                 "tags": ["cram", sample_id],
             },
+            {
+                "path": str(balsamic_panel_analysis_dir / "coverage_qc_report.pdf"),
+                "archive": False,
+                "tags": ["delivery-report"],
+            },
         ],
     }
-    return data
 
 
 @pytest.fixture(name="balsamic_analysis_hk_version")

--- a/tests/meta/upload/scout/test_generate_load_config.py
+++ b/tests/meta/upload/scout/test_generate_load_config.py
@@ -1,7 +1,6 @@
 """Test the methods that generate a scout load config"""
 
 import pytest
-
 from cg.constants import Pipeline
 from cg.meta.upload.scout.mip_config_builder import MipConfigBuilder
 from cg.meta.upload.scout.scout_load_config import (

--- a/tests/meta/upload/scout/test_scout_config_builder.py
+++ b/tests/meta/upload/scout/test_scout_config_builder.py
@@ -1,9 +1,6 @@
 """Tests for the file handlers"""
 from typing import Optional
 
-from tests.mocks.limsmock import MockLimsAPI
-from tests.mocks.madeline import MockMadelineAPI
-
 from cg.meta.upload.scout.balsamic_config_builder import BalsamicConfigBuilder
 from cg.meta.upload.scout.hk_tags import CaseTags, SampleTags
 from cg.meta.upload.scout.mip_config_builder import MipConfigBuilder
@@ -15,6 +12,8 @@ from cg.meta.upload.scout.scout_load_config import (
 )
 from cg.store import models
 from housekeeper.store import models as hk_models
+from tests.mocks.limsmock import MockLimsAPI
+from tests.mocks.madeline import MockMadelineAPI
 
 from .conftest import MockAnalysis
 
@@ -55,7 +54,7 @@ def test_balsamic_config_builder(
     assert isinstance(file_handler.case_tags, CaseTags)
 
 
-def test_include_delivery_report(mip_config_builder: MipConfigBuilder):
+def test_include_delivery_report_mip(mip_config_builder: MipConfigBuilder):
     # GIVEN a config builder with some data
 
     # GIVEN a config without a delivery report
@@ -123,6 +122,20 @@ def test_include_balsamic_case_files(balsamic_config_builder: BalsamicConfigBuil
 
     # THEN assert that the mandatory snv vcf was added
     assert balsamic_config_builder.load_config.vcf_cancer
+
+
+def test_include_balsamic_delivery_report(balsamic_config_builder: BalsamicConfigBuilder):
+    # GIVEN a housekeeper version bundle with some balsamic analysis files
+    # GIVEN a case load object
+
+    # WHEN including the case level files
+    balsamic_config_builder.build_load_config()
+
+    # THEN assert that the coverage_qc_report exists
+    assert balsamic_config_builder.load_config.coverage_qc_report
+
+    # THEN assert that the delivery_report is None
+    assert balsamic_config_builder.load_config.delivery_report is None
 
 
 def test_extract_generic_filepath(mip_config_builder: MipConfigBuilder):


### PR DESCRIPTION
## Description
This PR changes so that `coverage_qc_report` is used when uploading case to scout.


### How to test
- [x] tests are automated

### Expected test outcome
- [x] check that delivery report is uploaded to scout using the `balsamic_qc_report` field
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [x] code approved by MR
- [x] tests executed by GitHub
- [x] "Merge and deploy" approved by MM
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

