### PR TITLE
Fix bug in automation of delivery reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
+## [NG.NG.NG]
+### Fixed
+- Fixed bug in upload delivery report automation
 
 ## [20.9.8]
 ### Fixed

--- a/cg/cli/upload/delivery_report.py
+++ b/cg/cli/upload/delivery_report.py
@@ -197,7 +197,7 @@ def delivery_report(
 
     context.invoke(delivery_report_to_scout, case_id=case_id)
     report_api.update_delivery_report_date(
-        analysis_api.status_db, case_id, analysis_date=analysis_started_at
+        status_api=analysis_api.status_db, case_id=case_id, analysis_date=analysis_started_at
     )
 
 

--- a/cg/meta/report/api.py
+++ b/cg/meta/report/api.py
@@ -132,7 +132,8 @@ class ReportAPI:
     ) -> None:
         """Update date on analysis when delivery report was created"""
 
-        analysis_obj = status_api.analysis(case_id, analysis_date)
+        case_obj = status_api.family(case_id)
+        analysis_obj = status_api.analysis(case_obj, analysis_date)
         analysis_obj.delivery_report_created_at = datetime.now()
         status_api.commit()
 


### PR DESCRIPTION
## Description
This PR resolves #1032 causing automation of delivery reports to fail

### How to prepare for test
- [x] ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [x] us
- [x] cg upload delivery-report [caseid]

### Expected test outcome
- [x] check that it doesn't fail on anything
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [x] code approved by HS
- [x] tests executed by PG
- [x] "Merge and deploy" approved by PG
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [x] Document in changelog
- [ ] Deploy this branch
- [x] Inform to HS, production
