### PR TITLE
Handle nanopore fastq headers

### DIFF
--- a/cg/meta/workflow/analysis.py
+++ b/cg/meta/workflow/analysis.py
@@ -334,11 +334,11 @@ class AnalysisAPI(MetaAPI):
         fastq_dir = self.get_sample_fastq_destination_dir(case_obj=case_obj, sample_obj=sample_obj)
         fastq_dir.mkdir(parents=True, exist_ok=True)
 
+        counter = 0
         for fastq_data in sorted_files:
-            counter = 0
             fastq_path = Path(fastq_data["path"])
             fastq_name = self.fastq_handler.create_fastq_name(
-                lane=str(fastq_data["lane"]) + "_" + str(counter),
+                lane=str(fastq_data["lane"]) + str(counter),
                 flowcell=fastq_data["flowcell"],
                 sample=sample_obj.internal_id,
                 read=fastq_data["read"],

--- a/cg/meta/workflow/analysis.py
+++ b/cg/meta/workflow/analysis.py
@@ -366,7 +366,6 @@ class AnalysisAPI(MetaAPI):
             self.fastq_handler.concatenate(linked_reads_paths[read], concatenated_paths[read])
             self.fastq_handler.remove_files(value)
 
-
     def get_target_bed_from_lims(self, case_id: str) -> Optional[str]:
         """Get target bed filename from lims"""
         case_obj: models.Family = self.status_db.family(case_id)

--- a/cg/meta/workflow/analysis.py
+++ b/cg/meta/workflow/analysis.py
@@ -340,13 +340,12 @@ class AnalysisAPI(MetaAPI):
                 flowcell=fastq_data["flowcell"],
                 sample=sample_obj.internal_id,
                 filenr=str(counter),
+                meta=self.get_additional_naming_metadata(sample_obj),
             )
             counter += 1
             destination_path: Path = fastq_dir / fastq_name
             read_paths.append(destination_path)
-            concatenated_path = (
-                f"{fastq_dir}/{self.fastq_handler.get_concatenated_name(fastq_name)}"
-            )
+
             if not destination_path.exists():
                 LOG.info(f"Linking: {fastq_path} -> {destination_path}")
                 destination_path.symlink_to(fastq_path)
@@ -356,6 +355,9 @@ class AnalysisAPI(MetaAPI):
         if not concatenate:
             return
 
+        concatenated_path = (
+            f"{fastq_dir}/{self.fastq_handler.get_concatenated_name(fastq_name)}"
+        )
         LOG.info("Concatenation in progress for sample %s.", sample_obj.internal_id)
         self.fastq_handler.concatenate(read_paths, concatenated_path)
         self.fastq_handler.remove_files(read_paths)

--- a/cg/meta/workflow/analysis.py
+++ b/cg/meta/workflow/analysis.py
@@ -355,8 +355,14 @@ class AnalysisAPI(MetaAPI):
         if not concatenate:
             return
 
+        concatenated_fastq_name = self.fastq_handler.create_nanopore_fastq_name(
+            flowcell=fastq_data["flowcell"],
+            sample=sample_obj.internal_id,
+            filenr=str(1),
+            meta=self.get_additional_naming_metadata(sample_obj),
+        )
         concatenated_path = (
-            f"{fastq_dir}/{self.fastq_handler.get_concatenated_name(fastq_name)}"
+            f"{fastq_dir}/{self.fastq_handler.get_concatenated_name(concatenated_fastq_name)}"
         )
         LOG.info("Concatenation in progress for sample %s.", sample_obj.internal_id)
         self.fastq_handler.concatenate(read_paths, concatenated_path)

--- a/cg/meta/workflow/analysis.py
+++ b/cg/meta/workflow/analysis.py
@@ -312,62 +312,6 @@ class AnalysisAPI(MetaAPI):
             self.fastq_handler.concatenate(linked_reads_paths[read], concatenated_paths[read])
             self.fastq_handler.remove_files(value)
 
-    def get_metadata_for_nanopore_sample(self, sample_obj: models.Sample) -> List[dict]:
-        return [
-            self.fastq_handler.parse_nanopore_file_data(file_obj.full_path)
-            for file_obj in self.housekeeper_api.files(
-                bundle=sample_obj.internal_id, tags=["fastq"]
-            )
-        ]
-
-    def link_nanopore_fastq_for_sample(
-        self, case_obj: models.Family, sample_obj: models.Sample, concatenate: bool = False
-    ) -> None:
-        """
-        Link FASTQ files for a nanopore sample to working directory.
-        If pipeline input requires concatenated fastq, files can also be concatenated
-        """
-        read_paths = []
-        files: List[dict] = self.get_metadata_for_nanopore_sample(sample_obj=sample_obj)
-        sorted_files = sorted(files, key=lambda k: k["path"])
-        fastq_dir = self.get_sample_fastq_destination_dir(case_obj=case_obj, sample_obj=sample_obj)
-        fastq_dir.mkdir(parents=True, exist_ok=True)
-
-        counter = 0
-        for fastq_data in sorted_files:
-            fastq_path = Path(fastq_data["path"])
-            fastq_name = self.fastq_handler.create_nanopore_fastq_name(
-                flowcell=fastq_data["flowcell"],
-                sample=sample_obj.internal_id,
-                filenr=str(counter),
-                meta=self.get_additional_naming_metadata(sample_obj),
-            )
-            counter += 1
-            destination_path: Path = fastq_dir / fastq_name
-            read_paths.append(destination_path)
-
-            if not destination_path.exists():
-                LOG.info(f"Linking: {fastq_path} -> {destination_path}")
-                destination_path.symlink_to(fastq_path)
-            else:
-                LOG.warning(f"Destination path already exists: {destination_path}")
-
-        if not concatenate:
-            return
-
-        concatenated_fastq_name = self.fastq_handler.create_nanopore_fastq_name(
-            flowcell=fastq_data["flowcell"],
-            sample=sample_obj.internal_id,
-            filenr=str(1),
-            meta=self.get_additional_naming_metadata(sample_obj),
-        )
-        concatenated_path = (
-            f"{fastq_dir}/{self.fastq_handler.get_concatenated_name(concatenated_fastq_name)}"
-        )
-        LOG.info("Concatenation in progress for sample %s.", sample_obj.internal_id)
-        self.fastq_handler.concatenate(read_paths, concatenated_path)
-        self.fastq_handler.remove_files(read_paths)
-
     def get_target_bed_from_lims(self, case_id: str) -> Optional[str]:
         """Get target bed filename from lims"""
         case_obj: models.Family = self.status_db.family(case_id)

--- a/cg/meta/workflow/analysis.py
+++ b/cg/meta/workflow/analysis.py
@@ -312,7 +312,7 @@ class AnalysisAPI(MetaAPI):
             self.fastq_handler.concatenate(linked_reads_paths[read], concatenated_paths[read])
             self.fastq_handler.remove_files(value)
 
-    def get_metadata_for_nanopre_sample(self, sample_obj: models.Sample) -> List[dict]:
+    def get_metadata_for_nanopore_sample(self, sample_obj: models.Sample) -> List[dict]:
         return [
             self.fastq_handler.parse_nanopore_file_data(file_obj.full_path)
             for file_obj in self.housekeeper_api.files(
@@ -329,7 +329,7 @@ class AnalysisAPI(MetaAPI):
         """
         linked_reads_paths = {1: []}
         concatenated_paths = {1: ""}
-        files: List[dict] = self.get_metadata_for_nanopre_sample(sample_obj=sample_obj)
+        files: List[dict] = self.get_metadata_for_nanopore_sample(sample_obj=sample_obj)
         sorted_files = sorted(files, key=lambda k: k["path"])
         fastq_dir = self.get_sample_fastq_destination_dir(case_obj=case_obj, sample_obj=sample_obj)
         fastq_dir.mkdir(parents=True, exist_ok=True)

--- a/cg/meta/workflow/analysis.py
+++ b/cg/meta/workflow/analysis.py
@@ -338,7 +338,7 @@ class AnalysisAPI(MetaAPI):
             counter = 0
             fastq_path = Path(fastq_data["path"])
             fastq_name = self.fastq_handler.create_fastq_name(
-                lane=fastq_data["lane"] + "_" + str(counter),
+                lane=str(fastq_data["lane"]) + "_" + str(counter),
                 flowcell=fastq_data["flowcell"],
                 sample=sample_obj.internal_id,
                 read=fastq_data["read"],

--- a/cg/meta/workflow/analysis.py
+++ b/cg/meta/workflow/analysis.py
@@ -337,13 +337,10 @@ class AnalysisAPI(MetaAPI):
         counter = 0
         for fastq_data in sorted_files:
             fastq_path = Path(fastq_data["path"])
-            fastq_name = self.fastq_handler.create_fastq_name(
-                lane=str(fastq_data["lane"]) + str(counter),
+            fastq_name = self.fastq_handler.create_nanopore_fastq_name(
                 flowcell=fastq_data["flowcell"],
                 sample=sample_obj.internal_id,
-                read=fastq_data["read"],
-                undetermined=fastq_data["undetermined"],
-                meta=self.get_additional_naming_metadata(sample_obj),
+                filenr=str(counter),
             )
             counter += 1
             destination_path: Path = fastq_dir / fastq_name

--- a/cg/meta/workflow/fastq.py
+++ b/cg/meta/workflow/fastq.py
@@ -148,15 +148,6 @@ class FastqHandler:
         return fastq_meta
 
     @staticmethod
-    def create_nanopore_fastq_name(
-        flowcell: str,
-        sample: str,
-        filenr: str,
-        meta: Optional[str] = None,
-    ) -> str:
-        return f"{flowcell}_{sample}_{meta}_{filenr}.fastq.gz"
-
-    @staticmethod
     def parse_file_data(fastq_path: Path) -> dict:
         with gzip.open(fastq_path) as handle:
             header_line = handle.readline().decode()
@@ -174,16 +165,6 @@ class FastqHandler:
                 data["flowcell"] = f"{data['flowcell']}-{matches[0]}"
             return data
 
-    @staticmethod
-    def parse_nanopore_file_data(fastq_path: Path) -> dict:
-        with gzip.open(fastq_path) as handle:
-            header_line = handle.readline().decode()
-            header_info: dict = MutantFastqHandler.get_nanopore_header_info(line=header_line)
-            data = {
-                "path": fastq_path,
-                "flowcell": header_info["flowcell"],
-            }
-            return data
 
     @staticmethod
     def create_fastq_name(
@@ -281,10 +262,28 @@ class MutantFastqHandler(FastqHandler):
 
     @staticmethod
     def get_nanopore_header_info(line: str) -> dict:
-        fastq_meta = {"lane": None, "flowcell": None}
+        fastq_meta = {"flowcell": None}
         header_metadata: list = line.split(" ")
-        lane = header_metadata[3].split("=")
-        fastq_meta["lane"] = lane[1]
         flowcell = header_metadata[5].split("=")
         fastq_meta["flowcell"] = flowcell[1]
         return fastq_meta
+
+    @staticmethod
+    def create_nanopore_fastq_name(
+        flowcell: str,
+        sample: str,
+        filenr: str,
+        meta: Optional[str] = None,
+    ) -> str:
+        return f"{flowcell}_{sample}_{meta}_{filenr}.fastq.gz"
+
+    @staticmethod
+    def parse_nanopore_file_data(fastq_path: Path) -> dict:
+        with gzip.open(fastq_path) as handle:
+            header_line = handle.readline().decode()
+            header_info: dict = MutantFastqHandler.get_nanopore_header_info(line=header_line)
+            data = {
+                "path": fastq_path,
+                "flowcell": header_info["flowcell"],
+            }
+            return data

--- a/cg/meta/workflow/fastq.py
+++ b/cg/meta/workflow/fastq.py
@@ -147,7 +147,6 @@ class FastqHandler:
 
         return fastq_meta
 
-
     @staticmethod
     def parse_nanopore_header(line: str) -> dict:
         fastq_meta = {"lane": None, "flowcell": None}
@@ -158,19 +157,22 @@ class FastqHandler:
         fastq_meta["flowcell"] = flowcell[1]
         return fastq_meta
 
-
     @staticmethod
     def parse_file_data(fastq_path: Path) -> dict:
         with gzip.open(fastq_path) as handle:
             header_line = handle.readline().decode()
-            if "runid" in header_line and "flow_cell_id" in header_line and "barcode" in header_line:
+            if (
+                "runid" in header_line
+                and "flow_cell_id" in header_line
+                and "barcode" in header_line
+            ):
                 header_info: dict = FastqHandler.parse_nanopore_header(line=header_line)
                 data = {
                     "path": fastq_path,
                     "lane": int(header_info["lane"]),
                     "flowcell": header_info["flowcell"],
                     "read": 1,
-                    "undetermined": False
+                    "undetermined": False,
                 }
             else:
                 header_info = FastqHandler.parse_header(header_line)

--- a/cg/meta/workflow/fastq.py
+++ b/cg/meta/workflow/fastq.py
@@ -147,7 +147,6 @@ class FastqHandler:
 
         return fastq_meta
 
-
     @staticmethod
     def parse_file_data(fastq_path: Path) -> dict:
         with gzip.open(fastq_path) as handle:
@@ -166,7 +165,6 @@ class FastqHandler:
                 data["flowcell"] = f"{data['flowcell']}-{matches[0]}"
             return data
 
-
     @staticmethod
     def parse_nanopore_file_data(fastq_path: Path) -> dict:
         with gzip.open(fastq_path) as handle:
@@ -180,7 +178,6 @@ class FastqHandler:
                 "undetermined": False,
             }
             return data
-
 
     @staticmethod
     def create_fastq_name(

--- a/cg/meta/workflow/fastq.py
+++ b/cg/meta/workflow/fastq.py
@@ -167,24 +167,6 @@ class FastqHandler:
 
 
     @staticmethod
-    def parse_file_data(fastq_path: Path) -> dict:
-        with gzip.open(fastq_path) as handle:
-            header_line = handle.readline().decode()
-            header_info = FastqHandler.parse_header(header_line)
-            data = {
-                "path": fastq_path,
-                "lane": int(header_info["lane"]),
-                "flowcell": header_info["flowcell"],
-                "read": int(header_info["readnumber"]),
-                "undetermined": ("Undetermined" in fastq_path),
-            }
-            matches = re.findall(r"-l[1-9]t([1-9]{2})_", str(fastq_path))
-            if len(matches) > 0:
-                data["flowcell"] = f"{data['flowcell']}-{matches[0]}"
-        return data
-
-
-    @staticmethod
     def parse_nanopore_file_data(fastq_path: Path) -> dict:
         with gzip.open(fastq_path) as handle:
             header_line = handle.readline().decode()

--- a/cg/meta/workflow/fastq.py
+++ b/cg/meta/workflow/fastq.py
@@ -161,32 +161,18 @@ class FastqHandler:
     def parse_file_data(fastq_path: Path) -> dict:
         with gzip.open(fastq_path) as handle:
             header_line = handle.readline().decode()
-            if (
-                "runid" in header_line
-                and "flow_cell_id" in header_line
-                and "barcode" in header_line
-            ):
-                header_info: dict = FastqHandler.parse_nanopore_header(line=header_line)
-                data = {
-                    "path": fastq_path,
-                    "lane": int(header_info["lane"]),
-                    "flowcell": header_info["flowcell"],
-                    "read": 1,
-                    "undetermined": False,
-                }
-            else:
-                header_info = FastqHandler.parse_header(header_line)
-                data = {
-                    "path": fastq_path,
-                    "lane": int(header_info["lane"]),
-                    "flowcell": header_info["flowcell"],
-                    "read": int(header_info["readnumber"]),
-                    "undetermined": ("Undetermined" in fastq_path),
-                }
-                matches = re.findall(r"-l[1-9]t([1-9]{2})_", str(fastq_path))
-                if len(matches) > 0:
-                    data["flowcell"] = f"{data['flowcell']}-{matches[0]}"
-            return data
+            header_info = FastqHandler.parse_header(header_line)
+            data = {
+                "path": fastq_path,
+                "lane": int(header_info["lane"]),
+                "flowcell": header_info["flowcell"],
+                "read": int(header_info["readnumber"]),
+                "undetermined": ("Undetermined" in fastq_path),
+            }
+            matches = re.findall(r"-l[1-9]t([1-9]{2})_", str(fastq_path))
+            if len(matches) > 0:
+                data["flowcell"] = f"{data['flowcell']}-{matches[0]}"
+        return data
 
     @staticmethod
     def create_fastq_name(
@@ -281,3 +267,34 @@ class MutantFastqHandler(FastqHandler):
     def get_concatenated_name(linked_fastq_name: str) -> str:
         """ "Create a name for the concatenated file from multiple lanes"""
         return "_".join(linked_fastq_name.split("_")[2:])
+
+    @staticmethod
+    def parse_file_data(fastq_path: Path) -> dict:
+        with gzip.open(fastq_path) as handle:
+            header_line = handle.readline().decode()
+            if (
+                    "runid" in header_line
+                    and "flow_cell_id" in header_line
+                    and "barcode" in header_line
+            ):
+                header_info: dict = FastqHandler.parse_nanopore_header(line=header_line)
+                data = {
+                    "path": fastq_path,
+                    "lane": int(header_info["lane"]),
+                    "flowcell": header_info["flowcell"],
+                    "read": 1,
+                    "undetermined": False,
+                }
+            else:
+                header_info = FastqHandler.parse_header(header_line)
+                data = {
+                    "path": fastq_path,
+                    "lane": int(header_info["lane"]),
+                    "flowcell": header_info["flowcell"],
+                    "read": int(header_info["readnumber"]),
+                    "undetermined": ("Undetermined" in fastq_path),
+                }
+                matches = re.findall(r"-l[1-9]t([1-9]{2})_", str(fastq_path))
+                if len(matches) > 0:
+                    data["flowcell"] = f"{data['flowcell']}-{matches[0]}"
+            return data

--- a/cg/meta/workflow/fastq.py
+++ b/cg/meta/workflow/fastq.py
@@ -165,7 +165,6 @@ class FastqHandler:
                 data["flowcell"] = f"{data['flowcell']}-{matches[0]}"
             return data
 
-
     @staticmethod
     def create_fastq_name(
         lane: str,

--- a/cg/meta/workflow/fastq.py
+++ b/cg/meta/workflow/fastq.py
@@ -152,8 +152,9 @@ class FastqHandler:
         flowcell: str,
         sample: str,
         filenr: str,
+        meta: Optional[str] = None,
     ) -> str:
-        return f"{flowcell}_{sample}_{filenr}.fastq.gz"
+        return f"{flowcell}_{sample}_{meta}_{filenr}.fastq.gz"
 
     @staticmethod
     def parse_file_data(fastq_path: Path) -> dict:

--- a/cg/meta/workflow/fastq.py
+++ b/cg/meta/workflow/fastq.py
@@ -153,6 +153,7 @@ class FastqHandler:
         with gzip.open(fastq_path) as handle:
             header_line = handle.readline().decode()
             header_info = FastqHandler.parse_header(header_line)
+
             data = {
                 "path": fastq_path,
                 "lane": int(header_info["lane"]),
@@ -163,7 +164,7 @@ class FastqHandler:
             matches = re.findall(r"-l[1-9]t([1-9]{2})_", str(fastq_path))
             if len(matches) > 0:
                 data["flowcell"] = f"{data['flowcell']}-{matches[0]}"
-        return data
+            return data
 
 
     @staticmethod

--- a/cg/meta/workflow/fastq.py
+++ b/cg/meta/workflow/fastq.py
@@ -172,7 +172,7 @@ class FastqHandler:
             header_info: dict = MutantFastqHandler.get_nanopore_header_info(line=header_line)
             data = {
                 "path": fastq_path,
-                "lane": int(header_info["lane"]),
+                "lane": "NA",
                 "flowcell": header_info["flowcell"],
                 "read": 1,
                 "undetermined": False,

--- a/cg/meta/workflow/fastq.py
+++ b/cg/meta/workflow/fastq.py
@@ -147,15 +147,6 @@ class FastqHandler:
 
         return fastq_meta
 
-    @staticmethod
-    def parse_nanopore_header(line: str) -> dict:
-        fastq_meta = {"lane": None, "flowcell": None}
-        header_metadata: list = line.split(" ")
-        lane = header_metadata[3].split("=")
-        fastq_meta["lane"] = lane[1]
-        flowcell = header_metadata[5].split("=")
-        fastq_meta["flowcell"] = flowcell[1]
-        return fastq_meta
 
     @staticmethod
     def parse_file_data(fastq_path: Path) -> dict:
@@ -173,6 +164,40 @@ class FastqHandler:
             if len(matches) > 0:
                 data["flowcell"] = f"{data['flowcell']}-{matches[0]}"
         return data
+
+
+    @staticmethod
+    def parse_file_data(fastq_path: Path) -> dict:
+        with gzip.open(fastq_path) as handle:
+            header_line = handle.readline().decode()
+            header_info = FastqHandler.parse_header(header_line)
+            data = {
+                "path": fastq_path,
+                "lane": int(header_info["lane"]),
+                "flowcell": header_info["flowcell"],
+                "read": int(header_info["readnumber"]),
+                "undetermined": ("Undetermined" in fastq_path),
+            }
+            matches = re.findall(r"-l[1-9]t([1-9]{2})_", str(fastq_path))
+            if len(matches) > 0:
+                data["flowcell"] = f"{data['flowcell']}-{matches[0]}"
+        return data
+
+
+    @staticmethod
+    def parse_nanopore_file_data(fastq_path: Path) -> dict:
+        with gzip.open(fastq_path) as handle:
+            header_line = handle.readline().decode()
+            header_info: dict = MutantFastqHandler.get_nanopore_header_info(line=header_line)
+            data = {
+                "path": fastq_path,
+                "lane": int(header_info["lane"]),
+                "flowcell": header_info["flowcell"],
+                "read": 1,
+                "undetermined": False,
+            }
+            return data
+
 
     @staticmethod
     def create_fastq_name(
@@ -269,32 +294,11 @@ class MutantFastqHandler(FastqHandler):
         return "_".join(linked_fastq_name.split("_")[2:])
 
     @staticmethod
-    def parse_file_data(fastq_path: Path) -> dict:
-        with gzip.open(fastq_path) as handle:
-            header_line = handle.readline().decode()
-            if (
-                    "runid" in header_line
-                    and "flow_cell_id" in header_line
-                    and "barcode" in header_line
-            ):
-                header_info: dict = FastqHandler.parse_nanopore_header(line=header_line)
-                data = {
-                    "path": fastq_path,
-                    "lane": int(header_info["lane"]),
-                    "flowcell": header_info["flowcell"],
-                    "read": 1,
-                    "undetermined": False,
-                }
-            else:
-                header_info = FastqHandler.parse_header(header_line)
-                data = {
-                    "path": fastq_path,
-                    "lane": int(header_info["lane"]),
-                    "flowcell": header_info["flowcell"],
-                    "read": int(header_info["readnumber"]),
-                    "undetermined": ("Undetermined" in fastq_path),
-                }
-                matches = re.findall(r"-l[1-9]t([1-9]{2})_", str(fastq_path))
-                if len(matches) > 0:
-                    data["flowcell"] = f"{data['flowcell']}-{matches[0]}"
-            return data
+    def get_nanopore_header_info(line: str) -> dict:
+        fastq_meta = {"lane": None, "flowcell": None}
+        header_metadata: list = line.split(" ")
+        lane = header_metadata[3].split("=")
+        fastq_meta["lane"] = lane[1]
+        flowcell = header_metadata[5].split("=")
+        fastq_meta["flowcell"] = flowcell[1]
+        return fastq_meta

--- a/cg/meta/workflow/fastq.py
+++ b/cg/meta/workflow/fastq.py
@@ -148,6 +148,14 @@ class FastqHandler:
         return fastq_meta
 
     @staticmethod
+    def create_nanopore_fastq_name(
+        flowcell: str,
+        sample: str,
+        filenr: str,
+    ) -> str:
+        return f"{flowcell}_{sample}_{filenr}.fastq.gz"
+
+    @staticmethod
     def parse_file_data(fastq_path: Path) -> dict:
         with gzip.open(fastq_path) as handle:
             header_line = handle.readline().decode()
@@ -172,10 +180,7 @@ class FastqHandler:
             header_info: dict = MutantFastqHandler.get_nanopore_header_info(line=header_line)
             data = {
                 "path": fastq_path,
-                "lane": "NA",
                 "flowcell": header_info["flowcell"],
-                "read": 1,
-                "undetermined": False,
             }
             return data
 

--- a/cg/meta/workflow/mutant.py
+++ b/cg/meta/workflow/mutant.py
@@ -76,7 +76,7 @@ class MutantAnalysisAPI(AnalysisAPI):
         for sample_obj in samples:
             application = sample_obj.application_version.application
             if self._is_nanopore(application):
-                self.link_fastq_files_for_sample(case_obj=case_obj, sample_obj=sample_obj)
+                self.link_fastq_files_for_sample(case_obj=case_obj, sample_obj=sample_obj, concatenate=True)
                 continue
             if not sample_obj.sequencing_qc:
                 LOG.info("Sample %s read count below threshold, skipping!", sample_obj.internal_id)

--- a/cg/meta/workflow/mutant.py
+++ b/cg/meta/workflow/mutant.py
@@ -187,3 +187,59 @@ class MutantAnalysisAPI(AnalysisAPI):
             for case_object in self.get_running_cases()
             if Path(self.get_deliverables_file_path(case_id=case_object.internal_id)).exists()
         ]
+
+    def get_metadata_for_nanopore_sample(self, sample_obj: models.Sample) -> List[dict]:
+        return [
+            self.fastq_handler.parse_nanopore_file_data(file_obj.full_path)
+            for file_obj in self.housekeeper_api.files(
+                bundle=sample_obj.internal_id, tags=["fastq"]
+            )
+        ]
+
+    def link_nanopore_fastq_for_sample(
+        self, case_obj: models.Family, sample_obj: models.Sample, concatenate: bool = False
+    ) -> None:
+        """
+        Link FASTQ files for a nanopore sample to working directory.
+        If pipeline input requires concatenated fastq, files can also be concatenated
+        """
+        read_paths = []
+        files: List[dict] = self.get_metadata_for_nanopore_sample(sample_obj=sample_obj)
+        sorted_files = sorted(files, key=lambda k: k["path"])
+        fastq_dir = self.get_sample_fastq_destination_dir(case_obj=case_obj, sample_obj=sample_obj)
+        fastq_dir.mkdir(parents=True, exist_ok=True)
+
+        counter = 0
+        for fastq_data in sorted_files:
+            fastq_path = Path(fastq_data["path"])
+            fastq_name = self.fastq_handler.create_nanopore_fastq_name(
+                flowcell=fastq_data["flowcell"],
+                sample=sample_obj.internal_id,
+                filenr=str(counter),
+                meta=self.get_additional_naming_metadata(sample_obj),
+            )
+            counter += 1
+            destination_path: Path = fastq_dir / fastq_name
+            read_paths.append(destination_path)
+
+            if not destination_path.exists():
+                LOG.info(f"Linking: {fastq_path} -> {destination_path}")
+                destination_path.symlink_to(fastq_path)
+            else:
+                LOG.warning(f"Destination path already exists: {destination_path}")
+
+        if not concatenate:
+            return
+
+        concatenated_fastq_name = self.fastq_handler.create_nanopore_fastq_name(
+            flowcell=fastq_data["flowcell"],
+            sample=sample_obj.internal_id,
+            filenr=str(1),
+            meta=self.get_additional_naming_metadata(sample_obj),
+        )
+        concatenated_path = (
+            f"{fastq_dir}/{self.fastq_handler.get_concatenated_name(concatenated_fastq_name)}"
+        )
+        LOG.info("Concatenation in progress for sample %s.", sample_obj.internal_id)
+        self.fastq_handler.concatenate(read_paths, concatenated_path)
+        self.fastq_handler.remove_files(read_paths)

--- a/cg/meta/workflow/mutant.py
+++ b/cg/meta/workflow/mutant.py
@@ -76,13 +76,14 @@ class MutantAnalysisAPI(AnalysisAPI):
         for sample_obj in samples:
             application = sample_obj.application_version.application
             if self._is_nanopore(application):
-                self.link_nanopore_fastq_for_sample(case_obj=case_obj, sample_obj=sample_obj, concatenate=True)
+                self.link_nanopore_fastq_for_sample(
+                    case_obj=case_obj, sample_obj=sample_obj, concatenate=True
+                )
                 continue
             if not sample_obj.sequencing_qc:
                 LOG.info("Sample %s read count below threshold, skipping!", sample_obj.internal_id)
                 continue
             else:
-                print("HEEEEEEJ")
                 self.link_fastq_files_for_sample(
                     case_obj=case_obj, sample_obj=sample_obj, concatenate=True
                 )

--- a/cg/meta/workflow/mutant.py
+++ b/cg/meta/workflow/mutant.py
@@ -76,7 +76,7 @@ class MutantAnalysisAPI(AnalysisAPI):
         for sample_obj in samples:
             application = sample_obj.application_version.application
             if self._is_nanopore(application):
-                self.link_fastq_files_for_sample(case_obj=case_obj, sample_obj=sample_obj, concatenate=True)
+                self.link_fastq_files_for_sample(case_obj=case_obj, sample_obj=sample_obj)
                 continue
             if not sample_obj.sequencing_qc:
                 LOG.info("Sample %s read count below threshold, skipping!", sample_obj.internal_id)

--- a/cg/meta/workflow/mutant.py
+++ b/cg/meta/workflow/mutant.py
@@ -82,6 +82,7 @@ class MutantAnalysisAPI(AnalysisAPI):
                 LOG.info("Sample %s read count below threshold, skipping!", sample_obj.internal_id)
                 continue
             else:
+                print("HEEEEEEJ")
                 self.link_fastq_files_for_sample(
                     case_obj=case_obj, sample_obj=sample_obj, concatenate=True
                 )

--- a/cg/meta/workflow/mutant.py
+++ b/cg/meta/workflow/mutant.py
@@ -76,7 +76,7 @@ class MutantAnalysisAPI(AnalysisAPI):
         for sample_obj in samples:
             application = sample_obj.application_version.application
             if self._is_nanopore(application):
-                self.link_fastq_files_for_sample(case_obj=case_obj, sample_obj=sample_obj)
+                self.link_nanopore_fastq_for_sample(case_obj=case_obj, sample_obj=sample_obj, concatenate=True)
                 continue
             if not sample_obj.sequencing_qc:
                 LOG.info("Sample %s read count below threshold, skipping!", sample_obj.internal_id)


### PR DESCRIPTION
## Description
Currently cg assumes all data is illumina data. This PR allows pipelines to start via cg when it is nanopore data.

### Added

- Parsing of nanopore fastq header

### Changed

-

### Fixed

-


### How to prepare for test
- [ ] ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] paxa the environment: `paxa`
- [ ] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh no-qc-external`

### How to test
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
