### PR TITLE
Fix: check exhausts generator

### DIFF
--- a/cg/meta/clean/demultiplexed_flow_cells.py
+++ b/cg/meta/clean/demultiplexed_flow_cells.py
@@ -257,13 +257,14 @@ class DemultiplexedRunsFlowCell:
         globbed_unaligned_paths: Path.glob = Path(self.path).glob(
             DemultiplexingDirsAndFiles.UNALIGNED_DIR_NAME + ASTERISK
         )
-        if not list(globbed_unaligned_paths):
+        globbed_unaligned_paths_list: list = list(globbed_unaligned_paths)
+        if not globbed_unaligned_paths_list:
             LOG.warning(
                 "No Unaligned directory found for flow cell %s! No sample sheet to archive!",
                 self.run_name,
             )
             return
-        unaligned_path = list(globbed_unaligned_paths)[0]
+        unaligned_path: Path = list(globbed_unaligned_paths_list)[0]
         original_sample_sheet: Path = (
             Path(
                 unaligned_path,

--- a/cg/meta/clean/demultiplexed_flow_cells.py
+++ b/cg/meta/clean/demultiplexed_flow_cells.py
@@ -264,7 +264,7 @@ class DemultiplexedRunsFlowCell:
                 self.run_name,
             )
             return
-        unaligned_path: Path = list(globbed_unaligned_paths_list)[0]
+        unaligned_path: Path = globbed_unaligned_paths_list[0]
         original_sample_sheet: Path = (
             Path(
                 unaligned_path,


### PR DESCRIPTION
## Description
checking a generator exhausts it, leading to an indexerror

### Fixed
assign list(\<generator>) to variable so it's not exhausted

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
