### PR TITLE
Fetch analyses by data delivery

### DIFF
--- a/cg/store/api/status.py
+++ b/cg/store/api/status.py
@@ -7,7 +7,7 @@ from sqlalchemy import and_, or_
 from sqlalchemy.orm import Query
 from typing_extensions import Literal
 
-from cg.constants import CASE_ACTIONS, Pipeline
+from cg.constants import CASE_ACTIONS, Pipeline, DataDelivery
 from cg.store import models
 from cg.store.api.base import BaseHandler
 from cg.utils.date import get_date
@@ -633,7 +633,12 @@ class StatusHandler(BaseHandler):
             analyses_query.filter(models.Analysis.uploaded_at)
             .filter(VALID_DATA_IN_PRODUCTION < models.Analysis.started_at)
             .join(models.Family, models.Family.links, models.FamilySample.sample)
-            .filter(models.Analysis.pipeline == str(pipeline))
+            .filter(
+                and_(
+                    models.Analysis.pipeline == str(pipeline),
+                    models.Family.data_delivery.contains(DataDelivery.SCOUT),
+                )
+            )
             .filter(
                 models.Sample.delivered_at.isnot(None),
                 or_(


### PR DESCRIPTION
## Description

To automate uploads to Scout and avoid unnecessary error logs for non-Scout cases, retrieval of analysis to delivery reports will be temporary based on the `DeliveryData` field.

### Changed
- Fetches analyses to delivery reports by data delivery

### How to prepare for test
- [ ] ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] paxa the environment: `paxa`
- [ ] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
