### PR TITLE
changed qos for clinical trails

### DIFF
--- a/cg/constants/priority.py
+++ b/cg/constants/priority.py
@@ -35,5 +35,5 @@ PRIORITY_TO_SLURM_QOS = {
     Priority.standard: SlurmQos.NORMAL,
     Priority.priority: SlurmQos.HIGH,
     Priority.express: SlurmQos.EXPRESS,
-    Priority.clinical_trials: SlurmQos.LOW,
+    Priority.clinical_trials: SlurmQos.NORMAL,
 }

--- a/tests/meta/workflow/test_analysis.py
+++ b/tests/meta/workflow/test_analysis.py
@@ -10,7 +10,7 @@ from cg.meta.workflow.analysis import AnalysisAPI
 @pytest.mark.parametrize(
     "priority,expected_slurm_qos",
     [
-        (Priority.clinical_trials, SlurmQos.LOW),
+        (Priority.clinical_trials, SlurmQos.NORMAL),
         (Priority.research, SlurmQos.LOW),
         (Priority.standard, SlurmQos.NORMAL),
         (Priority.priority, SlurmQos.HIGH),


### PR DESCRIPTION
## Description

### Changed

- qos for clinical trials changed from low to normal according to AM doc 1256:12.

### How to prepare for test
- [x] ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh update-qos-clinical-trials`

### How to test
- [x] do `cg workflow mip-dna start -d puredove`
- [x] check which qos is set

### Expected test outcome
- [x]  qos is set to normal
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [X] tests executed by @moahaegglund 
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [X] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
