### PR TITLE
adding rna tags to deliver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ __________ DO NOT TOUCH ___________
 
 __________ DO NOT TOUCH ___________
 
+## [22.2.1]
+### Added
+- Add more files to the mip-rna delivery
+
 ## [22.2.0]
 ### Added
 - Add cg clean fluffy_past_run_dirs command

--- a/cg/constants/delivery.py
+++ b/cg/constants/delivery.py
@@ -82,13 +82,23 @@ MIP_DNA_ANALYSIS_CASE_TAGS = [
 
 MIP_DNA_ANALYSIS_SAMPLE_TAGS = [{"bam"}, {"bam-index"}, {"cram"}, {"cram-index"}]
 
-MIP_RNA_ANALYSIS_CASE_TAGS = []
+MIP_RNA_ANALYSIS_CASE_TAGS = [
+    {"fusion", "clinical", "pdf"},
+    {"fusion", "research", "pdf"},
+    {"fusion", "vcf"},
+    {"fusion", "vcf-index"},
+    {"vcf-snv-clinical"},
+    {"vcf-snv-clinical-index"},
+    {"vcf-snv-research"},
+    {"vcf-snv-research-index"},
+]
 
 MIP_RNA_ANALYSIS_SAMPLE_TAGS = [
-    {"bam"},
-    {"bam-index"},
     {"cram"},
     {"cram-index"},
+    {"fusion", "vcf"},
+    {"fusion", "vcf-index"},
+    {"salmon-quant"},
 ]
 
 MICROSALT_ANALYSIS_CASE_TAGS = [


### PR DESCRIPTION
## Description
This PR adds more files to the mip-rna delivery

### How to prepare for test
- [x] ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh deliver_rna`

### How to test
- [x] run `cg deliver analysis -d mip-rna  -c finequagga --dry-run`

### Expected test outcome
- [x] check that the following files would be linked to the inbox
  - [x] sample cram files
  - [x] case fusion vcf
  - [x] sample fusion vcf
  - [x] case clinical fusion report
  - [x] case research fusion report
  - [x] case clinical ASE vcf
  - [x] case research ASE vcf
  - [x] sample quant files
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [x] code approved by HS
- [x] tests executed by AJ
- [x] "Merge and deploy" approved by HS
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to data analysis
