### PR TITLE
update enough reads definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
+
+## [20.19.2]
+
+### Fixed
+- Update sequenced at timestamp of sample whenever sample has been sequenced and flowcell transferred
+
 ## [20.19.1]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,17 @@ Try to use the following format:
 ### Fixed
 
 
-## [20.19.2]
+## [20.19.3]
 
 ### Fixed
 - Update sequenced at timestamp of sample whenever sample has been sequenced and flowcell transferred
+
+
+## [20.19.2]
+
+### Fixed
+- Bug when instantiating analysis api in upload
+
 
 ## [20.19.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,12 +27,6 @@ Try to use the following format:
 - Bug when instantiating analysis api in upload
 
 
-## [20.19.2]
-
-### Fixed
-- Bug when instantiating analysis api in upload
-
-
 ## [20.19.1]
 
 ### Fixed

--- a/cg/meta/transfer/flowcell.py
+++ b/cg/meta/transfer/flowcell.py
@@ -66,7 +66,7 @@ class TransferFlowcell:
             newest_date = (sample_obj.sequenced_at is None) or (
                 flowcell_obj.sequenced_at > sample_obj.sequenced_at
             )
-            if enough_reads and newest_date:
+            if newest_date:
                 sample_obj.sequenced_at = flowcell_obj.sequenced_at
 
             if isinstance(sample_obj, models.Sample):

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -97,7 +97,7 @@ class Application(Model):
 
     @property
     def expected_reads(self):
-        return self.target_reads * 0.75
+        return self.target_reads * self.percent_reads_guaranteed / 100
 
     @property
     def analysis_type(self):


### PR DESCRIPTION
## Description
- Update definition of "enough reads"
- update sequenced at timestamp of sample when it was sequenced, no matter number of reads

This affects automatic start of fluffy, sarscov, and microbial rml samples which should be started without expecting a top-up. Workflows such as Mip and balsamic already perform a check for all samples in case having sufficient reads before starting

## Review
- [ ] code approved by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Deploy this branch
