### PR TITLE
Dropping indices

### DIFF
--- a/cg/meta/upload/fohm/fohm.py
+++ b/cg/meta/upload/fohm/fohm.py
@@ -75,7 +75,7 @@ class FOHMUploadAPI:
             self._reports_dataframe.drop_duplicates(inplace=True, ignore_index=True)
             self._reports_dataframe = self._reports_dataframe[
                 self._reports_dataframe["provnummer"].str.contains(SARS_COV_REGEX)
-            ].reset_index()
+            ].reset_index(drop=True)
         return self._reports_dataframe
 
     @property
@@ -88,7 +88,7 @@ class FOHMUploadAPI:
             self._pangolin_dataframe.drop_duplicates(inplace=True, ignore_index=True)
             self._pangolin_dataframe = self.pangolin_dataframe[
                 self._pangolin_dataframe["taxon"].str.contains(SARS_COV_REGEX)
-            ].reset_index()
+            ].reset_index(drop=True)
         return self._pangolin_dataframe
 
     @property


### PR DESCRIPTION
## Description
After previous patch of fohm upload where indices were reset the previous indices were added as a column.
### Fixed

- Previous index is now dropped when reset


### How to prepare for test
- [ ] ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] paxa the environment: `paxa`
- [ ] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
