### PR TITLE
fix demux report path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Try to use the following format:
 ### Changed
 ### Fixed
 
+## [21.8.1]
+### Changed
+- Changed so that barcode report is written to the correct path
+
 ## [21.8.0]
 ### Added
 - Command `cg demultplex report` to generate barcode report for demuxed flowcells

--- a/cg/apps/demultiplex/demux_report.py
+++ b/cg/apps/demultiplex/demux_report.py
@@ -69,8 +69,6 @@ def get_demux_report_data(
             report_data.extend(lane_samples)
     if skip_empty and not report_data:
         return report_data
-    LOG.warning("Unknown barcodes!")
-    LOG.warning("%s", conversion_stats.lanes_to_unknown_barcode)
     for lane, barcode_data in conversion_stats.lanes_to_unknown_barcode.items():
         report_data.extend(get_unknown_barcodes(unknown_barcodes=barcode_data, lane=lane))
     return report_data

--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -119,7 +119,7 @@ class DemuxPostProcessingAPI:
     @staticmethod
     def create_barcode_summary_report(demux_results: DemuxResults) -> None:
         report_content = create_demux_report(conversion_stats=demux_results.conversion_stats)
-        report_path: Path = demux_results.conversion_stats_path
+        report_path: Path = demux_results.barcode_report
         LOG.info("Write demux report to %s", report_path)
         with report_path.open("w") as report_file:
             report_file.write("\n".join(report_content))

--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -120,6 +120,9 @@ class DemuxPostProcessingAPI:
     def create_barcode_summary_report(demux_results: DemuxResults) -> None:
         report_content = create_demux_report(conversion_stats=demux_results.conversion_stats)
         report_path: Path = demux_results.barcode_report
+        if report_path.exists():
+            LOG.warning("Report path already exists!")
+            return
         LOG.info("Write demux report to %s", report_path)
         with report_path.open("w") as report_file:
             report_file.write("\n".join(report_content))


### PR DESCRIPTION
## Description
This is a critical bugfix that make sure that the demux report path is not writing over another file
- Update barcode report path


## Review
- [x] code approved by BS
- [x] "Merge and deploy" approved by MM
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


