### PR TITLE
Add(paralell upload)

### DIFF
--- a/cg/cli/upload/base.py
+++ b/cg/cli/upload/base.py
@@ -78,13 +78,16 @@ def upload(context: click.Context, family_id: Optional[str], restart: bool):
         suggest_cases_to_upload(status_db=upload_api.status_db)
         raise click.Abort()
 
+
 def spawn_thread(ctx, family_id: str) -> threading.Thread:
     def wrapper():
         with ctx:
             ctx.invoke(upload, family_id=family_id)
+
     t = threading.Thread(target=wrapper)
     t.start()
     return t
+
 
 @upload.command()
 @click.option("--pipeline", type=EnumChoice(Pipeline), help="Limit to specific pipeline")
@@ -117,7 +120,7 @@ def auto(context: click.Context, pipeline: Pipeline = None):
             exit_code = 1
     for job in jobs:
         job.run()
-        
+
     sys.exit(exit_code)
 
 

--- a/cg/cli/upload/base.py
+++ b/cg/cli/upload/base.py
@@ -104,7 +104,7 @@ def auto(context: click.Context, pipeline: Pipeline = None):
         LOG.info("Uploading analysis for case: %s", case_id)
         with ui.patch_click():
             try:
-                t = Thread(target=upload(context=context, family_id=case_id))
+                t = Thread(target=upload(family_id=case_id))
                 t.start()
                 ui.run()
             except Exception:

--- a/cg/meta/upload/upload_api.py
+++ b/cg/meta/upload/upload_api.py
@@ -22,12 +22,12 @@ class UploadAPI(MetaAPI):
         super().__init__(config=config)
         self.analysis_api = analysis_api
         self.scout_upload_api: UploadScoutAPI = UploadScoutAPI(
-            hk_api=config.housekeeper_api,
-            scout_api=config.scout_api,
-            madeline_api=config.madeline_api,
+            hk_api=self.housekeeper_api,
+            scout_api=self.scout_api,
+            madeline_api=self.madeline_api,
             analysis_api=self.analysis_api,
-            lims_api=config.lims_api,
-            status_db=config.status_db,
+            lims_api=self.lims_api,
+            status_db=self.status_db,
         )
 
     def upload(self, ctx: click.Context, case_obj: models.Family, restart: bool) -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ werkzeug<1.0.0              # due to breaking changes in 1.0.0
 alive_progress
 ansi
 cgmodels>=0.10.1
+click-threading
 coloredlogs
 email-validator
 lxml


### PR DESCRIPTION
## Description

### Added

- Threading for upload processes

### How to prepare for test
- [ ] ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] paxa the environment: `paxa`
- [ ] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh add/paralell-uploads`

### How to test
- [ ] `cg upload auto --pipeline <pipeline>`

### Expected test outcome
- [ ] check that analyses are uploaded at approximately the same time
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
