### PR TITLE
Raise sbatch memory parameter for demultiplexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ __________ DO NOT TOUCH ___________
 
 __________ DO NOT TOUCH ___________
 
+## [22.18.0]
+### Changed
+- Raised sbatch memory parameter for demultiplexing
+
 ## [22.17.0]
 ### Added
 - Added support for multiple delivery flags for the command cg deliver analysis.

--- a/cg/apps/demultiplex/demultiplex_api.py
+++ b/cg/apps/demultiplex/demultiplex_api.py
@@ -226,7 +226,7 @@ class DemultiplexingAPI:
                 job_name=self.get_run_name(flowcell),
                 account=self.slurm_account,
                 number_tasks=18,
-                memory=95,
+                memory=125,
                 log_dir=log_path.parent.as_posix(),
                 email=self.mail,
                 hours=36,


### PR DESCRIPTION
## Description


### Changed

- Raising the sbatch memory parameter in order to avoid failure of the demultiplexing. The demultiplexing of flowcell H2322DSX2 had a maximum memory usage of 109.9G. 

### How to prepare for test
- [x] ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh raise_sbatch_memory_for_demultiplexing`

### How to test
- [x] do `cg demultiplex flowcell --dry-run 210616_A00689_0284_BHVH7FDSXY`

### Expected test outcome
- [x] check that `#SBATCH --mem` is set to 125G.
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [x] code approved by HS
- [x] tests executed by @moahaegglund 
- [x] "Merge and deploy" approved by HS
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
