### PR TITLE
Fix(ordering): handle None as synopsis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ __________ DO NOT TOUCH ___________
 
 __________ DO NOT TOUCH ___________ -->
 
+
+## [22.22.4]
+### Fixed
+- Handle empty values for synopsis in excel orders
+
 ## [22.22.3]
 ### Fixed
 - Add proxy-protocol to dockerfile

--- a/cg/meta/orders/status.py
+++ b/cg/meta/orders/status.py
@@ -160,7 +160,8 @@ class StatusHandler:
             cohorts: Set[str] = {
                 cohort for sample in case_samples for cohort in sample.get("cohorts", []) if cohort
             }
-            synopsis: str = ", ".join(set(sample.get("synopsis", "") for sample in case_samples))
+            synopsis: str = ", ".join(set(sample.get("synopsis") or "" for sample in case_samples))
+
             case_internal_id: str = cls.get_single_value(
                 case_name, case_samples, "case_internal_id"
             )

--- a/tests/meta/orders/test_meta_orders_status.py
+++ b/tests/meta/orders/test_meta_orders_status.py
@@ -123,10 +123,13 @@ def test_sarscov2_samples_to_status(sarscov2_order_to_submit):
     assert sample_data["volume"] == "1"
 
 
-def test_families_to_status(mip_order_to_submit):
+def test_cases_to_status(mip_order_to_submit):
+
     # GIVEN a scout order with a trio case
+
     # WHEN parsing for status
     data = StatusHandler.cases_to_status(mip_order_to_submit)
+
     # THEN it should pick out the case
     assert len(data["families"]) == 2
     family = data["families"][0]
@@ -153,6 +156,17 @@ def test_families_to_status(mip_order_to_submit):
 
     # ... second sample has a comment
     assert isinstance(family["samples"][1]["comment"], str)
+
+
+def test_cases_to_status_synopsis(mip_order_to_submit):
+    # GIVEN a scout order with a trio case where synopsis is None
+    for sample in mip_order_to_submit["samples"]:
+        sample["synopsis"] = None
+
+    # WHEN parsing for status
+    StatusHandler.cases_to_status(mip_order_to_submit)
+
+    # THEN No exception should have been raised on synopsis
 
 
 def test_store_rml(orders_api, base_store, rml_status_data):


### PR DESCRIPTION
## Description

### Fixed
- Handle None value for synopsis without crashing


### How to prepare for test
- [x] ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [x] do create an order from excel
- [x] make sure not to do anything with the synopsis field in the order
- [x] submit

### Expected test outcome
- [x] check that the order is processed ok
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [x] code approved by MR
- [x] tests executed by PG
- [x] "Merge and deploy" approved by PG
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [x] Document in changelog
- [ ] Deploy this branch
- [ ] Inform to AG
