### PR TITLE
fix(scout upload config) Change representation of new types

### DIFF
--- a/cg/constants/subject.py
+++ b/cg/constants/subject.py
@@ -8,12 +8,18 @@ class Gender(str, Enum):
     OTHER = "other"
     MISSING = None
 
+    def __repr__(self):
+        return self.value
+
 
 class PhenotypeStatus(str, Enum):
     UNKNOWN = "unknown"
     UNAFFECTED = "unaffected"
     AFFECTED = "affected"
     MISSING = None
+
+    def __repr__(self):
+        return self.value
 
 
 class PlinkPhenotypeStatus(IntEnum):

--- a/cg/models/scout/scout_load_config.py
+++ b/cg/models/scout/scout_load_config.py
@@ -24,7 +24,12 @@ class ScoutIndividual(BaseModel):
     confirmed_sex: Optional[bool] = None
     father: Optional[str] = None
     mother: Optional[str] = None
-    phenotype: PhenotypeStatus = PhenotypeStatus.MISSING
+    phenotype: Literal[
+        PhenotypeStatus.AFFECTED,
+        PhenotypeStatus.UNAFFECTED,
+        PhenotypeStatus.UNKNOWN,
+        PhenotypeStatus.MISSING,
+    ] = PhenotypeStatus.MISSING
     sample_id: str = None
     sample_name: Optional[str] = None
     sex: Literal[Gender.MALE, Gender.FEMALE, Gender.UNKNOWN] = Gender.MISSING


### PR DESCRIPTION
## Description
Fixes scout upload config issue that started occurring after #1464 was merged.


### Changed

- Representation of the types Gender and PhenotypeStatus



### How to prepare for test
- [ ] ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] paxa the environment: `paxa`
- [ ] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh fix-scout-config`

### How to test
- [ ] do run `cg upload create-scout-load-config -p usefuloyster`

### Expected test outcome
- [ ] check that the output in the prompt looks correct
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [x] tests executed by VJ
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
