### PR TITLE
Fix(ordering): Quick fix to allow missing volume for existing samples

### DIFF
--- a/cg/models/orders/samples.py
+++ b/cg/models/orders/samples.py
@@ -29,6 +29,10 @@ class OptionalFloatValidator:
 
 
 class OrderInSample(BaseModel):
+    # Order portal specific
+    internal_id: Optional[
+        constr(max_length=models.Sample.internal_id.property.columns[0].type.length)
+    ]
     _suitable_project: OrderType = None
     application: constr(max_length=models.Application.tag.property.columns[0].type.length)
     comment: Optional[constr(max_length=models.Sample.comment.property.columns[0].type.length)]
@@ -62,12 +66,6 @@ class Of1508Sample(OrderInSample):
             max_length=models.Sample.name.property.columns[0].type.length,
         )
     ]
-
-    @validator("name", "source", "volume", "container", "container_name")
-    def required_for_new_samples(cls, value, values, **kwargs):
-        if not value and not values.get("internal_id"):
-            raise ValueError("required for new samples")
-        return value
 
     # customer
     age_at_sampling: Optional[str]
@@ -115,6 +113,12 @@ class Of1508Sample(OrderInSample):
         )
     ]
     synopsis: Optional[str]
+
+    @validator("container", "container_name", "name", "source", "volume")
+    def required_for_new_samples(cls, value, values, **kwargs):
+        if not value and not values.get("internal_id"):
+            raise ValueError("required for new sample '%s'" % (values.get("name")))
+        return value
 
     @validator(
         "tumour_purity",


### PR DESCRIPTION
## Description

### Fixed
- Quick fix to allow missing volume for existing samples

### How to prepare for test
- [x] ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [x] submit an order with an existing sample without volume

### Expected test outcome
- [x] check that no validation error occurs on the missing volume
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [x] code approved by PG
- [x] tests executed by PG
- [x] "Merge and deploy" approved by PG
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Deploy this branch
- [ ] Inform to AG
