### PR TITLE
Added support for sarscov2 delivery

### DIFF
--- a/cg/constants/delivery.py
+++ b/cg/constants/delivery.py
@@ -102,7 +102,7 @@ SARSCOV2_ANALYSIS_CASE_TAGS = [
 ]
 
 SARSCOV2_ANALYSIS_SAMPLE_TAGS = [
-    {"variants"},
+    {"vcf-report"},
     {"consensus"},
 ]
 

--- a/cg/constants/delivery.py
+++ b/cg/constants/delivery.py
@@ -96,6 +96,16 @@ FASTQ_ANALYSIS_SAMPLE_TAGS = [
     {"fastq"},
 ]
 
+SARSCOV2_ANALYSIS_CASE_TAGS = [
+    {"SARS-CoV-2-articreport-variants"},
+    {"SARS-CoV-2-articreport-results"},
+]
+
+SARSCOV2_ANALYSIS_SAMPLE_TAGS = [
+    {"variants"},
+    {"consensus"},
+]
+
 PIPELINE_ANALYSIS_TAG_MAP = {
     "balsamic": {
         "case_tags": BALSAMIC_ANALYSIS_CASE_TAGS,
@@ -114,14 +124,17 @@ PIPELINE_ANALYSIS_TAG_MAP = {
         "case_tags": MIP_RNA_ANALYSIS_CASE_TAGS,
         "sample_tags": MIP_RNA_ANALYSIS_SAMPLE_TAGS,
     },
-    # These are not ready yet, add when microsalt cases are stored in db
-    # "microsalt": {
-    #     "case_tags": MICROSALT_ANALYSIS_CASE_TAGS,
-    #     "sample_tags": MICROSALT_ANALYSIS_SAMPLE_TAGS,
-    # },
+    "microsalt": {
+        "case_tags": MICROSALT_ANALYSIS_CASE_TAGS,
+        "sample_tags": MICROSALT_ANALYSIS_SAMPLE_TAGS,
+    },
     "fastq": {
         "case_tags": FASTQ_ANALYSIS_CASE_TAGS,
         "sample_tags": FASTQ_ANALYSIS_SAMPLE_TAGS,
+    },
+    "sarscov2": {
+        "case_tags": SARSCOV2_ANALYSIS_CASE_TAGS,
+        "sample_tags": SARSCOV2_ANALYSIS_SAMPLE_TAGS,
     },
 }
 

--- a/cg/meta/deliver.py
+++ b/cg/meta/deliver.py
@@ -58,13 +58,13 @@ class DeliverAPI:
         """
         case_id: str = case_obj.internal_id
         case_name: str = case_obj.name
+        link_objs: List[FamilySample] = self.store.family_samples(case_id)
+        if not link_objs:
+            LOG.warning("Could not find any samples linked to case %s", case_id)
+            return
         LOG.debug("Fetch latest version for case %s", case_id)
         last_version: hk_models.Version = self.hk_api.last_version(bundle=case_id)
         if last_version:
-            link_objs: List[FamilySample] = self.store.family_samples(case_id)
-            if not link_objs:
-                LOG.warning("Could not find any samples linked to case %s", case_id)
-                return
             samples: List[Sample] = [link.sample for link in link_objs]
             if not self.ticket_id:
                 self.set_ticket_id(sample_obj=samples[0])

--- a/cg/meta/deliver.py
+++ b/cg/meta/deliver.py
@@ -60,27 +60,26 @@ class DeliverAPI:
         case_name: str = case_obj.name
         LOG.debug("Fetch latest version for case %s", case_id)
         last_version: hk_models.Version = self.hk_api.last_version(bundle=case_id)
-        if not last_version:
-            raise SyntaxError("Could not find any version for {}".format(case_id))
-        link_objs: List[FamilySample] = self.store.family_samples(case_id)
-        if not link_objs:
-            LOG.warning("Could not find any samples linked to case %s", case_id)
-            return
-        samples: List[Sample] = [link.sample for link in link_objs]
-        if not self.ticket_id:
-            self.set_ticket_id(sample_obj=samples[0])
-        if not self.customer_id:
-            self.set_customer_id(case_obj=case_obj)
+        if last_version:
+            link_objs: List[FamilySample] = self.store.family_samples(case_id)
+            if not link_objs:
+                LOG.warning("Could not find any samples linked to case %s", case_id)
+                return
+            samples: List[Sample] = [link.sample for link in link_objs]
+            if not self.ticket_id:
+                self.set_ticket_id(sample_obj=samples[0])
+            if not self.customer_id:
+                self.set_customer_id(case_obj=case_obj)
 
-        sample_ids: Set[str] = set([sample.internal_id for sample in samples])
+            sample_ids: Set[str] = set([sample.internal_id for sample in samples])
 
-        if self.case_tags:
-            self.deliver_case_files(
-                case_id=case_id,
-                case_name=case_name,
-                version_obj=last_version,
-                sample_ids=sample_ids,
-            )
+            if self.case_tags:
+                self.deliver_case_files(
+                    case_id=case_id,
+                    case_name=case_name,
+                    version_obj=last_version,
+                    sample_ids=sample_ids,
+                )
 
         if not self.sample_tags:
             return


### PR DESCRIPTION
## Description
This PR adds support for `sarscov2` as a delivery-type with the `-d`-flag when running the command  `cg deliver analysis`, for example like this:
`cg deliver analysis -d sarscov2 -t <ticket-id>`

### How to prepare for test
- [ ] ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] paxa the environment: `paxa`
- [ ] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
