### PR TITLE
sanitize swedish values in mutant workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Try to use the following format:
 ### Fixed
 
 
+## [21.5.6]
+### Fixed
+- Use only the first item from region and lab code values in mutant workflow.
+
 ## [21.5.5]
 ### Fixed
 - Fix tag to deliver correct mutant result files to KS inbox

--- a/cg/meta/workflow/mutant.py
+++ b/cg/meta/workflow/mutant.py
@@ -122,10 +122,10 @@ class MutantAnalysisAPI(AnalysisAPI):
         sample_name = sample_obj.name
         region_code = self.lims_api.get_sample_attribute(
             lims_id=sample_obj.internal_id, key="region_code"
-        ).replace(" ", "_")
+        ).split(" ")[0]
         lab_code = self.lims_api.get_sample_attribute(
             lims_id=sample_obj.internal_id, key="lab_code"
-        ).replace(" ", "_")
+        ).split(" ")[0]
 
         return f"{region_code}_{lab_code}_{sample_name}"
 

--- a/cg/models/workflow/mutant.py
+++ b/cg/models/workflow/mutant.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 
 
 class MutantSampleConfig(BaseModel):
@@ -19,3 +19,7 @@ class MutantSampleConfig(BaseModel):
     method_sequencing: str
     sequencing_qc_pass: bool
     selection_criteria: str
+
+    @validator("region_code", "lab_code")
+    def sanitize_values(cls, value):
+        return value.split(" ")[0]


### PR DESCRIPTION
## Description
*This PR adds/fixes ...*
-Sanitize region code and lab code values in mutant workflow when linking files and creating case config

### How to prepare for test
- [x] ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [x] do cg workflow mutant start frankhusky

### Expected test outcome
- [x] check that analysis completes and bundle can be stored with all the files in place
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [x] tests executed by MR
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Deploy this branch
- [ ] Inform production
