### PR TITLE
get optional parents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
+## [NG.NG.NG]
+### Fixed
+- Bugfix allowing orders of single samples from existing families
+
 ## [20.17.4]
 ### Added
 - Added new covid prep method to lims constants

--- a/cg/meta/orders/status.py
+++ b/cg/meta/orders/status.py
@@ -274,8 +274,8 @@ class StatusHandler:
                     self.status.add(new_delivery)
 
             for sample in case["samples"]:
-                mother_obj = family_samples[sample["mother"]] if sample.get("mother") else None
-                father_obj = family_samples[sample["father"]] if sample.get("father") else None
+                mother_obj = family_samples.get(sample["mother"]) if sample.get("mother") else None
+                father_obj = family_samples.get(sample["father"]) if sample.get("father") else None
                 with self.status.session.no_autoflush:
                     link_obj = self.status.link(case_obj.internal_id, sample["internal_id"])
                 if link_obj:


### PR DESCRIPTION
## Description
This PR fixes the issue placing orders on singular samples of trio cases
Resolves #1015 

### How to prepare for test
- [x] ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [x] do order only a sample from a trio case

### Expected test outcome
- [x] check that there is no "Network Error" when submitting the order
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [x] code approved by MR
- [x] tests executed by PG
- [x] "Merge and deploy" approved by PG
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [x] Document in changelog
- [ ] Deploy this branch
- [ ] Inform to team data-analysis
