### PR TITLE
remove dead dependency blinker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ __________ DO NOT TOUCH ___________
 
 __________ DO NOT TOUCH ___________
 
+## [NG.NG.NG]
+### Fixed
+- Remove dependency to outdated project blinker
+
 ## [22.1.0]
 ### Changed
 - Rsync now run on slurm instead of the login node

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ Flask-CORS
 Flask-Dance
 Flask-SQLAlchemy==2.1
 Flask>=1.1.1                # versioned due to setup.py install misselecting Flask-SQLAlchemy otherwise
-blinker
 google-auth
 gunicorn
 requests[security]


### PR DESCRIPTION
## Description
*This PR adds/fixes ...*
- remove dead dependency blinker 

### How to prepare for test
- [x] ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`
- [x] pip uninstall blinker
- [x] pip uninstall colorclass, leftover from #1196 

### How to test
- [x] ssh hasta
- [x] us
- [x] cg --version

### Expected test outcome
- [x] check that the command works
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [x] code approved by HS
- [x] tests executed by PG
- [x] "Merge and deploy" approved by PG
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [x] Document in changelog
- [ ] Deploy this branch
- [ ] pip uninstall blinker in production
- [ ] pip uninstall colorclass in production, leftover from #1196
- [ ] Inform to ES
