### PR TITLE
Config via cli

### DIFF
--- a/cg/cli/workflow/commands.py
+++ b/cg/cli/workflow/commands.py
@@ -25,7 +25,9 @@ OPTION_DRY = click.option(
 OPTION_YES = click.option("-y", "--yes", is_flag=True, help="Skip confirmation")
 ARGUMENT_BEFORE_STR = click.argument("before_str", type=str)
 ARGUMENT_CASE_ID = click.argument("case_id", required=True)
-OPTION_ANALYSIS_PARAMETERS_CONFIG = click.option("--config-artic", type=str)
+OPTION_ANALYSIS_PARAMETERS_CONFIG = click.option(
+    "--config-artic", type=str, help="Config with computational and lab related settings"
+)
 
 LOG = logging.getLogger(__name__)
 

--- a/cg/cli/workflow/commands.py
+++ b/cg/cli/workflow/commands.py
@@ -25,6 +25,7 @@ OPTION_DRY = click.option(
 OPTION_YES = click.option("-y", "--yes", is_flag=True, help="Skip confirmation")
 ARGUMENT_BEFORE_STR = click.argument("before_str", type=str)
 ARGUMENT_CASE_ID = click.argument("case_id", required=True)
+ARGUMENT_ANALYSIS_PARAMETERS_CONFIG = click.argument("--config-artic", type=str)
 
 LOG = logging.getLogger(__name__)
 

--- a/cg/cli/workflow/commands.py
+++ b/cg/cli/workflow/commands.py
@@ -25,7 +25,7 @@ OPTION_DRY = click.option(
 OPTION_YES = click.option("-y", "--yes", is_flag=True, help="Skip confirmation")
 ARGUMENT_BEFORE_STR = click.argument("before_str", type=str)
 ARGUMENT_CASE_ID = click.argument("case_id", required=True)
-ARGUMENT_ANALYSIS_PARAMETERS_CONFIG = click.argument("--config-artic", type=str)
+OPTION_ANALYSIS_PARAMETERS_CONFIG = click.option("--config-artic", type=str)
 
 LOG = logging.getLogger(__name__)
 

--- a/cg/cli/workflow/mutant/base.py
+++ b/cg/cli/workflow/mutant/base.py
@@ -49,7 +49,7 @@ def config_case(context: CGConfig, dry_run: bool, case_id: str) -> None:
 @mutant.command("run")
 @OPTION_DRY
 @ARGUMENT_CASE_ID
-@ARGUMENT_CASE_CONFIG
+@ARGUMENT_ANALYSIS_PARAMETERS_CONFIG
 @click.pass_obj
 def run(context: CGConfig, dry_run: bool, case_id: str, config_artic: str = None) -> None:
     """Run mutant analysis command for a case"""

--- a/cg/cli/workflow/mutant/base.py
+++ b/cg/cli/workflow/mutant/base.py
@@ -49,7 +49,6 @@ def config_case(context: CGConfig, dry_run: bool, case_id: str) -> None:
 @mutant.command("run")
 @OPTION_DRY
 @ARGUMENT_CASE_ID
-@ARGUMENT_ANALYSIS_PARAMETERS_CONFIG
 @click.pass_obj
 def run(context: CGConfig, dry_run: bool, case_id: str, config_artic: str = None) -> None:
     """Run mutant analysis command for a case"""
@@ -68,6 +67,7 @@ def run(context: CGConfig, dry_run: bool, case_id: str, config_artic: str = None
 @mutant.command("start")
 @OPTION_DRY
 @ARGUMENT_CASE_ID
+@ARGUMENT_ANALYSIS_PARAMETERS_CONFIG
 @click.pass_context
 def start(context: click.Context, dry_run: bool, case_id: str, config_artic: str) -> None:
     """Start full analysis workflow for a case"""

--- a/cg/cli/workflow/mutant/base.py
+++ b/cg/cli/workflow/mutant/base.py
@@ -8,7 +8,7 @@ from cg.cli.workflow.commands import (
     resolve_compression,
     store,
     store_available,
-    ARGUMENT_ANALYSIS_PARAMETERS_CONFIG,
+    OPTION_ANALYSIS_PARAMETERS_CONFIG,
 )
 from cg.constants import EXIT_FAIL, EXIT_SUCCESS
 from cg.exc import CgError, DecompressionNeededError
@@ -67,7 +67,7 @@ def run(context: CGConfig, dry_run: bool, case_id: str, config_artic: str = None
 @mutant.command("start")
 @OPTION_DRY
 @ARGUMENT_CASE_ID
-@ARGUMENT_ANALYSIS_PARAMETERS_CONFIG
+@OPTION_ANALYSIS_PARAMETERS_CONFIG
 @click.pass_context
 def start(context: click.Context, dry_run: bool, case_id: str, config_artic: str) -> None:
     """Start full analysis workflow for a case"""

--- a/cg/cli/workflow/mutant/base.py
+++ b/cg/cli/workflow/mutant/base.py
@@ -8,6 +8,7 @@ from cg.cli.workflow.commands import (
     resolve_compression,
     store,
     store_available,
+    ARGUMENT_ANALYSIS_PARAMETERS_CONFIG,
 )
 from cg.constants import EXIT_FAIL, EXIT_SUCCESS
 from cg.exc import CgError, DecompressionNeededError
@@ -48,8 +49,9 @@ def config_case(context: CGConfig, dry_run: bool, case_id: str) -> None:
 @mutant.command("run")
 @OPTION_DRY
 @ARGUMENT_CASE_ID
+@ARGUMENT_CASE_CONFIG
 @click.pass_obj
-def run(context: CGConfig, dry_run: bool, case_id: str) -> None:
+def run(context: CGConfig, dry_run: bool, case_id: str, config_artic: str = None) -> None:
     """Run mutant analysis command for a case"""
     analysis_api: MutantAnalysisAPI = context.meta_apis["analysis_api"]
     analysis_api.check_analysis_ongoing(case_id=case_id)
@@ -57,7 +59,7 @@ def run(context: CGConfig, dry_run: bool, case_id: str) -> None:
         analysis_api.add_pending_trailblazer_analysis(case_id=case_id)
         analysis_api.set_statusdb_action(case_id=case_id, action="running")
     try:
-        analysis_api.run_analysis(case_id=case_id, dry_run=dry_run)
+        analysis_api.run_analysis(case_id=case_id, dry_run=dry_run, config_artic=config_artic)
     except:
         analysis_api.set_statusdb_action(case_id=case_id, action=None)
         raise
@@ -67,13 +69,13 @@ def run(context: CGConfig, dry_run: bool, case_id: str) -> None:
 @OPTION_DRY
 @ARGUMENT_CASE_ID
 @click.pass_context
-def start(context: click.Context, dry_run: bool, case_id: str) -> None:
+def start(context: click.Context, dry_run: bool, case_id: str, config_artic: str) -> None:
     """Start full analysis workflow for a case"""
     try:
 
         context.invoke(link, case_id=case_id, dry_run=dry_run)
         context.invoke(config_case, case_id=case_id, dry_run=dry_run)
-        context.invoke(run, case_id=case_id, dry_run=dry_run)
+        context.invoke(run, case_id=case_id, dry_run=dry_run, config_artic=config_artic)
         context.invoke(store, case_id=case_id, dry_run=dry_run)
     except DecompressionNeededError:
         LOG.info("Workflow not ready to run, can continue after decompression")

--- a/cg/meta/workflow/mutant.py
+++ b/cg/meta/workflow/mutant.py
@@ -130,23 +130,39 @@ class MutantAnalysisAPI(AnalysisAPI):
 
         return f"{region_code}_{lab_code}_{sample_name}"
 
-    def run_analysis(self, case_id: str, dry_run: bool) -> None:
+    def run_analysis(self, case_id: str, dry_run: bool, config_artic: str = None) -> None:
         if self.get_case_output_path(case_id=case_id).exists():
             LOG.info("Found old output files, directory will be cleaned!")
             shutil.rmtree(self.get_case_output_path(case_id=case_id), ignore_errors=True)
 
-        self.process.run_command(
-            [
-                "analyse",
-                "sarscov2",
-                "--config_case",
-                self.get_case_config_path(case_id=case_id).as_posix(),
-                "--outdir",
-                self.get_case_output_path(case_id=case_id).as_posix(),
-                self.get_case_fastq_dir(case_id=case_id).as_posix(),
-            ],
-            dry_run=dry_run,
-        )
+        if config_artic:
+            self.process.run_command(
+                [
+                    "analyse",
+                    "sarscov2",
+                    "--config_case",
+                    self.get_case_config_path(case_id=case_id).as_posix(),
+                    "--config_artic",
+                    config_artic,
+                    "--outdir",
+                    self.get_case_output_path(case_id=case_id).as_posix(),
+                    self.get_case_fastq_dir(case_id=case_id).as_posix(),
+                ],
+                dry_run=dry_run,
+            )
+        else:
+            self.process.run_command(
+                [
+                    "analyse",
+                    "sarscov2",
+                    "--config_case",
+                    self.get_case_config_path(case_id=case_id).as_posix(),
+                    "--outdir",
+                    self.get_case_output_path(case_id=case_id).as_posix(),
+                    self.get_case_fastq_dir(case_id=case_id).as_posix(),
+                ],
+                dry_run=dry_run,
+            )
 
     def get_cases_to_store(self) -> List[models.Family]:
         """Retrieve a list of cases where analysis has a deliverables file,


### PR DESCRIPTION
## Description
Set config for mutant in cg via cli

### Added

- Flag for mutant config in cg cli 

### Changed

-

### Fixed

-


### How to prepare for test
- [x] ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh config-via-cli`

### How to test
- [x] run: cg workflow mutant start --help 
- [x] run: cg workflow mutant start --config-artic /home/proj/stage/mutant/MUTANT/mutant/config/hasta/default_config_stage.json maturejay
- [x] run: cg workflow mutant start maturejay

### Expected test outcome
- [x] check that the flag is included in the help text
- [x] check that the config is used when given as an option
- [x] check that the default config is used when ´--config-artic´ is NOT given as option
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [x] tests executed by @GustavLagneborgScilifelab 
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
