### PR TITLE
Feat(Ordering): Let JSON orders have line breaks in string values

### DIFF
--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -407,7 +407,7 @@ def orderform():
             order_parser = ExcelOrderformParser()
             order_parser.parse_orderform(excel_path=saved_path)
         else:
-            json_data = json.load(input_file.stream)
+            json_data = json.load(input_file.stream, strict=False)
             order_parser = JsonOrderformParser()
             order_parser.parse_orderform(order_data=json_data)
         parsed_order: Orderform = order_parser.generate_orderform()


### PR DESCRIPTION
## Description

This PR resolves #1340

### Fixed
- Lets JSON orders have line breaks in string values

### How to test
- [x] do submit an order with at least on line break in a string value (e.g "synopsis": "Synopsis1
Synopsis2" )

### Expected test outcome
- [x] check that there are no complaints on the control characters
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [x] code approved by MR
- [x] tests executed by PG
- [x] "Merge and deploy" approved by PG
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Deploy this branch
- [ ] Inform to customer 
