### PR TITLE
bugfix instantiating cgstats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
+## [20.19.4]
 
+### Fixed
+- fixed bug that cgstats configs was saved as cg_stats in CGConfig
 
 ## [20.19.3]
 

--- a/cg/models/cg_config.py
+++ b/cg/models/cg_config.py
@@ -130,7 +130,7 @@ class CGConfig(BaseModel):
 
     # App APIs that can be instantiated in CGConfig
     backup: BackupConfig = None
-    cg_stats: CGStatsConfig = None
+    cgstats: CGStatsConfig = None
     cg_stats_api_: StatsAPI = None
     chanjo: CommonAppConfig = None
     chanjo_api_: ChanjoAPI = None
@@ -160,12 +160,12 @@ class CGConfig(BaseModel):
     vogue_api_: VogueAPI = None
 
     # Meta APIs that will use the apps from CGConfig
-    fluffy: FluffyConfig = None
     balsamic: BalsamicConfig = None
-    mutant: MutantConfig = None
+    fluffy: FluffyConfig = None
+    microsalt: MicrosaltConfig = None
     mip_rd_dna: MipConfig = Field(None, alias="mip-rd-dna")
     mip_rd_rna: MipConfig = Field(None, alias="mip-rd-rna")
-    microsalt: MicrosaltConfig = None
+    mutant: MutantConfig = None
 
     # These are meta APIs that gets instantiated in the code
     meta_apis: dict = {}


### PR DESCRIPTION
## Description
Fix bug with how cgstats config data waas stored

### Expected test outcome
- [ ] check that cgstats can be instantiated (hasta.scilifelab.se/crontabs/transfer-pools-received.sh passes)

## Review
- [ ] code approved by
- [x] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


