### PR TITLE
Fix slow clean demultiplexed runs

### DIFF
--- a/cg/cli/clean.py
+++ b/cg/cli/clean.py
@@ -228,7 +228,10 @@ def remove_invalid_flow_cell_directories(context: CGConfig, failed_only: bool, d
             fastq_files_in_housekeeper,
             spring_files_in_housekeeper,
         )
-        checked_flow_cells.append(flow_cell_obj)
+        if not flow_cell_obj.is_demultiplexing_ongoing_or_started_and_not_completed:
+            checked_flow_cells.append(flow_cell_obj)
+        else:
+            LOG.warning("Skipping check!")
 
     failed_flow_cells: List[DemultiplexedRunsFlowCell] = [
         flow_cell for flow_cell in checked_flow_cells if not flow_cell.passed_check


### PR DESCRIPTION
## Description
The script that cleans up demultiplexed-runs is slow, partly because some checks are executed twice. This is a fix

### Fixed
Exclude all files that should not be checked to prevent double and unneeded checks.

### Tests
Tested locally.

### How to prepare for test
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
