### PR TITLE
Fix/external rsync caesar

### DIFF
--- a/cg/cli/add.py
+++ b/cg/cli/add.py
@@ -290,8 +290,11 @@ def external(context: CGConfig, ticket_id: int, dry_run: bool):
     required=True,
 )
 @click.option("--dry-run", is_flag=True)
+@click.option(
+    "--force", help="Overwrites any any previous samples in the customer directory", is_flag=True
+)
 @click.pass_obj
-def external_hk(context: CGConfig, ticket_id: int, dry_run: bool):
+def external_hk(context: CGConfig, ticket_id: int, dry_run: bool, force):
     """Adds external data to housekeeper"""
     external_data_api = ExternalDataAPI(config=context)
-    external_data_api.add_transfer_to_housekeeper(dry_run=dry_run, ticket_id=ticket_id)
+    external_data_api.add_transfer_to_housekeeper(dry_run=dry_run, ticket_id=ticket_id, force=force)

--- a/cg/meta/transfer/external_data.py
+++ b/cg/meta/transfer/external_data.py
@@ -169,9 +169,9 @@ class ExternalDataAPI(MetaAPI):
         ):
             sample_folder.rename(customer_folder.joinpath(sample.internal_id))
         elif not sample and not self.status_db.sample(sample_folder.name):
-            raise CgDataError(
-                message=f"{sample_folder} is not a sample present in statusdb. Move or remove it to continue"
-            )
+            message = f"{sample_folder} is not a sample present in statusdb. Move or remove it to continue"
+            LOG.error(msg=message)
+            raise CgDataError(message=message)
 
     def add_transfer_to_housekeeper(
         self, ticket_id: int, dry_run: bool = False, force: bool = False

--- a/cg/meta/transfer/external_data.py
+++ b/cg/meta/transfer/external_data.py
@@ -63,10 +63,6 @@ class ExternalDataAPI(MetaAPI):
     def transfer_sample_files_from_source(self, dry_run: bool, ticket_id: int) -> None:
         """Transfers all sample files, related to given ticket, from source to destination"""
         cust: str = self.status_db.get_customer_id_from_ticket(ticket_id=ticket_id)
-        available_samples: List[models.Sample] = self.get_available_samples(
-            folder=self.get_source_path(customer=cust, ticket_id=ticket_id),
-            ticket_id=ticket_id,
-        )
         log_dir: Path = self.create_log_dir(ticket_id=ticket_id, dry_run=dry_run)
         error_function: str = ERROR_RSYNC_FUNCTION.format()
         Path(self.destination_path % cust).mkdir(exist_ok=True)
@@ -90,9 +86,10 @@ class ExternalDataAPI(MetaAPI):
         sbatch_content: str = self.slurm_api.generate_sbatch_content(Sbatch.parse_obj(sbatch_info))
         sbatch_path: Path = Path(log_dir, str(ticket_id) + self.RSYNC_FILE_POSTFIX + ".sh")
         self.slurm_api.submit_sbatch(sbatch_content=sbatch_content, sbatch_path=sbatch_path)
-        LOG.info(msg=[sample.name for sample in available_samples])
         LOG.info(
-            "The transfer of the {numb} samples above has begun".format(numb=len(available_samples))
+            "The folder {src_path} is now being rsynced to hasta".format(
+                src_path=self.get_source_path()
+            )
         )
 
     def get_all_fastq(self, sample_folder: Path) -> List[Path]:

--- a/cg/meta/transfer/external_data.py
+++ b/cg/meta/transfer/external_data.py
@@ -163,7 +163,10 @@ class ExternalDataAPI(MetaAPI):
         sample: models.Sample = self.status_db.find_samples(
             customer=customer, name=sample_folder.name
         ).first()
-        print((sample, customer_folder.joinpath(sample.internal_id).exists(), force))
+        print(sample)
+        print(sample_folder)
+        print(customer_folder.joinpath(sample.internal_id).exists())
+
         if (sample and not customer_folder.joinpath(sample.internal_id).exists()) or (
             sample and force
         ):

--- a/cg/meta/transfer/external_data.py
+++ b/cg/meta/transfer/external_data.py
@@ -69,18 +69,9 @@ class ExternalDataAPI(MetaAPI):
         error_function: str = ERROR_RSYNC_FUNCTION.format()
         Path(self.destination_path % cust).mkdir(exist_ok=True)
 
-        commands: str = "".join(
-            [
-                RSYNC_CONTENTS_COMMAND.format(
-                    source_path=self.get_source_path(
-                        cust_sample_id=sample.name, customer=cust, ticket_id=ticket_id
-                    ),
-                    destination_path=self.get_destination_path(
-                        customer=cust, lims_sample_id=sample.internal_id
-                    ),
-                )
-                for sample in available_samples
-            ]
+        command: str = RSYNC_CONTENTS_COMMAND.format(
+            source_path=self.get_source_path(customer=cust, ticket_id=ticket_id),
+            destination_path=self.get_destination_path(customer=cust),
         )
         sbatch_info = {
             "job_name": str(ticket_id) + self.RSYNC_FILE_POSTFIX,
@@ -90,7 +81,7 @@ class ExternalDataAPI(MetaAPI):
             "log_dir": str(log_dir),
             "email": self.mail_user,
             "hours": 24,
-            "commands": commands,
+            "commands": command,
             "error": error_function,
         }
         self.slurm_api.set_dry_run(dry_run=dry_run)
@@ -164,13 +155,30 @@ class ExternalDataAPI(MetaAPI):
         )
         return fastq_paths_to_add
 
-    def add_transfer_to_housekeeper(self, ticket_id: int, dry_run: bool = False) -> None:
+    def curate_sample_folder(self, cust_name: str, force: bool, sample_folder: Path):
+        """Changes the name of the folder to the internal_id. If force is true replaces any previous folder"""
+        customer: models.Customer = self.status_db.customer(internal_id=cust_name)
+        customer_folder: Path = sample_folder.parent
+        sample: models.Sample = self.status_db.find_samples(
+            customer=customer, name=str(sample_folder)
+        ).first()
+        if sample and force:
+            sample_folder.rename(customer_folder.joinpath(sample.internal_id))
+        else:
+            sample_folder.unlink()
+
+    def add_transfer_to_housekeeper(
+        self, ticket_id: int, dry_run: bool = False, force: bool = False
+    ) -> None:
         """Creates sample bundles in housekeeper and adds the available files corresponding to the ticket to the
         bundle"""
         failed_paths: List[Path] = []
         cust: str = self.status_db.get_customer_id_from_ticket(ticket_id=ticket_id)
+        destination_folder_path: Path = self.get_destination_path(customer=cust)
+        for sample_folder in destination_folder_path.iterdir():
+            self.curate_sample_folder(sample_folder, force=force)
         available_samples: List[models.Sample] = self.get_available_samples(
-            folder=self.get_destination_path(customer=cust), ticket_id=ticket_id
+            folder=destination_folder_path
         )
         cases_to_start: list[dict] = []
         for sample in available_samples:

--- a/cg/meta/transfer/external_data.py
+++ b/cg/meta/transfer/external_data.py
@@ -176,9 +176,9 @@ class ExternalDataAPI(MetaAPI):
         cust: str = self.status_db.get_customer_id_from_ticket(ticket_id=ticket_id)
         destination_folder_path: Path = self.get_destination_path(customer=cust)
         for sample_folder in destination_folder_path.iterdir():
-            self.curate_sample_folder(sample_folder, force=force)
+            self.curate_sample_folder(cust_name=cust, sample_folder=sample_folder, force=force)
         available_samples: List[models.Sample] = self.get_available_samples(
-            folder=destination_folder_path
+            folder=destination_folder_path, ticket_id=ticket_id
         )
         cases_to_start: list[dict] = []
         for sample in available_samples:

--- a/cg/meta/transfer/external_data.py
+++ b/cg/meta/transfer/external_data.py
@@ -171,6 +171,7 @@ class ExternalDataAPI(MetaAPI):
         elif not sample and not self.status_db.sample(sample_folder.name):
             message = f"{sample_folder} is not a sample present in statusdb. Move or remove it to continue"
             LOG.error(msg=message)
+            raise Exception(message)
             raise CgDataError(
                 f"{sample_folder} is not a sample present in statusdb. Move or remove it to continue"
             )

--- a/cg/meta/transfer/external_data.py
+++ b/cg/meta/transfer/external_data.py
@@ -161,7 +161,7 @@ class ExternalDataAPI(MetaAPI):
         customer: models.Customer = self.status_db.customer(internal_id=cust_name)
         customer_folder: Path = sample_folder.parent
         sample: models.Sample = self.status_db.find_samples(
-            customer=customer, name=str(sample_folder)
+            customer=customer, name=sample_folder.name
         ).first()
         print((sample, customer_folder.joinpath(sample.internal_id).exists(), force))
         if (sample and not customer_folder.joinpath(sample.internal_id).exists()) or (

--- a/cg/meta/transfer/external_data.py
+++ b/cg/meta/transfer/external_data.py
@@ -2,6 +2,7 @@
 import datetime as dt
 import itertools
 import logging
+import shutil
 from pathlib import Path
 from typing import List, Tuple, Optional
 
@@ -164,6 +165,8 @@ class ExternalDataAPI(MetaAPI):
         ).first()
         if sample and force:
             sample_folder.rename(customer_folder.joinpath(sample.internal_id))
+        elif sample_folder.is_dir():
+            shutil.rmtree(path=sample_folder)
         else:
             sample_folder.unlink()
 

--- a/cg/meta/transfer/external_data.py
+++ b/cg/meta/transfer/external_data.py
@@ -171,7 +171,9 @@ class ExternalDataAPI(MetaAPI):
         elif not sample and not self.status_db.sample(sample_folder.name):
             message = f"{sample_folder} is not a sample present in statusdb. Move or remove it to continue"
             LOG.error(msg=message)
-            raise CgDataError(message)
+            raise CgDataError(
+                f"{sample_folder} is not a sample present in statusdb. Move or remove it to continue"
+            )
 
     def add_transfer_to_housekeeper(
         self, ticket_id: int, dry_run: bool = False, force: bool = False

--- a/cg/meta/transfer/external_data.py
+++ b/cg/meta/transfer/external_data.py
@@ -88,7 +88,7 @@ class ExternalDataAPI(MetaAPI):
         self.slurm_api.submit_sbatch(sbatch_content=sbatch_content, sbatch_path=sbatch_path)
         LOG.info(
             "The folder {src_path} is now being rsynced to hasta".format(
-                src_path=self.get_source_path()
+                src_path=self.get_source_path(customer=cust, ticket_id=ticket_id)
             )
         )
 

--- a/cg/meta/transfer/external_data.py
+++ b/cg/meta/transfer/external_data.py
@@ -171,7 +171,7 @@ class ExternalDataAPI(MetaAPI):
         elif not sample and not self.status_db.sample(sample_folder.name):
             message = f"{sample_folder} is not a sample present in statusdb. Move or remove it to continue"
             LOG.error(msg=message)
-            raise CgDataError(message=message)
+            raise CgDataError(message)
 
     def add_transfer_to_housekeeper(
         self, ticket_id: int, dry_run: bool = False, force: bool = False

--- a/cg/meta/transfer/external_data.py
+++ b/cg/meta/transfer/external_data.py
@@ -163,10 +163,10 @@ class ExternalDataAPI(MetaAPI):
         sample: models.Sample = self.status_db.find_samples(
             customer=customer, name=str(sample_folder)
         ).first()
+        print((sample, customer_folder.joinpath(sample.internal_id).exists(), force))
         if (sample and not customer_folder.joinpath(sample.internal_id).exists()) or (
             sample and force
         ):
-            print("Korrekt")
             sample_folder.rename(customer_folder.joinpath(sample.internal_id))
         elif sample_folder.is_dir():
             shutil.rmtree(path=sample_folder)

--- a/cg/meta/transfer/external_data.py
+++ b/cg/meta/transfer/external_data.py
@@ -166,6 +166,7 @@ class ExternalDataAPI(MetaAPI):
         if (sample and not customer_folder.joinpath(sample.internal_id).exists()) or (
             sample and force
         ):
+            print("Korrekt")
             sample_folder.rename(customer_folder.joinpath(sample.internal_id))
         elif sample_folder.is_dir():
             shutil.rmtree(path=sample_folder)

--- a/cg/meta/transfer/external_data.py
+++ b/cg/meta/transfer/external_data.py
@@ -169,10 +169,7 @@ class ExternalDataAPI(MetaAPI):
         ):
             sample_folder.rename(customer_folder.joinpath(sample.internal_id))
         elif not sample and not self.status_db.sample(sample_folder.name):
-            message = f"{sample_folder} is not a sample present in statusdb. Move or remove it to continue"
-            LOG.error(msg=message)
-            raise Exception(message)
-            raise CgDataError(
+            raise Exception(
                 f"{sample_folder} is not a sample present in statusdb. Move or remove it to continue"
             )
 

--- a/cg/meta/transfer/external_data.py
+++ b/cg/meta/transfer/external_data.py
@@ -156,14 +156,16 @@ class ExternalDataAPI(MetaAPI):
         )
         return fastq_paths_to_add
 
-    def curate_sample_folder(self, cust_name: str, force: bool, sample_folder: Path):
+    def curate_sample_folder(self, cust_name: str, force: bool, sample_folder: Path) -> None:
         """Changes the name of the folder to the internal_id. If force is true replaces any previous folder"""
         customer: models.Customer = self.status_db.customer(internal_id=cust_name)
         customer_folder: Path = sample_folder.parent
         sample: models.Sample = self.status_db.find_samples(
             customer=customer, name=str(sample_folder)
         ).first()
-        if sample and force:
+        if (sample and not customer_folder.joinpath(sample.internal_id).exists()) or (
+            sample and force
+        ):
             sample_folder.rename(customer_folder.joinpath(sample.internal_id))
         elif sample_folder.is_dir():
             shutil.rmtree(path=sample_folder)

--- a/tests/meta/transfer/test_external_data.py
+++ b/tests/meta/transfer/test_external_data.py
@@ -146,6 +146,12 @@ def test_add_files_to_bundles(
     assert str(fastq_file.absolute()) in [idx.path for idx in hk_version_obj.files]
 
 
+def test_curate_sample_folder(
+    external_data_api: ExternalDataAPI,
+):
+    pass
+
+
 def test_add_transfer_to_housekeeper(
     case_id,
     dna_case,
@@ -174,7 +180,7 @@ def test_add_transfer_to_housekeeper(
     MockHousekeeperAPI.get_files.return_value = []
 
     mocker.patch.object(Path, "iterdir")
-    Path.iterdir.return_value = None
+    Path.iterdir.return_value = []
 
     mocker.patch.object(ExternalDataAPI, "get_available_samples")
     ExternalDataAPI.get_available_samples.return_value = samples[:-1]

--- a/tests/meta/transfer/test_external_data.py
+++ b/tests/meta/transfer/test_external_data.py
@@ -89,7 +89,7 @@ def test_transfer_sample_files_from_source(
     Store.get_customer_id_from_ticket.return_value = customer_id
 
     mocker.patch.object(ExternalDataAPI, "get_source_path")
-    external_data_api.get_source_path.return_value = Path("").joinpath(external_data_directory)
+    external_data_api.get_source_path.return_value = external_data_directory
 
     external_data_api.source_path = str(Path("").joinpath(*external_data_directory.parts[:-2]))
     external_data_api.destination_path = str(
@@ -100,9 +100,8 @@ def test_transfer_sample_files_from_source(
     external_data_api.transfer_sample_files_from_source(ticket_id=ticket_nr, dry_run=True)
 
     # THEN only the two samples present in the source directory are included in the rsync
-    assert all([sample in caplog.text for sample in [sample_name1, sample_name2]])
 
-    assert sample_name3 not in caplog.text
+    assert str(external_data_directory) in caplog.text
 
 
 def test_get_all_fastq(external_data_api: ExternalDataAPI, external_data_directory: Path):

--- a/tests/meta/transfer/test_external_data.py
+++ b/tests/meta/transfer/test_external_data.py
@@ -173,6 +173,9 @@ def test_add_transfer_to_housekeeper(
     mocker.patch.object(MockHousekeeperAPI, "get_files")
     MockHousekeeperAPI.get_files.return_value = []
 
+    mocker.patch.object(Path, "iterdir")
+    Path.iterdir.return_value = None
+
     mocker.patch.object(ExternalDataAPI, "get_available_samples")
     ExternalDataAPI.get_available_samples.return_value = samples[:-1]
 

--- a/tests/meta/transfer/test_external_data.py
+++ b/tests/meta/transfer/test_external_data.py
@@ -146,12 +146,6 @@ def test_add_files_to_bundles(
     assert str(fastq_file.absolute()) in [idx.path for idx in hk_version_obj.files]
 
 
-def test_curate_sample_folder(
-    external_data_api: ExternalDataAPI,
-):
-    pass
-
-
 def test_add_transfer_to_housekeeper(
     case_id,
     dna_case,
@@ -227,6 +221,21 @@ def test_get_available_samples(
     )
     # THEN the function should return a list containing the sample object
     assert available_samples == [sample_obj]
+
+
+def test_curate_sample_folder(
+    case_id, customer_id, dna_case, external_data_api: ExternalDataAPI, tmpdir_factory
+):
+    cases = external_data_api.status_db.query(models.Family).filter(
+        models.Family.internal_id == case_id
+    )
+    sample: models.Sample = cases.first().links[0].sample
+    tmp_folder = Path(tmpdir_factory.mktemp(sample.name, numbered=False))
+    external_data_api.curate_sample_folder(
+        cust_name=customer_id, sample_folder=tmp_folder, force=False
+    )
+    assert (tmp_folder.parent / sample.internal_id).exists()
+    assert not tmp_folder.exists()
 
 
 def test_get_available_samples_no_samples_avail(


### PR DESCRIPTION
## Description
Some old code was not removed in the previous PR.

### Fixed

- Removed `get_available_samples` function call.

### How to prepare for test
- [x] ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh fix/external-rsync-caesar`

### How to test
#### Test 1
- [x] do `cd /home/proj/stage/external-data/cust002/`
- [x] remove folders: `rm -r ACC8123*` or `rm -r 2021*` depending on the folder content.
- [x] run command: `cg add external -t 423832`
#### Test 2
- [x] Stil l in folder `cd /home/proj/stage/external-data/cust002/` run command: `cg add external-hk -t 423832`
### Expected test outcome
#### Test 1
- [x] check that the folder is filled with the ten folders named as the customer's sample name.
#### Test 2
- [x] check that the folder is now filled with the same number of files but named as their internal-id.


- [x] Take a screenshot and attach or copy/paste the output.


## Review
- [ ] code approved by
- [x] tests executed by VJ 
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
