### PR TITLE
Validate cost center against "KTH" or "KI" for modified invoices

### DIFF
--- a/cg/server/invoices/views.py
+++ b/cg/server/invoices/views.py
@@ -199,6 +199,9 @@ def modified_invoice(invoice_id, cost_center):
     if not logged_in():
         return redirect(url_for("admin.index"))
 
+    if cost_center not in ["KTH", "KI"]:
+        return redirect(url_for("admin.index"))
+
     invoice_obj = db.invoice(invoice_id)
     file_name = "invoice_" + cost_center + str(invoice_id) + ".xlsx"
     temp_dir = tempfile.mkdtemp()


### PR DESCRIPTION
## Description

### Fixed

- Added validation of cost_center against "KTH" or "KI" to fix path injection vulnerability

### How to prepare for test
- [ ] ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] paxa the environment: `paxa`
- [ ] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] while logged in to https://cg-statusdb-stage.scilifelab.se/admin/
- [ ] try to download a modified invoice with an invalid (non "KTH" or "KI") cost center

### Expected test outcome
- [ ] check that you don't receive `500 Internal Server Error`
- [ ] check that you are redirected/receive an error message instead
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to production
