### PR TITLE
Feat(balsamic): Add delivery report fields to bed and bed-version

### DIFF
--- a/alembic/versions/1645e21f9d58_add_description_to_bed_version.py
+++ b/alembic/versions/1645e21f9d58_add_description_to_bed_version.py
@@ -1,0 +1,33 @@
+"""add description to bed_version
+
+Revision ID: 1645e21f9d58
+Revises: c76d655c8edf
+Create Date: 2022-02-04 10:25:52.878013
+
+"""
+from alembic import op
+from sqlalchemy import (
+    Column,
+    String,
+    types,
+)
+
+# revision identifiers, used by Alembic.
+revision = "1645e21f9d58"
+down_revision = "c76d655c8edf"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("bed_version", Column("description", String(256), nullable=True))
+    op.add_column("bed", Column("description", String(256), nullable=True))
+    op.add_column("bed", Column("details", types.Text, nullable=True))
+    op.add_column("bed", Column("limitations", types.Text, nullable=True))
+
+
+def downgrade():
+    op.drop_column("bed_version", "description")
+    op.drop_column("bed", "description")
+    op.add_column("bed", "details")
+    op.add_column("bed", "limitations")

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -179,7 +179,7 @@ class Bed(Model):
 
     id = Column(types.Integer, primary_key=True)
     name = Column(types.String(32), unique=True, nullable=False)
-    description = Column(types.String(256), nullable=False)
+    description = Column(types.String(256))
     details = Column(types.Text)
     limitations = Column(types.Text)
     comment = Column(types.Text)
@@ -200,7 +200,7 @@ class BedVersion(Model):
 
     id = Column(types.Integer, primary_key=True)
     shortname = Column(types.String(64))
-    description = Column(types.String(256), nullable=False)
+    description = Column(types.String(256))
     version = Column(types.Integer, nullable=False)
     filename = Column(types.String(256), nullable=False)
     checksum = Column(types.String(32))

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -179,6 +179,9 @@ class Bed(Model):
 
     id = Column(types.Integer, primary_key=True)
     name = Column(types.String(32), unique=True, nullable=False)
+    description = Column(types.String(256), nullable=False)
+    details = Column(types.Text)
+    limitations = Column(types.Text)
     comment = Column(types.Text)
     is_archived = Column(types.Boolean, default=False)
     created_at = Column(types.DateTime, default=dt.datetime.now)
@@ -197,6 +200,7 @@ class BedVersion(Model):
 
     id = Column(types.Integer, primary_key=True)
     shortname = Column(types.String(64))
+    description = Column(types.String(256), nullable=False)
     version = Column(types.Integer, nullable=False)
     filename = Column(types.String(256), nullable=False)
     checksum = Column(types.String(32))


### PR DESCRIPTION
## Description

### Added
- delivery report fields to bed and bed-version
  - bed.description
  - bed.details
  - bed.limitations
  - bed_version.description 

### How to prepare for test
- [ ] ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] paxa the environment: `paxa`
- [ ] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`
- [ ] install [THIS-BRANCH-NAME] on cg-statusdb-stage via https://github.com/Clinical-Genomics/cg/actions

### How to test bed
- [ ] do open cg-statusdb.stage/admin/bed

### Expected test outcome
- [ ] check that all new fields are visible/editable and saveable

--

### How to test bed-version
- [ ] do open cg-statusdb.stage/admin/bed-version

### Expected test outcome
- [ ] check that all new fields are visible/editable and saveable

- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in releasenotes
- [ ] Deploy this branch
- [ ] Inform to Vadym & Keyvan
