### PR TITLE
fix division by zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ __________ DO NOT TOUCH ___________
 ### Fixed
 
 __________ DO NOT TOUCH ___________ -->
+## [22.19.2]
+### Fixed
+- error in post demux process 
+
 ## [22.19.1]
 ### Fixed
 - demultiplexed runs project checks

--- a/cg/apps/cgstats/crud/create.py
+++ b/cg/apps/cgstats/crud/create.py
@@ -2,6 +2,7 @@ import logging
 from typing import Dict, Iterable, Optional, Union
 
 import sqlalchemy
+from cgmodels.demultiplex.sample_sheet import NovaSeqSample, SampleSheet
 
 from cg.apps.cgstats.crud import find
 from cg.apps.cgstats.db import models as stats_models
@@ -11,7 +12,6 @@ from cg.apps.cgstats.stats import StatsAPI
 from cg.constants.demultiplexing import DRAGEN_PASSED_FILTER_PCT
 from cg.constants.symbols import PERIOD
 from cg.models.demultiplex.demux_results import DemuxResults, LogfileParameters
-from cgmodels.demultiplex.sample_sheet import NovaSeqSample, SampleSheet
 
 LOG = logging.getLogger(__name__)
 
@@ -212,7 +212,10 @@ def _create_samples(
     if not sample_id:
         project_id: int = project_name_to_id[sample.project]
         sample_object: stats_models.Sample = create_sample(
-            manager=manager, sample_id=sample.sample_id, barcode=barcode, project_id=project_id,
+            manager=manager,
+            sample_id=sample.sample_id,
+            barcode=barcode,
+            project_id=project_id,
         )
         sample_id: int = sample_object.sample_id
     return sample_id
@@ -229,7 +232,8 @@ def _create_dragen_samples(
     tables in cgstats for samples demultiplexed with Dragen"""
 
     demux_samples: Dict[int, dict] = get_dragen_demux_samples(
-        demux_results=demux_results, sample_sheet=sample_sheet,
+        demux_results=demux_results,
+        sample_sheet=sample_sheet,
     )
 
     sample: NovaSeqSample
@@ -285,7 +289,10 @@ def _create_bcl2fastq_samples(
         if not unaligned_id:
             demux_sample: DemuxSample = demux_samples[sample.lane][sample.sample_id]
             create_unaligned(
-                manager=manager, demux_sample=demux_sample, sample_id=sample_id, demux_id=demux_id,
+                manager=manager,
+                demux_sample=demux_sample,
+                sample_id=sample_id,
+                demux_id=demux_id,
             )
 
 

--- a/cg/apps/cgstats/crud/create.py
+++ b/cg/apps/cgstats/crud/create.py
@@ -154,16 +154,22 @@ def create_dragen_unaligned(
 
 def _calculate_perfect_indexreads_pct(demux_sample: DragenDemuxSample) -> float:
     """calculates the percentage of perfect index reads"""
-    return round(demux_sample.perfect_reads / demux_sample.reads * 100, 2) if demux_sample.reads else 0
+    return (
+        round(demux_sample.perfect_reads / demux_sample.reads * 100, 2) if demux_sample.reads else 0
+    )
 
 
 def _calculate_q30_bases_pct(demux_sample: DragenDemuxSample) -> float:
     """calculates the percentage of bases with a sequencing quality score of 30 or over"""
-    return round(
-        demux_sample.pass_filter_q30
-        / (demux_sample.r1_sample_bases + demux_sample.r2_sample_bases)
-        * 100,
-        2,
+    return (
+        round(
+            demux_sample.pass_filter_q30
+            / (demux_sample.r1_sample_bases + demux_sample.r2_sample_bases)
+            * 100,
+            2,
+        )
+        if demux_sample.r1_sample_bases + demux_sample.r2_sample_bases
+        else 0
     )
 
 
@@ -206,10 +212,7 @@ def _create_samples(
     if not sample_id:
         project_id: int = project_name_to_id[sample.project]
         sample_object: stats_models.Sample = create_sample(
-            manager=manager,
-            sample_id=sample.sample_id,
-            barcode=barcode,
-            project_id=project_id,
+            manager=manager, sample_id=sample.sample_id, barcode=barcode, project_id=project_id,
         )
         sample_id: int = sample_object.sample_id
     return sample_id
@@ -226,8 +229,7 @@ def _create_dragen_samples(
     tables in cgstats for samples demultiplexed with Dragen"""
 
     demux_samples: Dict[int, dict] = get_dragen_demux_samples(
-        demux_results=demux_results,
-        sample_sheet=sample_sheet,
+        demux_results=demux_results, sample_sheet=sample_sheet,
     )
 
     sample: NovaSeqSample
@@ -283,10 +285,7 @@ def _create_bcl2fastq_samples(
         if not unaligned_id:
             demux_sample: DemuxSample = demux_samples[sample.lane][sample.sample_id]
             create_unaligned(
-                manager=manager,
-                demux_sample=demux_sample,
-                sample_id=sample_id,
-                demux_id=demux_id,
+                manager=manager, demux_sample=demux_sample, sample_id=sample_id, demux_id=demux_id,
             )
 
 

--- a/cg/apps/cgstats/crud/create.py
+++ b/cg/apps/cgstats/crud/create.py
@@ -154,7 +154,7 @@ def create_dragen_unaligned(
 
 def _calculate_perfect_indexreads_pct(demux_sample: DragenDemuxSample) -> float:
     """calculates the percentage of perfect index reads"""
-    return round(demux_sample.perfect_reads / demux_sample.reads * 100, 2)
+    return round(demux_sample.perfect_reads / demux_sample.reads * 100, 2) if demux_sample.reads else 0
 
 
 def _calculate_q30_bases_pct(demux_sample: DragenDemuxSample) -> float:


### PR DESCRIPTION
## Description

Dragen demux post processing fails if a sample has zero reads

- Division by zero error in case of zero reads


### How to prepare for test
- [x] ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
#### Prepare test data
`rsync -av --exclude Data --exclude InterOp --exclude Logs /home/proj/production/flowcells/novaseq/runs/210901_A00187_0566_AH235WDSX2 /home/proj/stage/flowcells/novaseq/runs/`
`rsync -av --exclude *fastq* /home/proj/production/demultiplexed-runs/210901_A00187_0566_AH235WDSX2 /home/proj/stage/demultiplexed-runs/`

Open `/home/proj/stage/demultiplexed-runs/210901_A00187_0566_AH235WDSX2/Unaligned/Reports/Demultiplex_Stats.csv`
Set `# reads` and `# perfect reads` of sample `ACC8341A4` to `0`

Open `/home/proj/stage/demultiplexed-runs/210901_A00187_0566_AH235WDSX2/Unaligned/Reports/Adapter_Metrics.csv` and set `R1_SampleBases`, `R2_SampleBases` and `# Reads` for sample  `ACC8341A4` to `0`

REMOVE UNALIGNED OBJECT FROM CGSTATS!

### Execute CLI command
`cg demultiplex finish flowcell -b dragen 210901_A00187_0566_AH235WDSX2 --dry-run --force`

### Expected test outcome
- [x] check that there's no more division by zero error
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [x] tests executed by @barrystokman 
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
