### PR TITLE
Include DRAGEN sample sheets in Housekeeper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ __________ DO NOT TOUCH ___________
 ### Fixed
 
 __________ DO NOT TOUCH ___________ -->
+## [22.19.3]
+### Fixed
+- include dragen samplesheet in HK
+
 ## [22.19.2]
 ### Fixed
 - error in post demux process 

--- a/cg/models/demultiplex/demux_results.py
+++ b/cg/models/demultiplex/demux_results.py
@@ -126,17 +126,7 @@ class DemuxResults:
     @property
     def demux_sample_sheet_path(self) -> Path:
         """Return the path to sample sheet in demuxed flowcell dir"""
-        demux_sample_sheet_path = {
-            "bcl2fastq": self.bcl2fastq_demux_sheet_path,
-            "dragen": self.dragen_demux_sheet_path,
-        }
-        return demux_sample_sheet_path[self.bcl_converter]()
-
-    def bcl2fastq_demux_sheet_path(self) -> Path:
         return self.results_dir / self.flowcell.sample_sheet_path.name
-
-    def dragen_demux_sheet_path(self) -> Path:
-        return self.results_dir / "Reports" / self.flowcell.sample_sheet_path.name
 
     @property
     def copy_complete_path(self) -> Path:

--- a/tests/meta/transfer/test_meta_transfer_flowcell.py
+++ b/tests/meta/transfer/test_meta_transfer_flowcell.py
@@ -4,8 +4,9 @@ import warnings
 from pathlib import Path
 
 import mock
-from cg.store import Store
 from sqlalchemy import exc as sa_exc
+
+from cg.store import Store
 
 
 @mock.patch("pathlib.Path.exists")
@@ -48,3 +49,24 @@ def test_transfer_flowcell(
 
     for hk_file in hk_bundle.versions[0].files:
         assert hk_file.path.endswith("fastq.gz") or hk_file.path.endswith("csv")
+
+
+def test_sample_sheet_path_bcl2fastq():
+    # GIVEN a bcl2fastq demultiplexed flowcell
+    # WHEN constructing the path to the sample sheet to be stored
+    # THEN the correct path should be returned
+    pass
+
+
+def test_sample_sheet_path_dragen():
+    # GIVEN a DRAGEN demultiplexed flowcell
+    # WHEN constructing the path to the sample sheet to be stored
+    # THEN the correct path should be returned
+    pass
+
+
+def test_sample_sheet_path_not_found():
+    # GIVEN any demultiplexed flowcell
+    # WHEN neither a bcl2fastq nor a dragen sample sheet is found
+    # THEN an exception should be raised
+    pass

--- a/tests/meta/transfer/test_meta_transfer_flowcell.py
+++ b/tests/meta/transfer/test_meta_transfer_flowcell.py
@@ -49,24 +49,3 @@ def test_transfer_flowcell(
 
     for hk_file in hk_bundle.versions[0].files:
         assert hk_file.path.endswith("fastq.gz") or hk_file.path.endswith("csv")
-
-
-def test_sample_sheet_path_bcl2fastq():
-    # GIVEN a bcl2fastq demultiplexed flowcell
-    # WHEN constructing the path to the sample sheet to be stored
-    # THEN the correct path should be returned
-    pass
-
-
-def test_sample_sheet_path_dragen():
-    # GIVEN a DRAGEN demultiplexed flowcell
-    # WHEN constructing the path to the sample sheet to be stored
-    # THEN the correct path should be returned
-    pass
-
-
-def test_sample_sheet_path_not_found():
-    # GIVEN any demultiplexed flowcell
-    # WHEN neither a bcl2fastq nor a dragen sample sheet is found
-    # THEN an exception should be raised
-    pass


### PR DESCRIPTION
## Description

Samplesheet was not included in HK. This PR fixes that.

### Fixed

- change copy destination of dragen samplesheet in post demux processing so `cg transfer flowcell <flowcell_id>` can include the samplesheet in HK.


### How to prepare for test
- [x] ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [x] `cg demultiplex flowcell -b dragen 210903_A00187_0568_BH233MDSX2`
- [x]  `cg demultiplex finish flowcell -b dragen 210903_A00187_0568_BH233MDSX2`
- [x]  `cg transfer flowcell H233MDSX2`
- [x] `housekeeper get file -t H233MDSX2 -t samplesheet`

### Expected test outcome
- [x] check that there is a samplesheet in `/home/proj/stage/demultiplexed-runs/210903_A00187_0568_BH233MDSX2/Unaligned`
- [x] check there's a samplesheet for this flowcell in HK
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [x] tests executed by @barrystokman 
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
