### PR TITLE
adding median_target_coverage to pydantic model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ __________ DO NOT TOUCH ___________
 
 __________ DO NOT TOUCH ___________ -->
 
+## [22.22.3]
+### Added
+- Added median target coverage to mip:s pydantic model
+
 ## [22.22.2]
 ### Fixed
 - Synopsis from old and new samples are combined

--- a/tests/fixtures/apps/mip/case_metrics_deliverables.yaml
+++ b/tests/fixtures/apps/mip/case_metrics_deliverables.yaml
@@ -108,3 +108,21 @@ metrics:
     name: MEAN_INSERT_SIZE
     step: collectmultiplemetricsinsertsize
     value: '415.673545'
+  - header: data
+    id: ADM1
+    input: ADM1_lanes_1_sorted_md_collecthsmetrics
+    name: MEDIAN_TARGET_COVERAGE
+    step: collecthsmetrics
+    value: '29'
+  - header: data
+    id: ADM2
+    input: ADM2_lanes_1_sorted_md_collecthsmetrics
+    name: MEDIAN_TARGET_COVERAGE
+    step: collecthsmetrics
+    value: '28'
+  - header: data
+    id: ADM3
+    input: ADM3_lanes_1_sorted_md_collecthsmetrics
+    name: MEDIAN_TARGET_COVERAGE
+    step: collecthsmetrics
+    value: '28'

--- a/tests/models/mip/conftest.py
+++ b/tests/models/mip/conftest.py
@@ -156,6 +156,20 @@ def fixture_mip_metrics_deliverables_raw() -> dict:
             {
                 "id": "an_id",
                 "input": "some_input",
+                "name": "MEDIAN_TARGET_COVERAGE",
+                "step": "collecthsmetrics",
+                "value": "29",
+            },
+            {
+                "id": "another_id",
+                "input": "some_input",
+                "name": "MEDIAN_TARGET_COVERAGE",
+                "step": "collecthsmetrics",
+                "value": "28",
+            },
+            {
+                "id": "an_id",
+                "input": "some_input",
                 "name": "gender",
                 "step": "chanjo_sexcheck",
                 "value": "female",

--- a/tests/models/mip/test_mip_metrics_deliverables.py
+++ b/tests/models/mip/test_mip_metrics_deliverables.py
@@ -115,8 +115,8 @@ def test_mip_metrics_set_meadian_target_coverage(mip_metrics_deliverables_raw: d
 
     # THEN assert that it was successfully created
     assert isinstance(median_target_coverage, MedianTargetCoverage)
-    
-    
+
+
 def test_mip_metrics_set_predicted_sex(mip_metrics_deliverables_raw: dict):
     """
     Tests set predicted sex

--- a/tests/models/mip/test_mip_metrics_deliverables.py
+++ b/tests/models/mip/test_mip_metrics_deliverables.py
@@ -1,12 +1,13 @@
 """Test MIP metrics deliverables"""
 
 from cg.models.mip.mip_metrics_deliverables import (
-    MetricsDeliverables,
     DuplicateReads,
-    ParsedMetrics,
     GenderCheck,
-    MeanInsertSize,
     MappedReads,
+    MeanInsertSize,
+    MedianTargetCoverage,
+    MetricsDeliverables,
+    ParsedMetrics,
     get_sample_id_metric,
 )
 
@@ -82,7 +83,7 @@ def test_mip_metrics_set_mapped_reads(mip_metrics_deliverables_raw: dict):
 
 def test_mip_metrics_set_mean_insert_size(mip_metrics_deliverables_raw: dict):
     """
-    Tests set predicted sex
+    Tests set mean insert size
     """
     # GIVEN a dictionary with the some metrics
 
@@ -98,6 +99,24 @@ def test_mip_metrics_set_mean_insert_size(mip_metrics_deliverables_raw: dict):
     assert isinstance(mean_insert_size, MeanInsertSize)
 
 
+def test_mip_metrics_set_meadian_target_coverage(mip_metrics_deliverables_raw: dict):
+    """
+    Tests set median target coverage
+    """
+    # GIVEN a dictionary with the some metrics
+
+    # WHEN instantiating a MetricsDeliverables object
+    metrics_object = MetricsDeliverables(**mip_metrics_deliverables_raw)
+
+    # THEN assert that mean insert size was set
+    assert metrics_object.median_target_coverage
+
+    median_target_coverage: MedianTargetCoverage = metrics_object.median_target_coverage.pop()
+
+    # THEN assert that it was successfully created
+    assert isinstance(median_target_coverage, MedianTargetCoverage)
+    
+    
 def test_mip_metrics_set_predicted_sex(mip_metrics_deliverables_raw: dict):
     """
     Tests set predicted sex


### PR DESCRIPTION
## Description

### Added

- target_medain_coverage from mip qc deliverables file to pydantic model


### How to prepare for test
- [ ] ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] paxa the environment: `paxa`
- [ ] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh mip_qc_value`

### How to test
- [ ] Try to upload a delivery report

### Expected test outcome
- [ ] check that a delivery report is generated 
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
