### PR TITLE
Fix: clean old flow cell run directories, flwo cell does not exist in statusdb

### DIFF
--- a/cg/cli/clean.py
+++ b/cg/cli/clean.py
@@ -367,7 +367,7 @@ def clean_run_directories(days_old, dry_run, housekeeper_api, run_directory, sta
     for flow_cell_dir in flow_cell_dirs:
         LOG.info("Checking flow cell %s", flow_cell_dir.name)
         run_dir_flow_cell = RunDirFlowCell(flow_cell_dir, status_db, housekeeper_api)
-        if run_dir_flow_cell.is_retrieved_from_pdc:
+        if run_dir_flow_cell.exists_in_statusdb and run_dir_flow_cell.is_retrieved_from_pdc:
             LOG.info(
                 "Skipping removal of flow cell %s, PDC retrieval status is '%s'!",
                 flow_cell_dir,

--- a/cg/meta/clean/flow_cell_run_directories.py
+++ b/cg/meta/clean/flow_cell_run_directories.py
@@ -34,6 +34,7 @@ class RunDirFlowCell:
         self.id: str = self.identifier[1:]
         self._age: Optional[timedelta] = None
         self._is_retrieved_from_pdc: Optional[bool] = None
+        self._exists_in_statusdb: Optional[bool] = None
         self._sequenced_date: Optional[datetime] = None
         self._flow_cell_status: Optional[str] = None
         self.sample_sheet_path: Path = (
@@ -75,6 +76,13 @@ class RunDirFlowCell:
         if self._flow_cell_status is None:
             self._flow_cell_status = self.status_db.flowcell(name=self.id).status
         return self._flow_cell_status
+
+    @property
+    def exists_in_statusdb(self) -> bool:
+        """The flow cell exists in statusdb"""
+        if self._exists_in_statusdb is None:
+            self._exists_in_statusdb = self.status_db.flowcell(name=self.id) is not None
+        return self._exists_in_statusdb
 
     def remove_run_directory(self):
         """Removes the flow cell run directory"""


### PR DESCRIPTION
## Description
If a flow cell does not exist in statusdb, the check to see if the flow cell is being retrieved or has been retrieved from PDC fails. Now we only check the status if the flow cell exists, the age check does not need to have a flow cell in statusdb.

### Fixed
Error while checking PDC retrieval status


### How to prepare for test
- [x] ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [x] do `cg --verbose clean remove-old-flow-cell-run-dirs --dry-run`

### Expected test outcome
- [x] check that flow cells not in statusdb are handled correcty 
- [x Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [x] tests executed by @barrystokman 
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Deploy this branch
