### PR TITLE
Fix/force nipt upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,7 @@ DEVELOP/
 
 # Editor specific files
 .tm_properties
+.vscode
 
 # Local stuff
 .flake8

--- a/cg/cli/upload/nipt/base.py
+++ b/cg/cli/upload/nipt/base.py
@@ -38,7 +38,6 @@ def nipt_upload_case(context: click.Context, case_id: Optional[str], dry_run: bo
 
     nipt_upload_api: NiptUploadAPI = NiptUploadAPI(context.obj)
     nipt_upload_api.set_dry_run(dry_run=dry_run)
-    print(force)
     if force or nipt_upload_api.flowcell_passed_qc_value(
         case_id=case_id, q30_threshold=Q30_THRESHOLD
     ):

--- a/cg/cli/upload/nipt/base.py
+++ b/cg/cli/upload/nipt/base.py
@@ -38,13 +38,13 @@ def nipt_upload_case(context: click.Context, case_id: Optional[str], dry_run: bo
 
     nipt_upload_api: NiptUploadAPI = NiptUploadAPI(context.obj)
     nipt_upload_api.set_dry_run(dry_run=dry_run)
-
+    print(force)
     if force or nipt_upload_api.flowcell_passed_qc_value(
         case_id=case_id, q30_threshold=Q30_THRESHOLD
     ):
         nipt_upload_api.update_analysis_upload_started_date(case_id)
-        context.invoke(batch, case_id=case_id, dry_run=dry_run)
-        context.invoke(nipt_upload_ftp_case, case_id=case_id, dry_run=dry_run)
+        context.invoke(batch, case_id=case_id, force=force, dry_run=dry_run)
+        context.invoke(nipt_upload_ftp_case, case_id=case_id, force=force, dry_run=dry_run)
         nipt_upload_api.update_analysis_uploaded_at_date(case_id)
         LOG.info("%s: analysis uploaded!", case_id)
     else:

--- a/cg/cli/upload/nipt/ftp.py
+++ b/cg/cli/upload/nipt/ftp.py
@@ -20,13 +20,16 @@ def ftp():
 @ftp.command("case")
 @click.argument("case_id", required=True)
 @click.option("--dry-run", is_flag=True)
+@click.option("--force", is_flag=True, help="Force upload of case to databases, despite qc")
 @click.pass_obj
-def nipt_upload_case(context: CGConfig, case_id: str, dry_run: bool):
+def nipt_upload_case(context: CGConfig, case_id: str, dry_run: bool, force: bool):
     """Upload the results file of a NIPT case"""
     nipt_upload_api: NiptUploadAPI = NiptUploadAPI(context)
     nipt_upload_api.set_dry_run(dry_run=dry_run)
 
-    if nipt_upload_api.flowcell_passed_qc_value(case_id=case_id, q30_threshold=Q30_THRESHOLD):
+    if force or nipt_upload_api.flowcell_passed_qc_value(
+        case_id=case_id, q30_threshold=Q30_THRESHOLD
+    ):
         LOG.info("*** NIPT FTP UPLOAD START ***")
 
         hk_results_file: str = nipt_upload_api.get_housekeeper_results_file(case_id=case_id)

--- a/cg/cli/upload/nipt/statina.py
+++ b/cg/cli/upload/nipt/statina.py
@@ -20,8 +20,9 @@ def statina():
 @statina.command("case")
 @click.argument("case_id", required=True)
 @click.option("--dry-run", is_flag=True)
+@click.option("--force", is_flag=True, help="Force upload of case to databases, despite qc")
 @click.pass_obj
-def batch(configs: CGConfig, case_id: str, dry_run: bool):
+def batch(configs: CGConfig, case_id: str, dry_run: bool, force: bool):
     """Loading batch into the NIPT database"""
 
     LOG.info("*** Statina UPLOAD START ***")
@@ -31,7 +32,9 @@ def batch(configs: CGConfig, case_id: str, dry_run: bool):
     statina_files: StatinaUploadFiles = nipt_upload_api.get_statina_files(case_id=case_id)
     if dry_run:
         LOG.info(f"Found file paths for statina upload: {statina_files.json(exclude_none=True)}")
-    elif nipt_upload_api.flowcell_passed_qc_value(case_id=case_id, q30_threshold=Q30_THRESHOLD):
+    elif force or nipt_upload_api.flowcell_passed_qc_value(
+        case_id=case_id, q30_threshold=Q30_THRESHOLD
+    ):
         nipt_upload_api.upload_to_statina_database(statina_files=statina_files)
     else:
         LOG.error("Uploading case failed: %s", case_id)

--- a/tests/cli/upload/test_cli_upload_nipt.py
+++ b/tests/cli/upload/test_cli_upload_nipt.py
@@ -200,7 +200,7 @@ def test_nipt_statina_upload_force_failed_case(
         nipt_upload_case, [case_id, "--force"], obj=upload_context, catch_exceptions=False
     )
 
-    # THEN both the nipt ftp and statina upload should start
+    # THEN both the nipt ftp and statina upload should finish successfully
     assert NIPT_CASE_SUCCESS in caplog.text
     assert NIPT_STATINA_SUCCESS in caplog.text
     assert NIPT_FTP_SUCCESS in caplog.text

--- a/tests/cli/upload/test_cli_upload_nipt.py
+++ b/tests/cli/upload/test_cli_upload_nipt.py
@@ -183,21 +183,18 @@ def test_nipt_statina_upload_force_failed_case(
 ):
     """Tests CLI command to upload a single case"""
 
-    # GIVEN a specified NIPT case that has its analysis stored but is not yet uploaded
+    # GIVEN a completed NIPT case, not yet uploaded
     caplog.set_level(logging.DEBUG)
 
     analysis_obj = helpers.add_analysis(store=upload_context.status_db)
     case_id = analysis_obj.family.internal_id
-    assert not analysis_obj.upload_started_at
-    assert not analysis_obj.uploaded_at
 
-    # WHEN uploading of a specified NIPT case...
+    # WHEN uploading of a specified NIPT case AND the qc fails but it forced to upload
     mocker.patch.object(NiptUploadAPI, "get_statina_files", return_value=MockStatinaUploadFiles())
     mocker.patch.object(NiptUploadAPI, "upload_to_statina_database")
     mocker.patch.object(NiptUploadAPI, "get_housekeeper_results_file")
     mocker.patch.object(NiptUploadAPI, "get_results_file_path")
     mocker.patch.object(NiptUploadAPI, "upload_to_ftp_server")
-    # AND the qc fails but it forced to upload
     mocker.patch.object(NiptUploadAPI, "flowcell_passed_qc_value", return_value=False)
     result = cli_runner.invoke(
         nipt_upload_case, [case_id, "--force"], obj=upload_context, catch_exceptions=False
@@ -207,12 +204,6 @@ def test_nipt_statina_upload_force_failed_case(
     assert NIPT_CASE_SUCCESS in caplog.text
     assert NIPT_STATINA_SUCCESS in caplog.text
     assert NIPT_FTP_SUCCESS in caplog.text
-
-    # THEN set analysis.upload_started_at in the database
-    assert analysis_obj.upload_started_at
-
-    # THEN set analysis.uploaded_at in the database
-    assert analysis_obj.uploaded_at
 
     # THEN exit without errors
     assert result.exit_code == 0

--- a/tests/cli/upload/test_cli_upload_nipt.py
+++ b/tests/cli/upload/test_cli_upload_nipt.py
@@ -178,7 +178,7 @@ def test_nipt_statina_upload_auto_dry_run(
     assert result.exit_code == 0
 
 
-def test_nipt_statina_upload_failed_case(
+def test_nipt_statina_upload_force_failed_case(
     upload_context: CGConfig, cli_runner: CliRunner, caplog, helpers, mocker
 ):
     """Tests CLI command to upload a single case"""
@@ -191,12 +191,13 @@ def test_nipt_statina_upload_failed_case(
     assert not analysis_obj.upload_started_at
     assert not analysis_obj.uploaded_at
 
-    # WHEN uploading of a specified NIPT case
+    # WHEN uploading of a specified NIPT case...
     mocker.patch.object(NiptUploadAPI, "get_statina_files", return_value=MockStatinaUploadFiles())
     mocker.patch.object(NiptUploadAPI, "upload_to_statina_database")
     mocker.patch.object(NiptUploadAPI, "get_housekeeper_results_file")
     mocker.patch.object(NiptUploadAPI, "get_results_file_path")
     mocker.patch.object(NiptUploadAPI, "upload_to_ftp_server")
+    # AND the qc fails but it forced to upload
     mocker.patch.object(NiptUploadAPI, "flowcell_passed_qc_value", return_value=False)
     result = cli_runner.invoke(
         nipt_upload_case, [case_id, "--force"], obj=upload_context, catch_exceptions=False


### PR DESCRIPTION
## Description

Forcing upload did not work as it was stopped down the line by daughter functions

### Fixed

- Force flag is properly propagated into daughter functions


### How to prepare for test
- [ ] ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] paxa the environment: `paxa`
- [ ] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh fix/force-nipt-upload`

### How to test
- [ ]

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to @Clinical-Genomics/production 
