### PR TITLE
no cg jobs on gpu nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ __________ DO NOT TOUCH ___________
 
 __________ DO NOT TOUCH ___________
 
+## [22.4.0]
+### Fixed
+- cg will no longer run slurm jobs on the gpu nodes
+
 ## [22.3.1]
 ### Fixed
 Fixed statina load bug where missing headers prevented data from being read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ __________ DO NOT TOUCH ___________
 
 ## [22.4.0]
 ### Fixed
-- cg will no longer run slurm jobs on the gpu nodes
+- cg will no longer run rsync on the gpu nodes
 
 ## [22.3.1]
 ### Fixed

--- a/cg/apps/slurm/sbatch.py
+++ b/cg/apps/slurm/sbatch.py
@@ -9,8 +9,7 @@ SBATCH_HEADER_TEMPLATE = """#! /bin/bash
 #SBATCH --mail-user={email}
 #SBATCH --time={hours}:{minutes}:00
 #SBATCH --qos={priority}
-#SBATCH --exclude=compute-0
-#SBATCH --exclude=compute-1
+#SBATCH --exclude=gpu-compute-0-[0-1]
 
 set -eu -o pipefail
 

--- a/cg/apps/slurm/sbatch.py
+++ b/cg/apps/slurm/sbatch.py
@@ -9,7 +9,8 @@ SBATCH_HEADER_TEMPLATE = """#! /bin/bash
 #SBATCH --mail-user={email}
 #SBATCH --time={hours}:{minutes}:00
 #SBATCH --qos={priority}
-#SBATCH --exclude=compute-[0-1]
+#SBATCH --exclude=compute-0
+#SBATCH --exclude=compute-1
 
 set -eu -o pipefail
 

--- a/cg/apps/slurm/sbatch.py
+++ b/cg/apps/slurm/sbatch.py
@@ -9,6 +9,7 @@ SBATCH_HEADER_TEMPLATE = """#! /bin/bash
 #SBATCH --mail-user={email}
 #SBATCH --time={hours}:{minutes}:00
 #SBATCH --qos={priority}
+#SBATCH --exclude=compute-[0-1]
 
 set -eu -o pipefail
 

--- a/cg/apps/slurm/sbatch.py
+++ b/cg/apps/slurm/sbatch.py
@@ -9,7 +9,7 @@ SBATCH_HEADER_TEMPLATE = """#! /bin/bash
 #SBATCH --mail-user={email}
 #SBATCH --time={hours}:{minutes}:00
 #SBATCH --qos={priority}
-#SBATCH --exclude=gpu-compute-0-[0-1]
+#SBATCH {exclude}
 
 set -eu -o pipefail
 

--- a/cg/meta/rsync.py
+++ b/cg/meta/rsync.py
@@ -106,6 +106,7 @@ class RsyncAPI(MetaAPI):
             "hours": 24,
             "commands": commands,
             "error": error_function,
+            "exclude": "--exclude=gpu-compute-0-[0-1],cg-dragen",
         }
         slurm_api = SlurmAPI()
         slurm_api.set_dry_run(dry_run=dry_run)

--- a/cg/models/slurm/sbatch.py
+++ b/cg/models/slurm/sbatch.py
@@ -18,3 +18,4 @@ class Sbatch(BaseModel):
     priority: SlurmQos = SlurmQos.LOW
     commands: str
     error: Optional[str]
+    exclude: Optional[str] = ""


### PR DESCRIPTION
## Description
This PR prevents cg from running slurm jobs on the gpu nodes. For example rsync is not installed on the gpu nodes that cg runs. I see no reason for cg to use gpu nodes.

### How to prepare for test
- [x] ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh no-rsync-on-gpu`

### How to test
- [x] do `cg deliver rsync 821682`

### Expected test outcome
- [x] check that an sbatch job could be submitted
- [x] check that `#SBATCH --exclude=gpu-compute-0-[0-1]` is included in `/home/proj/stage/rsync/821682_210618_11_21_52_554580/821682_rsync.sh`
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [x] tests executed by @henningonsbring 
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
