### PR TITLE
External data automation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ __________ DO NOT TOUCH ___________
 
 __________ DO NOT TOUCH ___________
 
+## [22.11.0]
+### Added
+- Function for downloading external data from caesar
 
 ## [22.10.3]
 ### Changed

--- a/cg/cli/add.py
+++ b/cg/cli/add.py
@@ -278,4 +278,4 @@ def relationship(
 def external(context: CGConfig, ticket_id: int, dry_run: bool):
     """Downloads external data from caesar and places it in appropriate folder on hasta"""
     external_data_api = ExternalDataAPI(config=context)
-    external_data_api.download_from_caesar(ticket_id=ticket_id, dry_run=dry_run)
+    external_data_api.download_ticket(ticket_id=ticket_id, dry_run=dry_run)

--- a/cg/cli/add.py
+++ b/cg/cli/add.py
@@ -3,6 +3,7 @@ from typing import List, Optional, Tuple
 
 import click
 from cg.constants import PRIORITY_OPTIONS, STATUS_OPTIONS, DataDelivery, Pipeline
+from cg.meta.orders.external_data import ExternalDataAPI
 from cg.models.cg_config import CGConfig
 from cg.store import Store, models
 from cg.utils.click.EnumChoice import EnumChoice
@@ -262,3 +263,19 @@ def relationship(
     )
     status_db.add_commit(new_record)
     LOG.info("related %s to %s", case_obj.internal_id, sample_obj.internal_id)
+
+
+@add.command()
+@click.option(
+    "-t",
+    "--ticket-id",
+    type=int,
+    help="Ticket id",
+    required=True,
+)
+@click.option("--dry-run", is_flag=True)
+@click.pass_obj
+def external(context: CGConfig, ticket_id: int, dry_run: bool):
+    """Downloads external data from caesar and places it in appropriate folder on hasta"""
+    external_data_api = ExternalDataAPI(config=context)
+    external_data_api.download_from_caesar(ticket_id=ticket_id, dry_run=dry_run)

--- a/cg/meta/orders/external_data.py
+++ b/cg/meta/orders/external_data.py
@@ -94,7 +94,7 @@ class ExternalDataAPI(MetaAPI):
         cases: List[models.Family] = self.status_db.get_cases_from_ticket(ticket_id=ticket_id).all()
         cust_id = cases[0].customer.internal_id
         for case in cases:
-            links = cases.links
+            links = case.links
             for link in links:
                 lims_sample_id = link.sample.internal_id
                 cust_sample_id = link.sample.name

--- a/cg/meta/orders/external_data.py
+++ b/cg/meta/orders/external_data.py
@@ -103,6 +103,6 @@ class ExternalDataAPI(MetaAPI):
                     dry_run=dry_run,
                 )
                 LOG.info(
-                    "Downloading sample %s from caesar by submitting sbatch job %s",
-                    (lims_sample_id, sbatch_number),
+                    "Downloading sample %s from caesar by submitting sbatch job %s"
+                    % (lims_sample_id, sbatch_number)
                 )

--- a/cg/meta/orders/external_data.py
+++ b/cg/meta/orders/external_data.py
@@ -1,10 +1,16 @@
 """Module for deliver and rsync customer inbox on hasta to customer inbox on caesar"""
+import datetime as dt
 import logging
+import os
 from pathlib import Path
+from typing import List
 
+from cg.apps.slurm.slurm_api import SlurmAPI
 from cg.meta.meta import MetaAPI
+from cg.meta.rsync.sbatch import RSYNC_COMMAND, ERROR_RSYNC_FUNCTION
 from cg.models.cg_config import CGConfig
-
+from cg.models.slurm.sbatch import Sbatch
+from cg.store import models
 
 LOG = logging.getLogger(__name__)
 
@@ -12,8 +18,94 @@ LOG = logging.getLogger(__name__)
 class ExternalDataAPI(MetaAPI):
     def __init__(self, config: CGConfig):
         super().__init__(config)
-        self.hasta_path: Path = Path(config.external.hasta)
-        self.caesar_path: Path = Path(config.external.caesar)
+        self.hasta_path: str = config.external.hasta
+        self.caesar_path: str = config.external.caesar
+        self.base_path: str = config.data_delivery.base_path
+        self.account: str = config.data_delivery.account
+        self.mail_user: str = config.data_delivery.mail_user
 
-    def download_from_caesar(self, ticket_id: int, dry_run: bool):
-        print("hej")
+    def create_log_dir(self, ticket_id: int, dry_run: bool) -> Path:
+        timestamp = dt.datetime.now()
+        timestamp_str = timestamp.strftime("%y%m%d_%H_%M_%S_%f")
+        folder_name = Path("_".join([str(ticket_id), timestamp_str]))
+        log_dir = Path(self.base_path) / folder_name
+        LOG.info("Creating folder: %s", log_dir)
+        if log_dir.exists():
+            LOG.warning("Could not create %s, this folder already exist", log_dir)
+        elif dry_run:
+            LOG.info("Would have created path %s, but this is a dry run", log_dir)
+        else:
+            os.makedirs(log_dir)
+        return log_dir
+
+    def create_source_path(
+        self, cust_id: str, ticket_id: int, raw_path: str, cust_sample_id: str
+    ) -> Path:
+        cust_id_added_to_path: Path = Path(
+            raw_path % cust_id + "/" + str(ticket_id) + "/" + cust_sample_id + "/"
+        )
+        return cust_id_added_to_path
+
+    def create_destination_path(
+        self, cust_id: str, ticket_id: int, raw_path: str, lims_sample_id: str
+    ) -> Path:
+        cust_id_added_to_path: Path = Path(raw_path % cust_id + "/" + lims_sample_id + "/")
+        return cust_id_added_to_path
+
+    def download_sample(
+        self, cust_id: str, ticket_id: int, cust_sample_id: str, lims_sample_id: str, dry_run: bool
+    ) -> int:
+        log_dir: Path = self.create_log_dir(ticket_id=ticket_id, dry_run=dry_run)
+        source_path: Path = self.create_source_path(
+            cust_id=cust_id,
+            ticket_id=ticket_id,
+            raw_path=self.caesar_path,
+            cust_sample_id=cust_sample_id,
+        )
+        destination_path: Path = self.create_destination_path(
+            cust_id=cust_id,
+            ticket_id=ticket_id,
+            raw_path=self.hasta_path,
+            lims_sample_id=lims_sample_id,
+        )
+        commands = RSYNC_COMMAND.format(source_path=source_path, destination_path=destination_path)
+        error_function = ERROR_RSYNC_FUNCTION.format()
+        sbatch_info = {
+            "job_name": "_".join([str(ticket_id), "rsync_external_data"]),
+            "account": self.account,
+            "number_tasks": 1,
+            "memory": 1,
+            "log_dir": log_dir.as_posix(),
+            "email": self.mail_user,
+            "hours": 24,
+            "commands": commands,
+            "error": error_function,
+        }
+        slurm_api = SlurmAPI()
+        slurm_api.set_dry_run(dry_run=dry_run)
+        sbatch_content: str = slurm_api.generate_sbatch_content(Sbatch.parse_obj(sbatch_info))
+        sbatch_path = log_dir / "_".join([str(ticket_id), "rsync_external_data.sh"])
+        sbatch_number: int = slurm_api.submit_sbatch(
+            sbatch_content=sbatch_content, sbatch_path=sbatch_path
+        )
+        return sbatch_number
+
+    def download_ticket(self, ticket_id: int, dry_run: bool) -> None:
+        cases: List[models.Family] = self.status_db.get_cases_from_ticket(ticket_id=ticket_id).all()
+        cust_id = cases[0].customer.internal_id
+        for case in cases:
+            links = cases.links
+            for link in links:
+                lims_sample_id = link.sample.internal_id
+                cust_sample_id = link.sample.name
+                sbatch_number = self.download_sample(
+                    cust_id=cust_id,
+                    ticket_id=ticket_id,
+                    cust_sample_id=cust_sample_id,
+                    lims_sample_id=lims_sample_id,
+                    dry_run=dry_run,
+                )
+                LOG.info(
+                    "Downloading sample %s from caesar by submitting sbatch job %s",
+                    (lims_sample_id, sbatch_number),
+                )

--- a/cg/meta/orders/external_data.py
+++ b/cg/meta/orders/external_data.py
@@ -40,31 +40,28 @@ class ExternalDataAPI(MetaAPI):
 
     def create_source_path(
         self, cust_id: str, ticket_id: int, raw_path: str, cust_sample_id: str
-    ) -> Path:
-        cust_id_added_to_path: Path = Path(
+    ) -> str:
+        cust_id_added_to_path = (
             raw_path % cust_id + "/" + str(ticket_id) + "/" + cust_sample_id + "/"
         )
         return cust_id_added_to_path
 
-    def create_destination_path(
-        self, cust_id: str, ticket_id: int, raw_path: str, lims_sample_id: str
-    ) -> Path:
-        cust_id_added_to_path: Path = Path(raw_path % cust_id + "/" + lims_sample_id + "/")
+    def create_destination_path(self, cust_id: str, raw_path: str, lims_sample_id: str) -> str:
+        cust_id_added_to_path = raw_path % cust_id + "/" + lims_sample_id + "/"
         return cust_id_added_to_path
 
     def download_sample(
         self, cust_id: str, ticket_id: int, cust_sample_id: str, lims_sample_id: str, dry_run: bool
     ) -> int:
         log_dir: Path = self.create_log_dir(ticket_id=ticket_id, dry_run=dry_run)
-        source_path: Path = self.create_source_path(
+        source_path: str = self.create_source_path(
             cust_id=cust_id,
             ticket_id=ticket_id,
             raw_path=self.caesar_path,
             cust_sample_id=cust_sample_id,
         )
-        destination_path: Path = self.create_destination_path(
+        destination_path: str = self.create_destination_path(
             cust_id=cust_id,
-            ticket_id=ticket_id,
             raw_path=self.hasta_path,
             lims_sample_id=lims_sample_id,
         )

--- a/cg/meta/orders/external_data.py
+++ b/cg/meta/orders/external_data.py
@@ -1,0 +1,19 @@
+"""Module for deliver and rsync customer inbox on hasta to customer inbox on caesar"""
+import logging
+from pathlib import Path
+
+from cg.meta.meta import MetaAPI
+from cg.models.cg_config import CGConfig
+
+
+LOG = logging.getLogger(__name__)
+
+
+class ExternalDataAPI(MetaAPI):
+    def __init__(self, config: CGConfig):
+        super().__init__(config)
+        self.hasta_path: Path = Path(config.external.hasta)
+        self.caesar_path: Path = Path(config.external.caesar)
+
+    def download_from_caesar(self, ticket_id: int, dry_run: bool):
+        print("hej")

--- a/cg/models/cg_config.py
+++ b/cg/models/cg_config.py
@@ -169,6 +169,11 @@ class FOHMConfig(BaseModel):
     email_host: str
 
 
+class ExternalConfig(BaseModel):
+    hasta: str
+    caesar: str
+
+
 class CGConfig(BaseModel):
     database: str
     environment: Literal["production", "stage"] = "stage"
@@ -194,6 +199,7 @@ class CGConfig(BaseModel):
     data_delivery: DataDeliveryConfig = Field(None, alias="data-delivery")
     demultiplex: DemultiplexConfig = None
     demultiplex_api_: DemultiplexingAPI = None
+    external: ExternalConfig = None
     genotype: CommonAppConfig = None
     genotype_api_: GenotypeAPI = None
     hermes: CommonAppConfig = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ from cg.apps.hermes.hermes_api import HermesApi
 from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.constants import Pipeline
 from cg.constants.priority import SlurmQos
+from cg.meta.orders.external_data import ExternalDataAPI
 from cg.meta.rsync import RsyncAPI
 from cg.models import CompressionData
 from cg.models.cg_config import CGConfig
@@ -237,6 +238,13 @@ def fixture_rsync_api(cg_context: CGConfig) -> RsyncAPI:
     """RsyncAPI fixture"""
     _rsync_api: RsyncAPI = RsyncAPI(config=cg_context)
     return _rsync_api
+
+
+@pytest.fixture(name="external_data_api")
+def fixture_external_data_api(cg_context: CGConfig) -> ExternalDataAPI:
+    """ExternalDataAPI fixture"""
+    _external_data_api: ExternalDataAPI = ExternalDataAPI(config=cg_context)
+    return _external_data_api
 
 
 @pytest.fixture(name="genotype_api")
@@ -1167,6 +1175,10 @@ def fixture_context_config(
             "base_path": "/another/path",
             "account": "development",
             "mail_user": "an@email.com",
+        },
+        "external": {
+            "hasta": "/path/on/hasta/%s",
+            "caesar": "server.name.se:/path/%s/on/caesar",
         },
         "shipping": {"host_config": "host_config_stage.yaml", "binary_path": "echo"},
         "housekeeper": {"database": fixture_hk_uri, "root": str(housekeeper_dir)},

--- a/tests/meta/orders/test_external_data.py
+++ b/tests/meta/orders/test_external_data.py
@@ -1,0 +1,71 @@
+"""Tests for the transfer of external data"""
+import logging
+from pathlib import Path
+
+from cgmodels.cg.constants import Pipeline
+from cg.meta.orders.external_data import ExternalDataAPI
+from cg.models.cg_config import CGConfig
+
+
+def test_create_log_dir(caplog, external_data_api: ExternalDataAPI):
+    """Test generating the directory for logging"""
+    caplog.set_level(logging.INFO)
+
+    # WHEN the log directory is created
+    log_dir = external_data_api.create_log_dir(ticket_id=999999, dry_run=True)
+
+    # THEN the path is not created since it is a dry run
+    assert "Would have created path" in caplog.text
+
+    # THEN the created path is
+    assert str(log_dir).startswith("/another/path/999999")
+
+
+def test_create_source_path(external_data_api: ExternalDataAPI):
+    """Test generating the source path"""
+
+    # WHEN the source path is created
+    source_path = external_data_api.create_source_path(
+        ticket_id=999999, raw_path="/path/%s", cust_sample_id="ABC123", cust_id="cust000"
+    )
+
+    # THEN the source path is
+    assert source_path == "/path/cust000/999999/ABC123/"
+
+
+def test_create_destination_path(external_data_api: ExternalDataAPI):
+    """Test generating the destination path"""
+
+    # WHEN the source path is created
+    destination_path = external_data_api.create_destination_path(
+        raw_path="/path/%s", lims_sample_id="ACC123", cust_id="cust000"
+    )
+
+    # THEN the source path is
+    assert destination_path == "/path/cust000/ACC123/"
+
+
+def test_download_sample(external_data_api: ExternalDataAPI, mocker):
+    """Test for running rsync on slurm"""
+
+    # GIVEN paths needed to run rsync
+    mocker.patch.object(ExternalDataAPI, "create_log_dir")
+    ExternalDataAPI.create_log_dir.return_value = Path("/path/to/log")
+
+    mocker.patch.object(ExternalDataAPI, "create_source_path")
+    ExternalDataAPI.create_source_path.return_value = Path("/path/to/source")
+
+    mocker.patch.object(ExternalDataAPI, "create_destination_path")
+    ExternalDataAPI.create_destination_path.return_value = Path("/path/to/destination")
+
+    # WHEN the destination path is created
+    sbatch_number = external_data_api.download_sample(
+        cust_id="cust000",
+        ticket_id=123456,
+        cust_sample_id="ABC123",
+        lims_sample_id="ACC123",
+        dry_run=True,
+    )
+
+    # THEN check that an integer was returned as sbatch number
+    assert isinstance(sbatch_number, int)


### PR DESCRIPTION
## Description
Allows the user to use the command `cg add external -t <ticket_id>`, this command will iterate over all samples in the order connected to the ticket and run:
`rsync -rvL caesar.scilifelab.se:/home/<cust_id>/outbox/<ticket_id>/<cust_sample_name>/ /home/proj/production/external-data/<cust_id>/<lims_sample_id>/`

### How to prepare for test
- [x] ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh external-data-automation`

### How to test
- [ ] do `cg add external -t 423832`

### Expected test outcome
- [x] check that folders named as internal lims IDs are added to `/home/proj/stage/external-data/cust002`
- [x] check that these folders contain .fastq.gz files
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [x] tests executed by @henningonsbring 
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
