### PR TITLE
Set external reference via cli in Fluffy

### DIFF
--- a/cg/cli/workflow/fluffy/base.py
+++ b/cg/cli/workflow/fluffy/base.py
@@ -59,7 +59,9 @@ def run(context: CGConfig, case_id: str, dry_run: bool, config: str, external_re
     """
     analysis_api: FluffyAnalysisAPI = context.meta_apis["analysis_api"]
     analysis_api.verify_case_id_in_statusdb(case_id=case_id)
-    analysis_api.run_fluffy(case_id=case_id, workflow_config=config, dry_run=dry_run, external_ref=external_ref)
+    analysis_api.run_fluffy(
+        case_id=case_id, workflow_config=config, dry_run=dry_run, external_ref=external_ref
+    )
     if dry_run:
         return
     # Submit analysis for tracking in Trailblazer
@@ -78,7 +80,9 @@ def run(context: CGConfig, case_id: str, dry_run: bool, config: str, external_re
 @click.option("-c", "--config", help="Path to fluffy config in .json format")
 @click.option("-e", "--external-ref", is_flag=True)
 @click.pass_context
-def start(context: click.Context, case_id: str, dry_run: bool, external_ref: bool, config: str = None):
+def start(
+    context: click.Context, case_id: str, dry_run: bool, external_ref: bool, config: str = None
+):
     """
     Starts full Fluffy analysis workflow
     """
@@ -88,7 +92,9 @@ def start(context: click.Context, case_id: str, dry_run: bool, external_ref: boo
     try:
         context.invoke(link, case_id=case_id, dry_run=dry_run)
         context.invoke(create_samplesheet, case_id=case_id, dry_run=dry_run)
-        context.invoke(run, case_id=case_id, config=config, dry_run=dry_run, external_ref=external_ref)
+        context.invoke(
+            run, case_id=case_id, config=config, dry_run=dry_run, external_ref=external_ref
+        )
     except DecompressionNeededError as e:
         LOG.error(e.message)
 

--- a/cg/cli/workflow/fluffy/base.py
+++ b/cg/cli/workflow/fluffy/base.py
@@ -53,13 +53,13 @@ def create_samplesheet(context: CGConfig, case_id: str, dry_run: bool):
 @OPTION_DRY
 @click.option("-c", "--config", help="Path to fluffy config in .json format")
 @click.pass_obj
-def run(context: CGConfig, case_id: str, dry_run: bool, config: str):
+def run(context: CGConfig, case_id: str, dry_run: bool, config: str, external_ref: bool = False):
     """
     Run Fluffy analysis
     """
     analysis_api: FluffyAnalysisAPI = context.meta_apis["analysis_api"]
     analysis_api.verify_case_id_in_statusdb(case_id=case_id)
-    analysis_api.run_fluffy(case_id=case_id, workflow_config=config, dry_run=dry_run)
+    analysis_api.run_fluffy(case_id=case_id, workflow_config=config, dry_run=dry_run, external_ref=external_ref)
     if dry_run:
         return
     # Submit analysis for tracking in Trailblazer
@@ -76,8 +76,9 @@ def run(context: CGConfig, case_id: str, dry_run: bool, config: str):
 @ARGUMENT_CASE_ID
 @OPTION_DRY
 @click.option("-c", "--config", help="Path to fluffy config in .json format")
+@click.option("-e", "--external-ref", is_flag=True)
 @click.pass_context
-def start(context: click.Context, case_id: str, dry_run: bool, config: str = None):
+def start(context: click.Context, case_id: str, dry_run: bool, external_ref: bool, config: str = None):
     """
     Starts full Fluffy analysis workflow
     """
@@ -87,7 +88,7 @@ def start(context: click.Context, case_id: str, dry_run: bool, config: str = Non
     try:
         context.invoke(link, case_id=case_id, dry_run=dry_run)
         context.invoke(create_samplesheet, case_id=case_id, dry_run=dry_run)
-        context.invoke(run, case_id=case_id, config=config, dry_run=dry_run)
+        context.invoke(run, case_id=case_id, config=config, dry_run=dry_run, external_ref=external_ref)
     except DecompressionNeededError as e:
         LOG.error(e.message)
 

--- a/cg/cli/workflow/fluffy/base.py
+++ b/cg/cli/workflow/fluffy/base.py
@@ -81,7 +81,7 @@ def run(context: CGConfig, case_id: str, dry_run: bool, config: str, external_re
 @click.option("-e", "--external-ref", is_flag=True)
 @click.pass_context
 def start(
-    context: click.Context, case_id: str, dry_run: bool, external_ref: bool, config: str = None
+    context: click.Context, case_id: str, dry_run: bool, external_ref: bool = False, config: str = None
 ):
     """
     Starts full Fluffy analysis workflow

--- a/cg/cli/workflow/fluffy/base.py
+++ b/cg/cli/workflow/fluffy/base.py
@@ -83,7 +83,11 @@ def run(context: CGConfig, case_id: str, dry_run: bool, config: str, external_re
 @OPTION_EXTERNAL_REF
 @click.pass_context
 def start(
-    context: click.Context, case_id: str, dry_run: bool, external_ref: bool = False, config: str = None
+    context: click.Context,
+    case_id: str,
+    dry_run: bool,
+    external_ref: bool = False,
+    config: str = None,
 ):
     """
     Starts full Fluffy analysis workflow

--- a/cg/cli/workflow/fluffy/base.py
+++ b/cg/cli/workflow/fluffy/base.py
@@ -11,6 +11,7 @@ OPTION_DRY = click.option(
     "-d", "--dry-run", "dry_run", help="Print command to console without executing", is_flag=True
 )
 ARGUMENT_CASE_ID = click.argument("case_id", required=True)
+OPTION_EXTERNAL_REF = click.option("-e", "--external-ref", is_flag=True)
 
 LOG = logging.getLogger(__name__)
 
@@ -52,6 +53,7 @@ def create_samplesheet(context: CGConfig, case_id: str, dry_run: bool):
 @ARGUMENT_CASE_ID
 @OPTION_DRY
 @click.option("-c", "--config", help="Path to fluffy config in .json format")
+@OPTION_EXTERNAL_REF
 @click.pass_obj
 def run(context: CGConfig, case_id: str, dry_run: bool, config: str, external_ref: bool = False):
     """
@@ -78,7 +80,7 @@ def run(context: CGConfig, case_id: str, dry_run: bool, config: str, external_re
 @ARGUMENT_CASE_ID
 @OPTION_DRY
 @click.option("-c", "--config", help="Path to fluffy config in .json format")
-@click.option("-e", "--external-ref", is_flag=True)
+@OPTION_EXTERNAL_REF
 @click.pass_context
 def start(
     context: click.Context, case_id: str, dry_run: bool, external_ref: bool = False, config: str = None

--- a/cg/meta/workflow/fluffy.py
+++ b/cg/meta/workflow/fluffy.py
@@ -207,7 +207,9 @@ class FluffyAnalysisAPI(AnalysisAPI):
                 samplesheet_workdir_path=samplesheet_workdir_path,
             )
 
-    def run_fluffy(self, case_id: str, dry_run: bool, workflow_config: str, external_ref: bool = False) -> None:
+    def run_fluffy(
+        self, case_id: str, dry_run: bool, workflow_config: str, external_ref: bool = False
+    ) -> None:
         """
         Call fluffy with the configured command-line arguments
         """

--- a/cg/meta/workflow/fluffy.py
+++ b/cg/meta/workflow/fluffy.py
@@ -207,7 +207,7 @@ class FluffyAnalysisAPI(AnalysisAPI):
                 samplesheet_workdir_path=samplesheet_workdir_path,
             )
 
-    def run_fluffy(self, case_id: str, dry_run: bool, workflow_config: str) -> None:
+    def run_fluffy(self, case_id: str, dry_run: bool, workflow_config: str, external_ref: bool = False) -> None:
         """
         Call fluffy with the configured command-line arguments
         """
@@ -218,6 +218,10 @@ class FluffyAnalysisAPI(AnalysisAPI):
                 shutil.rmtree(output_path, ignore_errors=True)
         if not workflow_config:
             workflow_config = self.fluffy_config.as_posix()
+        if not external_ref:
+            batch_ref_flag = "--batch-ref"
+        else:
+            batch_ref_flag = None
         command_args = [
             "--config",
             workflow_config,
@@ -228,7 +232,7 @@ class FluffyAnalysisAPI(AnalysisAPI):
             "--out",
             self.get_output_path(case_id=case_id).as_posix(),
             "--analyse",
-            "--batch-ref",
+            batch_ref_flag,
             "--slurm_params",
             self.get_slurm_param_qos(case_id=case_id),
         ]

--- a/cg/meta/workflow/fluffy.py
+++ b/cg/meta/workflow/fluffy.py
@@ -223,7 +223,7 @@ class FluffyAnalysisAPI(AnalysisAPI):
         if not external_ref:
             batch_ref_flag = "--batch-ref"
         else:
-            batch_ref_flag = None
+            batch_ref_flag = ""
         command_args = [
             "--config",
             workflow_config,


### PR DESCRIPTION
## Description
Previously the `--batch-ref` flag was hard coded. To allow using this flag or not (i.e. using an external reference or batch reference) this PR makes it possible to set this via cli.

### Added

- Set external or batch reference via cli for Fluffy

### Changed

-

### Fixed

-


### How to prepare for test
- [ ] ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] paxa the environment: `paxa`
- [ ] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh external-ref-fluffy`

### How to test
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
