### PR TITLE
Remove bam and bam index files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ __________ DO NOT TOUCH ___________
 
 __________ DO NOT TOUCH ___________
 
+## [22.14.0]
+### Changed
+
+- Removed balsamic bam and bam index files from cg deliver analysis command
+
 ## [22.13.0]
 
 ### Added
@@ -34,7 +39,6 @@ __________ DO NOT TOUCH ___________
 ### Changed
 - Use new metrics deliverables format, which is already part of qc_metrics file
 - Use new models when parsing mip analysis files
->>>>>>> bea6da8bd2de1ddde09221d4ff2bf4631e1c82f7
 
 ## [22.11.3]
 ### Fixed

--- a/cg/constants/delivery.py
+++ b/cg/constants/delivery.py
@@ -45,8 +45,6 @@ BALSAMIC_ANALYSIS_SAMPLE_TAGS = [
     {"cram-index"},
     {"cram", "tumor"},
     {"cram-index", "tumor"},
-    {"bam"},
-    {"bam-index"},
 ]
 
 BALSAMIC_QC_CASE_TAGS = [


### PR DESCRIPTION
## Description

### Changed

- Removed balsamic  bam and bam index files from cg deliver analysis command.


### How to prepare for test
- [x] ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh remove-delivery-of-balsamic-bam-files`

### How to test
- [X] do: `cg deliver analysis -d balsamic -c meetmouse --dry-run` ✔️ 

### Expected test outcome
- [X] check that the bam and bai files are not linked. ✔️ 
- [X] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [x] tests executed by @moahaegglund 
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Deploy this branch
- [ ] Inform to @Clinical-Genomics/data-analysis 
