### PR TITLE
Fix(ordering): accept optional empty/missing numerical values in json

### DIFF
--- a/cg/models/orders/samples.py
+++ b/cg/models/orders/samples.py
@@ -105,9 +105,9 @@ class Of1508Sample(OrderInSample):
     ]
     synopsis: Optional[str]
 
-    @validator("tumour_purity", "formalin_fixation_time", "post_formalin_fixation_time", pre=True)
+    @validator("tumour_purity", "formalin_fixation_time", "post_formalin_fixation_time", "quantity", pre=True)
     def str_to_int(cls, v: str) -> Optional[int]:
-        if not v:
+        if v in (None, ""):
             return None
         return int(v)
 

--- a/cg/models/orders/samples.py
+++ b/cg/models/orders/samples.py
@@ -121,7 +121,13 @@ class Of1508Sample(OrderInSample):
     ]
     synopsis: Optional[str]
 
-    @validator("tumour_purity", "formalin_fixation_time", "post_formalin_fixation_time", "quantity", pre=True)
+    @validator(
+        "tumour_purity",
+        "formalin_fixation_time",
+        "post_formalin_fixation_time",
+        "quantity",
+        pre=True,
+    )
     def str_to_int(cls, v: str) -> Optional[int]:
         return OptionalIntValidator.str_to_int(v=v)
 

--- a/cg/models/orders/samples.py
+++ b/cg/models/orders/samples.py
@@ -16,6 +16,22 @@ from cg.models.orders.sample_base import (
 from cg.store import models
 
 
+class OptionalIntValidator:
+    @classmethod
+    def str_to_int(cls, v: str) -> Optional[int]:
+        if v in (None, ""):
+            return None
+        return int(v)
+
+
+class OptionalFloatValidator:
+    @classmethod
+    def str_to_float(cls, v: str) -> Optional[float]:
+        if v in (None, ""):
+            return None
+        return float(v)
+
+
 class OrderInSample(BaseModel):
     _suitable_project: OrderType = None
     application: constr(max_length=models.Application.tag.property.columns[0].type.length)
@@ -107,9 +123,7 @@ class Of1508Sample(OrderInSample):
 
     @validator("tumour_purity", "formalin_fixation_time", "post_formalin_fixation_time", "quantity", pre=True)
     def str_to_int(cls, v: str) -> Optional[int]:
-        if v in (None, ""):
-            return None
-        return int(v)
+        return OptionalIntValidator.str_to_int(v=v)
 
 
 class MipDnaSample(Of1508Sample):
@@ -144,6 +158,10 @@ class FastqSample(OrderInSample):
     # "Not Required"
     quantity: Optional[int]
 
+    @validator("quantity", pre=True)
+    def str_to_int(cls, v: str) -> Optional[int]:
+        return OptionalIntValidator.str_to_int(v=v)
+
 
 class RmlSample(OrderInSample):
     _suitable_project = OrderType.RML
@@ -163,6 +181,10 @@ class RmlSample(OrderInSample):
     index_sequence: Optional[str]
     # "Not required"
     control: Optional[str]
+
+    @validator("concentration_sample", pre=True)
+    def str_to_float(cls, v: str) -> Optional[float]:
+        return OptionalFloatValidator.str_to_float(v=v)
 
 
 class FluffySample(RmlSample):
@@ -186,6 +208,14 @@ class MetagenomeSample(OrderInSample):
     quantity: Optional[int]
     extraction_method: Optional[str]
 
+    @validator("quantity", pre=True)
+    def str_to_int(cls, v: str) -> Optional[int]:
+        return OptionalIntValidator.str_to_int(v=v)
+
+    @validator("concentration_sample", pre=True)
+    def str_to_float(cls, v: str) -> Optional[float]:
+        return OptionalFloatValidator.str_to_float(v=v)
+
 
 class MicrobialSample(OrderInSample):
 
@@ -207,6 +237,14 @@ class MicrobialSample(OrderInSample):
     concentration_sample: Optional[float]
     quantity: Optional[int]
     verified_organism: Optional[bool]  # sent to LIMS
+
+    @validator("quantity", pre=True)
+    def str_to_int(cls, v: str) -> Optional[int]:
+        return OptionalIntValidator.str_to_int(v=v)
+
+    @validator("concentration_sample", pre=True)
+    def str_to_float(cls, v: str) -> Optional[float]:
+        return OptionalFloatValidator.str_to_float(v=v)
 
 
 class MicrosaltSample(MicrobialSample):

--- a/tests/meta/orders/conftest.py
+++ b/tests/meta/orders/conftest.py
@@ -23,6 +23,7 @@ def all_orders_to_submit(
     return {
         OrderType.BALSAMIC: OrderIn.parse_obj(balsamic_order_to_submit, project=OrderType.BALSAMIC),
         OrderType.FASTQ: OrderIn.parse_obj(fastq_order_to_submit, project=OrderType.FASTQ),
+        OrderType.FLUFFY: OrderIn.parse_obj(rml_order_to_submit, project=OrderType.RML),
         OrderType.METAGENOME: OrderIn.parse_obj(
             metagenome_order_to_submit, project=OrderType.METAGENOME
         ),

--- a/tests/meta/orders/test_meta_orders_api.py
+++ b/tests/meta/orders/test_meta_orders_api.py
@@ -1,5 +1,4 @@
 import datetime as dt
-from typing import List
 
 import pytest
 from cg.constants import DataDelivery
@@ -17,10 +16,10 @@ PROCESS_LIMS_FUNCTION = "cg.meta.orders.api.process_lims"
 
 
 def test_too_long_order_name():
-    # GIVEN order with more than 64 chars name
+    # GIVEN order with more than allowed characters name
     long_name = "A super long order name that is longer than sixty-four characters."
-    assert len(long_name) > 64
-    assert models.Sample.order.property.columns[0].type.length == 64
+    assert len(long_name) > models.Sample.order.property.columns[0].type.length
+
     # WHEN placing it in the pydantic order model
     # THEN an error is raised
     with pytest.raises(ValueError):
@@ -32,6 +31,7 @@ def test_too_long_order_name():
     [
         OrderType.BALSAMIC,
         OrderType.FASTQ,
+        OrderType.FLUFFY,
         OrderType.METAGENOME,
         OrderType.MICROSALT,
         OrderType.MIP_DNA,


### PR DESCRIPTION
## Description

### Fixed
- Optional numerical values can be empty

### How to prepare for test
- [ ] ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] paxa the environment: `paxa`
- [ ] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] submit an json mip-dna order without quantity specified

### Expected test outcome
- [ ] check that the order is accepted without pydantic errora
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Deploy this branch
- [ ] Inform to MG
