### PR TITLE
Add new values to fluffy samplesheet according to customer wishes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Try to use the following format:
 ### Fixed
 
 
+## [21.5.2]
+### Fixed
+- Fixed content of fluffy samplesheet according to customer specification
+
+
 ## [21.5.1]
 ### Fixed
 - By default fetch related flowcell information using `cg get sample <sample_id>`

--- a/cg/meta/workflow/fluffy.py
+++ b/cg/meta/workflow/fluffy.py
@@ -114,7 +114,7 @@ class FluffyAnalysisAPI(AnalysisAPI):
 
     def get_sample_sequenced_date(self, sample_id: str) -> Optional[dt.date]:
         sample_obj: models.Sample = self.status_db.sample(sample_id)
-        sequenced_at = sample_obj.sequenced_at
+        sequenced_at: dt.datetime = sample_obj.sequenced_at
         if sequenced_at:
             return sequenced_at.date()
 

--- a/cg/meta/workflow/fluffy.py
+++ b/cg/meta/workflow/fluffy.py
@@ -1,13 +1,9 @@
 import csv
 import datetime as dt
 import logging
-import os
 import shutil
-from abc import ABC
 from pathlib import Path
-from subprocess import CalledProcessError
-from typing import List
-
+from typing import List, Optional
 from alchy import Query
 from cg.constants import Pipeline
 from cg.exc import CgError
@@ -48,7 +44,8 @@ class FluffyAnalysisAPI(AnalysisAPI):
         Location in case folder where samplesheet is expected to be stored. Samplesheet is used as a config
         required to run Fluffy
         """
-        return Path(self.root_dir, case_id, "SampleSheet.csv")
+        starlims_id: str = self.status_db.family(case_id).links[0].sample.order
+        return Path(self.root_dir, case_id, f"SampleSheet_{starlims_id}.csv")
 
     def get_workdir_path(self, case_id: str) -> Path:
         """
@@ -111,6 +108,16 @@ class FluffyAnalysisAPI(AnalysisAPI):
         """Get sample concentration from LIMS"""
         return self.lims_api.get_sample_attribute(lims_id=sample_id, key="concentration_sample")
 
+    def get_sample_starlims_id(self, sample_id: str) -> int:
+        sample_obj: models.Sample = self.status_db.sample(sample_id)
+        return sample_obj.order
+
+    def get_sample_sequenced_date(self, sample_id: str) -> Optional[dt.date]:
+        sample_obj: models.Sample = self.status_db.sample(sample_id)
+        sequenced_at = sample_obj.sequenced_at
+        if sequenced_at:
+            return sequenced_at.date()
+
     def add_concentrations_to_samplesheet(
         self, samplesheet_housekeeper_path: Path, samplesheet_workdir_path: Path
     ) -> None:
@@ -124,17 +131,22 @@ class FluffyAnalysisAPI(AnalysisAPI):
 
         sample_name_index = None
         sample_id_index = None
+        project_index = None
         for row in csv_reader:
             if "SampleID" in row and not sample_id_index:
                 sample_name_index = row.index("SampleName")
                 sample_id_index = row.index("SampleID")
+                project_index = row.index("Project")
                 row.append("Library_nM")
+                row.append("SequencingDate")
                 csv_writer.writerow(row)
                 continue
             if sample_id_index:
                 sample_id = row[sample_id_index]
                 row[sample_name_index] = self.get_sample_name_from_lims_id(lims_id=sample_id)
+                row[project_index] = str(self.get_sample_starlims_id(sample_id=sample_id))
                 row.append(str(self.get_concentrations_from_lims(sample_id=sample_id)))
+                row.append(str(self.get_sample_sequenced_date(sample_id=sample_id)))
                 csv_writer.writerow(row)
 
     def get_samplesheet_housekeeper_path(self, flowcell_name: str) -> Path:

--- a/tests/cli/workflow/fluffy/test_cli_create_samplesheet.py
+++ b/tests/cli/workflow/fluffy/test_cli_create_samplesheet.py
@@ -3,6 +3,7 @@ from cg.constants import EXIT_SUCCESS
 from cg.meta.workflow.fluffy import FluffyAnalysisAPI
 from cg.models.cg_config import CGConfig
 from click.testing import CliRunner
+import datetime as dt
 
 
 def test_create_samplesheet_dry(
@@ -74,6 +75,14 @@ def test_create_samplesheet_success(
     # GIVEN every sample in SampleSheet has been given a name in StatusDB
     mocker.patch.object(FluffyAnalysisAPI, "get_sample_name_from_lims_id")
     FluffyAnalysisAPI.get_sample_name_from_lims_id.return_value = "CustName"
+
+    # GIVEN every sample in SampleSheet has valid order field in StatusDB
+    mocker.patch.object(FluffyAnalysisAPI, "get_sample_starlims_id")
+    FluffyAnalysisAPI.get_sample_starlims_id.return_value = 12345678
+
+    # GIVEN every sample in SampleSheet sequenced_at set in StatusDB
+    mocker.patch.object(FluffyAnalysisAPI, "get_sample_sequenced_date")
+    FluffyAnalysisAPI.get_sample_sequenced_date.return_value = dt.datetime.now().date()
 
     # WHEN running command to create samplesheet
     result = cli_runner.invoke(create_samplesheet, [fluffy_case_id_existing], obj=fluffy_context)

--- a/tests/cli/workflow/fluffy/test_cli_start.py
+++ b/tests/cli/workflow/fluffy/test_cli_start.py
@@ -5,6 +5,7 @@ from cg.constants import EXIT_SUCCESS
 from cg.meta.workflow.fluffy import FluffyAnalysisAPI
 from cg.models.cg_config import CGConfig
 from click.testing import CliRunner
+import datetime as dt
 
 
 def test_start_available_dry(
@@ -50,17 +51,25 @@ def test_start_available(
     mocker.patch.object(FluffyAnalysisAPI, "run_fluffy")
     FluffyAnalysisAPI.run_fluffy.return_value = None
 
-    # GIVEN samplesheet exists in Housekeeper
+    # GIVEN an existing samplesheet in Housekeeper
     mocker.patch.object(FluffyAnalysisAPI, "get_samplesheet_housekeeper_path")
     FluffyAnalysisAPI.get_samplesheet_housekeeper_path.return_value = samplesheet_fixture_path
 
-    # GIVEN concentrations on samples are set in LIMS
+    # GIVEN Concentrations are set in LIMS on sample level
     mocker.patch.object(FluffyAnalysisAPI, "get_concentrations_from_lims")
-    FluffyAnalysisAPI.get_concentrations_from_lims.return_value = "10"
+    FluffyAnalysisAPI.get_concentrations_from_lims.return_value = "20"
 
-    # GIVEN samples in samplesheet have corresponding StatusDB entries with customer-set sample name
+    # GIVEN every sample in SampleSheet has been given a name in StatusDB
     mocker.patch.object(FluffyAnalysisAPI, "get_sample_name_from_lims_id")
     FluffyAnalysisAPI.get_sample_name_from_lims_id.return_value = "CustName"
+
+    # GIVEN every sample in SampleSheet has valid order field in StatusDB
+    mocker.patch.object(FluffyAnalysisAPI, "get_sample_starlims_id")
+    FluffyAnalysisAPI.get_sample_starlims_id.return_value = 12345678
+
+    # GIVEN every sample in SampleSheet sequenced_at set in StatusDB
+    mocker.patch.object(FluffyAnalysisAPI, "get_sample_sequenced_date")
+    FluffyAnalysisAPI.get_sample_sequenced_date.return_value = dt.datetime.now().date()
 
     # WHEN running command
     result = cli_runner.invoke(start_available, [], obj=fluffy_context)


### PR DESCRIPTION
## Description
New fields in fluffy samplesheet
Appends starlims id to samplesheet name

### How to prepare for test
- [x] ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [x] do cg workflow fluffy start lovedkitten

### Expected test outcome
- [x] check that samplesheet generated correctly
```
[0|231|1754] θ64° [maryia.ropart@hasta:/home/proj/stage/nipt/cases/lovedkitten] [S_main] $ cat SampleSheet_#342712.csv 
FCID,Lane,SampleID,SampleRef,index,index2,SampleName,Control,Recipe,Operator,Project,Library_nM,SequencingDate
HWJFTDRXX,1,ACC7534A1,hg19,AATCGTTA,ACGTTATT,11c-2021-00010-05,N,R1,script,#342712,53.47,None
HWJFTDRXX,1,ACC7534A2,hg19,AATCGGCG,TCAATATT,11c-2021-00061-05,N,R1,script,#342712,6.89,None
HWJFTDRXX,1,ACC7534A3,hg19,AATCCGTT,AGCATATT,11c-2021-00062-05,N,R1,script,#342712,22.31,None
HWJFTDRXX,1,ACC7534A4,hg19,AAGATACA,CAGATATT,11c-2021-00063-05,N,R1,script,#342712,51.02,None
HWJFTDRXX,1,ACC7534A5,hg19,AAGACGAA,AATCTATT,11c-2021-00064-05,N,R1,script,#342712,24.59,None
HWJFTDRXX,1,ACC7534A6,hg19,AAGTAAGT,GGACTATT,11c-2021-00065-05,N,R1,script,#342712,28.03,None

```
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [x] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Deploy this branch
- [ ] Inform Nipt team that new fields are there and send new samplesheets
