### PR TITLE
parse flowcell dir name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
+## [21.6.7]
+### Changed
+- Validate that flowcell name is correct when demultiplexing
+
 ## [21.6.6]
 ### Changed
 - Check that logfile exists before doing demux post-processing

--- a/cg/cli/demultiplex/add.py
+++ b/cg/cli/demultiplex/add.py
@@ -37,7 +37,7 @@ def add_flowcell_cmd(context: CGConfig, flowcell_id: str):
         raise click.Abort
     try:
         flowcell: Flowcell = Flowcell(flowcell_path=flowcell_run_path)
-    except FlowcellError as exc:
+    except FlowcellError:
         raise click.Abort
     demux_results: DemuxResults = DemuxResults(demux_dir=demux_results_path, flowcell=flowcell)
     create_novaseq_flowcell(manager=stats_api, demux_results=demux_results)

--- a/cg/cli/demultiplex/add.py
+++ b/cg/cli/demultiplex/add.py
@@ -11,6 +11,7 @@ from cg.apps.cgstats.crud.create import create_novaseq_flowcell
 from cg.apps.cgstats.stats import StatsAPI
 from cg.apps.demultiplex.demultiplex_api import DemultiplexingAPI
 from cg.constants.cgstats import STATS_HEADER
+from cg.exc import FlowcellError
 from cg.meta.demultiplex.demux_post_processing import DemuxPostProcessingAPI
 from cg.models.cg_config import CGConfig
 from cg.models.demultiplex.demux_results import DemuxResults
@@ -34,7 +35,10 @@ def add_flowcell_cmd(context: CGConfig, flowcell_id: str):
     if not demux_results_path.exists():
         LOG.warning("Could not find demultiplex result path %s", demux_results_path)
         raise click.Abort
-    flowcell: Flowcell = Flowcell(flowcell_path=flowcell_run_path)
+    try:
+        flowcell: Flowcell = Flowcell(flowcell_path=flowcell_run_path)
+    except FlowcellError as exc:
+        raise click.Abort
     demux_results: DemuxResults = DemuxResults(demux_dir=demux_results_path, flowcell=flowcell)
     create_novaseq_flowcell(manager=stats_api, demux_results=demux_results)
 

--- a/cg/cli/demultiplex/demux.py
+++ b/cg/cli/demultiplex/demux.py
@@ -35,7 +35,7 @@ def demultiplex_all(
         LOG.info("Found directory %s", sub_dir)
         try:
             flowcell_obj = Flowcell(flowcell_path=sub_dir)
-        except FlowcellError as err:
+        except FlowcellError:
             continue
         if not demultiplex_api.is_demultiplexing_possible(flowcell=flowcell_obj) and not dry_run:
             continue

--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -6,6 +6,7 @@ from cg.apps.cgstats.crud import create, find
 from cg.apps.cgstats.stats import StatsAPI
 from cg.apps.demultiplex.demultiplex_api import DemultiplexingAPI
 from cg.constants.cgstats import STATS_HEADER
+from cg.exc import FlowcellError
 from cg.meta.demultiplex import files
 from cg.models.cg_config import CGConfig
 from cg.models.cgstats.stats_sample import StatsSample
@@ -134,7 +135,10 @@ class DemuxPostProcessingAPI:
         Force is used to finish a flowcell even if the files are renamed already
         """
         LOG.info("Check demuxed flowcell %s", flowcell_name)
-        flowcell: Flowcell = Flowcell(flowcell_path=self.demux_api.run_dir / flowcell_name)
+        try:
+            flowcell: Flowcell = Flowcell(flowcell_path=self.demux_api.run_dir / flowcell_name)
+        except FlowcellError:
+            return
         if not self.demux_api.is_demultiplexing_completed(flowcell=flowcell):
             LOG.warning("Demultiplex is not ready for %s", flowcell_name)
             return

--- a/cg/models/demultiplex/flowcell.py
+++ b/cg/models/demultiplex/flowcell.py
@@ -19,7 +19,6 @@ class Flowcell:
     def __init__(self, flowcell_path: Path):
         LOG.debug("Instantiating Flowcell with path %s", flowcell_path)
         self.path = flowcell_path
-        LOG.debug("Set flowcell id to %s", self.flowcell_id)
         self._run_parameters: Optional[RunParameters] = None
         self.run_date: datetime.datetime = datetime.datetime.now()
         self.machine_name: str = ""
@@ -45,6 +44,7 @@ class Flowcell:
         self.machine_name = split_name[1]
         base_name: str = split_name[-1]
         self.base_name = base_name
+        LOG.debug("Set flowcell id to %s", self.flowcell_id)
         self.flowcell_id = base_name[1:]
         self.flowcell_position = base_name[0]
 

--- a/cg/models/demultiplex/flowcell.py
+++ b/cg/models/demultiplex/flowcell.py
@@ -1,7 +1,9 @@
+import datetime
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
+from cg.exc import FlowcellError
 from cg.models.demultiplex.run_parameters import RunParameters
 from cgmodels.demultiplex.sample_sheet import SampleSheet, get_sample_sheet_from_file
 from cgmodels.exceptions import SampleSheetError
@@ -19,23 +21,36 @@ class Flowcell:
         self.path = flowcell_path
         LOG.debug("Set flowcell id to %s", self.flowcell_id)
         self._run_parameters: Optional[RunParameters] = None
+        self.run_date: datetime.datetime = datetime.datetime.now()
+        self.machine_name: str = ""
+        # Base name is flowcell-id + flowcell position
+        self.base_name: str = ""
+        self.flowcell_id: str = ""
+        self.flowcell_position: Literal["A", "B"] = "A"
+        self.parse_flowcell_name()
+
+    def parse_flowcell_name(self):
+        """Parse relevant information from flowcell name
+
+        This will assume that the flowcell naming convention is used. If not we skip the flowcell.
+        Convention is: <date>_<machine>_<some_numbers>_<A|B><flowcell_id>
+        Example: 201203_A00689_0200_AHVKJCDRXX
+        """
+        split_name: List[str] = self.path.name.split("_")
+        if len(split_name) != 4:
+            message = f"Flowcell {self.path.name} does not follow the flowcell naming convention"
+            LOG.warning(message)
+            raise FlowcellError(message)
+        self.run_date = datetime.datetime.strptime(split_name[0], "%y%m%d")
+        self.machine_name = split_name[1]
+        base_name: str = split_name[-1]
+        self.base_name = base_name
+        self.flowcell_id = base_name[1:]
+        self.flowcell_position = base_name[0]
 
     @property
     def flowcell_full_name(self) -> str:
         return self.path.name
-
-    @property
-    def base_name(self) -> str:
-        return self.path.name.split("_")[-1]
-
-    @property
-    def flowcell_id(self) -> str:
-        return self.base_name[1:]
-
-    @property
-    def flowcell_position(self) -> Literal["A", "B"]:
-        """get the flowcell position: A|B"""
-        return self.base_name[0]
 
     @property
     def sample_sheet_path(self) -> Path:

--- a/cg/models/demultiplex/flowcell.py
+++ b/cg/models/demultiplex/flowcell.py
@@ -33,7 +33,7 @@ class Flowcell:
         """Parse relevant information from flowcell name
 
         This will assume that the flowcell naming convention is used. If not we skip the flowcell.
-        Convention is: <date>_<machine>_<some_numbers>_<A|B><flowcell_id>
+        Convention is: <date>_<machine>_<run_numbers>_<A|B><flowcell_id>
         Example: 201203_A00689_0200_AHVKJCDRXX
         """
         split_name: List[str] = self.path.name.split("_")

--- a/cg/models/demultiplex/flowcell.py
+++ b/cg/models/demultiplex/flowcell.py
@@ -22,6 +22,7 @@ class Flowcell:
         self._run_parameters: Optional[RunParameters] = None
         self.run_date: datetime.datetime = datetime.datetime.now()
         self.machine_name: str = ""
+        self.machine_number: int = 0
         # Base name is flowcell-id + flowcell position
         self.base_name: str = ""
         self.flowcell_id: str = ""
@@ -42,6 +43,7 @@ class Flowcell:
             raise FlowcellError(message)
         self.run_date = datetime.datetime.strptime(split_name[0], "%y%m%d")
         self.machine_name = split_name[1]
+        self.machine_number = int(split_name[2])
         base_name: str = split_name[-1]
         self.base_name = base_name
         LOG.debug("Set flowcell id to %s", self.flowcell_id)

--- a/tests/models/test_flowcell_class.py
+++ b/tests/models/test_flowcell_class.py
@@ -7,7 +7,14 @@ from cg.models.demultiplex.flowcell import Flowcell
 
 def test_get_run_parameters_when_non_existing(fixtures_dir: Path):
     # GIVEN a flowcell object with a directory without run parameters
-    flowcell = Flowcell(flowcell_path=fixtures_dir)
+    flowcell_path: Path = (
+        fixtures_dir
+        / "apps"
+        / "demultiplexing"
+        / "demultiplexed-runs"
+        / "201203_A00689_0200_AHVKJCDRXX"
+    )
+    flowcell = Flowcell(flowcell_path=flowcell_path)
     assert flowcell.run_parameters_path.exists() is False
 
     # WHEN fetching the run parameters object


### PR DESCRIPTION
## Description
This PR adds so that the code will fail if flowcell directories does not follow the naming convention.
Result of this will be that directories that are not named accordingly will be skipped when looping over all flowcell dirs.

### How to prepare for test
- [ ] Tests are automated


## Review
- [ ] code approved by
- [x] "Merge and deploy" approved by MM
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

