### PR TITLE
Fixed so samples with missing bundle will be skipped and delivery won…

### DIFF
--- a/cg/constants/delivery.py
+++ b/cg/constants/delivery.py
@@ -8,6 +8,12 @@ ONLY_ONE_CASE_PER_TICKET = [
     "sarscov2",
 ]
 
+SKIP_MISSING = [
+    "fastq",
+    "microsalt",
+    "sarscov2",
+]
+
 BALSAMIC_ANALYSIS_ONLY_CASE_TAGS = [
     {"cnvkit", "filtered", "sv-vcf"},
     {"cnvkit", "filtered", "sv-vcf-index"},


### PR DESCRIPTION
…t break for some delivery types

## Description
When delivering files to customer inbox with `cg deliver analysis -d <analysis type> -t <ticket id>` then the delivery should not break if a bundle is missing.

Bundles can be missing for example when delivering fastqs if one mikrobial sample had low Q30 (in this situation a bundle will never be generated).

### How to prepare for test
- [ ] ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] paxa the environment: `paxa`
- [ ] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh skip-missing`

### How to test
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
