### PR TITLE
correct mean qscore calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ __________ DO NOT TOUCH ___________
 __________ DO NOT TOUCH ___________
 
 
+## [22.9.5]
+### Fixed
+- Fixed mean Q score added to cgstats by `cg demultiplex add <flowcell>` being of by a factor off 
+100.
+
 ## [22.9.4]
 ### Fixed
 - Cases removed from FOHM batch properly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ __________ DO NOT TOUCH ___________
 
 ## [22.9.5]
 ### Fixed
-- Fixed mean Q score added to cgstats by `cg demultiplex add <flowcell>` being of by a factor off 
+- Fixed mean Q score added to cgstats by `cg demultiplex add <flowcell>` being off by a factor of 
 100.
 
 ## [22.9.4]

--- a/cg/apps/cgstats/demux_sample.py
+++ b/cg/apps/cgstats/demux_sample.py
@@ -105,8 +105,7 @@ class DemuxSample(BaseModel):
             return value
         return round(
             conversion_stats.pass_filter_quality_score_sum
-            / conversion_stats.pass_filter_yield
-            * 100,
+            / conversion_stats.pass_filter_yield,
             2,
         )
 

--- a/cg/apps/cgstats/demux_sample.py
+++ b/cg/apps/cgstats/demux_sample.py
@@ -3,10 +3,11 @@ import logging
 from pathlib import Path
 from typing import Dict
 
+from pydantic import BaseModel, validator
+
 from cg.apps.cgstats.parsers.conversion_stats import ConversionStats, SampleConversionResults
 from cg.apps.cgstats.parsers.demux_stats import DemuxStats, SampleBarcodeStats
 from cgmodels.demultiplex.sample_sheet import NovaSeqSample, SampleSheet
-from pydantic import BaseModel, validator
 
 LOG = logging.getLogger(__name__)
 
@@ -104,8 +105,7 @@ class DemuxSample(BaseModel):
         if not conversion_stats.pass_filter_yield:
             return value
         return round(
-            conversion_stats.pass_filter_quality_score_sum
-            / conversion_stats.pass_filter_yield,
+            conversion_stats.pass_filter_quality_score_sum / conversion_stats.pass_filter_yield,
             2,
         )
 


### PR DESCRIPTION
## Description
*This PR adds/fixes mean Q score in cgstats being off by two orders of magnitude*

### How to prepare for test
- [ ] ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] paxa the environment: `paxa`
- [ ] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
See coment below

### Expected test outcome
Correct mean Q scores: usually around 35, two decimals.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
