### PR TITLE
Fix/fohm pandas indices

### DIFF
--- a/cg/meta/upload/fohm/fohm.py
+++ b/cg/meta/upload/fohm/fohm.py
@@ -75,7 +75,7 @@ class FOHMUploadAPI:
             self._reports_dataframe.drop_duplicates(inplace=True, ignore_index=True)
             self._reports_dataframe = self._reports_dataframe[
                 self._reports_dataframe["provnummer"].str.contains(SARS_COV_REGEX)
-            ]
+            ].reset_index()
         return self._reports_dataframe
 
     @property
@@ -88,7 +88,7 @@ class FOHMUploadAPI:
             self._pangolin_dataframe.drop_duplicates(inplace=True, ignore_index=True)
             self._pangolin_dataframe = self.pangolin_dataframe[
                 self._pangolin_dataframe["taxon"].str.contains(SARS_COV_REGEX)
-            ]
+            ].reset_index()
         return self._pangolin_dataframe
 
     @property

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,7 @@ coloredlogs
 email-validator
 lxml
 marshmallow>3               # due to code expects behaviour from >3
+markupsafe<2.1              # due to soft_unicode import error from markupsafe
 openpyxl
 packaging
 pandas


### PR DESCRIPTION
## Description
The sarscov2 case luckykite failed fohm upload with the following pandas error: `pandas.core.indexing.IndexingError: Unalignable boolean Series provided as indexer (index of the boolean Series and of the indexed object do not match).`

### Fixed

- The indices for the pandas dataframes are now the customer sample names, removing the need to ignore and/or reset indices when comparing dataframes.


### How to prepare for test
- [x] ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh fix/fohm_pandas_indices`

### How to test
- [x] do `cg upload fohm preprocess-all --dry-run -c luckykite`

### Expected test outcome
- [x] check that the function reaches `PermissionError: [Errno 13] Permission denied: '/home/hiseq.clinical/.ssh/external/cust124_id_ed25519'` (Apparently that's how a dry-run ends)
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
