### PR TITLE
fix analyze action on mip/balsamic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,13 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
-## [21.5.8]
+## [21.6.1]
 ### Fixed
 - Fix bug in mip and balmsamic crontab
+
+## [21.6.0]
+### Added
+- Functionality to do demultiplexing post processing from CG
 
 ## [21.5.7]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ Try to use the following format:
 
 ## [21.6.1]
 ### Fixed
-- Fix bug in mip and balmsamic crontab
+- Fix bug in mip and balsamic crontab
+
 
 ## [21.6.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
+## [21.5.8]
+### Fixed
+- Fix bug in mip and balmsamic crontab
+
 ## [21.5.7]
 ### Fixed
 - Set status to analyze when resolving decompression

--- a/cg/meta/workflow/balsamic.py
+++ b/cg/meta/workflow/balsamic.py
@@ -60,7 +60,7 @@ class BalsamicAnalysisAPI(AnalysisAPI):
         )
         cases_to_analyze = []
         for case_obj in cases_query:
-            if not case_obj.latest_analyzed:
+            if case_obj.action == "analyze" or not case_obj.latest_analyzed:
                 cases_to_analyze.append(case_obj)
             elif (
                 self.trailblazer_api.get_latest_analysis_status(case_id=case_obj.internal_id)

--- a/cg/meta/workflow/mip.py
+++ b/cg/meta/workflow/mip.py
@@ -238,7 +238,7 @@ class MipAnalysisAPI(AnalysisAPI):
         )
         cases_to_analyze = []
         for case_obj in cases_query:
-            if not case_obj.latest_analyzed:
+            if case_obj.action == "analyze" or not case_obj.latest_analyzed:
                 cases_to_analyze.append(case_obj)
             elif (
                 self.trailblazer_api.get_latest_analysis_status(case_id=case_obj.internal_id)


### PR DESCRIPTION
## Description
*This PR adds/fixes ...*
Fix mip and balsamic crontab issue that wouldnt allow cases with status analyze to start

### How to prepare for test
- [x] ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [x] do cg workflow mip-dna start-available

### Expected test outcome
- [x] check that drivendane starts
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [x] tests executed by MR
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instruction

## Implementation Plan
- [ ] Deploy this branch

