### PR TITLE
Always get new certs on request to cg api

### DIFF
--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -7,6 +7,7 @@ from json import JSONDecodeError
 from pathlib import Path
 from typing import List, Optional
 
+import requests
 from pymysql import IntegrityError
 from urllib3.exceptions import MaxRetryError, NewConnectionError
 
@@ -60,7 +61,9 @@ def before_request():
 
     jwt_token = auth_header.split("Bearer ")[-1]
     try:
-        user_data = jwt.decode(jwt_token, certs=current_app.config["GOOGLE_OAUTH_CERTS"])
+        user_data = jwt.decode(
+            jwt_token, certs=requests.get("https://www.googleapis.com/oauth2/v1/certs").json()
+        )
     except ValueError:
         return abort(
             make_response(


### PR DESCRIPTION
## Description

### Changed
- New certs are fetched before requests



### How to prepare for test
- [ ] ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] paxa the environment: `paxa`
- [ ] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
