### PR TITLE
Fix(admin): Hide fields not relevant for production

### DIFF
--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -329,10 +329,8 @@ class SampleView(BaseView):
         "from_sample",
         "invoiced_at",
         "loqusdb_id",
-        "organism",
         "_phenotype_groups",
         "_phenotype_terms",
-        "reference_genome",
         "time_point",
     ]
     column_default_sort = ("created_at", True)

--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -194,7 +194,7 @@ class FamilyView(BaseView):
 
     column_default_sort = ("created_at", True)
     column_editable_list = ["action", "comment"]
-    column_exclude_list = ["created_at"]
+    column_exclude_list = ["created_at", "_cohorts", "synopsis", "avatar_url"]
     column_filters = [
         "customer.internal_id",
         "priority",
@@ -208,6 +208,7 @@ class FamilyView(BaseView):
         "avatar_url": _list_thumbnail,
     }
     column_searchable_list = ["internal_id", "name", "customer.internal_id"]
+    form_excluded_columns = ["cohorts", "synopsis"]
     form_extra_fields = {
         "data_analysis": SelectEnumField(enum_class=Pipeline),
         "data_delivery": SelectEnumField(enum_class=DataDelivery),
@@ -323,7 +324,7 @@ class PoolView(BaseView):
 class SampleView(BaseView):
     """Admin view for Model.Sample"""
 
-    column_exclude_list = ["invoiced_at"]
+    column_exclude_list = ["age_at_sampling", "from_sample", "invoiced_at", "loqusdb_id", "organism", "_phenotype_groups", "_phenotype_terms", "reference_genome", "time_point"]
     column_default_sort = ("created_at", True)
     column_editable_list = [
         "sex",
@@ -341,7 +342,7 @@ class SampleView(BaseView):
         "priority": view_human_priority,
     }
     column_searchable_list = ["internal_id", "name", "ticket_number", "customer.internal_id"]
-    form_excluded_columns = ["is_external", "invoiced_at"]
+    form_excluded_columns = ["age_at_sampling", "from_sample", "invoiced_at", "is_external", "_phenotype_groups", "_phenotype_terms", "time_point"]
 
     @staticmethod
     def view_sample_link(unused1, unused2, model, unused3):

--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -208,7 +208,12 @@ class FamilyView(BaseView):
         "avatar_url": _list_thumbnail,
     }
     column_searchable_list = ["internal_id", "name", "customer.internal_id"]
-    form_excluded_columns = ["cohorts", "synopsis"]
+    form_excluded_columns = [
+        "analyses",
+        "_cohorts",
+        "links",
+        "synopsis",
+    ]
     form_extra_fields = {
         "data_analysis": SelectEnumField(enum_class=Pipeline),
         "data_delivery": SelectEnumField(enum_class=DataDelivery),
@@ -349,12 +354,16 @@ class SampleView(BaseView):
     column_searchable_list = ["internal_id", "name", "ticket_number", "customer.internal_id"]
     form_excluded_columns = [
         "age_at_sampling",
-        "from_sample",
+        "deliveries",
+        "father_links",
+        "flowcells",
         "invoiced_at",
+        "invoice",
         "is_external",
         "_phenotype_groups",
         "_phenotype_terms",
-        "time_point",
+        "links",
+        "mother_links",
     ]
 
     @staticmethod

--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -326,12 +326,9 @@ class SampleView(BaseView):
 
     column_exclude_list = [
         "age_at_sampling",
-        "from_sample",
         "invoiced_at",
-        "loqusdb_id",
         "_phenotype_groups",
         "_phenotype_terms",
-        "time_point",
     ]
     column_default_sort = ("created_at", True)
     column_editable_list = [

--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -194,7 +194,7 @@ class FamilyView(BaseView):
 
     column_default_sort = ("created_at", True)
     column_editable_list = ["action", "comment"]
-    column_exclude_list = ["created_at", "_cohorts", "synopsis", "avatar_url"]
+    column_exclude_list = ["created_at", "_cohorts", "synopsis"]
     column_filters = [
         "customer.internal_id",
         "priority",

--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -324,7 +324,17 @@ class PoolView(BaseView):
 class SampleView(BaseView):
     """Admin view for Model.Sample"""
 
-    column_exclude_list = ["age_at_sampling", "from_sample", "invoiced_at", "loqusdb_id", "organism", "_phenotype_groups", "_phenotype_terms", "reference_genome", "time_point"]
+    column_exclude_list = [
+        "age_at_sampling",
+        "from_sample",
+        "invoiced_at",
+        "loqusdb_id",
+        "organism",
+        "_phenotype_groups",
+        "_phenotype_terms",
+        "reference_genome",
+        "time_point",
+    ]
     column_default_sort = ("created_at", True)
     column_editable_list = [
         "sex",
@@ -342,7 +352,15 @@ class SampleView(BaseView):
         "priority": view_human_priority,
     }
     column_searchable_list = ["internal_id", "name", "ticket_number", "customer.internal_id"]
-    form_excluded_columns = ["age_at_sampling", "from_sample", "invoiced_at", "is_external", "_phenotype_groups", "_phenotype_terms", "time_point"]
+    form_excluded_columns = [
+        "age_at_sampling",
+        "from_sample",
+        "invoiced_at",
+        "is_external",
+        "_phenotype_groups",
+        "_phenotype_terms",
+        "time_point",
+    ]
 
     @staticmethod
     def view_sample_link(unused1, unused2, model, unused3):

--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -332,12 +332,12 @@ class SampleView(BaseView):
     ]
     column_default_sort = ("created_at", True)
     column_editable_list = [
-        "sex",
-        "downsampled_to",
-        "sequenced_at",
-        "ticket_number",
-        "is_tumour",
         "comment",
+        "downsampled_to",
+        "is_tumour",
+        "sequenced_at",
+        "sex",
+        "ticket_number",
     ]
     column_filters = ["customer.internal_id", "sex", "application_version.application"]
     column_formatters = {

--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -44,7 +44,7 @@ def public(route_function):
 def before_request():
     """Authorize API routes with JSON Web Tokens."""
     if request.method == "OPTIONS":
-        return make_response(jsonify(ok=True), 204)
+        return make_response(jsonify(ok=True), http.HTTPStatus.NO_CONTENT)
 
     endpoint_func = current_app.view_functions[request.endpoint]
     if getattr(endpoint_func, "is_public", None):


### PR DESCRIPTION
## Description

Some fields ought to be hidden, see suggestion https://github.com/Clinical-Genomics/Deviations/issues/198

### Changed
- Family view: 
  - hide columns: "created_at", "_cohorts", "synopsis"]
  - hide form fields: "analyses", "cohorts", "links", "synopsis"
- Sample view:
  - hide columns: "age_at_sampling", "invoiced_at", "_phenotype_groups", "_phenotype_terms"
  - hide form fields: "age_at_sampling", "deliveries", "father_links", "flowcells", "invoiced_at", "invoice", "is_external", "_phenotype_groups", "_phenotype_terms", "links", "mother_links"

### Fixed 
- Sample records fast to edit
- Family records fast to edit

### How to prepare for test
- [x] deploy to stage

### How to test family view
- [x] do open family view

### Expected test outcome
- [x] check that all fields mentioned in PR are hidden

### How to test sample view
- [x] do open sample view

### Expected test outcome
- [x] check that all fields mentioned in PR are hidden

- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [x] tests executed by PG
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Deploy this branch
- [ ] Inform to production, AL, VW, production
