### PR TITLE
Fix bug with running the select command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
+## [21.4.1]
+### Changed
+- Change how samples are fetched for cgstats select command
+### Fixed
+- Bug when fetching info with `cg demultiplex select`-command
+
+
 ## [21.4.0]
 ### Added
 - A column in customer-group admin view in to show customers in the group

--- a/cg/apps/cgstats/crud/find.py
+++ b/cg/apps/cgstats/crud/find.py
@@ -86,22 +86,6 @@ def get_unaligned_id(sample_id: int, demux_id: int, lane: int) -> Optional[int]:
 
 
 def project_sample_stats(flowcell: str, project_name: Optional[str] = None) -> alchy.Query:
-    #    query = """ SELECT sample.samplename AS smp, flowcell.flowcellname AS flc,
-    #    GROUP_CONCAT(unaligned.lane ORDER BY unaligned.lane) AS lanes,
-    #    GROUP_CONCAT(unaligned.readcounts ORDER BY unaligned.lane) AS rds, SUM(unaligned.readcounts) AS readsum,
-    #    GROUP_CONCAT(unaligned.yield_mb ORDER BY unaligned.lane) AS yield, SUM(unaligned.yield_mb) AS yieldsum,
-    #    GROUP_CONCAT(TRUNCATE(q30_bases_pct,2) ORDER BY unaligned.lane) AS q30,
-    #    GROUP_CONCAT(TRUNCATE(mean_quality_score,2) ORDER BY unaligned.lane) AS meanq
-    #    FROM sample, flowcell, unaligned, project, demux
-    #    WHERE sample.sample_id = unaligned.sample_id
-    #    AND flowcell.flowcell_id = demux.flowcell_id
-    #    AND unaligned.demux_id = demux.demux_id
-    #    AND sample.project_id = project.project_id
-    #    AND project.projectname = '""" + proje + """'
-    #    AND flowcell.flowcellname = '""" + flowc + """'
-    #    GROUP BY samplename, flowcell.flowcell_id
-    #    ORDER BY lane, sample.samplename, flowcellname """
-
     query: alchy.Query = models.Sample.query.join(
         models.Sample.unaligned, models.Unaligned.demux, models.Demux.flowcell
     )

--- a/cg/apps/cgstats/crud/find.py
+++ b/cg/apps/cgstats/crud/find.py
@@ -85,11 +85,12 @@ def get_unaligned_id(sample_id: int, demux_id: int, lane: int) -> Optional[int]:
     return None
 
 
-def project_sample_stats(flowcell: str, project_name: str) -> alchy.Query:
+def project_sample_stats(flowcell: str, project_name: Optional[str] = None) -> alchy.Query:
     query: alchy.Query = models.Sample.query.join(
         models.Sample.unaligned, models.Unaligned.demux, models.Demux.flowcell
     )
-    query = query.join(models.Sample.project).filter(models.Project.projectname == project_name)
+    if project_name:
+        query = query.join(models.Sample.project).filter(models.Project.projectname == project_name)
 
     query = query.with_entities(
         models.Sample.samplename,

--- a/cg/cli/demultiplex/add.py
+++ b/cg/cli/demultiplex/add.py
@@ -1,14 +1,14 @@
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
-import alchy
 import click
 from cg.apps.cgstats.crud.create import create_novaseq_flowcell
 from cg.apps.cgstats.crud.find import project_sample_stats
 from cg.apps.cgstats.stats import StatsAPI
 from cg.apps.demultiplex.demultiplex_api import DemultiplexingAPI
 from cg.models.cg_config import CGConfig
+from cg.models.cgstats.stats_sample import StatsSample
 from cg.models.demultiplex.demux_results import DemuxResults
 from cg.models.demultiplex.flowcell import Flowcell
 
@@ -43,7 +43,10 @@ def select_project_cmd(context: CGConfig, flowcell_id: str, project: Optional[st
     """Select a flowcell to fetch statistics from"""
     # Need to instantiate API
     stats_api: StatsAPI = context.cg_stats_api
-    query: alchy.Query = project_sample_stats(flowcell=flowcell_id, project_name=project)
+    stats_samples: List[StatsSample] = project_sample_stats(
+        flowcell=flowcell_id, project_name=project
+    )
+
     stats_header = [
         "sample",
         "Flowcell",
@@ -56,20 +59,26 @@ def select_project_cmd(context: CGConfig, flowcell_id: str, project: Optional[st
         "MeanQscore",
     ]
     click.echo("\t".join(stats_header))
-    for line in query:
+    if not stats_samples:
+        LOG.warning("Could not find any samples for flowcell %s, project %s", flowcell_id, project)
+        return
+    print_lanes: List[str] = ",".join(str(lane) for lane in stats_samples[0].lanes)
+    for stats_sample in stats_samples:
         click.echo(
             "\t".join(
                 str(s)
                 for s in [
-                    line.samplename,
-                    line.flowcellname,
-                    line.lanes,
-                    line.reads,
-                    line.readsum,
-                    line.yld,
-                    line.yieldsum,
-                    line.q30,
-                    line.meanq,
+                    stats_sample.sample_name,
+                    flowcell_id,
+                    print_lanes,
+                    ",".join(str(unaligned.read_count) for unaligned in stats_sample.unaligned),
+                    stats_sample.read_count_sum,
+                    ",".join(str(unaligned.yield_mb) for unaligned in stats_sample.unaligned),
+                    stats_sample.sum_yield,
+                    ",".join(str(unaligned.q30_bases_pct) for unaligned in stats_sample.unaligned),
+                    ",".join(
+                        str(unaligned.mean_quality_score) for unaligned in stats_sample.unaligned
+                    ),
                 ]
             )
         )

--- a/cg/cli/demultiplex/add.py
+++ b/cg/cli/demultiplex/add.py
@@ -1,5 +1,6 @@
 import logging
 from pathlib import Path
+from typing import Optional
 
 import alchy
 import click
@@ -36,14 +37,11 @@ def add_flowcell_cmd(context: CGConfig, flowcell_id: str):
 
 @click.command(name="select")
 @click.argument("flowcell-id")
-@click.option("--project", help="Name of project to fetch data for", required=True)
+@click.option("--project", help="Name of project to fetch data for")
 @click.pass_obj
-def select_project_cmd(context: CGConfig, flowcell_id: str, project: str):
+def select_project_cmd(context: CGConfig, flowcell_id: str, project: Optional[str]):
     """Select a flowcell to fetch statistics from"""
-    stats_api: StatsAPI = context.cg_stats_api
-    query: alchy.Query = project_sample_stats(
-        manager=stats_api, flowcell=flowcell_id, project_name=project
-    )
+    query: alchy.Query = project_sample_stats(flowcell=flowcell_id, project_name=project)
     stats_header = [
         "sample",
         "Flowcell",

--- a/cg/cli/demultiplex/add.py
+++ b/cg/cli/demultiplex/add.py
@@ -41,6 +41,8 @@ def add_flowcell_cmd(context: CGConfig, flowcell_id: str):
 @click.pass_obj
 def select_project_cmd(context: CGConfig, flowcell_id: str, project: Optional[str]):
     """Select a flowcell to fetch statistics from"""
+    # Need to instantiate API
+    stats_api: StatsAPI = context.cg_stats_api
     query: alchy.Query = project_sample_stats(flowcell=flowcell_id, project_name=project)
     stats_header = [
         "sample",

--- a/cg/cli/demultiplex/add.py
+++ b/cg/cli/demultiplex/add.py
@@ -63,7 +63,7 @@ def select_project_cmd(context: CGConfig, flowcell_id: str, project: Optional[st
         LOG.warning("Could not find any samples for flowcell %s, project %s", flowcell_id, project)
         return
     print_lanes: List[str] = ",".join(str(lane) for lane in stats_samples[0].lanes)
-    for stats_sample in stats_samples:
+    for stats_sample in sorted(stats_samples, key=lambda x: x.sample_name):
         click.echo(
             "\t".join(
                 str(s)

--- a/cg/models/cgstats/stats_sample.py
+++ b/cg/models/cgstats/stats_sample.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, Field, validator
 class Unaligned(BaseModel):
     lane: int
     read_count: int = Field(..., alias="readcounts")
-    yield_mb: float
+    yield_mb: int
     passed_filter_pct: float
 
     q30_bases_pct: float

--- a/cg/models/cgstats/stats_sample.py
+++ b/cg/models/cgstats/stats_sample.py
@@ -1,0 +1,56 @@
+from typing import List, Optional, Set
+
+from pydantic import BaseModel, Field, validator
+
+
+class Unaligned(BaseModel):
+    lane: int
+    read_count: int = Field(..., alias="readcounts")
+    yield_mb: float
+    passed_filter_pct: float
+
+    q30_bases_pct: float
+    mean_quality_score: float
+
+    class Config:
+        orm_mode = True
+
+
+class StatsSample(BaseModel):
+    sample_name: str = Field(..., alias="samplename")
+    unaligned: List[Unaligned]
+    lanes: List[int] = []
+    read_count_sum: int = 0
+    sum_yield: int = 0
+
+    @validator("lanes", always=True)
+    def set_lanes(cls, _, values: dict) -> List[int]:
+        """Set the number of pass filter clusters"""
+        unaligned_reads: List[Unaligned] = values["unaligned"]
+        lanes_found: Set[int] = set()
+        for read in unaligned_reads:
+            lanes_found.add(read.lane)
+        return list(lanes_found)
+
+    @validator("read_count_sum", always=True)
+    def set_read_count(cls, _, values: dict):
+        unaligned_reads: List[Unaligned] = values["unaligned"]
+        count: int = 0
+        for read in unaligned_reads:
+            count += read.read_count
+        return count
+
+    @validator("sum_yield", always=True)
+    def set_sum_yield(cls, _, values: dict):
+        unaligned_reads: List[Unaligned] = values["unaligned"]
+        count: int = 0
+        for read in unaligned_reads:
+            count += read.yield_mb
+        return count
+
+    @validator("unaligned")
+    def sort_unaligned(cls, values):
+        return sorted(values, key=lambda x: x.lane)
+
+    class Config:
+        orm_mode = True

--- a/tests/apps/cgstats/conftest.py
+++ b/tests/apps/cgstats/conftest.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+from cg.apps.cgstats.crud import create
 from cg.apps.cgstats.stats import StatsAPI
 from cg.models.demultiplex.demux_results import DemuxResults
 from tests.apps.demultiplex.conftest import fixture_demultiplex_fixtures
@@ -22,6 +23,12 @@ def fixture_stats_api(project_dir: Path) -> StatsAPI:
     _store.create_all()
     yield _store
     _store.drop_all()
+
+
+@pytest.fixture(name="populated_stats_api")
+def fixture_populated_stats_api(stats_api: StatsAPI, demux_results: DemuxResults) -> StatsAPI:
+    create.create_novaseq_flowcell(manager=stats_api, demux_results=demux_results)
+    return stats_api
 
 
 @pytest.fixture(name="demultiplexing_stats_path")

--- a/tests/cli/demultiplex/conftest.py
+++ b/tests/cli/demultiplex/conftest.py
@@ -9,7 +9,13 @@ from cg.models.cg_config import CGConfig, DemultiplexConfig
 from cg.models.demultiplex.flowcell import Flowcell
 from cg.utils import Process
 from click.testing import CliRunner
-from tests.apps.cgstats.conftest import fixture_stats_api
+from tests.apps.cgstats.conftest import (
+    fixture_populated_stats_api,
+    fixture_stats_api,
+    fixture_demux_results,
+    fixture_demultiplexed_flowcell,
+    fixture_demultiplexed_runs,
+)
 from tests.apps.crunchy.conftest import fixture_sbatch_process
 from tests.apps.demultiplex.conftest import (
     fixture_demultiplex_fixtures,

--- a/tests/cli/demultiplex/test_stats_command.py
+++ b/tests/cli/demultiplex/test_stats_command.py
@@ -29,7 +29,5 @@ def test_select_command(
 
     # THEN assert that the command exits with success
     assert result.exit_code == 0
-    # THEN assert that the sample information was printed
-    print(result.exit_code)
-    print(result.output)
-    assert 0
+    # THEN assert that the flowcell id if in the printing
+    assert flowcell_id in result.output

--- a/tests/cli/demultiplex/test_stats_command.py
+++ b/tests/cli/demultiplex/test_stats_command.py
@@ -1,0 +1,35 @@
+from cg.apps.cgstats.crud import find
+from cg.apps.cgstats.stats import StatsAPI
+from cg.cli.demultiplex.add import select_project_cmd
+from cg.models.cg_config import CGConfig
+from cg.models.demultiplex.demux_results import DemuxResults
+from click.testing import CliRunner
+
+
+def test_select_command(
+    cli_runner: CliRunner,
+    populated_stats_api: StatsAPI,
+    demux_results: DemuxResults,
+    demultiplex_context: CGConfig,
+):
+    demultiplex_context.cg_stats_api_ = populated_stats_api
+    # GIVEN a stats api with some information about a flowcell
+    flowcell_id: str = demux_results.flowcell.flowcell_id
+    assert find.get_flowcell_id(flowcell_id)
+    # GIVEN a project id
+    project_id: str = ""
+    for project in demux_results.projects:
+        project_id = project.split("_")[-1]
+    assert project_id
+
+    # WHEN exporting the sample information
+    result = cli_runner.invoke(
+        select_project_cmd, [flowcell_id, "--project", project_id], obj=demultiplex_context
+    )
+
+    # THEN assert that the command exits with success
+    assert result.exit_code == 0
+    # THEN assert that the sample information was printed
+    print(result.exit_code)
+    print(result.output)
+    assert 0


### PR DESCRIPTION
## Description
This PR fixes a bug when running the cg demultiplex select command

### How to prepare for test
- [x] ssh to hasta
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh fix-demux-stats`

### How to test
- [x] do run command `cg demultiplex select HW72JDRXX`
- [x] do run command `cg demultiplex select HW72JDRXX --project 269990`

```
[0|0|1189] θ67° [mans.magnusson@hasta:~] [S_main] 5h48m10s $ cg demultiplex select HW72JDRXX --project 269990
/home/proj/bin/conda/envs/S_main/lib/python3.7/site-packages/sqlalchemy/orm/relationships.py:2231: SAWarning: Cascade settings "delete, merge, save-update" should not be combined with a viewonly=True relationship.   This configuration will raise an error in version 1.4.  Note that in versions prior to 1.4, these cascade settings may still produce a mutating effect even though this relationship is marked as viewonly=True.
  "viewonly=True." % (", ".join(sorted(non_viewonly)))
Running CG demultiplex
/home/proj/bin/conda/envs/S_main/lib/python3.7/site-packages/sqlalchemy/orm/relationships.py:1998: SAWarning: Setting backref / back_populates on relationship Demux.samples to refer to viewonly relationship Sample.demuxes should include sync_backref=False set on the Demux.samples relationship.  (this warning may be suppressed after 10 occurrences)
  (rel_b, rel_a, rel_b),
/home/proj/bin/conda/envs/S_main/lib/python3.7/site-packages/sqlalchemy/orm/relationships.py:1998: SAWarning: Setting backref / back_populates on relationship Sample.demuxes to refer to viewonly relationship Demux.samples should include sync_backref=False set on the Sample.demuxes relationship.  (this warning may be suppressed after 10 occurrences)
  (rel_b, rel_a, rel_b),
sample	Flowcell	Lanes	readcounts/lane	sum_readcounts	yieldMB/lane	sum_yield	%Q30	MeanQscore
2020-26658-05	HW72JDRXX	1,2	23470566,23586728	47057294	1197,1203	2400	95.14,95.22	36.18,36.19
2020-26678-05	HW72JDRXX	1,2	22387466,22495626	44883092	1142,1147	2289	94.68,94.77	36.09,36.11
2020-26776-05	HW72JDRXX	1,2	25678844,25645458	51324302	1310,1308	2618	95.47,95.54	36.25,36.26
2020-26783-05	HW72JDRXX	1,2	25781934,25955112	51737046	1315,1324	2639	93.56,93.59	35.83,35.84
.
.
.
[0|0|1187] θ65° [mans.magnusson@hasta:~] [S_main] 5h48m23s $ cg demultiplex select HW72JDRXX
/home/proj/bin/conda/envs/S_main/lib/python3.7/site-packages/sqlalchemy/orm/relationships.py:2231: SAWarning: Cascade settings "delete, merge, save-update" should not be combined with a viewonly=True relationship.   This configuration will raise an error in version 1.4.  Note that in versions prior to 1.4, these cascade settings may still produce a mutating effect even though this relationship is marked as viewonly=True.
  "viewonly=True." % (", ".join(sorted(non_viewonly)))
Running CG demultiplex
/home/proj/bin/conda/envs/S_main/lib/python3.7/site-packages/sqlalchemy/orm/relationships.py:1998: SAWarning: Setting backref / back_populates on relationship Demux.samples to refer to viewonly relationship Sample.demuxes should include sync_backref=False set on the Demux.samples relationship.  (this warning may be suppressed after 10 occurrences)
  (rel_b, rel_a, rel_b),
sample	Flowcell	Lanes	readcounts/lane	sum_readcounts	yieldMB/lane	sum_yield	%Q30	MeanQscore
2020-26657-05	HW72JDRXX	1,2	22476326,22599030	45075356	1146,1153	2299	95.39,95.47	36.23,36.24
2020-26658-05	HW72JDRXX	1,2	23470566,23586728	47057294	1197,1203	2400	95.14,95.22	36.18,36.19
2020-26757-05	HW72JDRXX	1,2	23573832,23661208	47235040	1202,1207	2409	94.88,94.93	36.11,36.12
2020-26776-05	HW72JDRXX	1,2	25678844,25645458	51324302	1310,1308	2618	95.47,95.54	36.25,36.26
2020-26877-05	HW72JDRXX	1,2	25839350,25909720	51749070	1318,1321	2639	95.22,95.28	36.19,36.21
.
.
.
```

### Expected test outcome
- [x] check that the information is displayes
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [x] code approved by MR
- [x] tests executed by MM
- [x] "Merge and deploy" approved by MM
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


