### PR TITLE
Support Fluffy 2.0.0

### DIFF
--- a/cg/meta/workflow/fluffy.py
+++ b/cg/meta/workflow/fluffy.py
@@ -221,7 +221,7 @@ class FluffyAnalysisAPI(AnalysisAPI):
             self.get_workdir_path(case_id=case_id).as_posix(),
             "--out",
             self.get_output_path(case_id=case_id).as_posix(),
-            "analyse",
+            "--analyse",
             "--batch-ref",
         ]
         self.process.run_command(command_args, dry_run=dry_run)


### PR DESCRIPTION
## Description
In Fluffy 2.0.0, the analysis mode is sepcified by --analysis or --reference, instead of analysis or reference (Fluffy c< 1.4.0)
### Added

--analysis

### Changed

fluffy cg command

### Fixed

fluffy cg command


### How to prepare for test
- [ ] ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] paxa the environment: `paxa`
- [ ] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
