### PR TITLE
Mutant set running status sooner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
+## [20.17.1]
+### Changed
+- Status of mutant cases is set to running before running analysis, and revoked if start fails. 
+  This prevents users and cron jobs from starting the case which already started, given they check in statusDB first.
+
 ## [20.17.0]
 ### Added
 

--- a/cg/cli/workflow/mutant/base.py
+++ b/cg/cli/workflow/mutant/base.py
@@ -52,8 +52,12 @@ def config_case(context: click.Context, dry_run: bool, case_id: str) -> None:
 def run(context: click.Context, dry_run: bool, case_id: str) -> None:
     """Run mutant analysis command for a case"""
     analysis_api: MutantAnalysisAPI = context.obj["analysis_api"]
-    analysis_api.run_analysis(case_id=case_id, dry_run=dry_run)
     analysis_api.set_statusdb_action(case_id=case_id, action="running")
+    try:
+        analysis_api.run_analysis(case_id=case_id, dry_run=dry_run)
+    except:
+        analysis_api.set_statusdb_action(case_id=case_id, action=None)
+        raise
 
 
 @mutant.command("start")

--- a/cg/constants/compression.py
+++ b/cg/constants/compression.py
@@ -40,6 +40,7 @@ VALIDATION_CASES = [
     "finequagga",
     "firstfawn",
     "fleetjay",
+    "frankhusky",
     "gamedeer",
     "gladthrush",
     "helpedfilly",


### PR DESCRIPTION
## Description

Previously there was a delay before statusdb would set status of case to running. This was due to process being occupied by Nextflow daemon.
This change sets analysis status to running right away before running analysis, and revokes if anything goes wrong.
This should prevent users and crontabs from starting the case again within this time window.


## Review
- [x] code approved by MB
- [x] "Merge and deploy" approved by MR
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Deploy this branch
