### PR TITLE
Skip sample sheet archiving if no unaligned dir exists

### DIFF
--- a/cg/meta/clean/demultiplexed_flow_cells.py
+++ b/cg/meta/clean/demultiplexed_flow_cells.py
@@ -257,6 +257,12 @@ class DemultiplexedRunsFlowCell:
         globbed_unaligned_paths: Path.glob = Path(self.path).glob(
             DemultiplexingDirsAndFiles.UNALIGNED_DIR_NAME + ASTERISK
         )
+        if len(list(globbed_unaligned_paths)) == 0:
+            LOG.warning(
+                "No Unaligned directory found for flow cell %s! No sample sheet to archive!",
+                self.run_name,
+            )
+            return
         unaligned_path = list(globbed_unaligned_paths)[0]
         original_sample_sheet: Path = (
             Path(

--- a/cg/meta/clean/demultiplexed_flow_cells.py
+++ b/cg/meta/clean/demultiplexed_flow_cells.py
@@ -257,7 +257,7 @@ class DemultiplexedRunsFlowCell:
         globbed_unaligned_paths: Path.glob = Path(self.path).glob(
             DemultiplexingDirsAndFiles.UNALIGNED_DIR_NAME + ASTERISK
         )
-        if len(list(globbed_unaligned_paths)) == 0:
+        if not list(globbed_unaligned_paths):
             LOG.warning(
                 "No Unaligned directory found for flow cell %s! No sample sheet to archive!",
                 self.run_name,


### PR DESCRIPTION
## Description
Older flow cells with no unaligned dir should skip sample sheet archiving

### Fixed
Error on non existent unaligned dir

## Review
- [ ] code approved by
- [x] tests executed by @barrystokman 
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
