### PR TITLE
Clean demultiplexed runs: check and remove in parallel

### DIFF
--- a/cg/cli/clean.py
+++ b/cg/cli/clean.py
@@ -229,7 +229,14 @@ def remove_invalid_flow_cell_directories(context: CGConfig, failed_only: bool, d
             spring_files_in_housekeeper,
         )
         if not flow_cell_obj.is_demultiplexing_ongoing_or_started_and_not_completed:
+            LOG.info("Found flow cell ready to be checked: %s!", flow_cell_obj.path)
             checked_flow_cells.append(flow_cell_obj)
+            if not flow_cell_obj.passed_check:
+                LOG.warning("Invalid flow cell directory found: %s", flow_cell_obj.path)
+                if dry_run:
+                    continue
+                LOG.warning("Removing %s!", flow_cell_obj.path)
+                flow_cell_obj.remove_failed_flow_cell()
         else:
             LOG.warning("Skipping check!")
 
@@ -261,14 +268,6 @@ def remove_invalid_flow_cell_directories(context: CGConfig, failed_only: bool, d
             missingval="N/A",
         ),
     )
-
-    for flow_cell in failed_flow_cells:
-        LOG.warning("Invalid flow cell directory found: %s", flow_cell.path)
-        LOG.warning("Removing %s!", flow_cell.path)
-        if dry_run:
-            continue
-
-        flow_cell.remove_failed_flow_cell()
 
 
 @clean.command("fix-flow-cell-status")

--- a/cg/meta/clean/demultiplexed_flow_cells.py
+++ b/cg/meta/clean/demultiplexed_flow_cells.py
@@ -288,7 +288,7 @@ class DemultiplexedRunsFlowCell:
 
         hk_bundle: hk_models.Bundle = self.hk.bundle(self.id)
         if hk_bundle is None:
-            self.hk.create_new_bundle_and_version(name=self.id)
+            hk_bundle = self.hk.create_new_bundle_and_version(name=self.id)
 
         with self.hk.session_no_autoflush():
             hk_version: hk_models.Version = self.hk.last_version(bundle=hk_bundle.name)


### PR DESCRIPTION
## Description
Check and remove in parallel to improve running time

### Changed
Remove flow cell immediately when check fails instead of at the end

### Fixed
Bundle creation defect

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
