### PR TITLE
fix/missing-backup-api-meta-api

### DIFF
--- a/cg/meta/meta.py
+++ b/cg/meta/meta.py
@@ -41,10 +41,10 @@ class MetaAPI:
                 demux_root=config.demultiplex.out_dir,
                 backup_api=SpringBackupAPI(
                     encryption_api=SpringEncryptionAPI(
-                        binary_path=config["encryption"]["binary_path"]
+                        binary_path=config.dict()["encryption"]["binary_path"]
                     ),
                     hk_api=config.housekeeper_api,
-                    pdc_api=PdcAPI(config["pdc"]["binary_path"]),
+                    pdc_api=PdcAPI(config.dict()["pdc"]["binary_path"]),
                 ),
             ),
         )

--- a/cg/meta/meta.py
+++ b/cg/meta/meta.py
@@ -9,11 +9,14 @@ from cg.apps.mutacc_auto import MutaccAutoAPI
 from cg.apps.scout.scoutapi import ScoutAPI
 from cg.apps.tb import TrailblazerAPI
 from cg.apps.vogue import VogueAPI
+from cg.meta.backup.backup import SpringBackupAPI
 from cg.meta.compress import CompressAPI
+from cg.meta.encryption.encryption import SpringEncryptionAPI
 from cg.meta.upload.vogue import UploadVogueAPI
 from cg.meta.workflow.prepare_fastq import PrepareFastqAPI
 from cg.models.cg_config import CGConfig
 from cg.store import Store
+from cg.meta.backup.pdc import PdcAPI
 
 
 class MetaAPI:
@@ -36,6 +39,13 @@ class MetaAPI:
                 hk_api=config.housekeeper_api,
                 crunchy_api=config.crunchy_api,
                 demux_root=config.demultiplex.out_dir,
+                backup_api=SpringBackupAPI(
+                    encryption_api=SpringEncryptionAPI(
+                        binary_path=config["encryption"]["binary_path"]
+                    ),
+                    hk_api=config.housekeeper_api,
+                    pdc_api=PdcAPI(config["pdc"]["binary_path"]),
+                ),
             ),
         )
         self.status_db: Store = config.status_db

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1233,6 +1233,8 @@ def fixture_context_config(
             "hasta": "/path/on/hasta/%s",
             "caesar": "server.name.se:/path/%s/on/caesar",
         },
+        "encryption": {"binary_path": "bin/gpg"},
+        "pdc": {"binary_path": "/bin/dsmc"},
         "shipping": {"host_config": "host_config_stage.yaml", "binary_path": "echo"},
         "housekeeper": {"database": fixture_hk_uri, "root": str(housekeeper_dir)},
         "trailblazer": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1233,8 +1233,6 @@ def fixture_context_config(
             "hasta": "/path/on/hasta/%s",
             "caesar": "server.name.se:/path/%s/on/caesar",
         },
-        "encryption": {"binary_path": "bin/gpg"},
-        "pdc": {"binary_path": "/bin/dsmc"},
         "shipping": {"host_config": "host_config_stage.yaml", "binary_path": "echo"},
         "housekeeper": {"database": fixture_hk_uri, "root": str(housekeeper_dir)},
         "trailblazer": {


### PR DESCRIPTION
## Description

When running workflows and accessing the MetaAPI a BackupAPI was not passed. 

### Fixed

- Call of backup_api in CompressionAPI

### How to prepare for test
- [x] ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [x] `cg workflow balsamic start -a single -qos low -r sweetelf`

### Expected test outcome
- [x] Code is exited without issues
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [x] tests executed by @karlnyr
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to @Clinical-Genomics/data-analysis 
