### PR TITLE
Fix(BalsamicAnalysisAPI) change cases_to_store from finish-file to tb-check

### DIFF
--- a/cg/cli/workflow/balsamic/base.py
+++ b/cg/cli/workflow/balsamic/base.py
@@ -138,7 +138,7 @@ def report_deliver(context: CGConfig, case_id: str, analysis_type: str, dry_run:
     try:
         analysis_api.verify_case_id_in_statusdb(case_id=case_id)
         analysis_api.verify_case_config_file_exists(case_id=case_id)
-        analysis_api.verify_analysis_finish_file_exists(case_id=case_id)
+        analysis_api.trailblazer_api.is_latest_analysis_completed(case_id=case_id)
         analysis_api.report_deliver(case_id=case_id, analysis_type=analysis_type, dry_run=dry_run)
     except CgError as e:
         LOG.error(f"Could not create report file: {e.message}")

--- a/cg/meta/workflow/analysis.py
+++ b/cg/meta/workflow/analysis.py
@@ -55,10 +55,6 @@ class AnalysisAPI(MetaAPI):
         if not Path(self.get_case_config_path(case_id=case_id)).exists():
             raise CgError(f"No config file found for case {case_id}")
 
-    def verify_analysis_finish_file_exists(self, case_id: str):
-        if not Path(self.get_analysis_finish_path(case_id=case_id)).exists():
-            raise CgError(f"No analysis_finish file found for case {case_id}")
-
     def verify_case_id_in_statusdb(self, case_id: str) -> None:
         """Passes silently if case exists in StatusDB, raises error if case is missing"""
 
@@ -253,7 +249,13 @@ class AnalysisAPI(MetaAPI):
         return self.status_db.get_running_cases_for_pipeline(pipeline=self.pipeline)
 
     def get_cases_to_store(self) -> List[models.Family]:
-        raise NotImplementedError
+        """Retrieve a list of cases where analysis finished successfully,
+        and is ready to be stored in Housekeeper"""
+        return [
+            case_object
+            for case_object in self.get_running_cases()
+            if self.trailblazer_api.is_latest_analysis_completed(case_id=case_object.internal_id)
+        ]
 
     def get_sample_fastq_destination_dir(self, case_obj: models.Family, sample_obj: models.Sample):
         raise NotImplementedError

--- a/cg/meta/workflow/balsamic.py
+++ b/cg/meta/workflow/balsamic.py
@@ -420,7 +420,7 @@ class BalsamicAnalysisAPI(AnalysisAPI):
         return [
             case_object
             for case_object in self.get_running_cases()
-            if Path(self.get_analysis_finish_path(case_id=case_object.internal_id)).exists()
+            if self.trailblazer_api.is_latest_analysis_completed(case_id=case_object.internal_id)
         ]
 
     @staticmethod

--- a/cg/meta/workflow/balsamic.py
+++ b/cg/meta/workflow/balsamic.py
@@ -89,11 +89,6 @@ class BalsamicAnalysisAPI(AnalysisAPI):
         """
         return Path(self.root_dir, case_id, case_id + ".json")
 
-    def get_analysis_finish_path(self, case_id: str) -> Path:
-        """Returns path to analysis_finish file.
-        (Optional) Checks if analysis_finish file exists"""
-        return Path(self.root_dir, case_id, "analysis", "analysis_finish")
-
     def get_trailblazer_config_path(self, case_id: str) -> Path:
         return Path(self.root_dir, case_id, "analysis", "slurm_jobids.yaml")
 
@@ -412,15 +407,6 @@ class BalsamicAnalysisAPI(AnalysisAPI):
             case_object.internal_id
             for case_object in self.get_cases_to_analyze()
             if self.family_has_correct_number_tumor_normal_samples(case_object.internal_id)
-        ]
-
-    def get_cases_to_store(self) -> List[models.Family]:
-        """Retrieve a list of cases where analysis finished successfully,
-        and is ready to be stored in Housekeeper"""
-        return [
-            case_object
-            for case_object in self.get_running_cases()
-            if self.trailblazer_api.is_latest_analysis_completed(case_id=case_object.internal_id)
         ]
 
     @staticmethod

--- a/cg/meta/workflow/mip.py
+++ b/cg/meta/workflow/mip.py
@@ -310,14 +310,3 @@ class MipAnalysisAPI(AnalysisAPI):
         sample_info_raw = yaml.safe_load(self.get_sample_info_path(case_id).open())
         sample_info: MipBaseSampleInfo = MipBaseSampleInfo(**sample_info_raw)
         return sample_info.mip_version
-
-    def get_cases_to_store(self) -> List[models.Family]:
-        """Retrieve a list of cases where analysis finished successfully,
-        and is ready to be stored in Housekeeper"""
-        finished_cases: List[models.Family] = [
-            case_object
-            for case_object in self.get_running_cases()
-            if self.trailblazer_api.is_latest_analysis_completed(case_id=case_object.internal_id)
-        ]
-
-        return finished_cases

--- a/tests/cli/workflow/balsamic/test_report_deliver.py
+++ b/tests/cli/workflow/balsamic/test_report_deliver.py
@@ -66,27 +66,6 @@ def test_without_config(cli_runner: CliRunner, balsamic_context: CGConfig, caplo
     assert NO_CONFIG_FOUND in caplog.text
 
 
-def test_case_without_analysis_finish(cli_runner: CliRunner, balsamic_context: CGConfig, caplog):
-    """Test command with case_id and config file but no analysis_finish"""
-    caplog.set_level(logging.ERROR)
-    # GIVEN case-id
-    case_id = "balsamic_case_wgs_single"
-    # WHEN ensuring case config exists where it should be stored
-    Path.mkdir(
-        Path(balsamic_context.meta_apis["analysis_api"].get_case_config_path(case_id)).parent,
-        exist_ok=True,
-    )
-    Path(balsamic_context.meta_apis["analysis_api"].get_case_config_path(case_id)).touch(
-        exist_ok=True
-    )
-    # WHEN dry running with dry specified
-    result = cli_runner.invoke(report_deliver, [case_id, "--dry-run"], obj=balsamic_context)
-    # THEN command should NOT execute successfully
-    assert result.exit_code != EXIT_SUCCESS
-    # THEN warning should be printed that no analysis_finish is found
-    assert "No analysis_finish file" in caplog.text
-
-
 def test_dry_run(cli_runner: CliRunner, balsamic_context: CGConfig, caplog):
     """Test command with case_id and analysis_finish which should execute successfully"""
     caplog.set_level(logging.INFO)
@@ -100,13 +79,6 @@ def test_dry_run(cli_runner: CliRunner, balsamic_context: CGConfig, caplog):
     Path(balsamic_context.meta_apis["analysis_api"].get_case_config_path(case_id)).touch(
         exist_ok=True
     )
-    Path.mkdir(
-        Path(balsamic_context.meta_apis["analysis_api"].get_analysis_finish_path(case_id)).parent,
-        exist_ok=True,
-    )
-    Path(balsamic_context.meta_apis["analysis_api"].get_analysis_finish_path(case_id)).touch(
-        exist_ok=True
-    )
     # WHEN dry running with dry specified
     result = cli_runner.invoke(report_deliver, [case_id, "--dry-run"], obj=balsamic_context)
     # THEN command should execute successfully
@@ -117,8 +89,7 @@ def test_dry_run(cli_runner: CliRunner, balsamic_context: CGConfig, caplog):
 
 
 def test_qc_option(cli_runner: CliRunner, balsamic_context: CGConfig, caplog):
-    """Test command with case_id and qc option + config and analysis_finish
-    which should execute successfully"""
+    """Test command with case_id and qc option + config which should execute successfully"""
     caplog.set_level(logging.INFO)
     # GIVEN case-id
     case_id = "balsamic_case_wgs_single"
@@ -130,13 +101,6 @@ def test_qc_option(cli_runner: CliRunner, balsamic_context: CGConfig, caplog):
         exist_ok=True,
     )
     Path(balsamic_context.meta_apis["analysis_api"].get_case_config_path(case_id)).touch(
-        exist_ok=True
-    )
-    Path.mkdir(
-        Path(balsamic_context.meta_apis["analysis_api"].get_analysis_finish_path(case_id)).parent,
-        exist_ok=True,
-    )
-    Path(balsamic_context.meta_apis["analysis_api"].get_analysis_finish_path(case_id)).touch(
         exist_ok=True
     )
     # WHEN dry running with dry specified

--- a/tests/cli/workflow/mip/test_cli_mip_store.py
+++ b/tests/cli/workflow/mip/test_cli_mip_store.py
@@ -144,10 +144,6 @@ def test_cli_store_available_case_is_running(
     mocker.patch.object(MipDNAAnalysisAPI, "get_deliverables_file_path")
     MipDNAAnalysisAPI.get_deliverables_file_path.return_value = mip_deliverables_file
 
-    # GIVEN deliverables were generated and could be found
-    mocker.patch.object(MipDNAAnalysisAPI, "get_analysis_finish_path")
-    MipDNAAnalysisAPI.get_analysis_finish_path.return_value = mip_deliverables_file
-
     # GIVEN the same timestamp is attained when storing analysis in different databases
     mocker.patch.object(MipDNAAnalysisAPI, "get_date_from_file_path")
     MipDNAAnalysisAPI.get_date_from_file_path.return_value = timestamp_yesterday

--- a/tests/mocks/tb_mock.py
+++ b/tests/mocks/tb_mock.py
@@ -38,3 +38,6 @@ class MockTB:
         self.get_latest_analysis_response[analysis_dict["family"]] = TrailblazerAnalysis.parse_obj(
             analysis_dict
         )
+
+    def is_latest_analysis_completed(self, case_id: str):
+        return True


### PR DESCRIPTION
## Description
If a case has the status FAILED in trailblazer production intervenes. If the case is deemed to be finished production sets the case to completed in Trailblazer using the Make complete button. Production expects that the storing of analysis files is done, and that the case is ready to be uploaded to its services. However Balsamic requires a analysis_finished file for it to be stored.

### Changed

- The `get_cases_to_store` for `BalsamicAnalysisAPI` no longer looks for an analysis_finished file, but instead asks trailbazer if the latest analysis is complet (Like MIP)


### How to prepare for test
- [ ] ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] paxa the environment: `paxa`
- [ ] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh fix/remove_analysis_finish_balsamic_store`

### How to test
- [ ] find a failed balsamic case i cigrid stage
- [ ] make sure the case is set to running in statusdb
- [ ] set it to complete
- [ ] Run store available

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
