### PR TITLE
rsync -a flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ __________ DO NOT TOUCH ___________
 
 __________ DO NOT TOUCH ___________ -->
 
+## [22.27.0]
+### Changed
+- Read and write permissions stay the same when sending files to caesar
+
 ## [22.26.0]
 ### Added
 - Added median target coverage to mip:s pydantic model

--- a/cg/meta/rsync/sbatch.py
+++ b/cg/meta/rsync/sbatch.py
@@ -1,16 +1,16 @@
 """Sbatch templates for the rsync function"""
 
 RSYNC_COMMAND = """
-rsync -rvL {source_path} {destination_path}
+rsync -rvLa {source_path} {destination_path}
 """
 
 RSYNC_CONTENTS_COMMAND = """
-rsync -rvL {source_path}/ {destination_path}
+rsync -rvLa {source_path}/ {destination_path}
 """
 
 COVID_RSYNC = """
-rsync -rvL {source_path} {destination_path}
-rsync -rvL {covid_report_path} {covid_destination_path}
+rsync -rvLa {source_path} {destination_path}
+rsync -rvLa {covid_report_path} {covid_destination_path}
 """
 
 ERROR_RSYNC_FUNCTION = """

--- a/cg/meta/rsync/sbatch.py
+++ b/cg/meta/rsync/sbatch.py
@@ -1,16 +1,16 @@
 """Sbatch templates for the rsync function"""
 
 RSYNC_COMMAND = """
-rsync -rvLa {source_path} {destination_path}
+rsync -avL {source_path} {destination_path}
 """
 
 RSYNC_CONTENTS_COMMAND = """
-rsync -rvLa {source_path}/ {destination_path}
+rsync -avL {source_path}/ {destination_path}
 """
 
 COVID_RSYNC = """
-rsync -rvLa {source_path} {destination_path}
-rsync -rvLa {covid_report_path} {covid_destination_path}
+rsync -avL {source_path} {destination_path}
+rsync -avL {covid_report_path} {covid_destination_path}
 """
 
 ERROR_RSYNC_FUNCTION = """


### PR DESCRIPTION
## Description
Currently when we rsync `-rw-rw----+` the customer gets `-rw-r-----+` on caesar. This is causing some customers problems. If we add `a` to the rsync-flag the `-rw-rw----+` permissions will be retained.

### Added

-

### Changed

- Read and write permissions are retained

### Fixed

-


### How to prepare for test
- [ ] ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] paxa the environment: `paxa`
- [ ] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
