### PR TITLE
Only start mutant if negative controls are clean

### DIFF
--- a/cg/apps/lims/api.py
+++ b/cg/apps/lims/api.py
@@ -410,7 +410,7 @@ class LimsAPI(Lims, OrderHandler):
             artifacts.append((date, artifact.id, artifact))
 
         artifacts.sort()
-        date, id, latest_art = artifacts[-1]
+        date, sample_id, latest_art = artifacts[-1]
 
         return latest_art
 

--- a/cg/cli/workflow/mutant/base.py
+++ b/cg/cli/workflow/mutant/base.py
@@ -69,8 +69,12 @@ def run(context: CGConfig, dry_run: bool, case_id: str) -> None:
 @click.pass_context
 def start(context: click.Context, dry_run: bool, case_id: str) -> None:
     """Start full analysis workflow for a case"""
+    analysis_api: MutantAnalysisAPI = context.obj.meta_apis["analysis_api"]
+    are_NTCs_clean: bool = analysis_api.check_if_NTCs_are_clean(case_id=case_id)
+    if not are_NTCs_clean:
+        LOG.error("Analysis won't start, a negative control is contaminated")
+        return
     try:
-
         context.invoke(link, case_id=case_id, dry_run=dry_run)
         context.invoke(config_case, case_id=case_id, dry_run=dry_run)
         context.invoke(run, case_id=case_id, dry_run=dry_run)

--- a/cg/cli/workflow/mutant/base.py
+++ b/cg/cli/workflow/mutant/base.py
@@ -72,7 +72,7 @@ def start(context: click.Context, dry_run: bool, case_id: str, force: bool) -> N
     """Start full analysis workflow for a case"""
     if not force:
         analysis_api: MutantAnalysisAPI = context.obj.meta_apis["analysis_api"]
-        are_NTCs_clean: bool = analysis_api.check_if_NTCs_are_clean(case_id=case_id)
+        are_NTCs_clean: bool = analysis_api.are_all_negative_controls_clean(case_id=case_id)
         if not are_NTCs_clean:
             LOG.error("Analysis won't start, a negative control is contaminated")
             return

--- a/cg/cli/workflow/mutant/base.py
+++ b/cg/cli/workflow/mutant/base.py
@@ -66,14 +66,16 @@ def run(context: CGConfig, dry_run: bool, case_id: str) -> None:
 @mutant.command("start")
 @OPTION_DRY
 @ARGUMENT_CASE_ID
+@click.option("--force", is_flag=True)
 @click.pass_context
-def start(context: click.Context, dry_run: bool, case_id: str) -> None:
+def start(context: click.Context, dry_run: bool, case_id: str, force: bool) -> None:
     """Start full analysis workflow for a case"""
-    analysis_api: MutantAnalysisAPI = context.obj.meta_apis["analysis_api"]
-    are_NTCs_clean: bool = analysis_api.check_if_NTCs_are_clean(case_id=case_id)
-    if not are_NTCs_clean:
-        LOG.error("Analysis won't start, a negative control is contaminated")
-        return
+    if not force:
+        analysis_api: MutantAnalysisAPI = context.obj.meta_apis["analysis_api"]
+        are_NTCs_clean: bool = analysis_api.check_if_NTCs_are_clean(case_id=case_id)
+        if not are_NTCs_clean:
+            LOG.error("Analysis won't start, a negative control is contaminated")
+            return
     try:
         context.invoke(link, case_id=case_id, dry_run=dry_run)
         context.invoke(config_case, case_id=case_id, dry_run=dry_run)

--- a/cg/constants/constants.py
+++ b/cg/constants/constants.py
@@ -49,6 +49,8 @@ SEX_OPTIONS = ("male", "female", "unknown")
 
 SARS_COV_REGEX = "^[0-9]{2}CS[0-9]{6}$"
 
+SARS_COV_NTC_READ_THRESHOLD = 10000
+
 STATUS_OPTIONS = ("affected", "unaffected", "unknown")
 
 

--- a/cg/meta/workflow/mutant.py
+++ b/cg/meta/workflow/mutant.py
@@ -105,6 +105,27 @@ class MutantAnalysisAPI(AnalysisAPI):
             ),
         )
 
+    def get_internal_NTCs(self, case_id: str) -> List[models.Sample]:
+        """Retrieve a list of lims ids for negative controls created by Clinical Genomics"""
+        case_obj = self.status_db.family(case_id)
+        samples: List[models.Sample] = [link.sample for link in case_obj.links]
+        ticket_id: int = samples[0].ticket_number
+        # 1. ticket_id will lead to samples that all come from the same pool
+        # 2. In the pool from "1." there will be samples from another ticket than ticket_id given as input
+        # 3. Return a list of sample objects from "2."
+
+    def check_if_NTCs_are_clean(self, case_id: str) -> bool:
+        """Returns true if all samples in given list got less than 10k reads"""
+        is_clean = True
+        ntcs: List[models.Sample] = self.get_internal_NTCs(case_id=case_id)
+        if not ntcs:
+            LOG.info("No negative controls found for case: %s", case_id)
+        for ntc in ntcs:
+            if ntc.reads > 10000:
+                is_clean = False
+                return is_clean
+        return is_clean
+
     def create_case_config(self, case_id: str, dry_run: bool) -> None:
         case_obj = self.status_db.family(case_id)
         samples: List[models.Sample] = [link.sample for link in case_obj.links]


### PR DESCRIPTION
## Description
Clinical genomics uses internal negative controls (NTCs) to asses if we introduce contamination when we prepare sarscov2 samples for sequencing. Right now all sarscov2 analyses starts automatically. The analyses where a NTC is contaminated should not start automatically.

### Added

-

### Changed

- SARS-CoV-2 analyses won't start if a NTC is contaminated

### Fixed

-


### How to prepare for test
- [ ] ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] paxa the environment: `paxa`
- [ ] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh sarscov2-start`

### How to test
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
