### PR TITLE
Feat: get family analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,12 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
+## [NG.NG.NG]
+### Added
+- Add command `cg get analysis` to view analysis information
 
 ## [20.21.1]
-### Added
+### Fixed
 - Fix subprocess wildcard issue in deliver rsync
 
 ## [20.21.0]

--- a/cg/cli/get.py
+++ b/cg/cli/get.py
@@ -118,7 +118,7 @@ def relations(context: CGConfig, family_id: str):
 @click.option("-n", "--name", is_flag=True, help="search family by name")
 @click.option("--samples/--no-samples", default=True, help="display related samples")
 @click.option("--relate/--no-relate", default=True, help="display relations to samples")
-@click.option("--analysis/--no-analysis", default=True, help="display related analyses")
+@click.option("--analyses/--no-analyses", default=True, help="display related analyses")
 @click.argument("family_ids", nargs=-1)
 @click.pass_context
 def family(
@@ -127,7 +127,7 @@ def family(
     name: bool,
     samples: bool,
     relate: bool,
-    analysis: bool,
+    analyses: bool,
     family_ids: List[str],
 ):
     """Get information about a family."""

--- a/cg/cli/get.py
+++ b/cg/cli/get.py
@@ -8,7 +8,7 @@ from cg.store import Store, models
 from tabulate import tabulate
 
 LOG = logging.getLogger(__name__)
-ANALYSIS_HEADERS = ["Date", "Pipeline", "Version"]
+ANALYSIS_HEADERS = ["Analysis Date", "Pipeline", "Version"]
 FAMILY_HEADERS = ["Family", "Name", "Customer", "Priority", "Panels", "Action"]
 FLOWCELL_HEADERS = ["Flowcell", "Type", "Sequencer", "Date", "Archived?", "Status"]
 LINK_HEADERS = ["Sample", "Mother", "Father"]

--- a/tests/cli/get/test_cli_get_analysis.py
+++ b/tests/cli/get/test_cli_get_analysis.py
@@ -16,8 +16,7 @@ def test_get_analysis_bad_case(cli_runner: CliRunner, base_context: CGConfig):
     name = "dummy_name"
     result = cli_runner.invoke(get, ["analysis", name], obj=base_context)
 
-    # THEN then it should warn about missing analysis id instead of getting a analysis
-    # it will not fail since the API accepts multiple analysis
+    # THEN then it should error about missing case instead of getting a analysis
     assert result.exit_code != RETURN_SUCCESS
 
 
@@ -25,7 +24,7 @@ def test_get_analysis_required(
     cli_runner: CliRunner, base_context: CGConfig, disk_store: Store, helpers: StoreHelpers
 ):
     """Test to get a analysis using only the required argument"""
-    # GIVEN a database with a analysis
+    # GIVEN a database with an analysis
     analysis: models.Analysis = helpers.add_analysis(disk_store, pipeline_version="9.3")
     internal_id = analysis.family.internal_id
     assert disk_store.Analysis.query.count() == 1
@@ -33,7 +32,7 @@ def test_get_analysis_required(
     # WHEN getting a analysis
     result = cli_runner.invoke(get, ["analysis", internal_id], obj=base_context)
 
-    # THEN then it should have been get
+    # THEN then it should have been gotten
     assert result.exit_code == RETURN_SUCCESS
     assert str(analysis.started_at) in result.output
     assert analysis.pipeline in result.output

--- a/tests/cli/get/test_cli_get_analysis.py
+++ b/tests/cli/get/test_cli_get_analysis.py
@@ -37,4 +37,3 @@ def test_get_analysis_required(
     assert str(analysis.started_at) in result.output
     assert analysis.pipeline in result.output
     assert analysis.pipeline_version in result.output
-

--- a/tests/cli/get/test_cli_get_analysis.py
+++ b/tests/cli/get/test_cli_get_analysis.py
@@ -1,0 +1,41 @@
+"""This script tests the cli methods to get analysis in status-db"""
+
+from cg.cli.get import get
+from cg.constants import RETURN_SUCCESS
+from cg.models.cg_config import CGConfig
+from cg.store import Store, models
+from click.testing import CliRunner
+from tests.store_helpers import StoreHelpers
+
+
+def test_get_analysis_bad_case(cli_runner: CliRunner, base_context: CGConfig):
+    """Test to get a analysis using a non-existing analysis-id """
+    # GIVEN an empty database
+
+    # WHEN getting a analysis
+    name = "dummy_name"
+    result = cli_runner.invoke(get, ["analysis", name], obj=base_context)
+
+    # THEN then it should warn about missing analysis id instead of getting a analysis
+    # it will not fail since the API accepts multiple analysis
+    assert result.exit_code != RETURN_SUCCESS
+
+
+def test_get_analysis_required(
+    cli_runner: CliRunner, base_context: CGConfig, disk_store: Store, helpers: StoreHelpers
+):
+    """Test to get a analysis using only the required argument"""
+    # GIVEN a database with a analysis
+    analysis: models.Analysis = helpers.add_analysis(disk_store, pipeline_version="9.3")
+    internal_id = analysis.family.internal_id
+    assert disk_store.Analysis.query.count() == 1
+
+    # WHEN getting a analysis
+    result = cli_runner.invoke(get, ["analysis", internal_id], obj=base_context)
+
+    # THEN then it should have been get
+    assert result.exit_code == RETURN_SUCCESS
+    assert str(analysis.started_at) in result.output
+    assert analysis.pipeline in result.output
+    assert analysis.pipeline_version in result.output
+

--- a/tests/cli/get/test_cli_get_family.py
+++ b/tests/cli/get/test_cli_get_family.py
@@ -1,0 +1,37 @@
+"""This script tests the cli methods to get analysis in status-db"""
+
+from cg.cli.get import get
+from cg.constants import RETURN_SUCCESS
+from cg.models.cg_config import CGConfig
+from cg.store import Store, models
+from click.testing import CliRunner
+from tests.store_helpers import StoreHelpers
+
+
+def test_get_family_bad_case(cli_runner: CliRunner, base_context: CGConfig):
+    """Test to get a analysis using a non-existing analysis-id """
+    # GIVEN an empty database
+
+    # WHEN getting a analysis
+    name = "dummy_name"
+    result = cli_runner.invoke(get, ["family", name], obj=base_context)
+
+    # THEN then it should error about missing case instead of getting a case
+    assert result.exit_code != RETURN_SUCCESS
+
+
+def test_get_family_required(
+    cli_runner: CliRunner, base_context: CGConfig, disk_store: Store, helpers: StoreHelpers
+):
+    """Test to get a case using only the required argument"""
+    # GIVEN a database with a analysis
+    family: models.Family = helpers.add_case(disk_store)
+    internal_id = family.internal_id
+    assert disk_store.Family.query.count() == 1
+
+    # WHEN getting a analysis
+    result = cli_runner.invoke(get, ["family", internal_id], obj=base_context)
+
+    # THEN then it should have been gotten
+    assert result.exit_code == RETURN_SUCCESS
+    assert internal_id in result.output


### PR DESCRIPTION
## Description
*This PR adds CLI functionality to get information about case analysis*

### How to prepare for test
- [x] ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test analysis info from  `get family`
- [x] do `cg get family justhusky`

### Expected test outcome
- [x] check that analysis information is present


### How to test analysis info from  `get analysis`
- [x] do `cg get analysis justhusky`

### Expected test outcome
- [x] check that analysis information is present

- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [x] code approved by MR
- [x] tests executed by PG
- [x] "Merge and deploy" approved by PG
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [x] Document in changelog
- [ ] Deploy this branch
- [ ] Inform to team data-analysis
