### PR TITLE
Re-use upload gisaid log between bundles

### DIFF
--- a/cg/apps/housekeeper/hk.py
+++ b/cg/apps/housekeeper/hk.py
@@ -128,9 +128,7 @@ class HousekeeperAPI:
         """Wrap property in Housekeeper Store"""
         return self._store.session.no_autoflush
 
-    def get_files(
-        self, bundle: str, tags: Optional[list], version: Optional[int] = None
-    ) -> Query[models.File]:
+    def get_files(self, bundle: str, tags: Optional[list], version: Optional[int] = None) -> Query:
         """Fetch all the files in housekeeper, optionally filtered by bundle and/or tags and/or
         version
 

--- a/cg/apps/housekeeper/hk.py
+++ b/cg/apps/housekeeper/hk.py
@@ -130,7 +130,7 @@ class HousekeeperAPI:
 
     def get_files(
         self, bundle: str, tags: Optional[list], version: Optional[int] = None
-    ) -> Iterable[models.File]:
+    ) -> Query[models.File]:
         """Fetch all the files in housekeeper, optionally filtered by bundle and/or tags and/or
         version
 

--- a/cg/constants/constants.py
+++ b/cg/constants/constants.py
@@ -54,4 +54,4 @@ SEX_OPTIONS = ("male", "female", "unknown")
 STATUS_OPTIONS = ("affected", "unaffected", "unknown")
 ANALYSIS_TYPES = ["tumor_wgs", "tumor_normal_wgs", "tumor_panel", "tumor_normal_panel"]
 
-SARS_COV_REGEX = "\(|\)|\d{2}CS\(|\)|\d{6}"
+SARS_COV_REGEX = "^\d{2}CS\d{6}"

--- a/cg/constants/constants.py
+++ b/cg/constants/constants.py
@@ -53,3 +53,5 @@ SEX_OPTIONS = ("male", "female", "unknown")
 
 STATUS_OPTIONS = ("affected", "unaffected", "unknown")
 ANALYSIS_TYPES = ["tumor_wgs", "tumor_normal_wgs", "tumor_panel", "tumor_normal_panel"]
+
+SARS_COV_REGEX = "\(|\)|\d{2}CS\(|\)|\d{6}"

--- a/cg/meta/upload/fohm/fohm.py
+++ b/cg/meta/upload/fohm/fohm.py
@@ -9,6 +9,7 @@ import pandas as pd
 
 from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.apps.lims import LimsAPI
+from cg.constants.constants import SARS_COV_REGEX
 from cg.exc import CgError
 from cg.models.cg_config import CGConfig
 from cg.models.email import EmailInfo
@@ -73,7 +74,7 @@ class FOHMUploadAPI:
             ).sort_values(by=["provnummer"])
             self._reports_dataframe.drop_duplicates(inplace=True)
             self._reports_dataframe = self._reports_dataframe[
-                self._reports_dataframe["provnummer"].str.contains("21CS\(|\)|\d{6}")
+                self._reports_dataframe["provnummer"].str.contains(SARS_COV_REGEX)
             ]
         return self._reports_dataframe
 
@@ -86,7 +87,7 @@ class FOHMUploadAPI:
             ).sort_values(by=["taxon"])
             self._pangolin_dataframe.drop_duplicates(inplace=True)
             self._pangolin_dataframe = self.pangolin_dataframe[
-                self._pangolin_dataframe["taxon"].str.contains("21CS\(|\)|\d{6}")
+                self._pangolin_dataframe["taxon"].str.contains(SARS_COV_REGEX)
             ]
         return self._pangolin_dataframe
 

--- a/cg/meta/upload/gisaid/gisaid.py
+++ b/cg/meta/upload/gisaid/gisaid.py
@@ -179,7 +179,7 @@ class GisaidAPI:
             bundle=case_id, tags=["gisaid-log", case_id]
         ).first()
         if gisaid_log_file:
-            LOG.info("GISAID log exists in latest bundle in Housekeeper")
+            LOG.info("GISAID log exists in case bundle in Housekeeper")
             return
 
         log_file_path = Path(self.gisaid_log_dir, case_id).with_suffix(".log")


### PR DESCRIPTION
## Description
Enable continuing to uplaod to gisaid when a batch is re-run

### Changed

- GISAID upload API will find and re-use the gisaid upload log file from older versions
- Update regex



### How to prepare for test
- [ ] ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] paxa the environment: `paxa`
- [ ] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
