### PR TITLE
Change threshold of clinical_trials

### DIFF
--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -530,11 +530,16 @@ class Sample(Model, PriorityMixin):
     def sequencing_qc(self) -> bool:
         """Return sequencing qc passed or failed."""
         application = self.application_version.application
-        if self.priority < Priority.express:
-            return self.reads > application.expected_reads
         # Express priority and higher needs to be analyzed regardless at a lower threshold for primary analysis
-        one_half_of_target_reads = application.target_reads / 2
-        return self.reads >= one_half_of_target_reads
+        if self.priority == Priority.express:
+            one_half_of_target_reads = application.target_reads / 2
+            return self.reads >= one_half_of_target_reads
+        return self.reads > application.expected_reads
+
+    def sequencing_qc(self) -> bool:
+        """Return sequencing qc passed or failed."""
+        application = self.application_version.application
+        return self.reads > application.expected_reads
 
     @property
     def phenotype_groups(self) -> List[str]:

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -530,7 +530,7 @@ class Sample(Model, PriorityMixin):
     def sequencing_qc(self) -> bool:
         """Return sequencing qc passed or failed."""
         application = self.application_version.application
-        # Express priority and higher needs to be analyzed regardless at a lower threshold for primary analysis
+        # Express priority needs to be analyzed at a lower threshold for primary analysis
         if self.priority == Priority.express:
             one_half_of_target_reads = application.target_reads / 2
             return self.reads >= one_half_of_target_reads

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -536,11 +536,6 @@ class Sample(Model, PriorityMixin):
             return self.reads >= one_half_of_target_reads
         return self.reads > application.expected_reads
 
-    def sequencing_qc(self) -> bool:
-        """Return sequencing qc passed or failed."""
-        application = self.application_version.application
-        return self.reads > application.expected_reads
-
     @property
     def phenotype_groups(self) -> List[str]:
         """Return a list of phenotype_groups."""


### PR DESCRIPTION
## Description

### Changed

- Updated the function sequencing_qc in order to not start analysis of samples with priority clinical_trials if amount of reads is between 50% and percent reads guaranteed, it's only express samples that should be started with this amount of reads. 

### How to prepare for test
- [X] ssh to relevant server (depending on type of change)
- [X] Use stage: `us`
- [X] paxa the environment: `paxa`
- [X] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh change_threshold_of_clinical_trials`

### How to test
- [X] Set a case to analyse (cutedoe)
- [X] Set the amount of reads to 400M, which  corresponds to 62% of target reads.
- [X] Run `cg workflow mip-dna start-available -d`

### Expected test outcome
- [X] check that analysis is started if the sample has priority express
- [X] check that analysis is not started if the sample has priority clinical_trials
- [X] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [X] tests executed by @moahaegglund 
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
