### PR TITLE
Fix basemask generation from RunInfo

### DIFF
--- a/cg/apps/cgstats/crud/create.py
+++ b/cg/apps/cgstats/crud/create.py
@@ -78,7 +78,7 @@ def create_demux(
     demux.flowcell_id = flowcell_id
     demux.datasource_id = datasource_id
     if demux_results.bcl_converter == "dragen":
-        basemask: str = demux_results.run_info.basemask
+        demux.basemask: str = demux_results.run_info.basemask
     else:
         demux.basemask = ""
     demux.time = sqlalchemy.func.now()

--- a/cg/apps/cgstats/crud/create.py
+++ b/cg/apps/cgstats/crud/create.py
@@ -78,10 +78,7 @@ def create_demux(
     demux.flowcell_id = flowcell_id
     demux.datasource_id = datasource_id
     if demux_results.bcl_converter == "dragen":
-        demux.basemask = "{read_length},{index_length},{index_length},{read_length}".format(
-            index_length=demux_results.run_info.index_length,
-            read_length=demux_results.run_info.read_length,
-        )
+        basemask: str = demux_results.run_info.basemask
     else:
         demux.basemask = ""
     demux.time = sqlalchemy.func.now()

--- a/cg/apps/cgstats/demux_sample.py
+++ b/cg/apps/cgstats/demux_sample.py
@@ -174,7 +174,7 @@ def get_dragen_demux_samples(
             mean_quality_score=float(demultiplexing_stats["Mean Quality Score (PF)"]),
             r1_sample_bases=int(adapter_metrics["R1_SampleBases"]),
             r2_sample_bases=int(adapter_metrics["R2_SampleBases"]),
-            read_length=demux_results.run_info.read_length,
+            read_length=demux_results.run_info.mean_read_length(),
         )
 
     return demux_samples

--- a/cg/apps/cgstats/parsers/run_info.py
+++ b/cg/apps/cgstats/parsers/run_info.py
@@ -30,4 +30,4 @@ class RunInfo:
             for read in self.root.findall("Run/Reads/Read")
             if read.attrib["IsIndexedRead"] == "N"
         ]
-        return int(sum(read_lengths) / len(read_lengths))
+        return round(sum(read_lengths) / len(read_lengths), 0)

--- a/cg/apps/cgstats/parsers/run_info.py
+++ b/cg/apps/cgstats/parsers/run_info.py
@@ -26,7 +26,7 @@ class RunInfo:
     def mean_read_length(self) -> int:
         """Get the mean read length for this flowcell"""
         read_lengths = [
-            read.attrib["NumCycles"]
+            int(read.attrib["NumCycles"])
             for read in self.root.findall("Run/Reads/Read")
             if read.attrib["IsIndexedRead"] == "N"
         ]

--- a/cg/apps/cgstats/parsers/run_info.py
+++ b/cg/apps/cgstats/parsers/run_info.py
@@ -23,7 +23,11 @@ class RunInfo:
         """Return base mask from RunInfo.xml"""
         return ",".join([read.attrib["NumCycles"] for read in self.root.findall("Run/Reads/Read")])
 
-    @property
-    def read_length(self) -> int:
-        """Get the read length for this flowcell"""
-        return int(self.root.find("Run/Reads/Read"))
+    def mean_read_length(self) -> int:
+        """Get the mean read length for this flowcell"""
+        read_lengths = [
+            read.attrib["NumCycles"]
+            for read in self.root.findall("Run/Reads/Read")
+            if read.attrib["IsIndexedRead"] == "N"
+        ]
+        return sum(read_lengths) / len(read_lengths)

--- a/cg/apps/cgstats/parsers/run_info.py
+++ b/cg/apps/cgstats/parsers/run_info.py
@@ -21,9 +21,7 @@ class RunInfo:
     @property
     def basemask(self) -> str:
         """Return base mask from RunInfo.xml"""
-        return ",".join(
-            [read.attrib["NumCycles"] for read in self.root.findall("Run/Reads/Read")]
-        )
+        return ",".join([read.attrib["NumCycles"] for read in self.root.findall("Run/Reads/Read")])
 
     @property
     def read_length(self) -> int:

--- a/cg/apps/cgstats/parsers/run_info.py
+++ b/cg/apps/cgstats/parsers/run_info.py
@@ -30,4 +30,4 @@ class RunInfo:
             for read in self.root.findall("Run/Reads/Read")
             if read.attrib["IsIndexedRead"] == "N"
         ]
-        return sum(read_lengths) / len(read_lengths)
+        return int(sum(read_lengths) / len(read_lengths))

--- a/cg/apps/cgstats/parsers/run_info.py
+++ b/cg/apps/cgstats/parsers/run_info.py
@@ -19,13 +19,13 @@ class RunInfo:
         return tree.getroot()
 
     @property
-    def read_length(self) -> int:
-        """Get the read length for this flowcell"""
-        return int(self.root.find("Run/Reads/Read").attrib["NumCycles"])
+    def basemask(self) -> str:
+        """Return base mask from RunInfo.xml"""
+        return ",".join(
+            [read.attrib["NumCycles"] for read in self.root.findall("Run/Reads/Read")]
+        )
 
     @property
-    def index_length(self) -> int:
-        """Get the read length of the index used on the flowcell"""
-        for element in self.root.findall("Run/Reads/Read"):
-            if element.attrib["IsIndexedRead"] == "Y":
-                return int(element.attrib["NumCycles"])
+    def read_length(self) -> int:
+        """Get the read length for this flowcell"""
+        return int(self.root.find("Run/Reads/Read"))

--- a/tests/apps/cgstats/conftest.py
+++ b/tests/apps/cgstats/conftest.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from pathlib import Path
+from typing import Dict
 
 import pytest
 from pydantic import BaseModel
@@ -7,6 +8,7 @@ from pydantic import BaseModel
 from cg.apps.cgstats.crud import create
 from cg.apps.cgstats.db import models as stats_models
 from cg.apps.cgstats.stats import StatsAPI
+from cg.apps.cgstats.parsers.run_info import RunInfo
 from cg.models.demultiplex.demux_results import DemuxResults
 from cg.models.demultiplex.flowcell import Flowcell
 from tests.models.demultiplexing.conftest import (
@@ -45,8 +47,7 @@ class MockDemuxResults:
         time: datetime = datetime.now()
 
     class RunInfo(BaseModel):
-        index_length: int = 10
-        read_length: int = 151
+        basemask: str = "151,10,10,151"
 
     def get_logfile_parameters(self) -> LogfileParameters:
         return self.LogfileParameters()
@@ -144,3 +145,10 @@ def fixture_demultiplexing_stats_path(bcl2fastq_demux_results: DemuxResults) -> 
 @pytest.fixture(name="conversion_stats_path")
 def fixture_conversion_stats_path(bcl2fastq_demux_results: DemuxResults) -> Path:
     return bcl2fastq_demux_results.conversion_stats_path
+
+
+@pytest.fixture(name="run_info_path")
+def fixture_run_info(context_config: Dict[str, str]) -> Path:
+    return Path(context_config["demultiplex"]["out_dir"]).joinpath(
+        "211101_A00187_0615_AHLG5GDRXY/Unaligned/Reports/RunInfo.xml"
+    )

--- a/tests/apps/cgstats/parsers/test_run_info.py
+++ b/tests/apps/cgstats/parsers/test_run_info.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+from cg.apps.cgstats.parsers.run_info import RunInfo
+
+
+def test_parse_run_info(run_info_path: Path):
+    """Test if RunInfo parser is working properly and generates information"""
+    # GIVEN an existing RunInfo.xml path
+    assert run_info_path.exists()
+
+    # WHEN instantiation a RunInfo object
+    run_info_obj: RunInfo = RunInfo(run_info_path)
+
+    # THEN the object should be successfully parsed and contain information_sheet
+    assert run_info_obj.basemask
+
+
+def test_run_info_basemask(run_info_path: Path):
+    """Test if basemask generation is working as expected"""
+    # GIVEN a expected basemask structure
+    expected_basemask: str = "51,8,8,51"
+
+    # WHEN generating the basemask from runinfo
+    generated_basemask: str = RunInfo(run_info_path).basemask
+
+    # THEN the generated basemask should match the expected one
+    assert generated_basemask == expected_basemask


### PR DESCRIPTION
## Description

With the changes made in #1345 a bug was introduced based on the assumption that read lengths was to be equal in both directions. However Libraries from 10X genomics breaks these assumption (for instance 26 forward, 90 reverse) and a change is needed.

### Fixed

- Generation of base mask from RunInfo.xml  


### How to prepare for test
- [x] ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh fix/adding-novaseq-basemask`

### How to test
- [x] `cg demultiplex add -b dragen 220325_A00621_0651_BH2MFNDRX2`

### Expected test outcome
- [x] Check that uneven read length base mask is generated
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [x] code approved by @mropat
- [x] tests executed by @karlnyr 
- [x] "Merge and deploy" approved by @karlnyr 

Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [x] Document in *NA*
- [x] Deploy this branch on hasta.scilifelab.se
- [x] Inform to @Clinical-Genomics/data-analysis 
