### PR TITLE
Add number of samples in ticket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
-Please add a new candidate release at the top after changing the latest one. Feel free to copy paste from the "squash and commit" box that gets generated when creating PRs
+<!-- Please add a new candidate release at the top after changing the latest one. Feel free to copy paste from the "squash and commit" box that gets generated when creating PRs
 
 Try to use the following format:
-
 
 __________ DO NOT TOUCH ___________
 
@@ -17,7 +16,11 @@ __________ DO NOT TOUCH ___________
 ### Changed
 ### Fixed
 
-__________ DO NOT TOUCH ___________
+__________ DO NOT TOUCH ___________ -->
+
+## [22.18.0]
+### Added
+- Display number of samples in order ticket
 
 ## [22.17.2]
 ### Changed

--- a/cg/meta/orders/ticket_handler.py
+++ b/cg/meta/orders/ticket_handler.py
@@ -52,7 +52,7 @@ class TicketHandler:
         return ticket_nr
 
     def create_new_ticket_message(self, order: OrderIn, user_name: str, project: str) -> str:
-        message = f"data:text/html;charset=utf-8,New incoming {project} samples: "
+        message = f"data:text/html;charset=utf-8, {len(order.samples)} new incoming {project} samples: "
 
         for sample in order.samples:
             message = self.add_sample_name_to_message(

--- a/cg/meta/orders/ticket_handler.py
+++ b/cg/meta/orders/ticket_handler.py
@@ -53,7 +53,7 @@ class TicketHandler:
 
     def create_new_ticket_message(self, order: OrderIn, user_name: str, project: str) -> str:
         message = (
-            f"data:text/html;charset=utf-8, {len(order.samples)} new incoming {project} samples: "
+            f"data:text/html;charset=utf-8, New order with {len(order.samples)} {project} samples: "
         )
 
         for sample in order.samples:

--- a/cg/meta/orders/ticket_handler.py
+++ b/cg/meta/orders/ticket_handler.py
@@ -52,7 +52,9 @@ class TicketHandler:
         return ticket_nr
 
     def create_new_ticket_message(self, order: OrderIn, user_name: str, project: str) -> str:
-        message = f"data:text/html;charset=utf-8, {len(order.samples)} new incoming {project} samples: "
+        message = (
+            f"data:text/html;charset=utf-8, {len(order.samples)} new incoming {project} samples: "
+        )
 
         for sample in order.samples:
             message = self.add_sample_name_to_message(


### PR DESCRIPTION
## Description

### Added

- Number of ordered samples in the ticket

### How to prepare for test
- [ ] ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] paxa the environment: `paxa`
- [ ] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] do submit a new order

### Expected test outcome
- [ ] check that the number of samples are visible in the ticket
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [x] code approved by karlnyr
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [x] Document in changelog
- [ ] Deploy this branch
- [ ] Inform to production
