### PR TITLE
Fix(Orderportal): Catch and show attribute errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,19 +19,18 @@ __________ DO NOT TOUCH ___________
 
 __________ DO NOT TOUCH ___________
 
-
+## [22.11.3]
+### Fixed
+- Show more errors from parsing orderforms 
 
 ## [22.11.2]
 ### Changed
-* Update deployment instructions
-
+- Update deployment instructions
 
 ## [22.11.1]
-
 ### Changed
 - Updated bump2version action to v3
 - Removed build container action (for time being) since we never use the containers
-
 
 ## [22.11.0]
 ### Fixed
@@ -40,7 +39,6 @@ __________ DO NOT TOUCH ___________
 ## [22.10.3]
 ### Changed
 - Increased flowcells ondisk cap
-
 
 ## [22.10.2]
 ### Fixed

--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -365,7 +365,7 @@ def orderform():
             json_data = json.load(input_file.stream)
             order_parser = JsonOrderformParser()
             order_parser.parse_orderform(order_data=json_data)
-    except (OrderFormError, ValidationError) as error:
+    except (OrderFormError, ValidationError, AttributeError) as error:
         if hasattr(error, "message"):
             message = error.message
         else:

--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -152,7 +152,7 @@ def family_in_customer_group(family_id):
     case_obj = db.family(family_id)
     if case_obj is None:
         return abort(404)
-    elif not g.current_user.is_admin and (
+    if not g.current_user.is_admin and (
         case_obj.customer.customer_group
         not in set(customer.customer_group for customer in g.current_user.customers)
     ):
@@ -203,7 +203,7 @@ def sample(sample_id):
     sample_obj = db.sample(sample_id)
     if sample_obj is None:
         return abort(404)
-    elif not g.current_user.is_admin and (sample_obj.customer not in g.current_user.customers):
+    if not g.current_user.is_admin and (sample_obj.customer not in g.current_user.customers):
         return abort(401)
     data = sample_obj.to_dict(links=True, flowcells=True)
     return jsonify(**data)
@@ -215,7 +215,7 @@ def sample_in_customer_group(sample_id):
     sample_obj = db.sample(sample_id)
     if sample_obj is None:
         return abort(404)
-    elif not g.current_user.is_admin and (
+    if not g.current_user.is_admin and (
         sample_obj.customer.customer_group
         not in set(customer.customer_group for customer in g.current_user.customers)
     ):
@@ -241,7 +241,7 @@ def pool(pool_id):
     record = db.pool(pool_id)
     if record is None:
         return abort(404)
-    elif not g.current_user.is_admin and (record.customer not in g.current_user.customers):
+    if not g.current_user.is_admin and (record.customer not in g.current_user.customers):
         return abort(401)
     return jsonify(**record.to_dict())
 


### PR DESCRIPTION
## Description

### Fixed

- Show attribute errors from parsing orderform to the end user instead of "Network Error"


### How to prepare for test
- [x] ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage 
`bash /home/proj/production/servers/resources/clinical-db.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [x] In the Orderportal use "-" where a numeric value is expected in an excel orderform

### Expected test outcome
- [x] check that the system shows "Non numeric value -"
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [x] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in changelog
- [ ] Deploy this branch
- [ ] Inform to customer E.T and A.L, Internal: APJ, MGG, AG, Aly, LF