### PR TITLE
Remove mip-dna from Vogue upload to be able to upload TGA data to Vogue DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
+## [x.x.x]
+### Changed
+- Only upload BALSAMIC results to Vogue
+
 ## [20.9.7]
 ### Fixed
 - Added missing pipeline option in database for SARS-CoV-2 on case in database

--- a/cg/cli/upload/vogue.py
+++ b/cg/cli/upload/vogue.py
@@ -153,9 +153,11 @@ def bioinfo(context, case_name, cleanup, target_load, dry):
 
     # Get workflow_name and workflow_version
     workflow_name, workflow_version = _get_analysis_workflow_details(store, case_name)
-    if workflow_name not in VOGUE_VALID_BIOINFO:
+    if workflow_name is None:
+        raise AnalysisUploadError(f"Case upload failed: {case_name}. Reason: non-existing workflow name.")
+    elif workflow_name.lower() not in VOGUE_VALID_BIOINFO:
         raise AnalysisUploadError(f"Case upload failed: {case_name}. Reason: Bad workflow name.")
-    load_bioinfo_raw_inputs["analysis_workflow_name"] = workflow_name
+    load_bioinfo_raw_inputs["analysis_workflow_name"] = workflow_name.lower()
     load_bioinfo_raw_inputs["analysis_workflow_version"] = workflow_version
 
     if dry:
@@ -256,4 +258,4 @@ def _get_analysis_workflow_details(status_api: Store, case_name: str) -> Tuple[A
         workflow_name = case_obj.analyses[0].pipeline
         workflow_version = case_obj.analyses[0].pipeline_version
 
-    return workflow_name.lower(), workflow_version
+    return workflow_name, workflow_version

--- a/cg/cli/upload/vogue.py
+++ b/cg/cli/upload/vogue.py
@@ -16,7 +16,7 @@ from cg.store import Store, models
 
 LOG = logging.getLogger(__name__)
 
-VOGUE_VALID_BIOINFO = [str(Pipeline.MIP_DNA), str(Pipeline.BALSAMIC)]
+VOGUE_VALID_BIOINFO = [str(Pipeline.BALSAMIC)]
 
 
 @click.group()

--- a/cg/cli/upload/vogue.py
+++ b/cg/cli/upload/vogue.py
@@ -155,7 +155,7 @@ def bioinfo(context, case_name, cleanup, target_load, dry):
     workflow_name, workflow_version = _get_analysis_workflow_details(store, case_name)
     if workflow_name is None:
         raise AnalysisUploadError(f"Case upload failed: {case_name}. Reason: non-existing workflow name.")
-    elif workflow_name.lower() not in VOGUE_VALID_BIOINFO:
+    if workflow_name.lower() not in VOGUE_VALID_BIOINFO:
         raise AnalysisUploadError(f"Case upload failed: {case_name}. Reason: Bad workflow name.")
     load_bioinfo_raw_inputs["analysis_workflow_name"] = workflow_name.lower()
     load_bioinfo_raw_inputs["analysis_workflow_version"] = workflow_version


### PR DESCRIPTION
## Description

Temporarily addresses #1013 where lingering data_analysis field are causing issue. We have a meeting on Friday to look into all TGA data in Vogue and all BALSAMIC data in Vogue must exist.

### How to prepare for test
- [ ] ssh to hasta
- [ ] Use stage: `us`
- [ ] paxa the environment: `paxa`
- [ ] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh fix/temp_fix_1013`

### How to test
- [ ] do `cg upload vogue bioinfo-all`

### Expected test outcome
- [ ] check that data is being loaded to Vogue successfully
- [ ] Take a screenshot and attach or copy/paste the output

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
