### PR TITLE
Fix different synopsis

### DIFF
--- a/cg/meta/orders/status.py
+++ b/cg/meta/orders/status.py
@@ -161,7 +161,7 @@ class StatusHandler:
                 cohort for sample in case_samples for cohort in sample.get("cohorts", []) if cohort
             }
 
-            synopsis = cls.get_single_value(case_name, case_samples, "synopsis")
+            synopsis = cls.get_single_value(case_name, case_samples, "synopsis", value_default='')
             case_internal_id: str = cls.get_single_value(
                 case_name, case_samples, "case_internal_id"
             )

--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -365,7 +365,7 @@ def orderform():
             json_data = json.load(input_file.stream)
             order_parser = JsonOrderformParser()
             order_parser.parse_orderform(order_data=json_data)
-    except (OrderFormError, ValidationError, AttributeError) as error:
+    except (OrderFormError, ValidationError, AttributeError, ValueError) as error:
         if hasattr(error, "message"):
             message = error.message
         else:

--- a/tests/fixtures/orderforms/mip-json.json
+++ b/tests/fixtures/orderforms/mip-json.json
@@ -29,10 +29,10 @@
       "quantity": "200",
       "require_qcok": false,
       "sex": "male",
-      "source": "other",
+      "source": "blood",
       "status": "affected",
       "subject_id": "2020-12345-67",
-      "synopsis": [""],
+      "synopsis": [],
       "volume": "1",
       "well_position": ""
     },
@@ -65,7 +65,7 @@
       "source": "blood",
       "status": "affected",
       "subject_id": "2020-56789-10",
-      "synopsis": [""],
+      "synopsis": "",
       "volume": "1",
       "well_position": ""
     },
@@ -128,10 +128,10 @@
       "quantity": "200",
       "require_qcok": false,
       "sex": "male",
-      "source": "other",
+      "source": "blood",
       "status": "affected",
       "subject_id": "2020-12131-41",
-      "synopsis": [""],
+      "synopsis": "",
       "volume": "1",
       "well_position": ""
     },
@@ -228,10 +228,10 @@
       "quantity": "200",
       "require_qcok": false,
       "sex": "male",
-      "source": "other",
+      "source": "blood",
       "status": "affected",
       "subject_id": "2020-20212-22",
-      "synopsis": [""],
+      "synopsis": "",
       "volume": "1",
       "well_position": ""
     },
@@ -261,14 +261,12 @@
       "quantity": "200",
       "require_qcok": false,
       "sex": "male",
-      "source": "other",
+      "source": "blood",
       "status": "affected",
       "subject_id": "2020-24252-62",
-      "synopsis": [""],
+      "synopsis": "",
       "volume": "1",
       "well_position": ""
     }
   ]
 }
-
-


### PR DESCRIPTION
## Description

### Fixed

- Avoid situation where None and '' is deemed different values of synopsis when using existing samples


### How to prepare for test
- [ ] ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] paxa the environment: `paxa`
- [ ] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] do create an order
- [ ] add new sample
- [ ] add existing sample

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
