### PR TITLE
Adding control to udf list

### DIFF
--- a/cg/constants/lims.py
+++ b/cg/constants/lims.py
@@ -4,7 +4,7 @@ PROP2UDF = {
     "capture_kit": "Capture Library version",
     "collection_date": "Collection Date",
     "comment": "Comment",
-    "control": "control",
+    "control": "Control",
     "concentration": "Concentration (nM)",
     "concentration_sample": "Sample Conc.",
     "customer": "customer",

--- a/cg/constants/lims.py
+++ b/cg/constants/lims.py
@@ -4,6 +4,7 @@ PROP2UDF = {
     "capture_kit": "Capture Library version",
     "collection_date": "Collection Date",
     "comment": "Comment",
+    "control": "control",
     "concentration": "Concentration (nM)",
     "concentration_sample": "Sample Conc.",
     "customer": "customer",

--- a/cg/models/lims/sample.py
+++ b/cg/models/lims/sample.py
@@ -15,6 +15,7 @@ class Udf(BaseModel):
     concentration: Optional[str]
     concentration_sample: Optional[str]
     customer: str
+    control: Optional[str]
     data_analysis: Optional[str]
     data_delivery: Optional[str]
     elution_buffer: Optional[str]

--- a/tests/fixtures/cgweb_orders/rml.json
+++ b/tests/fixtures/cgweb_orders/rml.json
@@ -4,7 +4,7 @@
   "comment": "order comment",
   "samples": [
     {
-      "application": "RMLP05R800",
+      "application": "RMLS05R150",
       "comment": "test comment",
       "concentration": "5",
       "concentration_sample": "6",
@@ -20,7 +20,7 @@
       "volume": "30"
     },
     {
-      "application": "RMLP05R800",
+      "application": "RMLS05R150",
       "comment": "",
       "concentration": "5",
       "concentration_sample": "6",
@@ -38,7 +38,7 @@
       "well_position_rml": ""
     },
     {
-      "application": "RMLP05R800",
+      "application": "RMLS05R150",
       "comment": "test comment",
       "concentration": "5",
       "concentration_sample": "6",
@@ -56,7 +56,7 @@
       "well_position_rml": "A:1"
     },
     {
-      "application": "RMLP05R800",
+      "application": "RMLS05R150",
       "comment": "",
       "concentration": "5",
       "concentration_sample": "6",

--- a/tests/fixtures/cgweb_orders/rml.json
+++ b/tests/fixtures/cgweb_orders/rml.json
@@ -4,7 +4,7 @@
   "comment": "order comment",
   "samples": [
     {
-      "application": "RMLS05R150",
+      "application": "RMLP05R800",
       "comment": "test comment",
       "concentration": "5",
       "concentration_sample": "6",
@@ -20,7 +20,7 @@
       "volume": "30"
     },
     {
-      "application": "RMLS05R150",
+      "application": "RMLP05R800",
       "comment": "",
       "concentration": "5",
       "concentration_sample": "6",
@@ -38,7 +38,7 @@
       "well_position_rml": ""
     },
     {
-      "application": "RMLS05R150",
+      "application": "RMLP05R800",
       "comment": "test comment",
       "concentration": "5",
       "concentration_sample": "6",
@@ -56,7 +56,7 @@
       "well_position_rml": "A:1"
     },
     {
-      "application": "RMLS05R150",
+      "application": "RMLP05R800",
       "comment": "",
       "concentration": "5",
       "concentration_sample": "6",


### PR DESCRIPTION
## Description
Contol is set in NIPT orders and should also be propagated to lims. The udf control has ben added to sample level in lims


### Added
- Control field in list of UDFs to set when creating a order.

## Review
- [ ] code approved by
- [x] tests executed by @mayabrandi 
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
