### PR TITLE
Add support for creating fohm names for mutant fastq in cg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
+## [20.15.1]
+### Fixed
+- cg to rename mutant fastq files directly
+
 ## [20.15.0]
 ### Added
 - CLI methods for starting mutant

--- a/cg/meta/workflow/analysis.py
+++ b/cg/meta/workflow/analysis.py
@@ -289,6 +289,7 @@ class AnalysisAPI(MetaAPI):
                 flowcell=fastq_data["flowcell"],
                 sample=sample_obj.internal_id,
                 read=fastq_data["read"],
+                meta=self.get_additional_naming_metadata(sample_obj),
             )
             destination_path: Path = fastq_dir / fastq_name
             linked_reads_paths[fastq_data["read"]].append(destination_path)
@@ -380,3 +381,6 @@ class AnalysisAPI(MetaAPI):
         Get date from deliverables path using date created metadata.
         """
         return dt.datetime.fromtimestamp(int(os.path.getctime(file_path)))
+
+    def get_additional_naming_metadata(self, sample_obj: models.Sample) -> Optional[str]:
+        return None

--- a/cg/meta/workflow/fastq.py
+++ b/cg/meta/workflow/fastq.py
@@ -301,5 +301,5 @@ class MutantFastqHandler(FastqHandler):
 
     @staticmethod
     def get_concatenated_name(linked_fastq_name: str) -> str:
-        """"create a name for the concatenated file for some read files"""
+        """"Create a name for the concatenated file from multiple lanes"""
         return "_".join(linked_fastq_name.split("_")[2:])

--- a/cg/meta/workflow/fastq.py
+++ b/cg/meta/workflow/fastq.py
@@ -90,7 +90,7 @@ class FastqHandler:
         raise NotImplementedError
 
     @staticmethod
-    def get_concatenated_name(linked_fastq_name) -> str:
+    def get_concatenated_name(linked_fastq_name: str) -> str:
         """"create a name for the concatenated file for some read files"""
         return f"concatenated_{'_'.join(linked_fastq_name.split('_')[-4:])}"
 
@@ -219,6 +219,7 @@ class FastqHandler:
         date: dt.datetime = DEFAULT_DATE_STR,
         index: str = DEFAULT_INDEX,
         undetermined: Optional[str] = None,
+        meta: Optional[str] = None,
     ):
         raise NotImplementedError
 
@@ -233,6 +234,7 @@ class BalsamicFastqHandler(FastqHandler):
         date: dt.datetime = DEFAULT_DATE_STR,
         index: str = DEFAULT_INDEX,
         undetermined: Optional[str] = None,
+        meta: Optional[str] = None,
     ) -> str:
         """Name a FASTQ file following Balsamic conventions. Naming must be
         xxx_R_1.fastq.gz and xxx_R_2.fastq.gz"""
@@ -251,6 +253,7 @@ class MipFastqHandler(FastqHandler):
         date: dt.datetime = DEFAULT_DATE_STR,
         index: str = DEFAULT_INDEX,
         undetermined: Optional[str] = None,
+        meta: Optional[str] = None,
     ) -> str:
         """Name a FASTQ file following MIP conventions."""
         flowcell = f"{flowcell}-undetermined" if undetermined else flowcell
@@ -268,6 +271,7 @@ class MicrosaltFastqHandler(FastqHandler):
         date: dt.datetime = DEFAULT_DATE_STR,
         index: str = DEFAULT_INDEX,
         undetermined: Optional[str] = None,
+        meta: Optional[str] = None,
     ) -> str:
         """Name a FASTQ file following usalt conventions. Naming must be
         xxx_R_1.fastq.gz and xxx_R_2.fastq.gz"""
@@ -275,3 +279,27 @@ class MicrosaltFastqHandler(FastqHandler):
 
         flowcell = f"{flowcell}-undetermined" if undetermined else flowcell
         return f"{sample}_{flowcell}_L{lane}_{read}.fastq.gz"
+
+
+class MutantFastqHandler(FastqHandler):
+    @staticmethod
+    def create_fastq_name(
+        lane: str,
+        flowcell: str,
+        sample: str,
+        read: str,
+        date: dt.datetime = DEFAULT_DATE_STR,
+        index: str = DEFAULT_INDEX,
+        undetermined: Optional[str] = None,
+        meta: Optional[str] = None,
+    ) -> str:
+        """Name a FASTQ file following mutant conventions. Naming must be
+        xxx_R_1.fastq.gz and xxx_R_2.fastq.gz"""
+        # ACC1234A1_FCAB1ABC2_L1_1.fastq.gz sample_flowcell_lane_read.fastq.gz
+
+        return f"{flowcell}_L{lane}_{meta}_{read}.fastq.gz"
+
+    @staticmethod
+    def get_concatenated_name(linked_fastq_name: str) -> str:
+        """"create a name for the concatenated file for some read files"""
+        return "_".join(linked_fastq_name.split("_")[2:])


### PR DESCRIPTION
## Description

Links fastq files to mutant working dir with FOHM standard names

### Expected test outcome
- [x] check that files are named correctly

## Review
- [x] code approved by PG
- [x] tests executed by MR
- [x] "Merge and deploy" approved by MR
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Deploy this branch

