### PR TITLE
--panel do not need to be set when creating a new family with "cg add family"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ __________ DO NOT TOUCH ___________
 
 __________ DO NOT TOUCH ___________
 
+## [22.11.0]
+### Fixed
+- New families can be created without the --panel flag
 
 ## [22.10.2]
 ### Fixed

--- a/cg/cli/add.py
+++ b/cg/cli/add.py
@@ -162,7 +162,7 @@ def sample(
 @click.option(
     "--priority", type=click.Choice(PRIORITY_OPTIONS), default="standard", help="analysis priority"
 )
-@click.option("-p", "--panel", "panels", multiple=True, required=False, help="default gene panels")
+@click.option("-p", "--panel", "panels", multiple=True, help="default gene panels")
 @click.option(
     "-a",
     "--analysis",

--- a/cg/cli/add.py
+++ b/cg/cli/add.py
@@ -162,7 +162,7 @@ def sample(
 @click.option(
     "--priority", type=click.Choice(PRIORITY_OPTIONS), default="standard", help="analysis priority"
 )
-@click.option("-p", "--panel", "panels", multiple=True, required=True, help="default gene panels")
+@click.option("-p", "--panel", "panels", multiple=True, required=False, help="default gene panels")
 @click.option(
     "-a",
     "--analysis",


### PR DESCRIPTION
## Description
This PR fixes so families can be created via `cg add family` without forcing the user to give a panel in the input via the `--panel` flag.

Background to why we need this:
Some pipelines analyse families that do not have a panel given, for example the SARS-CoV-2 pipeline. See family "goodcamel", there is no panel assigned to this petname when the family is created automatically from the customers order. But when I need to make a family manually via the cli, then it is not possible to do so without giving a panel in the input.

### How to prepare for test
- [ ] ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] paxa the environment: `paxa`
- [ ] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh allow-no-panel`

### How to test
- [ ] do `cg add family --priority standard -dd fastq -a sars-cov-2 cust124 TestFamily`

### Expected test outcome
- [ ] check that there is no panel for this family on statusdb
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
