### PR TITLE
fix(mip_start_available): Add "start-available" again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
+## [20.10.1]
+### Fixed
+- Mip start-available command
+
 ## [20.10.0]
 ### Added
 - Panel command to mip-rna analysis workflow

--- a/cg/cli/workflow/mip/base.py
+++ b/cg/cli/workflow/mip/base.py
@@ -165,7 +165,7 @@ def start(
         LOG.error(e.message)
 
 
-@click.command()
+@click.command("start-available")
 @OPTION_DRY
 @click.pass_context
 def start_available(context: click.Context, dry_run: bool = False):


### PR DESCRIPTION
## Description
*This PR adds/fixes ...*
- Add "start-available" again

### How to prepare for test
- [x] ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh fix-mip-start-available`

### How to test
- [x] do `cg workflow mip-dna start-available -d`

### Expected test outcome
- [x] check that no errors are produced
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [x] code approved by HS
- [x] tests executed by HS
- [x] "Merge and deploy" approved by HS
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
