### PR TITLE
Added if clause to upload command

### DIFF
--- a/cg/cli/upload/base.py
+++ b/cg/cli/upload/base.py
@@ -118,7 +118,7 @@ def upload(context: click.Context, family_id: Optional[str], force_restart: bool
         context.invoke(validate, family_id=family_id)
         context.invoke(genotypes, re_upload=False, family_id=family_id)
         context.invoke(observations, case_id=family_id)
-        if DataDelivery.SCOUT in case_obj.data_analysis:
+        if DataDelivery.SCOUT in case_obj.data_delivery:
             context.invoke(scout, case_id=family_id)
         analysis_obj.uploaded_at = dt.datetime.now()
         status_db.commit()

--- a/cg/cli/upload/base.py
+++ b/cg/cli/upload/base.py
@@ -8,7 +8,7 @@ from typing import Optional
 import click
 
 from cg.cli.upload.nipt import nipt
-from cg.constants import Pipeline
+from cg.constants import Pipeline, DataDelivery
 from cg.exc import AnalysisUploadError, CgError
 from cg.meta.upload.scout.uploadscoutapi import UploadScoutAPI
 from cg.meta.workflow.analysis import AnalysisAPI
@@ -118,7 +118,8 @@ def upload(context: click.Context, family_id: Optional[str], force_restart: bool
         context.invoke(validate, family_id=family_id)
         context.invoke(genotypes, re_upload=False, family_id=family_id)
         context.invoke(observations, case_id=family_id)
-        context.invoke(scout, case_id=family_id)
+        if DataDelivery.SCOUT in case_obj.data_analysis:
+            context.invoke(scout, case_id=family_id)
         analysis_obj.uploaded_at = dt.datetime.now()
         status_db.commit()
         click.echo(click.style(f"{family_id}: analysis uploaded!", fg="green"))


### PR DESCRIPTION
## Description


### Changed

- Changed the `cg upload` command so that the upload scout part is put behind an if clause.


### How to prepare for test
- [x] ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh fix/conditional-scout-upload`

### How to test
- [x] Make sure the analysis of cosmictoad does not have and uploaded_at or upload_started_at
- [x] do `cg upload -f cosmictoad`

### Expected test outcome
- [x] The function does not attempt to upload the case to scout.
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
