### PR TITLE
Fix(Options endpoint) External apptags also returned per prep category

### DIFF
--- a/cg/models/orders/samples.py
+++ b/cg/models/orders/samples.py
@@ -297,6 +297,7 @@ class SarsCov2Sample(MicrobialSample):
     region: str
     region_code: str
     selection_criteria: str
+    volume: Optional[str]
 
 
 def sample_class_for(project: OrderType):

--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -330,13 +330,11 @@ def options():
         if not application_obj.versions:
             LOG.debug("Skipping application %s that doesn't have a price", application)
             continue
-
         if application_obj.is_external:
             apptag_groups["ext"].append(application_obj.tag)
-        else:
-            if application_obj.prep_category not in apptag_groups:
-                apptag_groups[application_obj.prep_category] = []
-            apptag_groups[application_obj.prep_category].append(application_obj.tag)
+        if application_obj.prep_category not in apptag_groups:
+            apptag_groups[application_obj.prep_category] = []
+        apptag_groups[application_obj.prep_category].append(application_obj.tag)
 
     source_groups = {"metagenome": METAGENOME_SOURCES, "analysis": ANALYSIS_SOURCES}
 


### PR DESCRIPTION
## Description
App tags for external samples are returned under the key "ext" in a dict and not under their respective prep category. This PR makes it so that they are returned both in "ext" and under their prep category.

Linked to [this cgweb PR](https://github.com/Clinical-Genomics/cgweb/pull/430)
### Changed

-  App tags for external samples are now returned under two keys in the dict returned by the options endpoint


### How to prepare for test
- [x] Deploy this and the cgweb branch on cg-vm1

### How to test
- [x] Try placing a sarscov2 order and use the app tag VWXONTR000. Select no container and leave volume out.
- [x] Create a mip order and make sure the external sample apptags are still available
- [x] Try selecting no container with a normal app tag
- [x] Try selecting tube with the external sample app tag

### Expected test outcome
- [x] Check that the sarscov2 order can be placed
- [x] Check that MIP orders for external samples are still available.
- [x] None of the wrong combinations work

## Review
- [ ] code approved by
- [x] tests executed by VJ
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Merge this PR
- [ ] Deploy cg master to cg-vm1
- [ ] Merge & deploy [cgweb PR](https://github.com/Clinical-Genomics/cgweb/pull/430)
- [ ] Inform HO
