### PR TITLE
feat(osTicket) Attach json representation of order to ticket upon creation

### DIFF
--- a/cg/apps/osticket.py
+++ b/cg/apps/osticket.py
@@ -27,9 +27,17 @@ class OsTicket(object):
         self.headers = {"X-API-Key": api_key}
         self.url = os.path.join(domain, "api/tickets.json")
 
-    def open_ticket(self, name: str, email: str, subject: str, message: str) -> Optional[int]:
+    def open_ticket(
+        self, name: str, email: str, order_json: dict, subject: str, message: str
+    ) -> Optional[int]:
         """Open a new ticket through the REST API."""
-        data = dict(name=name, email=email, subject=subject, message=message)
+        data = dict(
+            name=name,
+            email=email,
+            subject=subject,
+            message=message,
+            attachments=[{"order.json": f"data:text/plain;charset=utf-8,{order_json}"}],
+        )
         res = requests.post(self.url, json=data, headers=self.headers)
         if res.ok:
             try:

--- a/cg/meta/orders/api.py
+++ b/cg/meta/orders/api.py
@@ -58,7 +58,14 @@ class OrdersAPI:
         self.status = status
         self.ticket_handler: TicketHandler = TicketHandler(osticket_api=osticket, status_db=status)
 
-    def submit(self, project: OrderType, order_in: OrderIn, user_name: str, user_mail: str) -> dict:
+    def submit(
+        self,
+        project: OrderType,
+        order_in: OrderIn,
+        order_json: dict,
+        user_name: str,
+        user_mail: str,
+    ) -> dict:
         """Submit a batch of samples.
 
         Main entry point for the class towards interfaces that implements it.
@@ -70,7 +77,11 @@ class OrdersAPI:
         ticket_number: Optional[int] = TicketHandler.parse_ticket_number(order_in.name)
         if not ticket_number:
             ticket_number = self.ticket_handler.create_ticket(
-                order=order_in, user_name=user_name, user_mail=user_mail, project=project
+                order=order_in,
+                order_json=order_json,
+                user_name=user_name,
+                user_mail=user_mail,
+                project=project,
             )
 
         order_in.ticket = ticket_number

--- a/cg/meta/orders/ticket_handler.py
+++ b/cg/meta/orders/ticket_handler.py
@@ -33,13 +33,14 @@ class TicketHandler:
         return None
 
     def create_ticket(
-        self, order: OrderIn, user_name: str, user_mail: str, project: str
+        self, order: OrderIn, order_json: dict, user_name: str, user_mail: str, project: str
     ) -> Optional[int]:
         """Create a ticket and return the ticket number"""
         message = self.create_new_ticket_message(order=order, user_name=user_name, project=project)
         ticket_nr: Optional[int] = self.osticket.open_ticket(
             name=user_name,
             email=user_mail,
+            order_json=order_json,
             subject=order.name,
             message=message,
         )

--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -86,13 +86,14 @@ def submit_order(order_type):
     error_message: str
     try:
         request_json = request.get_json()
-        LOG.info("processing order: %s", request_json)
+        LOG.info("processing order: %s, %s", request_json)
         project: OrderType = OrderType(order_type)
         order_in: OrderIn = OrderIn.parse_obj(request_json, project=project)
 
         result = api.submit(
             project=project,
             order_in=order_in,
+            order_json=request_json,
             user_name=g.current_user.name,
             user_mail=g.current_user.email,
         )

--- a/tests/apps/test_osticket.py
+++ b/tests/apps/test_osticket.py
@@ -21,6 +21,7 @@ def test_osticket_respone_500(monkeypatch, caplog, response):
         osticket_api.open_ticket(
             name="dummy_name",
             email="dummy_email",
+            order_json={"dummy": "order"},
             subject="dummy_subject",
             message="dummy_message",
         )

--- a/tests/meta/orders/test_meta_orders_api.py
+++ b/tests/meta/orders/test_meta_orders_api.py
@@ -72,7 +72,11 @@ def test_submit(
     # WHEN submitting the order
 
     result = orders_api.submit(
-        project=order_type, order_in=order_data, user_name=user_name, user_mail=user_mail
+        project=order_type,
+        order_in=order_data,
+        order_json=order_data.dict(),
+        user_name=user_name,
+        user_mail=user_mail,
     )
 
     # THEN the result should contain the ticket number for the order
@@ -119,7 +123,11 @@ def test_submit_ticketexception(
     # THEN the TicketCreationError is not excepted
     with pytest.raises(TicketCreationError):
         orders_api.submit(
-            project=order_type, order_in=order_data, user_name=user_name, user_mail=user_mail
+            project=order_type,
+            order_in=order_data,
+            order_json=order_data.dict(),
+            user_name=user_name,
+            user_mail=user_mail,
         )
 
 
@@ -165,7 +173,11 @@ def test_submit_illegal_sample_customer(
     # THEN an OrderError should be raised on illegal customer
     with pytest.raises(OrderError):
         orders_api.submit(
-            project=order_type, order_in=order_data, user_name=user_name, user_mail=user_mail
+            project=order_type,
+            order_in=order_data,
+            order_json=order_data.dict(),
+            user_name=user_name,
+            user_mail=user_mail,
         )
 
 
@@ -220,7 +232,11 @@ def test_submit_scout_legal_sample_customer(
     # WHEN calling submit
     # THEN an OrderError should not be raised on illegal customer
     orders_api.submit(
-        project=order_type, order_in=order_data, user_name=user_name, user_mail=user_mail
+        project=order_type,
+        order_in=order_data,
+        order_json=order_data.dict(),
+        user_name=user_name,
+        user_mail=user_mail,
     )
 
 
@@ -243,6 +259,7 @@ def test_submit_duplicate_sample_case_name(
     customer_obj = store.customer(order_data.customer)
 
     for sample in order_data.samples:
+        print(type(order_data))
         case_id = sample.family_name
         if not store.find_family(customer=customer_obj, name=case_id):
             case_obj = store.add_case(
@@ -260,7 +277,11 @@ def test_submit_duplicate_sample_case_name(
     # THEN an OrderError should be raised on duplicate case name
     with pytest.raises(OrderError):
         orders_api.submit(
-            project=order_type, order_in=order_data, user_name=user_name, user_mail=user_mail
+            project=order_type,
+            order_in=order_data,
+            order_json=order_data.dict(),
+            user_name=user_name,
+            user_mail=user_mail,
         )
 
 
@@ -282,14 +303,22 @@ def test_submit_fluffy_duplicate_sample_case_name(
     monkeypatch_process_lims(monkeypatch, order_data)
 
     orders_api.submit(
-        project=order_type, order_in=order_data, user_name=user_name, user_mail=user_mail
+        project=order_type,
+        order_in=order_data,
+        order_json=order_data.dict(),
+        user_name=user_name,
+        user_mail=user_mail,
     )
 
     # WHEN calling submit
     # THEN an OrderError should be raised on duplicate case name
     with pytest.raises(OrderError):
         orders_api.submit(
-            project=order_type, order_in=order_data, user_name=user_name, user_mail=user_mail
+            project=order_type,
+            order_in=order_data,
+            order_json=order_data.dict(),
+            user_name=user_name,
+            user_mail=user_mail,
         )
 
 
@@ -316,7 +345,11 @@ def test_submit_unique_sample_case_name(
 
     # WHEN calling submit
     orders_api.submit(
-        project=OrderType.MIP_DNA, order_in=order_data, user_name=user_name, user_mail=user_mail
+        project=OrderType.MIP_DNA,
+        order_in=order_data,
+        order_json=order_data.dict(),
+        user_name=user_name,
+        user_mail=user_mail,
     )
 
     # Then no exception about duplicate names should be thrown
@@ -474,7 +507,11 @@ def test_submit_unique_sample_name(
 
     # WHEN calling submit
     orders_api.submit(
-        project=order_type, order_in=order_data, user_name=user_name, user_mail=user_mail
+        project=order_type,
+        order_in=order_data,
+        order_json=order_data.dict(),
+        user_name=user_name,
+        user_mail=user_mail,
     )
 
     # Then no exception about duplicate names should be thrown
@@ -504,7 +541,11 @@ def test_sarscov2_submit_duplicate_sample_name(
     # THEN an OrderError should be raised on duplicate sample name
     with pytest.raises(OrderError):
         orders_api.submit(
-            project=order_type, order_in=order_data, user_name=user_name, user_mail=user_mail
+            project=order_type,
+            order_in=order_data,
+            order_json=order_data.dict(),
+            user_name=user_name,
+            user_mail=user_mail,
         )
 
 
@@ -548,7 +589,11 @@ def test_not_sarscov2_submit_duplicate_sample_name(
 
     # WHEN calling submit
     orders_api.submit(
-        project=order_type, order_in=order_data, user_name=user_name, user_mail=user_mail
+        project=order_type,
+        order_in=order_data,
+        order_json=order_data.dict(),
+        user_name=user_name,
+        user_mail=user_mail,
     )
 
     # THEN no OrderError should be raised on duplicate sample name

--- a/tests/mocks/osticket.py
+++ b/tests/mocks/osticket.py
@@ -34,7 +34,9 @@ class MockOsTicket(OsTicket):
         self.headers = {"X-API-Key": api_key}
         self.url = os.path.join(domain, "api/tickets.json")
 
-    def open_ticket(self, name: str, email: str, subject: str, message: str) -> Optional[int]:
+    def open_ticket(
+        self, name: str, email: str, order_json, subject: str, message: str
+    ) -> Optional[int]:
         """Open a new ticket through the REST API."""
         if self._should_fail:
             LOG.error("res.text: %s, reason: %s", self._ticket_nr, "Unknown reason")


### PR DESCRIPTION
## Description
Due to orders sometimes needing to be placed again by the cg-staff (see [issue](https://github.com/Clinical-Genomics/cgweb/issues/384)). To facilitate this a json representation of the order is attached to newly created tickets.
### Added

- Attaches json file of order to ticket


### How to prepare for test
- [ ] ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] paxa the environment: `paxa`
- [ ] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
