### PR TITLE
Feat(Ordering): Validate length of organism name

### DIFF
--- a/cg/models/orders/samples.py
+++ b/cg/models/orders/samples.py
@@ -228,7 +228,7 @@ class MicrobialSample(OrderInSample):
 
     # 1603 Orderform Microbial WGS
     # "These fields are required"
-    organism: str
+    organism: constr(max_length=models.Organism.internal_id.property.columns[0].type.length)
     reference_genome: constr(
         max_length=models.Sample.reference_genome.property.columns[0].type.length
     )
@@ -239,12 +239,13 @@ class MicrobialSample(OrderInSample):
     container_name: Optional[str]
     well_position: Optional[str]
     # "Required if "Other" is chosen in column "Species""
-    organism_other: Optional[str]
+    organism_other: Optional[
+        constr(max_length=models.Organism.internal_id.property.columns[0].type.length)
+    ]
     # "These fields are not required"
     concentration_sample: Optional[float]
     quantity: Optional[int]
     verified_organism: Optional[bool]  # sent to LIMS
-
     control: Optional[str]
 
     @validator("quantity", pre=True)


### PR DESCRIPTION
## Description

### Added
- Validation of organism name length

### How to prepare for test
- [ ] ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] paxa the environment: `paxa`
- [ ] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [x] do submit order with other organism name longer than 32 chars

### Expected test outcome
- [x] check that pydantic stops the order
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [x] code approved by MR
- [x] tests executed by PG
- [x] "Merge and deploy" approved by PG
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Deploy this branch on server-farm
- [ ] Inform to AG
