### PR TITLE
Fix(DeliverAPI) Support for multiple customer and tickets per instance

### DIFF
--- a/cg/meta/deliver.py
+++ b/cg/meta/deliver.py
@@ -71,10 +71,8 @@ class DeliverAPI:
             LOG.warning("Could not find any samples linked to case %s", case_id)
             return
         samples: List[Sample] = [link.sample for link in link_objs]
-        if not self.ticket_id:
-            self.set_ticket_id(sample_obj=samples[0])
-        if not self.customer_id:
-            self.set_customer_id(case_obj=case_obj)
+        self.set_ticket_id(self.store.get_ticket_from_case(case_id=case_id))
+        self.set_customer_id(case_obj=case_obj)
 
         sample_ids: Set[str] = {sample.internal_id for sample in samples}
 
@@ -266,9 +264,9 @@ class DeliverAPI:
         """Set the customer_id for this upload"""
         self._set_customer_id(case_obj.customer.internal_id)
 
-    def set_ticket_id(self, sample_obj: Sample) -> None:
+    def set_ticket_id(self, ticket_id: int) -> None:
         """Set the ticket_id for this upload"""
-        self._set_ticket_id(sample_obj.ticket_number)
+        self._set_ticket_id(ticket_nr=ticket_id)
 
     def create_delivery_dir_path(self, case_name: str = None, sample_name: str = None) -> Path:
         """Create a path for delivering files


### PR DESCRIPTION
## Description
The DeliverAPI in cg has functions that set customer_id and ticket_id if these are None. So if one tries to deliver multiple tickets with one API instance all files will be sent to the same customer under the same ticket.
### Changed

- Removed if clause for setting customer and ticket, so that this is done correctly for every case.
- Changed so that instead of setting the ticket to that of the first sample in the list, it now uses the `get_ticket_from_case` function which returns the ticket of the latest sample.

### How to prepare for test
- [ ] ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] paxa the environment: `paxa`
- [ ] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh fix/deliveryAPI-attributes`

### How to test
- [ ] Fin two fastq cases with different customers. remove their analysis in statusdb.
- [ ] run `cg workflow fastq store-available`
- [ ] run `cg upload fastq all-available`

### Expected test outcome
- [ ] check that files are sent to different customer inboxes
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
