### PR TITLE
Fix: clean flow cell run only check directories

### DIFF
--- a/cg/cli/clean.py
+++ b/cg/cli/clean.py
@@ -363,7 +363,7 @@ def remove_old_flow_cell_run_dirs(context: CGConfig, sequencer: str, days_old: i
 
 def clean_run_directories(days_old, dry_run, housekeeper_api, run_directory, status_db):
     """Cleans up all flow cell directories in the specified run directory"""
-    flow_cell_dirs = [item for item in Path(run_directory).iterdir() if item.is_dir()]
+    flow_cell_dirs: List[Path] = [item for item in Path(run_directory).iterdir() if item.is_dir()]
     for flow_cell_dir in flow_cell_dirs:
         LOG.info("Checking flow cell %s", flow_cell_dir.name)
         run_dir_flow_cell = RunDirFlowCell(flow_cell_dir, status_db, housekeeper_api)

--- a/cg/cli/clean.py
+++ b/cg/cli/clean.py
@@ -363,7 +363,8 @@ def remove_old_flow_cell_run_dirs(context: CGConfig, sequencer: str, days_old: i
 
 def clean_run_directories(days_old, dry_run, housekeeper_api, run_directory, status_db):
     """Cleans up all flow cell directories in the specified run directory"""
-    for flow_cell_dir in Path(run_directory).iterdir():
+    flow_cell_dirs = [item for item in Path(run_directory).iterdir() if item.is_dir()]
+    for flow_cell_dir in flow_cell_dirs:
         LOG.info("Checking flow cell %s", flow_cell_dir.name)
         run_dir_flow_cell = RunDirFlowCell(flow_cell_dir, status_db, housekeeper_api)
         if run_dir_flow_cell.age < days_old:


### PR DESCRIPTION
## Description
### Fixed
Clean up script errors when encountering files used for checking the NAS -> hasta sync status. Solution: check only directories.


### How to prepare for test
tested locally

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
