### PR TITLE
Only submit new samples to lims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
+## [20.14.1]
+### Fixed
+- So that existing samples don't get added to lims again
+
 ## [20.14.0]
 ### Added
 - Possibility to associate more than one customer to each user 

--- a/cg/meta/orders/api.py
+++ b/cg/meta/orders/api.py
@@ -69,7 +69,9 @@ class OrdersAPI(StatusHandler):
 
     def _submit_pools(self, order):
         status_data = self.pools_to_status(order)
-        project_data, lims_map = process_lims(lims_api=self.lims, lims_order=order)
+        project_data, lims_map = process_lims(
+            lims_api=self.lims, lims_order=order, new_samples=order["samples"]
+        )
         samples = [sample for pool in status_data["pools"] for sample in pool["samples"]]
         self._fill_in_sample_ids(samples, lims_map, id_key="internal_id")
         new_records = self.store_rml(
@@ -84,7 +86,9 @@ class OrdersAPI(StatusHandler):
     def _submit_fastq(self, order: dict) -> dict:
         """Submit a batch of samples for FASTQ delivery."""
         status_data = self.samples_to_status(order)
-        project_data, lims_map = process_lims(lims_api=self.lims, lims_order=order)
+        project_data, lims_map = process_lims(
+            lims_api=self.lims, lims_order=order, new_samples=order["samples"]
+        )
         self._fill_in_sample_ids(status_data["samples"], lims_map)
         new_samples = self.store_fastq_samples(
             customer=status_data["customer"],
@@ -99,7 +103,9 @@ class OrdersAPI(StatusHandler):
     def _submit_metagenome(self, order: dict) -> dict:
         """Submit a batch of metagenome samples."""
         status_data = self.samples_to_status(order)
-        project_data, lims_map = process_lims(lims_api=self.lims, lims_order=order)
+        project_data, lims_map = process_lims(
+            lims_api=self.lims, lims_order=order, new_samples=order["samples"]
+        )
         self._fill_in_sample_ids(status_data["samples"], lims_map)
         new_samples = self.store_samples(
             customer=status_data["customer"],
@@ -150,7 +156,9 @@ class OrdersAPI(StatusHandler):
         status_data = self.microbial_samples_to_status(order)
         self._fill_in_sample_verified_organism(order["samples"])
         # submit samples to LIMS
-        project_data, lims_map = process_lims(lims_api=self.lims, lims_order=order)
+        project_data, lims_map = process_lims(
+            lims_api=self.lims, lims_order=order, new_samples=order["samples"]
+        )
         self._fill_in_sample_ids(status_data["samples"], lims_map, id_key="internal_id")
         # submit samples to Status
         samples = self.store_microbial_samples(
@@ -176,7 +184,9 @@ class OrdersAPI(StatusHandler):
         status_data = self.cases_to_status(order)
         new_samples = [sample for sample in order["samples"] if sample.get("internal_id") is None]
         if new_samples:
-            project_data, lims_map = process_lims(lims_api=self.lims, lims_order=order)
+            project_data, lims_map = process_lims(
+                lims_api=self.lims, lims_order=order, new_samples=new_samples
+            )
         else:
             project_data = lims_map = None
         samples = [sample for family in status_data["families"] for sample in family["samples"]]

--- a/cg/meta/orders/lims.py
+++ b/cg/meta/orders/lims.py
@@ -20,10 +20,9 @@ def build_lims_sample(customer: str, samples: List[dict]) -> List[LimsSample]:
     return samples_lims
 
 
-def process_lims(lims_api: LimsAPI, lims_order: dict):
+def process_lims(lims_api: LimsAPI, lims_order: dict, new_samples: List[dict]):
     """Process samples to add them to LIMS."""
-    samples: List[dict] = lims_order["samples"]
-    samples_lims: List[LimsSample] = build_lims_sample(lims_order["customer"], samples)
+    samples_lims: List[LimsSample] = build_lims_sample(lims_order["customer"], samples=new_samples)
     project_name = lims_order.get("ticket", lims_order["name"])
     # Create new lims project
     project_data = lims_api.submit_project(


### PR DESCRIPTION
## Description
This PR fixes a bug that samples was created in lims even though they already existed in lims

### How to prepare for test
- [x] ssh to relevant server clinical-db
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh only-create-new-lims-samples`

### How to test
- [x] do submit a order where a sample already exists

### Expected test outcome
- [x] check that the existing sample was not created again
- [x] Take a screenshot and attach or copy/paste the output.

![Screen Shot 2021-03-30 at 15 49 17](https://user-images.githubusercontent.com/405278/112999763-842ef780-916f-11eb-9e66-43b8ab224f6e.png)



## Review
- [x] code approved by PG
- [x] tests executed by MM,PG
- [x] "Merge and deploy" approved by MM
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Deploy this branch on hasta and clinical-db
- [ ] Inform to production
