### PR TITLE
Patch(Orders) Fixed existing sample validation

### DIFF
--- a/cg/meta/orders/case_submitter.py
+++ b/cg/meta/orders/case_submitter.py
@@ -69,11 +69,7 @@ class CaseSubmitter(Submitter):
             existing_sample: models.Sample = self.status.sample(sample.internal_id)
             data_customer: models.Customer = self.status.customer(customer_id)
 
-            if existing_sample.customer not in [
-                customer
-                for collaboration in data_customer.collaborations
-                for customer in collaboration.customers
-            ]:
+            if existing_sample.customer not in data_customer.collaborators:
                 raise OrderError(f"Sample not available: {sample.name}")
 
     def _validate_case_names_are_unique(


### PR DESCRIPTION
## Description
Customer found bug when placing orders for existing samples. They cannot place orders on their own samples if they are not part of a customer group.
### Fixed

- Validation of existing samples now works as intended


### How to prepare for test
- deploy on cg-vm1

### How to test
- [x] attempt to place an order on an existing sample

### Expected test outcome
- [x] check that the order is placed

## Review
- [x] code approved by HO
- [x] tests executed by VJ
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
