### PR TITLE
Fix analyses to upload query

### DIFF
--- a/cg/cli/generate/report/base.py
+++ b/cg/cli/generate/report/base.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from typing import TextIO, Optional
 
 import click
+
+from cg.cli.upload.coverage import coverage
 from cg.store import models
 from cgmodels.cg.constants import Pipeline
 from housekeeper.store import models as hk_models
@@ -59,6 +61,10 @@ def delivery_report(
         )
         click.echo(delivery_report_html)
         return
+
+    if report_api.analysis_api.pipeline == Pipeline.MIP_DNA:
+        LOG.info(f"Uploading coverage data for {case.internal_id} delivery report")
+        context.invoke(coverage, family_id=case.internal_id, re_upload=True)
 
     delivery_report_file: TextIO = report_api.create_delivery_report_file(
         case_id,

--- a/cg/cli/generate/report/base.py
+++ b/cg/cli/generate/report/base.py
@@ -62,10 +62,6 @@ def delivery_report(
         click.echo(delivery_report_html)
         return
 
-    if report_api.analysis_api.pipeline == Pipeline.MIP_DNA:
-        LOG.info(f"Uploading coverage data for {case.internal_id} delivery report")
-        context.invoke(coverage, family_id=case.internal_id, re_upload=True)
-
     delivery_report_file: TextIO = report_api.create_delivery_report_file(
         case_id,
         file_path=Path(report_api.analysis_api.root, case_id),

--- a/cg/cli/generate/report/base.py
+++ b/cg/cli/generate/report/base.py
@@ -8,7 +8,6 @@ from typing import TextIO, Optional
 
 import click
 
-from cg.cli.upload.coverage import coverage
 from cg.store import models
 from cgmodels.cg.constants import Pipeline
 from housekeeper.store import models as hk_models

--- a/cg/meta/upload/mip_dna/mip_dna.py
+++ b/cg/meta/upload/mip_dna/mip_dna.py
@@ -3,12 +3,14 @@
 import logging
 
 import click
+
+from cg.cli.generate.report.base import delivery_report
 from cg.cli.upload.scout import scout
 from cg.cli.upload.observations import observations
 from cg.cli.upload.genotype import genotypes
 from cg.cli.upload.validate import validate
 from cg.cli.upload.coverage import coverage
-from cg.constants import DataDelivery
+from cg.constants import DataDelivery, REPORT_SUPPORTED_DATA_DELIVERY
 from cg.meta.workflow.mip_dna import MipDNAAnalysisAPI
 from cg.models.cg_config import CGConfig
 from cg.meta.upload.upload_api import UploadAPI
@@ -36,6 +38,10 @@ class MipDNAUploadAPI(UploadAPI):
         ctx.invoke(validate, family_id=case_obj.internal_id)
         ctx.invoke(genotypes, family_id=case_obj.internal_id, re_upload=restart)
         ctx.invoke(observations, case_id=case_obj.internal_id)
+
+        # Delivery report generation
+        if case_obj.data_delivery in REPORT_SUPPORTED_DATA_DELIVERY:
+            ctx.invoke(delivery_report, case_id=case_obj.internal_id)
 
         # Scout specific upload
         if DataDelivery.SCOUT in case_obj.data_delivery:

--- a/cg/store/api/status.py
+++ b/cg/store/api/status.py
@@ -554,13 +554,13 @@ class StatusHandler(BaseHandler):
             "order_analyses_by_completed_at",
         ]
         for filter_function in analysis_filter_functions:
-            records = apply_analysis_filter(
+            records: Query = apply_analysis_filter(
                 function=filter_function, analyses=records, pipeline=pipeline
             )
 
         if pipeline and Pipeline.BALSAMIC in pipeline:
             # BALSAMIC only supports Scout uploads
-            records = apply_filter(
+            records: Query = apply_filter(
                 function="cases_with_scout_data_delivery", cases=records, pipeline=pipeline
             )
 
@@ -636,7 +636,9 @@ class StatusHandler(BaseHandler):
             "filter_report_cases_with_valid_data_delivery",
         ]
         for filter_function in case_filter_functions:
-            records = apply_filter(function=filter_function, cases=records, pipeline=pipeline)
+            records: Query = apply_filter(
+                function=filter_function, cases=records, pipeline=pipeline
+            )
 
         analysis_filter_functions: List[str] = [
             "filter_report_analyses_by_pipeline",
@@ -645,7 +647,7 @@ class StatusHandler(BaseHandler):
             "order_analyses_by_completed_at",
         ]
         for filter_function in analysis_filter_functions:
-            records = apply_analysis_filter(
+            records: Query = apply_analysis_filter(
                 function=filter_function, analyses=records, pipeline=pipeline
             )
 
@@ -660,7 +662,9 @@ class StatusHandler(BaseHandler):
             "cases_with_scout_data_delivery",
         ]
         for filter_function in case_filter_functions:
-            records = apply_filter(function=filter_function, cases=records, pipeline=pipeline)
+            records: Query = apply_filter(
+                function=filter_function, cases=records, pipeline=pipeline
+            )
 
         analysis_filter_functions: List[str] = [
             "filter_report_analyses_by_pipeline",
@@ -670,7 +674,7 @@ class StatusHandler(BaseHandler):
             "order_analyses_by_completed_at",
         ]
         for filter_function in analysis_filter_functions:
-            records = apply_analysis_filter(
+            records: Query = apply_analysis_filter(
                 function=filter_function, analyses=records, pipeline=pipeline
             )
 

--- a/cg/store/api/status.py
+++ b/cg/store/api/status.py
@@ -560,7 +560,9 @@ class StatusHandler(BaseHandler):
 
         if pipeline and Pipeline.BALSAMIC in pipeline:
             # BALSAMIC only supports Scout uploads
-            records.filter(models.Family.data_delivery.contains(DataDelivery.SCOUT))
+            records = apply_filter(
+                function="cases_with_scout_data_delivery", cases=records, pipeline=pipeline
+            )
 
         return records
 

--- a/cg/store/api/status.py
+++ b/cg/store/api/status.py
@@ -549,19 +549,12 @@ class StatusHandler(BaseHandler):
             "analyses_with_pipeline",
             "completed_analyses",
             "not_uploaded_analyses",
-            "records_ready_for_upload",
             "valid_analyses_in_production",
             "order_analyses_by_completed_at",
         ]
         for filter_function in analysis_filter_functions:
             records: Query = apply_analysis_filter(
                 function=filter_function, analyses=records, pipeline=pipeline
-            )
-
-        if pipeline and Pipeline.BALSAMIC in pipeline:
-            # BALSAMIC only supports Scout uploads
-            records: Query = apply_filter(
-                function="cases_with_scout_data_delivery", cases=records, pipeline=pipeline
             )
 
         return records

--- a/cg/store/status_analysis_filters.py
+++ b/cg/store/status_analysis_filters.py
@@ -1,19 +1,18 @@
 from alchy import Query
-from sqlalchemy import or_, and_
 
 from cg.constants import REPORT_SUPPORTED_PIPELINES
-from cg.constants.constants import VALID_DATA_IN_PRODUCTION, DataDelivery
+from cg.constants.constants import VALID_DATA_IN_PRODUCTION
 from cg.store import models
 from cgmodels.cg.constants import Pipeline
 
 
 def filter_valid_analyses_in_production(analyses: Query, **kwargs) -> Query:
-    """Fetches analyses with a valid data in production"""
+    """Fetches analyses with a valid data in production."""
     return analyses.filter(VALID_DATA_IN_PRODUCTION < models.Analysis.completed_at)
 
 
 def filter_analyses_with_pipeline(analyses: Query, pipeline: Pipeline = None, **kwargs) -> Query:
-    """Return analyses that have been completed"""
+    """Return analyses that have been completed."""
     if pipeline:
         return analyses.filter(models.Analysis.pipeline == str(pipeline))
 
@@ -21,39 +20,39 @@ def filter_analyses_with_pipeline(analyses: Query, pipeline: Pipeline = None, **
 
 
 def filter_completed_analyses(analyses: Query, **kwargs) -> Query:
-    """Return analyses that have been completed"""
+    """Return analyses that have been completed."""
     return analyses.filter(models.Analysis.completed_at.isnot(None))
 
 
 def filter_not_completed_analyses(analyses: Query, **kwargs) -> Query:
-    """Return not completed analyses"""
+    """Return not completed analyses."""
     return analyses.filter(models.Analysis.completed_at.is_(None))
 
 
 def filter_uploaded_analyses(analyses: Query, **kwargs) -> Query:
-    """Fetches analyses that have been already uploaded"""
+    """Fetches analyses that have been already uploaded."""
     return analyses.filter(models.Analysis.uploaded_at.isnot(None))
 
 
 def filter_not_uploaded_analyses(analyses: Query, **kwargs) -> Query:
-    """Fetches analyses that have not been uploaded"""
+    """Fetches analyses that have not been uploaded."""
     return analyses.filter(models.Analysis.uploaded_at.is_(None))
 
 
 def filter_analyses_with_delivery_report(analyses: Query, **kwargs) -> Query:
-    """Return analyses that have a delivery report generated"""
+    """Return analyses that have a delivery report generated."""
     return analyses.filter(models.Analysis.delivery_report_created_at.isnot(None))
 
 
 def filter_analyses_without_delivery_report(analyses: Query, **kwargs) -> Query:
-    """Return analyses that do not have a delivery report generated"""
+    """Return analyses that do not have a delivery report generated."""
     return analyses.filter(models.Analysis.delivery_report_created_at.is_(None))
 
 
 def filter_report_analyses_by_pipeline(
     analyses: Query, pipeline: Pipeline = None, **kwargs
 ) -> Query:
-    """Fetches the delivery report related analyses associated to the provided or supported pipelines"""
+    """Fetches the delivery report related analyses associated to the provided or supported pipelines."""
     return (
         analyses.filter(models.Analysis.pipeline == str(pipeline))
         if pipeline
@@ -61,32 +60,18 @@ def filter_report_analyses_by_pipeline(
     )
 
 
-def filter_records_ready_for_upload(analyses: Query, **kwargs) -> Query:
-    """Fetches records that are ready to be uploaded. If the data delivery option includes Scout, the upload waits
-    for delivery report generation"""
-    return analyses.filter(
-        or_(
-            ~models.Family.data_delivery.contains(DataDelivery.SCOUT),
-            and_(
-                models.Family.data_delivery.contains(DataDelivery.SCOUT),
-                models.Analysis.delivery_report_created_at.isnot(None),
-            ),
-        )
-    )
-
-
 def order_analyses_by_completed_at(analyses: Query, **kwargs) -> Query:
-    """Return a query of ordered analyses (from old to new) by the completed_at field"""
+    """Return a query of ordered analyses (from old to new) by the completed_at field."""
     return analyses.order_by(models.Analysis.completed_at.asc())
 
 
 def order_analyses_by_uploaded_at(analyses: Query, **kwargs) -> Query:
-    """Return a query of ordered analyses (from old to new) by the uploaded_at field"""
+    """Return a query of ordered analyses (from old to new) by the uploaded_at field."""
     return analyses.order_by(models.Analysis.uploaded_at.asc())
 
 
 def apply_analysis_filter(function: str, analyses: Query, pipeline: Pipeline = None) -> Query:
-    """Apply filtering functions to the analyses queries and return filtered results"""
+    """Apply filtering functions to the analyses queries and return filtered results."""
 
     filter_map = {
         "valid_analyses_in_production": filter_valid_analyses_in_production,
@@ -98,7 +83,6 @@ def apply_analysis_filter(function: str, analyses: Query, pipeline: Pipeline = N
         "analyses_with_delivery_report": filter_analyses_with_delivery_report,
         "analyses_without_delivery_report": filter_analyses_without_delivery_report,
         "filter_report_analyses_by_pipeline": filter_report_analyses_by_pipeline,
-        "records_ready_for_upload": filter_records_ready_for_upload,
         "order_analyses_by_completed_at": order_analyses_by_completed_at,
         "order_analyses_by_uploaded_at": order_analyses_by_uploaded_at,
     }

--- a/tests/cli/generate/report/test_cli_delivery_report.py
+++ b/tests/cli/generate/report/test_cli_delivery_report.py
@@ -3,7 +3,9 @@
 import logging
 from datetime import datetime
 
-from cg.cli.generate.report.base import delivery_report, available_delivery_reports
+from cgmodels.cg.constants import Pipeline
+
+from cg.cli.generate.report.base import delivery_report
 from cg.constants import EXIT_SUCCESS, EXIT_FAIL
 
 
@@ -54,7 +56,8 @@ def test_delivery_report(mip_dna_context, cli_runner, case_id, caplog):
 
     caplog.set_level(logging.INFO)
 
-    # GIVEN a MIP DNA context object
+    # GIVEN a MIP DNA context object. Pipeline set to BALSAMIC to skip coverage upload.
+    mip_dna_context.meta_apis["report_api"].analysis_api.pipeline = Pipeline.BALSAMIC
 
     # WHEN calling delivery_report with a dry option
     cli_runner.invoke(

--- a/tests/cli/generate/report/test_cli_delivery_report.py
+++ b/tests/cli/generate/report/test_cli_delivery_report.py
@@ -3,8 +3,6 @@
 import logging
 from datetime import datetime
 
-from cgmodels.cg.constants import Pipeline
-
 from cg.cli.generate.report.base import delivery_report
 from cg.constants import EXIT_SUCCESS, EXIT_FAIL
 
@@ -56,8 +54,7 @@ def test_delivery_report(mip_dna_context, cli_runner, case_id, caplog):
 
     caplog.set_level(logging.INFO)
 
-    # GIVEN a MIP DNA context object. Pipeline set to BALSAMIC to skip coverage upload.
-    mip_dna_context.meta_apis["report_api"].analysis_api.pipeline = Pipeline.BALSAMIC
+    # GIVEN a MIP DNA context object
 
     # WHEN calling delivery_report with a dry option
     cli_runner.invoke(

--- a/tests/store/api/test_store_api_status.py
+++ b/tests/store/api/test_store_api_status.py
@@ -201,48 +201,6 @@ def test_analyses_to_upload_when_filtering_with_missing_pipeline(helpers, sample
     assert len(records) == 0
 
 
-def test_analyses_to_upload_with_scout_as_data_delivery(helpers, sample_store, timestamp):
-    """Test analyses to upload to for a Scout data delivery analysis without a delivery report"""
-
-    # GIVEN a store with Scout as data delivery
-    helpers.add_analysis(
-        store=sample_store,
-        completed_at=timestamp,
-        pipeline=Pipeline.MIP_DNA,
-        data_delivery=DataDelivery.FASTQ_ANALYSIS_SCOUT,
-    )
-
-    # WHEN fetching all available analyses
-    records = [
-        analysis_obj for analysis_obj in sample_store.analyses_to_upload(pipeline=Pipeline.MIP_DNA)
-    ]
-
-    # THEN no analysis object should be returned since Scout uploads require a delivery report
-    assert len(records) == 0
-
-
-def test_analyses_to_upload_with_delivery_report(helpers, sample_store, timestamp):
-    """Test analyses to upload to when a delivery report has been generated and Scout is specified as data delivery"""
-
-    # GIVEN a store with Scout as data delivery
-    helpers.add_analysis(
-        store=sample_store,
-        completed_at=timestamp,
-        pipeline=Pipeline.BALSAMIC_UMI,
-        data_delivery=DataDelivery.FASTQ_ANALYSIS_SCOUT,
-        delivery_reported_at=timestamp,
-    )
-
-    # WHEN fetching all available analyses
-    records = [
-        analysis_obj
-        for analysis_obj in sample_store.analyses_to_upload(pipeline=Pipeline.BALSAMIC_UMI)
-    ]
-
-    # THEN a valid analysis object should be returned
-    assert len(records) == 1
-
-
 def test_multiple_analyses(analysis_store, helpers, timestamp_today, timestamp_yesterday):
     """Tests that analyses that are not latest are not returned"""
 

--- a/tests/store/test_status_analyses_filters.py
+++ b/tests/store/test_status_analyses_filters.py
@@ -15,7 +15,6 @@ from cg.store.status_analysis_filters import (
     filter_analyses_with_delivery_report,
     filter_analyses_without_delivery_report,
     filter_report_analyses_by_pipeline,
-    filter_records_ready_for_upload,
     order_analyses_by_uploaded_at,
     order_analyses_by_completed_at,
 )
@@ -29,7 +28,7 @@ def test_filter_valid_analyses_in_production(
     timestamp_today: datetime,
     old_timestamp: datetime,
 ):
-    """Test that an expected analysis is returned when it has a production valid completed_at date"""
+    """Test that an expected analysis is returned when it has a production valid completed_at date."""
 
     # GIVEN a set of mock analyses
     analysis: models.Analysis = helpers.add_analysis(store=base_store, completed_at=timestamp_today)
@@ -50,7 +49,7 @@ def test_filter_valid_analyses_in_production(
 def test_filter_analyses_with_pipeline(
     base_store: Store, helpers: StoreHelpers, case_obj: models.Family
 ):
-    """Test analyses filtering by pipeline"""
+    """Test analyses filtering by pipeline."""
 
     # GIVEN a set of mock analyses
     balsamic_analysis: models.Analysis = helpers.add_analysis(
@@ -74,7 +73,7 @@ def test_filter_analyses_with_pipeline(
 def test_filter_completed_analyses(
     base_store: Store, helpers: StoreHelpers, timestamp_today: datetime
 ):
-    """Test filtering of completed analyses"""
+    """Test filtering of completed analyses."""
 
     # GIVEN a mock analysis
     analysis: models.Analysis = helpers.add_analysis(store=base_store, completed_at=timestamp_today)
@@ -203,33 +202,6 @@ def test_filter_report_analyses_by_pipeline(
     # THEN only the delivery report supported analysis should be retrieved
     assert balsamic_analysis in analyses
     assert fluffy_analysis not in analyses
-
-
-def test_filter_records_ready_for_upload(
-    base_store: Store, helpers: StoreHelpers, case_obj: models.Family, timestamp_today: datetime
-):
-    """Test filtering of analyses ready to be uploaded."""
-
-    # GIVEN a set of mock analyses
-    ready_analysis: models.Analysis = helpers.add_analysis(
-        store=base_store, data_delivery=DataDelivery.SCOUT, delivery_reported_at=timestamp_today
-    )
-    not_ready_analysis: models.Analysis = helpers.add_analysis(
-        store=base_store,
-        case=case_obj,
-        data_delivery=DataDelivery.SCOUT,
-        delivery_reported_at=None,
-    )
-
-    # GIVEN an analysis query
-    analyses_query: Query = base_store.latest_analyses()
-
-    # WHEN filtering analyses ready to be uploaded
-    analyses: Query = filter_records_ready_for_upload(analyses_query)
-
-    # THEN only the expected analyses should be returned
-    assert ready_analysis in analyses
-    assert not_ready_analysis not in analyses
 
 
 def test_order_analyses_by_completed_at(

--- a/tests/store/test_status_analyses_filters.py
+++ b/tests/store/test_status_analyses_filters.py
@@ -90,7 +90,7 @@ def test_filter_completed_analyses(
 
 
 def test_filter_not_completed_analyses(base_store: Store, helpers: StoreHelpers):
-    """Test filtering of ongoing analyses"""
+    """Test filtering of ongoing analyses."""
 
     # GIVEN a mock not completed analysis
     analysis_not_completed: models.Analysis = helpers.add_analysis(
@@ -110,7 +110,7 @@ def test_filter_not_completed_analyses(base_store: Store, helpers: StoreHelpers)
 def test_filter_uploaded_analyses(
     base_store: Store, helpers: StoreHelpers, timestamp_today: datetime
 ):
-    """Test filtering of analysis with an uploaded_at field"""
+    """Test filtering of analysis with an uploaded_at field."""
 
     # GIVEN a mock uploaded analysis
     analysis: models.Analysis = helpers.add_analysis(store=base_store, uploaded_at=timestamp_today)
@@ -126,7 +126,7 @@ def test_filter_uploaded_analyses(
 
 
 def test_filter_not_uploaded_analyses(base_store: Store, helpers: StoreHelpers):
-    """Test filtering of analysis that has not been uploaded"""
+    """Test filtering of analysis that has not been uploaded."""
 
     # GIVEN a mock not uploaded analysis
     not_uploaded_analysis: models.Analysis = helpers.add_analysis(
@@ -146,7 +146,7 @@ def test_filter_not_uploaded_analyses(base_store: Store, helpers: StoreHelpers):
 def test_filter_analyses_with_delivery_report(
     base_store: Store, helpers: StoreHelpers, timestamp_today: datetime
 ):
-    """Test filtering of analysis with a delivery report generated"""
+    """Test filtering of analysis with a delivery report generated."""
 
     # GIVEN an analysis with a delivery report
     analysis: models.Analysis = helpers.add_analysis(
@@ -164,7 +164,7 @@ def test_filter_analyses_with_delivery_report(
 
 
 def test_filter_analyses_without_delivery_report(base_store: Store, helpers: StoreHelpers):
-    """Test filtering of analysis without a delivery report generated"""
+    """Test filtering of analysis without a delivery report generated."""
 
     # GIVEN an analysis with a delivery report
     analysis_without_delivery_report: models.Analysis = helpers.add_analysis(
@@ -184,7 +184,7 @@ def test_filter_analyses_without_delivery_report(base_store: Store, helpers: Sto
 def test_filter_report_analyses_by_pipeline(
     base_store: Store, helpers: StoreHelpers, case_obj: models.Family
 ):
-    """Test filtering delivery report related analysis by pipeline"""
+    """Test filtering delivery report related analysis by pipeline."""
 
     # GIVEN a set of mock analysis
     balsamic_analysis: models.Analysis = helpers.add_analysis(
@@ -208,7 +208,7 @@ def test_filter_report_analyses_by_pipeline(
 def test_filter_records_ready_for_upload(
     base_store: Store, helpers: StoreHelpers, case_obj: models.Family, timestamp_today: datetime
 ):
-    """Test filtering of analyses ready to be uploaded"""
+    """Test filtering of analyses ready to be uploaded."""
 
     # GIVEN a set of mock analyses
     ready_analysis: models.Analysis = helpers.add_analysis(
@@ -239,7 +239,7 @@ def test_order_analyses_by_completed_at(
     timestamp_today: datetime,
     timestamp_yesterday: datetime,
 ):
-    """Test sorting of analyses by the completed_at field"""
+    """Test sorting of analyses by the completed_at field."""
 
     # GIVEN a set of mock analyses
     new_analysis: models.Analysis = helpers.add_analysis(
@@ -267,7 +267,7 @@ def test_order_analyses_by_uploaded_at(
     timestamp_today: datetime,
     timestamp_yesterday: datetime,
 ):
-    """Test sorting of analyses by the uploaded_at field"""
+    """Test sorting of analyses by the uploaded_at field."""
 
     # GIVEN a set of mock analyses
     new_analysis: models.Analysis = helpers.add_analysis(

--- a/tests/store/test_status_cases_filters.py
+++ b/tests/store/test_status_cases_filters.py
@@ -20,7 +20,7 @@ from tests.store_helpers import StoreHelpers
 def test_filter_cases_has_sequence(
     base_store: Store, helpers: StoreHelpers, timestamp_today: datetime
 ):
-    """Test that a case is returned when there is a cases with a sequenced sample"""
+    """Test that a case is returned when there is a cases with a sequenced sample."""
 
     # GIVEN a sequenced sample
     test_sample: models.Sample = helpers.add_sample(base_store, sequenced_at=timestamp_today)
@@ -42,7 +42,7 @@ def test_filter_cases_has_sequence(
 
 
 def test_filter_cases_has_sequence_when_external(base_store: Store, helpers: StoreHelpers):
-    """Test that a case is returned when there is a case with an externally sequenced sample"""
+    """Test that a case is returned when there is a case with an externally sequenced sample."""
 
     # GIVEN a sequenced sample
     test_sample: models.Sample = helpers.add_sample(base_store, sequenced_at=None, is_external=True)
@@ -64,7 +64,7 @@ def test_filter_cases_has_sequence_when_external(base_store: Store, helpers: Sto
 
 
 def test_filter_cases_has_sequence_when_not_sequenced(base_store: Store, helpers: StoreHelpers):
-    """Test that no case is returned when there is a cases with sample that has not been sequenced"""
+    """Test that no case is returned when there is a cases with sample that has not been sequenced."""
 
     # GIVEN a sequenced sample
     test_sample: models.Sample = helpers.add_sample(base_store, sequenced_at=None)
@@ -88,7 +88,7 @@ def test_filter_cases_has_sequence_when_not_sequenced(base_store: Store, helpers
 def test_filter_cases_has_sequence_when_not_external_nor_sequenced(
     base_store: Store, helpers: StoreHelpers
 ):
-    """Test that no case is returned when there is a cases with sample that has not been sequenced nor is external"""
+    """Test that no case is returned when there is a cases with sample that has not been sequenced nor is external."""
 
     # GIVEN a sequenced sample
     test_sample: models.Sample = helpers.add_sample(
@@ -114,7 +114,7 @@ def test_filter_cases_has_sequence_when_not_external_nor_sequenced(
 def test_filter_cases_with_pipeline_when_correct_pipline(
     base_store: Store, helpers: StoreHelpers, timestamp_today: datetime
 ):
-    """Test that no case is returned when there are no cases with the  specified pipeline"""
+    """Test that no case is returned when there are no cases with the  specified pipeline."""
 
     # GIVEN a sequenced sample
     test_sample: models.Sample = helpers.add_sample(base_store, sequenced_at=timestamp_today)
@@ -138,7 +138,7 @@ def test_filter_cases_with_pipeline_when_correct_pipline(
 def test_filter_cases_with_pipeline_when_incorrect_pipline(
     base_store: Store, helpers: StoreHelpers, timestamp_today: datetime
 ):
-    """Test that no case is returned when there are no cases with the  specified pipeline"""
+    """Test that no case is returned when there are no cases with the  specified pipeline."""
 
     # GIVEN a sequenced sample
     test_sample: models.Sample = helpers.add_sample(base_store, sequenced_at=timestamp_today)
@@ -162,7 +162,7 @@ def test_filter_cases_with_pipeline_when_incorrect_pipline(
 def test_filter_cases_for_analysis(
     base_store: Store, helpers: StoreHelpers, timestamp_today: datetime
 ):
-    """Test that a case is returned when there is a cases with an action set to analyse"""
+    """Test that a case is returned when there is a cases with an action set to analyse."""
 
     # GIVEN a sequenced sample
     test_sample: models.Sample = helpers.add_sample(base_store, sequenced_at=timestamp_today)
@@ -191,7 +191,7 @@ def test_filter_cases_for_analysis(
 def test_filter_cases_for_analysis_when_sequenced_sample_and_no_analysis(
     base_store: Store, helpers: StoreHelpers, timestamp_today: datetime
 ):
-    """Test that a case is returned when there are internally created cases with no action set and no prior analysis"""
+    """Test that a case is returned when there are internally created cases with no action set and no prior analysis."""
 
     # GIVEN a sequenced sample
     test_sample: models.Sample = helpers.add_sample(
@@ -220,7 +220,7 @@ def test_filter_cases_for_analysis_when_cases_with_no_action_and_new_sequence_da
     timestamp_yesterday: datetime,
     timestamp_today: datetime,
 ):
-    """Test that a case is returned when cases with no action, but new sequence data"""
+    """Test that a case is returned when cases with no action, but new sequence data."""
 
     # GIVEN a sequenced sample
     test_sample: models.Sample = helpers.add_sample(
@@ -252,7 +252,7 @@ def test_filter_cases_for_analysis_when_cases_with_no_action_and_new_sequence_da
 def test_filter_cases_for_analysis_when_cases_with_no_action_and_old_sequence_data(
     base_store: Store, helpers: StoreHelpers, timestamp_yesterday: datetime
 ):
-    """Test that a case is not returned when cases with no action, but old sequence data"""
+    """Test that a case is not returned when cases with no action, but old sequence data."""
 
     # GIVEN a sequenced sample
     test_sample: models.Sample = helpers.add_sample(
@@ -281,7 +281,7 @@ def test_filter_cases_for_analysis_when_cases_with_no_action_and_old_sequence_da
 def test_filter_cases_with_scout_data_delivery(
     base_store: Store, helpers: StoreHelpers, timestamp_today: datetime
 ):
-    """Test that a case is returned when Scout is specified as a data delivery option"""
+    """Test that a case is returned when Scout is specified as a data delivery option."""
 
     # GIVEN a sequenced sample
     test_sample: models.Sample = helpers.add_sample(base_store)
@@ -305,7 +305,7 @@ def test_filter_cases_with_scout_data_delivery(
 def test_filter_report_supported_data_delivery_cases(
     base_store: Store, helpers: StoreHelpers, timestamp_today: datetime
 ):
-    """Test that a case is returned for a delivery report supported data delivery option"""
+    """Test that a case is returned for a delivery report supported data delivery option."""
 
     # GIVEN a sequenced sample
     test_sample: models.Sample = helpers.add_sample(base_store)


### PR DESCRIPTION
## Description

The delivery reports will be part of the upload. If there is nothing to upload, the uploaded_at fields will be still filled in.

### Fixed
- Added missing query assignment for analyses to upload retrieving
- Delivery report generation as part of the upload command


### How to prepare for test
- [x] ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh fix-analyses-to-upload-query`

---
### Tests

- [x] `cg upload auto --pipeline mip-dna`
- [x] `cg upload auto --pipeline balsamic-umi`
- [x] `cg upload auto --pipeline balsamic`

<img width="500" alt="Screen Shot 2022-09-05 at 16 59 47" src="https://user-images.githubusercontent.com/26309194/188477154-5f7040ce-3fce-4a1a-9933-90d66780dc86.png">



## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
