### PR TITLE
Do not check number of reads for nanopore (external data)

### DIFF
--- a/cg/meta/workflow/mutant.py
+++ b/cg/meta/workflow/mutant.py
@@ -115,6 +115,9 @@ class MutantAnalysisAPI(AnalysisAPI):
             lab_code=self.lims_api.get_sample_attribute(
                 lims_id=sample_obj.internal_id, key="lab_code"
             ),
+            primer=self.lims_api.get_sample_attribute(
+                lims_id=sample_obj.internal_id, key="primer"
+            ),
         )
 
     def create_case_config(self, case_id: str, dry_run: bool) -> None:

--- a/cg/meta/workflow/mutant.py
+++ b/cg/meta/workflow/mutant.py
@@ -74,12 +74,13 @@ class MutantAnalysisAPI(AnalysisAPI):
         case_obj = self.status_db.family(case_id)
         samples: List[models.Sample] = [link.sample for link in case_obj.links]
         for sample_obj in samples:
-            if not sample_obj.sequencing_qc:
-                LOG.info("Sample %s read count below threshold, skipping!", sample_obj.internal_id)
-                continue
             application = sample_obj.application_version.application
             if self._is_nanopore(application):
                 self.link_fastq_files_for_sample(case_obj=case_obj, sample_obj=sample_obj)
+                continue
+            if not sample_obj.sequencing_qc:
+                LOG.info("Sample %s read count below threshold, skipping!", sample_obj.internal_id)
+                continue
             else:
                 self.link_fastq_files_for_sample(
                     case_obj=case_obj, sample_obj=sample_obj, concatenate=True

--- a/cg/meta/workflow/mutant.py
+++ b/cg/meta/workflow/mutant.py
@@ -115,9 +115,7 @@ class MutantAnalysisAPI(AnalysisAPI):
             lab_code=self.lims_api.get_sample_attribute(
                 lims_id=sample_obj.internal_id, key="lab_code"
             ),
-            primer=self.lims_api.get_sample_attribute(
-                lims_id=sample_obj.internal_id, key="primer"
-            ),
+            primer=self.lims_api.get_sample_attribute(lims_id=sample_obj.internal_id, key="primer"),
         )
 
     def create_case_config(self, case_id: str, dry_run: bool) -> None:

--- a/cg/models/workflow/mutant.py
+++ b/cg/models/workflow/mutant.py
@@ -19,6 +19,7 @@ class MutantSampleConfig(BaseModel):
     method_sequencing: str
     sequencing_qc_pass: bool
     selection_criteria: str
+    primer: str
 
     @validator("region_code", "lab_code")
     def sanitize_values(cls, value):


### PR DESCRIPTION
## Description
External data will have 0 reads in statusdb, because of this we can never start a mutant analysis with external data since everything will be considered below the threshold. This PR skips qc for external data.

Also adding primer to mutant config

### Added

- Information about primer to mutant config

### Changed

- No qc is done for nanopore in mutant (not sequenced by us)

### Fixed

-


### How to prepare for test
- [ ] ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] paxa the environment: `paxa`
- [ ] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
