### PR TITLE
Remove old flow cell run directories: skip flow cells (being) retrieved from PDC

### DIFF
--- a/cg/cli/clean.py
+++ b/cg/cli/clean.py
@@ -307,13 +307,13 @@ def fix_flow_cell_status(context: CGConfig, dry_run: bool):
         status_db_flow_cell_status = flow_cell.status
         new_status = (
             FlowCellStatus.ONDISK
-            if flow_cell.run_name in physical_ondisk_flow_cell_names
+            if flow_cell.name in physical_ondisk_flow_cell_names
             else FlowCellStatus.REMOVED
         )
         if status_db_flow_cell_status != new_status:
             LOG.info(
                 "Setting status of flow cell %s from %s to %s",
-                flow_cell.run_name,
+                flow_cell.name,
                 status_db_flow_cell_status,
                 new_status,
             )
@@ -367,6 +367,13 @@ def clean_run_directories(days_old, dry_run, housekeeper_api, run_directory, sta
     for flow_cell_dir in flow_cell_dirs:
         LOG.info("Checking flow cell %s", flow_cell_dir.name)
         run_dir_flow_cell = RunDirFlowCell(flow_cell_dir, status_db, housekeeper_api)
+        if run_dir_flow_cell.is_retrieved_from_pdc:
+            LOG.info(
+                "Skipping removal of flow cell %s, PDC retrieval status is '%s'!",
+                flow_cell_dir,
+                run_dir_flow_cell.flow_cell_status,
+            )
+            continue
         if run_dir_flow_cell.age < days_old:
             LOG.info(
                 "Flow cell %s is %s days old and will NOT be removed.",

--- a/cg/meta/clean/demultiplexed_flow_cells.py
+++ b/cg/meta/clean/demultiplexed_flow_cells.py
@@ -38,7 +38,7 @@ class DemultiplexedRunsFlowCell:
         flow_cell_path: Path,
         status_db: Store,
         housekeeper_api: HousekeeperAPI,
-        trailblazer_api: TrailblazerAPI,
+        trailblazer_api: Optional[TrailblazerAPI] = None,
         sample_sheets_dir: Optional[str] = None,
         fastq_files: Optional[Query] = None,
         spring_files: Optional[Query] = None,


### PR DESCRIPTION
## Description
When removing old run directories, leave the one the are, or have been retrieved from PDC. Those flow cells will have the status `processing` or `retrieved`. Once those flow cells have been demultiplexed again, their status will be set to `ondisk`, making them eligible for future removal.

### Fixed
Unintended removal of flow cells that are (being) retrieved from PDC.

### How to prepare for test
- [ ] ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] paxa the environment: `paxa`
- [ ] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
