### PR TITLE
Fix(Ordering): Join synopsis list before processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ __________ DO NOT TOUCH ___________
 
 __________ DO NOT TOUCH ___________ -->
 
+## [22.21.1]
+### Fixed
+- Accept synopsis both as list and as string in ordering json
 
 ## [22.21.0]
 ### Fixed

--- a/cg/models/orders/json_sample.py
+++ b/cg/models/orders/json_sample.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Any
 
 from cg.constants import DataDelivery, Pipeline
 from cg.models.orders.sample_base import OrderSample
@@ -15,6 +15,12 @@ class JsonSample(OrderSample):
     quantity: Optional[str]
     synopsis: Optional[str]
     well_position: Optional[constr(regex=r"[A-H]:[0-9]+")]
+
+    @validator("synopsis", pre=True)
+    def join_list(cls, value: Any):
+        if isinstance(value, list):
+            return "".join(value)
+        return value
 
     @validator("priority", pre=True)
     def make_lower(cls, value: str):

--- a/tests/fixtures/orderforms/mip-json.json
+++ b/tests/fixtures/orderforms/mip-json.json
@@ -32,7 +32,7 @@
       "source": "other",
       "status": "affected",
       "subject_id": "2020-12345-67",
-      "synopsis": "",
+      "synopsis": [""],
       "volume": "1",
       "well_position": ""
     },
@@ -65,7 +65,7 @@
       "source": "blood",
       "status": "affected",
       "subject_id": "2020-56789-10",
-      "synopsis": "",
+      "synopsis": [""],
       "volume": "1",
       "well_position": ""
     },
@@ -98,7 +98,7 @@
       "source": "blood",
       "status": "affected",
       "subject_id": "2020-89101-11",
-      "synopsis": "",
+      "synopsis": [""],
       "volume": "1",
       "well_position": ""
     },
@@ -131,7 +131,7 @@
       "source": "other",
       "status": "affected",
       "subject_id": "2020-12131-41",
-      "synopsis": "",
+      "synopsis": [""],
       "volume": "1",
       "well_position": ""
     },
@@ -165,7 +165,7 @@
       "source": "blood",
       "status": "affected",
       "subject_id": "2020-16171-81",
-      "synopsis": "H\u00e4r kommer det att komma en v\u00e4ldigt l\u00e5ng text med f\u00f6r synopsis.",
+      "synopsis": ["H\u00e4r kommer det att komma en v\u00e4ldigt l\u00e5ng text med f\u00f6r synopsis."],
       "volume": "1",
       "well_position": "A1"
     },
@@ -198,7 +198,7 @@
       "source": "blood",
       "status": "affected",
       "subject_id": "2020-20212-22",
-      "synopsis": "H\u00e4r kommer det att komma en v\u00e4ldigt l\u00e5ng text med f\u00f6r synopsis.",
+      "synopsis": ["H\u00e4r kommer det att komma en v\u00e4ldigt l\u00e5ng text med f\u00f6r synopsis."],
       "volume": "1",
       "well_position": ""
     },
@@ -231,7 +231,7 @@
       "source": "other",
       "status": "affected",
       "subject_id": "2020-20212-22",
-      "synopsis": "",
+      "synopsis": [""],
       "volume": "1",
       "well_position": ""
     },
@@ -264,7 +264,7 @@
       "source": "other",
       "status": "affected",
       "subject_id": "2020-24252-62",
-      "synopsis": "",
+      "synopsis": [""],
       "volume": "1",
       "well_position": ""
     }


### PR DESCRIPTION
## Description

### Fixed
- Synopsis can now be either a list or a string


### How to prepare for test
- [x] ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test as list
- [x] do submit order with synopsis as a list

### Expected test outcome
- [x] check that the order has saved the synopsis as a string

### How to test as string
- [x] do submit order with synopsis as a string

### Expected test outcome
- [x] check that the order has saved the synopsis as a string

- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [x] code approved by @barrystokman 
- [x] tests executed by PG
- [x] "Merge and deploy" approved by @barrystokman 
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [x] Document in changelog
- [ ] Deploy this branch
- [ ] Inform to AG, DN, customer
