### PR TITLE
Fix(avatar): fix avatar name lookup problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ __________ DO NOT TOUCH ___________
 
 __________ DO NOT TOUCH ___________
 
+## [NG.NG.NG]
+### Fixed
+- Avatar name lookup problem 
+
 ## [22.5.0]
 ### Added
 - Avatars for cases

--- a/cg/apps/avatar/api.py
+++ b/cg/apps/avatar/api.py
@@ -36,7 +36,7 @@ class Avatar:
                 filters=filters,
                 verify_status_only=False,
             )
-            sleep(secrets.SystemRandom().randint(0, len(filter_array) - try_cnt))
+            sleep(secrets.SystemRandom().randint(0, min(len(filter_array) - try_cnt, 1)))
             if not urls:
                 query = f"{animal}"
                 urls = bing_image_urls(

--- a/cg/apps/avatar/api.py
+++ b/cg/apps/avatar/api.py
@@ -73,12 +73,12 @@ class Avatar:
         sorted_adjectives = sorted(petname.adjectives, key=len, reverse=True)
         sorted_pets = sorted(petname.names, key=len, reverse=True)
         for adjective in sorted_adjectives:
-            if adjective in merged_name:
+            if merged_name.startswith(adjective):
                 found_adj = adjective
                 break
         found_pet = ""
         for pet in sorted_pets:
-            if pet in merged_name:
+            if merged_name.endswith(pet):
                 found_pet = pet
                 break
 

--- a/tests/apps/avatar/test_avatar_api.py
+++ b/tests/apps/avatar/test_avatar_api.py
@@ -8,13 +8,13 @@ from cg.apps.avatar.api import Avatar
 def test_split_petname():
     """Test to instantiate a avatar api"""
     # GIVEN a merged petname
-    merged_petname = "justhusky"
+    merged_petname = "simpleox"
 
     # WHEN splitting the petname
-    split_petname = Avatar._split_petname(merged_petname)
+    split_adjective, split_pet = Avatar._split_petname(merged_petname)
 
     # THEN the parts of the petname should be the same as the original merged one
-    assert split_petname[0] + split_petname[1] == merged_petname
+    assert split_adjective + split_pet == merged_petname
 
 
 @pytest.mark.parametrize("adjective", ["apt", "adapted"])


### PR DESCRIPTION
## Description
*This PR adds/fixes ...*
- fixes name splitting where the expected word could be found in the middle of another word, (e.g. simpleox would become simpleimp since imp is found and is longer than ox)

### How to prepare for test
- [x] ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [x] make sure you have a case named simpleox
- [x] do cg set family --avatar-url "test" simpleox

### Expected test outcome
- [x] check that you get an avatar for simpleox and not simpleimp
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [x] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [x] Document in changelog
- [ ] Deploy this branch
- [ ] Inform to ES
