### PR TITLE
General q30 check for flow cells

### DIFF
--- a/cg/apps/cgstats/stats.py
+++ b/cg/apps/cgstats/stats.py
@@ -41,7 +41,6 @@ class StatsAPI(alchy.Manager):
             curated_sample_name: str = self.get_curated_sample_name(sample_obj.samplename)
             sample_data = {"name": curated_sample_name, "reads": 0, "fastqs": []}
             for fc_data in self.sample_reads(sample_obj):
-                read_length: str = ""
                 if fc_data.q30 >= FLOWCELL_Q30_THRESHOLD[fc_data.type]:
                     sample_data["reads"] += fc_data.reads
                 else:

--- a/cg/apps/cgstats/stats.py
+++ b/cg/apps/cgstats/stats.py
@@ -42,19 +42,10 @@ class StatsAPI(alchy.Manager):
             sample_data = {"name": curated_sample_name, "reads": 0, "fastqs": []}
             for fc_data in self.sample_reads(sample_obj):
                 read_length: str = ""
-                if fc_data.type == "novaseq":
-                    # Base mask is assumed to have structure of "read_length,index_length,index_length,read_length"
-                    read_length = fc_data.base_mask.split(",")[0]
-                    if fc_data.q30 >= FLOWCELL_Q30_THRESHOLD[fc_data.type][read_length]:
-                        sample_data["reads"] += fc_data.reads
-                elif fc_data.q30 >= FLOWCELL_Q30_THRESHOLD[fc_data.type]:
+                if fc_data.q30 >= FLOWCELL_Q30_THRESHOLD[fc_data.type]:
                     sample_data["reads"] += fc_data.reads
                 else:
-                    q30_threshold: int = (
-                        FLOWCELL_Q30_THRESHOLD[fc_data.type][read_length]
-                        if fc_data.type == "novaseq"
-                        else FLOWCELL_Q30_THRESHOLD[fc_data.type]
-                    )
+                    q30_threshold: int = FLOWCELL_Q30_THRESHOLD[fc_data.type]
                     LOG.warning(
                         f"q30 too low for {curated_sample_name} on {fc_data.name}:"
                         f"{fc_data.q30} < {q30_threshold}%"

--- a/cg/constants/constants.py
+++ b/cg/constants/constants.py
@@ -40,7 +40,7 @@ FLOWCELL_STATUS = ("ondisk", "removed", "requested", "processing", "retrieved")
 FLOWCELL_Q30_THRESHOLD = {
     "hiseqx": 75,
     "hiseqga": 80,
-    "novaseq": {"151": 75, "101": 75, "51": 75},
+    "novaseq": 75,
 }
 
 PREP_CATEGORIES = ("cov", "mic", "rml", "tgs", "wes", "wgs", "wts")


### PR DESCRIPTION
## Description

For NovaSeq flow cells Q30 was compared by read length, which created complexity when customer added new read lengths. We always used a threshold of 75% Q30 so a generalised solution would be appropriate.

### Changed

- Q30 check in demultiplexing generalised for NovaSeq

### How to prepare for test
- [x] ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [x] `cg demultiplex add -b dragen <run_name>`
- [x] `cg transfer flowcell <run_name>`

### Expected test outcome
- [x] Flow cell is added with new odd read lengths
- [x] Flow cell is properly transferred
- [x ] Take a screenshot and attach or copy/paste the output.

## Review
- [x] code approved by @henningonsbring 
- [x] tests executed by @karlnyr 
- [x] "Merge and deploy" approved by @henningonsbring 

Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [x] Document in *NA*
- [x] Deploy this branch on 2022-03-29
- [x] Inform to @Clinical-Genomics/data-analysis 
