### PR TITLE
Fix 2500 pdc backup destination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
+## [21.3.1]
+### Fixed
+- PDC backup destination server for 2500 flowcells
+
 ## [21.3.0]
 ### Changed
 - Remove dependency `cgstats` from requirements.txt and move used functionality into CG
@@ -20,6 +24,12 @@ Try to use the following format:
 ## [21.2.0]
 ### Added
 - Functionality for the cgstats api in CG
+
+## [21.1.0]
+### Added
+Select analyses to be uploaded to vogue based on analysis completed date (before or after a date, of between two dates)
+Add uploaded to vogue date to analysis table
+Only select potential analyses to upload that have not been uploaded
 
 ## [21.0.0]
 

--- a/cg/apps/pdc.py
+++ b/cg/apps/pdc.py
@@ -16,11 +16,7 @@ class PdcApi:
     ) -> None:
         """Fetch a flowcell back from the backup solution."""
         path = root_dir[sequencer_type]
-
-        if server is None:
-            raise ValueError(f"{sequencer_type}: invalid sequencer type")
-
-        bash_command = f"bash SCRIPTS/retrieve_run_nas.bash {flowcell_id} {HASTA} {path}"
+        bash_command = f"bash SCRIPTS/retrieve_run_nas.bash {flowcell_id} {SERVER} {path}"
         command = ["ssh", "nas-9.scilifelab.se", bash_command]
         LOG.info(" ".join(command))
         if not dry:

--- a/cg/apps/pdc.py
+++ b/cg/apps/pdc.py
@@ -7,6 +7,7 @@ LOG = logging.getLogger(__name__)
 
 SERVER = "hasta"
 
+
 class PdcApi:
     """Group PDC related commands"""
 

--- a/cg/apps/pdc.py
+++ b/cg/apps/pdc.py
@@ -5,6 +5,7 @@ import subprocess
 
 LOG = logging.getLogger(__name__)
 
+SERVER = "hasta"
 
 class PdcApi:
     """Group PDC related commands"""
@@ -14,17 +15,12 @@ class PdcApi:
         cls, flowcell_id: str, sequencer_type: str, root_dir: dict, dry: bool = False
     ) -> None:
         """Fetch a flowcell back from the backup solution."""
-        server = {
-            "hiseqga": "thalamus",
-            "hiseqx": "hasta",
-            "novaseq": "hasta",
-        }.get(sequencer_type)
         path = root_dir[sequencer_type]
 
         if server is None:
             raise ValueError(f"{sequencer_type}: invalid sequencer type")
 
-        bash_command = f"bash SCRIPTS/retrieve_run_nas.bash {flowcell_id} {server} {path}"
+        bash_command = f"bash SCRIPTS/retrieve_run_nas.bash {flowcell_id} {HASTA} {path}"
         command = ["ssh", "nas-9.scilifelab.se", bash_command]
         LOG.info(" ".join(command))
         if not dry:


### PR DESCRIPTION
## Description
*This PR fixes that 2500 flowcells retrieved from PDC are still being sent to thalamus*

### How to prepare for test
- [x] ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [x] set a flowcell to requested: `cg set flowcell --status requested H9M8MADXX`
- [x] run `cg backup fetch-flowcell --dry-run`

### Expected test outcome
- [x] Generated command: `ssh nas-9.scilifelab.se bash SCRIPTS/retrieve_run_nas.bash H9M8MADXX hasta /home/proj/stage/flowcells/2500/runs/`
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by HS
- [x] tests executed by @barrystokman 
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Deploy this branch
