### PR TITLE
fix projects bool in post-processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ __________ DO NOT TOUCH ___________
 ### Fixed
 
 __________ DO NOT TOUCH ___________ -->
+## [22.19.1]
+### Fixed
+- demultiplexed runs project checks
+
+## [22.19.0]
+### Added
+- Novaseq Dragen Demultiplexing
 
 ## [22.18.0]
 ### Added

--- a/cg/models/demultiplex/demux_results.py
+++ b/cg/models/demultiplex/demux_results.py
@@ -191,7 +191,7 @@ class DemuxResults:
 
         Check if the project files have been renamed, in that case it will not need post processing
         """
-        return bool(self.projects)
+        return bool(list(self.projects))
 
     def get_logfile_parameters(self) -> LogfileParameters:
         get_logfile_parameters = {


### PR DESCRIPTION
## Description
The check to see if projects are renamed incorrectly returns `True`, preventing demux-postprocessing from starting.

### Fixed

- The check to see if projects are renamed.


### How to prepare for test
- [x] ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [x] do `cg demultiplex finish flowcell -b dragen 210901_A00187_0566_AH235WDSX2`

### Expected test outcome
- [x] check that teh prject dirs have been renamed from `<project_id>` to `Project_<project_id`
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [x] code approved by
- [x] tests executed by @barrystokman 
- [x] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
