### PR TITLE
Delivery report failing for external samples

### DIFF
--- a/cg/cli/generate/base.py
+++ b/cg/cli/generate/base.py
@@ -7,7 +7,7 @@ from cg.cli.generate.report.base import delivery_report, available_delivery_repo
 
 @click.group()
 def generate():
-    """Generates and/or modifies files"""
+    """Generates and/or modifies files."""
 
 
 generate.add_command(delivery_report)

--- a/cg/cli/generate/report/base.py
+++ b/cg/cli/generate/report/base.py
@@ -45,7 +45,7 @@ def delivery_report(
     dry_run: bool,
     analysis_started_at: str = None,
 ):
-    """Creates a delivery report for the provided case"""
+    """Creates a delivery report for the provided case."""
 
     click.echo(click.style("--------------- DELIVERY REPORT ---------------"))
 
@@ -87,7 +87,7 @@ def delivery_report(
 def available_delivery_reports(
     context: click.Context, pipeline: Pipeline, force_report: bool, dry_run: bool
 ):
-    """Generates delivery reports for all cases that need one and stores them in housekeeper"""
+    """Generates delivery reports for all cases that need one and stores them in housekeeper."""
 
     click.echo(click.style("--------------- AVAILABLE DELIVERY REPORTS ---------------"))
 

--- a/cg/cli/generate/report/utils.py
+++ b/cg/cli/generate/report/utils.py
@@ -21,7 +21,7 @@ LOG = logging.getLogger(__name__)
 
 
 def get_report_case(context: click.Context, case_id: str) -> models.Family:
-    """Extracts a case object for delivery report generation"""
+    """Extracts a case object for delivery report generation."""
 
     # Default report API (MIP DNA report API)
     report_api: ReportAPI = (
@@ -75,7 +75,7 @@ def get_report_case(context: click.Context, case_id: str) -> models.Family:
 
 
 def get_report_api(context: click.Context, case: models.Family) -> ReportAPI:
-    """Returns a report API to be used for the delivery report generation"""
+    """Returns a report API to be used for the delivery report generation."""
 
     if context.obj.meta_apis.get("report_api"):
         return context.obj.meta_apis.get("report_api")
@@ -84,7 +84,7 @@ def get_report_api(context: click.Context, case: models.Family) -> ReportAPI:
 
 
 def get_report_api_pipeline(context: click.Context, pipeline: Pipeline) -> ReportAPI:
-    """Resolves the report API given a specific pipeline"""
+    """Resolves the report API given a specific pipeline."""
 
     # Default report API pipeline: MIP-DNA
     pipeline = pipeline if pipeline else Pipeline.MIP_DNA
@@ -107,7 +107,7 @@ def get_report_api_pipeline(context: click.Context, pipeline: Pipeline) -> Repor
 def get_report_analysis_started(
     case: models.Family, report_api: ReportAPI, analysis_started_at: Optional[str]
 ) -> datetime:
-    """Resolves and returns a valid analysis date"""
+    """Resolves and returns a valid analysis date."""
 
     if not analysis_started_at:
         analysis_started_at: datetime = (

--- a/cg/cli/upload/delivery_report.py
+++ b/cg/cli/upload/delivery_report.py
@@ -19,7 +19,7 @@ LOG = logging.getLogger(__name__)
 )
 @click.pass_context
 def upload_delivery_report_to_scout(context: click.Context, case_id: str, dry_run: bool):
-    """Fetches a delivery report from housekeeper and uploads it to scout"""
+    """Fetches a delivery report from housekeeper and uploads it to scout."""
 
     click.echo(click.style("--------------- DELIVERY REPORT UPLOAD ---------------"))
 

--- a/cg/constants/report.py
+++ b/cg/constants/report.py
@@ -58,7 +58,7 @@ REQUIRED_CASE_FIELDS = [
     "applications",
 ]
 
-# Application required fields (OPTIONAL: "version", "prep_category", "description", "limitations")
+# Application required fields (OPTIONAL: "version", "prep_category", "description", "limitations", "external")
 REQUIRED_APPLICATION_FIELDS = [
     "tag",
     "accredited",
@@ -108,7 +108,7 @@ REQUIRED_SAMPLE_METHODS_FIELDS = []
 # Timestamp required fields (OPTIONAL: "prepared_at", "sequenced_at")
 REQUIRED_SAMPLE_TIMESTAMP_FIELDS = [
     "ordered_at",
-    "received_at",
+    "received_at",  # Optional for external samples
 ]
 
 # Metadata required fields

--- a/cg/meta/report/balsamic.py
+++ b/cg/meta/report/balsamic.py
@@ -49,7 +49,11 @@ class BalsamicReportAPI(ReportAPI):
         """Fetches the sample metadata to include in the report"""
 
         sample_metrics = analysis_metadata.sample_metrics[sample.internal_id]
-        million_read_pairs = round(sample.reads / 2000000, 1) if sample.reads else None
+        million_read_pairs = (
+            round(sample.reads / 2000000, 1)
+            if sample.reads or isinstance(sample.reads, int)
+            else None
+        )
 
         if "wgs" in self.get_data_analysis_type(case):
             return self.get_wgs_metadata(million_read_pairs, sample_metrics)

--- a/cg/meta/report/balsamic.py
+++ b/cg/meta/report/balsamic.py
@@ -38,7 +38,7 @@ LOG = logging.getLogger(__name__)
 
 
 class BalsamicReportAPI(ReportAPI):
-    """API to create BALSAMIC delivery reports"""
+    """API to create BALSAMIC delivery reports."""
 
     def __init__(self, config: CGConfig, analysis_api: BalsamicAnalysisAPI):
         super().__init__(config=config, analysis_api=analysis_api)
@@ -47,7 +47,7 @@ class BalsamicReportAPI(ReportAPI):
     def get_sample_metadata(
         self, case: models.Family, sample: models.Sample, analysis_metadata: BalsamicAnalysis
     ) -> Union[BalsamicTargetedSampleMetadataModel, BalsamicWGSSampleMetadataModel]:
-        """Fetches the sample metadata to include in the report"""
+        """Fetches the sample metadata to include in the report."""
 
         sample_metrics = analysis_metadata.sample_metrics[sample.internal_id]
         million_read_pairs = get_million_read_pairs(sample.reads)
@@ -66,7 +66,7 @@ class BalsamicReportAPI(ReportAPI):
         sample_metrics: BalsamicTargetedQCMetrics,
         analysis_metadata: BalsamicAnalysis,
     ) -> BalsamicTargetedSampleMetadataModel:
-        """Returns a report metadata for BALSAMIC TGS analysis"""
+        """Returns a report metadata for BALSAMIC TGS analysis."""
 
         return BalsamicTargetedSampleMetadataModel(
             bait_set=sample.capture_kit,
@@ -85,7 +85,7 @@ class BalsamicReportAPI(ReportAPI):
     def get_wgs_metadata(
         self, million_read_pairs: float, sample_metrics: BalsamicWGSQCMetrics
     ) -> BalsamicWGSSampleMetadataModel:
-        """Returns a report metadata for BALSAMIC WGS analysis"""
+        """Returns a report metadata for BALSAMIC WGS analysis."""
 
         return BalsamicWGSSampleMetadataModel(
             million_read_pairs=million_read_pairs,
@@ -99,7 +99,7 @@ class BalsamicReportAPI(ReportAPI):
 
     @staticmethod
     def get_wgs_percent_duplication(sample_metrics: BalsamicWGSQCMetrics):
-        """Returns the duplication percentage taking into account both reads"""
+        """Returns the duplication percentage taking into account both reads."""
 
         return (
             (sample_metrics.percent_duplication_r1 + sample_metrics.percent_duplication_r2) / 2
@@ -108,19 +108,19 @@ class BalsamicReportAPI(ReportAPI):
         )
 
     def get_data_analysis_type(self, case: models.Family) -> str:
-        """Retrieves the data analysis type carried out"""
+        """Retrieves the data analysis type carried out."""
 
         return self.analysis_api.get_bundle_deliverables_type(case.internal_id)
 
     def get_genome_build(self, analysis_metadata: BalsamicAnalysis) -> str:
-        """Returns the build version of the genome reference of a specific case"""
+        """Returns the build version of the genome reference of a specific case."""
 
         return analysis_metadata.config.reference.reference_genome_version
 
     def get_variant_callers(self, analysis_metadata: BalsamicAnalysis) -> list:
         """
         Extracts the list of BALSAMIC variant-calling filters and their versions (if available) from the
-        config.json file
+        config.json file.
         """
 
         sequencing_type = analysis_metadata.config.analysis.sequencing_type
@@ -146,7 +146,7 @@ class BalsamicReportAPI(ReportAPI):
         var_caller_name: str,
         var_caller_versions: dict,
     ) -> Optional[str]:
-        """Returns the version of a specific BALSAMIC tool"""
+        """Returns the version of a specific BALSAMIC tool."""
 
         for tool_name, versions in var_caller_versions.items():
             if tool_name in var_caller_name:
@@ -157,7 +157,7 @@ class BalsamicReportAPI(ReportAPI):
     def get_report_accreditation(
         self, samples: List[SampleModel], analysis_metadata: BalsamicAnalysis
     ) -> bool:
-        """Checks if the report is accredited or not"""
+        """Checks if the report is accredited or not."""
 
         if analysis_metadata.config.analysis.sequencing_type == "targeted" and next(
             (
@@ -172,7 +172,7 @@ class BalsamicReportAPI(ReportAPI):
         return False
 
     def get_required_fields(self, case: CaseModel) -> dict:
-        """Retrieves a dictionary with the delivery report required fields for BALSAMIC"""
+        """Retrieves a dictionary with the delivery report required fields for BALSAMIC."""
 
         analysis_type = case.data_analysis.type
         required_sample_metadata_fields = list()
@@ -202,11 +202,11 @@ class BalsamicReportAPI(ReportAPI):
         }
 
     def get_template_name(self) -> str:
-        """Retrieves the template name to render the delivery report"""
+        """Retrieves the template name to render the delivery report."""
 
         return Pipeline.BALSAMIC + "_report.html"
 
     def get_upload_case_tags(self) -> dict:
-        """Retrieves BALSAMIC upload case tags"""
+        """Retrieves BALSAMIC upload case tags."""
 
         return BALSAMIC_CASE_TAGS

--- a/cg/meta/report/balsamic.py
+++ b/cg/meta/report/balsamic.py
@@ -19,6 +19,7 @@ from cg.constants import (
     REQUIRED_SAMPLE_METADATA_BALSAMIC_TO_WGS_FIELDS,
 )
 from cg.constants.scout_upload import BALSAMIC_CASE_TAGS
+from cg.meta.report.field_validators import get_million_read_pairs
 from cg.meta.workflow.balsamic import BalsamicAnalysisAPI
 from cg.meta.report.report_api import ReportAPI
 from cg.models.balsamic.analysis import BalsamicAnalysis
@@ -49,11 +50,7 @@ class BalsamicReportAPI(ReportAPI):
         """Fetches the sample metadata to include in the report"""
 
         sample_metrics = analysis_metadata.sample_metrics[sample.internal_id]
-        million_read_pairs = (
-            round(sample.reads / 2000000, 1)
-            if sample.reads or isinstance(sample.reads, int)
-            else None
-        )
+        million_read_pairs = get_million_read_pairs(sample.reads)
 
         if "wgs" in self.get_data_analysis_type(case):
             return self.get_wgs_metadata(million_read_pairs, sample_metrics)

--- a/cg/meta/report/balsamic.py
+++ b/cg/meta/report/balsamic.py
@@ -198,7 +198,9 @@ class BalsamicReportAPI(ReportAPI):
             "data_analysis": REQUIRED_DATA_ANALYSIS_BALSAMIC_FIELDS,
             "samples": self.get_sample_required_fields(case, REQUIRED_SAMPLE_BALSAMIC_FIELDS),
             "methods": self.get_sample_required_fields(case, REQUIRED_SAMPLE_METHODS_FIELDS),
-            "timestamps": self.get_sample_required_fields(case, REQUIRED_SAMPLE_TIMESTAMP_FIELDS),
+            "timestamps": self.get_timestamp_required_fields(
+                case, REQUIRED_SAMPLE_TIMESTAMP_FIELDS
+            ),
             "metadata": self.get_sample_required_fields(case, required_sample_metadata_fields),
         }
 

--- a/cg/meta/report/balsamic_umi.py
+++ b/cg/meta/report/balsamic_umi.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Optional
 
 from cg.constants.scout_upload import BALSAMIC_UMI_CASE_TAGS
 from cg.meta.report.balsamic import BalsamicReportAPI
@@ -11,13 +10,13 @@ LOG = logging.getLogger(__name__)
 
 
 class BalsamicUmiReportAPI(BalsamicReportAPI):
-    """API to create BALSAMIC UMI delivery reports"""
+    """API to create BALSAMIC UMI delivery reports."""
 
     def __init__(self, config: CGConfig, analysis_api: BalsamicUmiAnalysisAPI):
         super().__init__(config=config, analysis_api=analysis_api)
         self.analysis_api = analysis_api
 
     def get_upload_case_tags(self) -> dict:
-        """Retrieves BALSAMIC UMI upload case tags"""
+        """Retrieves BALSAMIC UMI upload case tags."""
 
         return BALSAMIC_UMI_CASE_TAGS

--- a/cg/meta/report/field_validators.py
+++ b/cg/meta/report/field_validators.py
@@ -1,11 +1,19 @@
 """Report field validation helper"""
 
+from typing import Optional
+
 from cg.constants import NA_FIELD
 from cg.models.report.report import ReportModel
 
 
+def get_million_read_pairs(reads: int) -> Optional[float]:
+    """Represents the number of sequencing reads as millions of read pairs"""
+
+    return round(reads / 2_000_000, 1) if reads or isinstance(reads, int) else None
+
+
 def get_missing_fields(empty_fields: list, required_fields: list) -> list:
-    """Extracts the missing fields that are required to generate successfully the delivery report"""
+    """Extracts the missing fields that are required to generate successfully the delivery report."""
 
     missing_fields = list()
 
@@ -17,7 +25,7 @@ def get_missing_fields(empty_fields: list, required_fields: list) -> list:
 
 
 def get_empty_fields(report_data: dict) -> list:
-    """Returns a list of empty report fields"""
+    """Returns a list of empty report fields."""
 
     empty_fields = list()
 
@@ -32,7 +40,7 @@ def get_empty_fields(report_data: dict) -> list:
 
 
 def get_empty_report_data(report_data: ReportModel) -> dict:
-    """Retrieve empty fields from a report data model"""
+    """Retrieve empty fields from a report data model."""
 
     empty_fields = {
         "report": get_empty_fields(report_data.dict()),
@@ -73,7 +81,7 @@ def get_empty_report_data(report_data: ReportModel) -> dict:
 
 
 def get_missing_report_data(empty_fields: dict, required_fields: dict) -> dict:
-    """Retrieve the missing required fields from a report data model"""
+    """Retrieve the missing required fields from a report data model."""
 
     nested_sources = ["applications", "samples", "methods", "timestamps", "metadata"]
     missing_fields = dict()

--- a/cg/meta/report/field_validators.py
+++ b/cg/meta/report/field_validators.py
@@ -7,7 +7,7 @@ from cg.models.report.report import ReportModel
 
 
 def get_million_read_pairs(reads: int) -> Optional[float]:
-    """Represents the number of sequencing reads as millions of read pairs"""
+    """Represents the number of sequencing reads as millions of read pairs."""
 
     return round(reads / 2_000_000, 1) if reads or isinstance(reads, int) else None
 

--- a/cg/meta/report/mip_dna.py
+++ b/cg/meta/report/mip_dna.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Union, Optional
+from typing import List
 
 from cgmodels.cg.constants import Pipeline
 
@@ -31,7 +31,7 @@ LOG = logging.getLogger(__name__)
 
 
 class MipDNAReportAPI(ReportAPI):
-    """API to create Rare disease DNA delivery reports"""
+    """API to create Rare disease DNA delivery reports."""
 
     def __init__(self, config: CGConfig, analysis_api: MipDNAAnalysisAPI):
         super().__init__(config=config, analysis_api=analysis_api)
@@ -40,7 +40,7 @@ class MipDNAReportAPI(ReportAPI):
     def get_sample_metadata(
         self, case: models.Family, sample: models.Sample, analysis_metadata: MipAnalysis
     ) -> MipDNASampleMetadataModel:
-        """Fetches the MIP DNA sample metadata to include in the report"""
+        """Fetches the MIP DNA sample metadata to include in the report."""
 
         parsed_metrics = get_sample_id_metric(
             sample_id=sample.internal_id, sample_id_metrics=analysis_metadata.sample_id_metrics
@@ -58,7 +58,7 @@ class MipDNAReportAPI(ReportAPI):
         )
 
     def get_sample_coverage(self, sample: models.Sample, case: models.Family) -> dict:
-        """Calculates coverage values for a specific sample"""
+        """Calculates coverage values for a specific sample."""
 
         genes = self.get_genes_from_scout(case.panels)
         sample_coverage = self.chanjo_api.sample_coverage(sample.internal_id, genes)
@@ -69,7 +69,7 @@ class MipDNAReportAPI(ReportAPI):
         return dict()
 
     def get_genes_from_scout(self, panels: list) -> list:
-        """Extracts panel gene IDs information from Scout"""
+        """Extracts panel gene IDs information from Scout."""
 
         panel_genes = list()
         for panel in panels:
@@ -79,7 +79,7 @@ class MipDNAReportAPI(ReportAPI):
         return panel_gene_ids
 
     def get_data_analysis_type(self, case: models.Family) -> str:
-        """Retrieves the data analysis type carried out"""
+        """Retrieves the data analysis type carried out."""
 
         case_sample = self.status_db.family_samples(case.internal_id)[0].sample
         lims_sample = self.get_lims_sample(case_sample.internal_id)
@@ -88,19 +88,19 @@ class MipDNAReportAPI(ReportAPI):
         return application.analysis_type
 
     def get_genome_build(self, analysis_metadata: MipAnalysis) -> str:
-        """Returns the build version of the genome reference of a specific case"""
+        """Returns the build version of the genome reference of a specific case."""
 
         return analysis_metadata.genome_build
 
     def get_variant_callers(self, analysis_metadata: MipAnalysis = None) -> list:
-        """Extracts the list of variant-calling filters used during analysis"""
+        """Extracts the list of variant-calling filters used during analysis."""
 
         return []
 
     def get_report_accreditation(
         self, samples: List[SampleModel], analysis_metadata: MipAnalysis = None
     ) -> bool:
-        """Checks if the report is accredited or not by evaluating each of the sample process accreditations"""
+        """Checks if the report is accredited or not by evaluating each of the sample process accreditations."""
 
         for sample in samples:
             if not sample.application.accredited:
@@ -109,7 +109,7 @@ class MipDNAReportAPI(ReportAPI):
         return True
 
     def get_required_fields(self, case: CaseModel) -> dict:
-        """Retrieves a dictionary with the delivery report required fields for MIP DNA"""
+        """Retrieves a dictionary with the delivery report required fields for MIP DNA."""
 
         return {
             "report": REQUIRED_REPORT_FIELDS,
@@ -127,7 +127,7 @@ class MipDNAReportAPI(ReportAPI):
 
     @staticmethod
     def get_sample_metadata_required_fields(case: CaseModel) -> dict:
-        """Retrieves sample metadata required fields associated to a specific sample ID"""
+        """Retrieves sample metadata required fields associated to a specific sample ID."""
 
         required_sample_metadata_fields = dict()
 
@@ -143,11 +143,11 @@ class MipDNAReportAPI(ReportAPI):
         return required_sample_metadata_fields
 
     def get_template_name(self) -> str:
-        """Retrieves the template name to render the delivery report"""
+        """Retrieves the template name to render the delivery report."""
 
         return Pipeline.MIP_DNA + "_report.html"
 
     def get_upload_case_tags(self) -> dict:
-        """Retrieves MIP DNA upload case tags"""
+        """Retrieves MIP DNA upload case tags."""
 
         return MIP_CASE_TAGS

--- a/cg/meta/report/mip_dna.py
+++ b/cg/meta/report/mip_dna.py
@@ -49,7 +49,9 @@ class MipDNAReportAPI(ReportAPI):
         return MipDNASampleMetadataModel(
             bait_set=self.lims_api.capture_kit(sample.internal_id),
             gender=parsed_metrics.predicted_sex,
-            million_read_pairs=round(sample.reads / 2000000, 1) if sample.reads else None,
+            million_read_pairs=round(sample.reads / 2000000, 1)
+            if sample.reads or isinstance(sample.reads, int)
+            else None,
             mapped_reads=parsed_metrics.mapped_reads,
             mean_target_coverage=sample_coverage.get("mean_coverage"),
             pct_10x=sample_coverage.get("mean_completeness"),

--- a/cg/meta/report/mip_dna.py
+++ b/cg/meta/report/mip_dna.py
@@ -16,6 +16,7 @@ from cg.constants import (
     REQUIRED_SAMPLE_METADATA_MIP_DNA_WGS_FIELDS,
 )
 from cg.constants.scout_upload import MIP_CASE_TAGS
+from cg.meta.report.field_validators import get_million_read_pairs
 from cg.models.cg_config import CGConfig
 from cg.meta.report.report_api import ReportAPI
 from cg.meta.workflow.mip_dna import MipDNAAnalysisAPI
@@ -49,9 +50,7 @@ class MipDNAReportAPI(ReportAPI):
         return MipDNASampleMetadataModel(
             bait_set=self.lims_api.capture_kit(sample.internal_id),
             gender=parsed_metrics.predicted_sex,
-            million_read_pairs=round(sample.reads / 2000000, 1)
-            if sample.reads or isinstance(sample.reads, int)
-            else None,
+            million_read_pairs=get_million_read_pairs(sample.reads),
             mapped_reads=parsed_metrics.mapped_reads,
             mean_target_coverage=sample_coverage.get("mean_coverage"),
             pct_10x=sample_coverage.get("mean_completeness"),

--- a/cg/meta/report/mip_dna.py
+++ b/cg/meta/report/mip_dna.py
@@ -120,7 +120,9 @@ class MipDNAReportAPI(ReportAPI):
             "data_analysis": REQUIRED_DATA_ANALYSIS_MIP_DNA_FIELDS,
             "samples": self.get_sample_required_fields(case, REQUIRED_SAMPLE_MIP_DNA_FIELDS),
             "methods": self.get_sample_required_fields(case, REQUIRED_SAMPLE_METHODS_FIELDS),
-            "timestamps": self.get_sample_required_fields(case, REQUIRED_SAMPLE_TIMESTAMP_FIELDS),
+            "timestamps": self.get_timestamp_required_fields(
+                case, REQUIRED_SAMPLE_TIMESTAMP_FIELDS
+            ),
             "metadata": self.get_sample_metadata_required_fields(case),
         }
 

--- a/cg/meta/report/report_api.py
+++ b/cg/meta/report/report_api.py
@@ -453,6 +453,7 @@ class ReportAPI(MetaAPI):
         for sample in case.samples:
             if sample.application.external:
                 required_fields.remove("received_at")
+                break
 
         return ReportAPI.get_sample_required_fields(case, required_fields)
 

--- a/cg/meta/report/report_api.py
+++ b/cg/meta/report/report_api.py
@@ -36,7 +36,7 @@ LOG = logging.getLogger(__name__)
 
 
 class ReportAPI(MetaAPI):
-    """Common Delivery Report API"""
+    """Common Delivery Report API."""
 
     def __init__(self, config: CGConfig, analysis_api: AnalysisAPI):
         super().__init__(config=config)
@@ -45,7 +45,7 @@ class ReportAPI(MetaAPI):
     def create_delivery_report(
         self, case_id: str, analysis_date: datetime, force_report: bool
     ) -> str:
-        """Generates the html contents of a delivery report"""
+        """Generates the html contents of a delivery report."""
 
         report_data: ReportModel = self.get_report_data(
             case_id=case_id, analysis_date=analysis_date
@@ -58,7 +58,7 @@ class ReportAPI(MetaAPI):
     def create_delivery_report_file(
         self, case_id: str, file_path: Path, analysis_date: datetime, force_report: bool
     ) -> TextIO:
-        """Generates a temporary file containing a delivery report"""
+        """Generates a temporary file containing a delivery report."""
 
         file_path.mkdir(parents=True, exist_ok=True)
         delivery_report = self.create_delivery_report(
@@ -76,7 +76,7 @@ class ReportAPI(MetaAPI):
     ) -> Optional[hk_models.File]:
         """
         Adds a delivery report file, if it has not already been generated, to an analysis bundle for a specific case
-        in HK and returns a pointer to it
+        in HK and returns a pointer to it.
         """
 
         version = self.housekeeper_api.version(case_id, analysis_date)
@@ -94,7 +94,7 @@ class ReportAPI(MetaAPI):
         return None
 
     def get_delivery_report_from_hk(self, case_id: str) -> str:
-        """Extracts the delivery reports of a specific case stored in HK"""
+        """Extracts the delivery reports of a specific case stored in HK."""
 
         version: hk_models.Version = self.housekeeper_api.last_version(case_id)
         delivery_report_files: Query = self.housekeeper_api.get_files(
@@ -108,7 +108,7 @@ class ReportAPI(MetaAPI):
         return delivery_report_files[0].full_path
 
     def get_scout_uploaded_file_from_hk(self, case_id: str, scout_tag: str) -> Optional[str]:
-        """Returns the file path of the uploaded to Scout file given its tag"""
+        """Returns the file path of the uploaded to Scout file given its tag."""
 
         version: hk_models.Version = self.housekeeper_api.last_version(case_id)
         tags: list = self.get_hk_scout_file_tags(scout_tag)
@@ -126,7 +126,7 @@ class ReportAPI(MetaAPI):
         return uploaded_files[0].full_path
 
     def render_delivery_report(self, report_data: dict) -> str:
-        """Renders the report on the Jinja template"""
+        """Renders the report on the Jinja template."""
 
         env = Environment(
             loader=PackageLoader("cg", "meta/report/templates"),
@@ -137,7 +137,7 @@ class ReportAPI(MetaAPI):
         return template.render(**report_data)
 
     def get_cases_without_delivery_report(self, pipeline: Pipeline) -> List[models.Family]:
-        """Returns a list of cases that has been stored and need a delivery report"""
+        """Returns a list of cases that has been stored and need a delivery report."""
 
         stored_cases = []
         analyses: Query = self.status_db.analyses_to_delivery_report(pipeline)[
@@ -161,7 +161,7 @@ class ReportAPI(MetaAPI):
         return stored_cases
 
     def get_cases_without_uploaded_delivery_report(self, pipeline: Pipeline) -> List[models.Family]:
-        """Returns a list of cases that need a delivery report to be uploaded"""
+        """Returns a list of cases that need a delivery report to be uploaded."""
 
         analyses: Query = self.status_db.analyses_to_upload_delivery_reports(pipeline)[
             :MAX_ITEMS_TO_RETRIEVE
@@ -170,14 +170,14 @@ class ReportAPI(MetaAPI):
         return [analysis_obj.family for analysis_obj in analyses]
 
     def update_delivery_report_date(self, case: models.Family, analysis_date: datetime) -> None:
-        """Updates the date when delivery report was created"""
+        """Updates the date when delivery report was created."""
 
         analysis: models.Analysis = self.status_db.analysis(case, analysis_date)
         analysis.delivery_report_created_at = datetime.now()
         self.status_db.commit()
 
     def get_report_data(self, case_id: str, analysis_date: datetime) -> ReportModel:
-        """Fetches all the data needed to generate a delivery report"""
+        """Fetches all the data needed to generate a delivery report."""
 
         case: models.Family = self.status_db.family(case_id)
         analysis: models.Analysis = self.status_db.analysis(case, analysis_date)
@@ -195,7 +195,7 @@ class ReportAPI(MetaAPI):
     def validate_report_fields(
         self, case_id: str, report_data: ReportModel, force_report
     ) -> ReportModel:
-        """Verifies that the required report fields are not empty"""
+        """Verifies that the required report fields are not empty."""
 
         required_fields: dict = self.get_required_fields(report_data.case)
         empty_report_fields: dict = get_empty_report_data(report_data)
@@ -217,7 +217,7 @@ class ReportAPI(MetaAPI):
 
     @staticmethod
     def get_customer_data(case: models.Family) -> CustomerModel:
-        """Returns customer validated attributes retrieved from status DB"""
+        """Returns customer validated attributes retrieved from status DB."""
 
         return CustomerModel(
             name=case.customer.name,
@@ -246,7 +246,7 @@ class ReportAPI(MetaAPI):
         analysis: models.Analysis,
         analysis_metadata: AnalysisModel,
     ) -> CaseModel:
-        """Returns case associated validated attributes"""
+        """Returns case associated validated attributes."""
 
         samples = self.get_samples_data(case, analysis_metadata)
         unique_applications = self.get_unique_applications(samples)
@@ -262,7 +262,7 @@ class ReportAPI(MetaAPI):
     def get_samples_data(
         self, case: models.Family, analysis_metadata: AnalysisModel
     ) -> List[SampleModel]:
-        """Extracts all the samples associated to a specific case and their attributes"""
+        """Extracts all the samples associated to a specific case and their attributes."""
 
         samples = list()
         case_samples = self.status_db.family_samples(case.internal_id)
@@ -290,7 +290,7 @@ class ReportAPI(MetaAPI):
         return samples
 
     def get_lims_sample(self, sample_id: str) -> dict:
-        """Fetches sample data from LIMS. Returns an empty dictionary if the request was unsuccessful"""
+        """Fetches sample data from LIMS. Returns an empty dictionary if the request was unsuccessful."""
 
         lims_sample = dict()
         try:
@@ -301,7 +301,7 @@ class ReportAPI(MetaAPI):
         return lims_sample
 
     def get_sample_application_data(self, lims_sample: dict) -> ApplicationModel:
-        """Retrieves the analysis application attributes"""
+        """Retrieves the analysis application attributes."""
 
         application: models.Application = self.status_db.application(
             tag=lims_sample.get("application")
@@ -319,7 +319,7 @@ class ReportAPI(MetaAPI):
 
     @staticmethod
     def get_unique_applications(samples: List[SampleModel]) -> List[ApplicationModel]:
-        """Returns the unique case associated applications"""
+        """Returns the unique case associated applications."""
 
         applications = list()
         for sample in samples:
@@ -329,7 +329,7 @@ class ReportAPI(MetaAPI):
         return applications
 
     def get_sample_methods_data(self, sample_id: str) -> MethodsModel:
-        """Fetches sample library preparation and sequencing methods from LIMS"""
+        """Fetches sample library preparation and sequencing methods from LIMS."""
 
         library_prep = None
         sequencing = None
@@ -347,7 +347,7 @@ class ReportAPI(MetaAPI):
         analysis: models.Analysis,
         analysis_metadata: AnalysisModel,
     ) -> DataAnalysisModel:
-        """Retrieves the pipeline attributes used for data analysis"""
+        """Retrieves the pipeline attributes used for data analysis."""
 
         return DataAnalysisModel(
             customer_pipeline=case.data_analysis,
@@ -362,7 +362,7 @@ class ReportAPI(MetaAPI):
         )
 
     def get_scout_uploaded_files(self, case: models.Family) -> ScoutReportFiles:
-        """Extracts the files that will be uploaded to Scout"""
+        """Extracts the files that will be uploaded to Scout."""
 
         return ScoutReportFiles(
             snv_vcf=self.get_scout_uploaded_file_from_hk(case.internal_id, "snv_vcf"),
@@ -373,7 +373,7 @@ class ReportAPI(MetaAPI):
 
     @staticmethod
     def get_sample_timestamp_data(sample: models.Sample) -> TimestampModel:
-        """Retrieves the sample processing dates"""
+        """Retrieves the sample processing dates."""
 
         return TimestampModel(
             ordered_at=sample.ordered_at,
@@ -388,45 +388,45 @@ class ReportAPI(MetaAPI):
         sample: models.Sample,
         analysis_metadata: AnalysisModel,
     ) -> SampleMetadataModel:
-        """Fetches the sample metadata to include in the report"""
+        """Fetches the sample metadata to include in the report."""
 
         raise NotImplementedError
 
     def get_data_analysis_type(self, case: models.Family) -> str:
-        """Retrieves the data analysis type carried out"""
+        """Retrieves the data analysis type carried out."""
 
         raise NotImplementedError
 
     def get_genome_build(self, analysis_metadata: AnalysisModel) -> str:
-        """Returns the build version of the genome reference of a specific case"""
+        """Returns the build version of the genome reference of a specific case."""
 
         raise NotImplementedError
 
     def get_variant_callers(self, analysis_metadata: AnalysisModel) -> list:
-        """Extracts the list of variant-calling filters used during analysis"""
+        """Extracts the list of variant-calling filters used during analysis."""
 
         raise NotImplementedError
 
     def get_report_accreditation(
         self, samples: List[SampleModel], analysis_metadata: AnalysisModel
     ) -> bool:
-        """Checks if the report is accredited or not"""
+        """Checks if the report is accredited or not."""
 
         raise NotImplementedError
 
     def get_required_fields(self, case: CaseModel) -> dict:
-        """Retrieves a dictionary with the delivery report required fields"""
+        """Retrieves a dictionary with the delivery report required fields."""
 
         raise NotImplementedError
 
     def get_template_name(self) -> str:
-        """Retrieves the pipeline specific template name"""
+        """Retrieves the pipeline specific template name."""
 
         raise NotImplementedError
 
     @staticmethod
     def get_application_required_fields(case: CaseModel, required_fields: list) -> dict:
-        """Retrieves sample required fields"""
+        """Retrieves sample required fields."""
 
         required_sample_fields = dict()
 
@@ -437,7 +437,7 @@ class ReportAPI(MetaAPI):
 
     @staticmethod
     def get_sample_required_fields(case: CaseModel, required_fields: list) -> dict:
-        """Retrieves sample required fields"""
+        """Retrieves sample required fields."""
 
         required_sample_fields = dict()
 
@@ -448,7 +448,7 @@ class ReportAPI(MetaAPI):
 
     @staticmethod
     def get_timestamp_required_fields(case: CaseModel, required_fields: list) -> dict:
-        """Retrieves sample timestamps required fields"""
+        """Retrieves sample timestamps required fields."""
 
         for sample in case.samples:
             if sample.application.external:
@@ -458,13 +458,13 @@ class ReportAPI(MetaAPI):
         return ReportAPI.get_sample_required_fields(case, required_fields)
 
     def get_hk_scout_file_tags(self, scout_tag: str) -> Optional[list]:
-        """Retrieves pipeline specific uploaded to Scout Housekeeper file tags given a Scout key"""
+        """Retrieves pipeline specific uploaded to Scout Housekeeper file tags given a Scout key."""
 
         tags = self.get_upload_case_tags().get(scout_tag)
 
         return list(tags) if tags else None
 
     def get_upload_case_tags(self):
-        """Retrieves pipeline specific upload case tags"""
+        """Retrieves pipeline specific upload case tags."""
 
         raise NotImplementedError

--- a/cg/models/report/sample.py
+++ b/cg/models/report/sample.py
@@ -25,7 +25,6 @@ class ApplicationModel(BaseModel):
         limitations: application limitations; source: StatusDB/application/limitations
         accredited: if the sample associated process is accredited or not; source: StatusDB/application/is_accredited
         external: whether the app tag is external or not; source: StatusDB/application/is_external
-
     """
 
     tag: Optional[str]

--- a/cg/models/report/sample.py
+++ b/cg/models/report/sample.py
@@ -23,7 +23,8 @@ class ApplicationModel(BaseModel):
         prep_category: library preparation category; source: StatusDB/application/prep_category
         description: analysis description; source: StatusDB/application/description
         limitations: application limitations; source: StatusDB/application/limitations
-        accredited: if the sample associated process is accredited or not; ; source: StatusDB/application/is_accredited
+        accredited: if the sample associated process is accredited or not; source: StatusDB/application/is_accredited
+        external: whether the app tag is external or not; source: StatusDB/application/is_external
 
     """
 
@@ -33,6 +34,7 @@ class ApplicationModel(BaseModel):
     description: Optional[str]
     limitations: Optional[str]
     accredited: Optional[bool]
+    external: Optional[bool]
 
     _prep_category = validator("prep_category", always=True, allow_reuse=True)(validate_rml_sample)
     _values = validator(

--- a/cg/models/report/validators.py
+++ b/cg/models/report/validators.py
@@ -39,7 +39,7 @@ def validate_boolean(value: Union[bool, str]) -> str:
 def validate_float(value: Union[float, str]) -> str:
     """Returns a processed float value"""
 
-    return str(round(float(value), PRECISION)) if value else NA_FIELD
+    return str(round(float(value), PRECISION)) if value or isinstance(value, float) else NA_FIELD
 
 
 def validate_date(date: datetime) -> str:

--- a/tests/meta/report/conftest.py
+++ b/tests/meta/report/conftest.py
@@ -21,7 +21,7 @@ from tests.mocks.report import MockChanjo, MockDB, MockHousekeeperMipDNAReportAP
 
 @pytest.fixture(scope="function", name="report_api_mip_dna")
 def report_api_mip_dna(cg_context: CGConfig, lims_samples) -> MipDNAReportAPI:
-    """MIP DNA ReportAPI fixture"""
+    """MIP DNA ReportAPI fixture."""
 
     cg_context.meta_apis["analysis_api"] = MockMipAnalysis()
     cg_context.status_db_ = MockDB(report_store)
@@ -33,7 +33,7 @@ def report_api_mip_dna(cg_context: CGConfig, lims_samples) -> MipDNAReportAPI:
 
 @pytest.fixture(scope="function", name="report_api_balsamic")
 def report_api_balsamic(cg_context: CGConfig, lims_samples) -> BalsamicReportAPI:
-    """BALSAMIC ReportAPI fixture"""
+    """BALSAMIC ReportAPI fixture."""
 
     cg_context.meta_apis["analysis_api"] = MockBalsamicAnalysis(cg_context)
     cg_context.status_db_ = MockDB(report_store)
@@ -44,35 +44,35 @@ def report_api_balsamic(cg_context: CGConfig, lims_samples) -> BalsamicReportAPI
 
 @pytest.fixture(scope="function", name="case_mip_dna")
 def case_mip_dna(case_id, report_api_mip_dna) -> models.Family:
-    """MIP DNA case instance"""
+    """MIP DNA case instance."""
 
     return report_api_mip_dna.status_db.family(case_id)
 
 
 @pytest.fixture(scope="function", name="case_balsamic")
 def case_balsamic(case_id, report_api_balsamic) -> models.Family:
-    """BALSAMIC case instance"""
+    """BALSAMIC case instance."""
 
     return report_api_balsamic.status_db.family(case_id)
 
 
 @pytest.fixture(scope="function", name="case_samples_data")
 def case_samples_data(case_id, report_api_mip_dna):
-    """MIP DNA family sample object"""
+    """MIP DNA family sample object."""
 
     return report_api_mip_dna.status_db.family_samples(case_id)
 
 
 @pytest.fixture(name="mip_analysis_api")
 def mip_analysis_api() -> MockMipAnalysis:
-    """MIP analysis mock data"""
+    """MIP analysis mock data."""
 
     return MockMipAnalysis()
 
 
 @pytest.fixture(name="lims_family")
 def fixture_lims_family(fixtures_dir: Path) -> dict:
-    """Returns a lims-like case of samples"""
+    """Returns a lims-like case of samples."""
     return ReadFile.get_content_from_file(
         file_format=FileFormat.JSON, file_path=Path(fixtures_dir, "report", "lims_family.json")
     )
@@ -80,14 +80,14 @@ def fixture_lims_family(fixtures_dir: Path) -> dict:
 
 @pytest.fixture(name="lims_samples")
 def fixture_lims_samples(lims_family: dict) -> List[dict]:
-    """Returns the samples of a lims case"""
+    """Returns the samples of a lims case."""
 
     return lims_family["samples"]
 
 
 @pytest.fixture(scope="function", autouse=True, name="report_store")
 def report_store(analysis_store, helpers, timestamp_yesterday):
-    """A mock store instance for report testing"""
+    """A mock store instance for report testing."""
 
     case = analysis_store.families()[0]
     helpers.add_analysis(

--- a/tests/meta/report/helper.py
+++ b/tests/meta/report/helper.py
@@ -4,11 +4,11 @@
 def recursive_assert(data):
     """Dictionary recursive assert test"""
 
-    for k, v in data.items():
-        if isinstance(v, dict):
-            recursive_assert(dict(v))
-        if isinstance(v, list):
-            for e in v:
-                recursive_assert(dict(e))
+    for key, value in data.items():
+        if isinstance(value, dict):
+            recursive_assert(dict(value))
+        if isinstance(value, list):
+            for element in value:
+                recursive_assert(dict(element))
         else:
-            assert v or isinstance(v, (int, float, bool)), f"{k} value is missing"
+            assert value or isinstance(value, (int, float, bool)), f"{key} field is missing"

--- a/tests/meta/report/helper.py
+++ b/tests/meta/report/helper.py
@@ -11,4 +11,4 @@ def recursive_assert(data):
             for e in v:
                 recursive_assert(dict(e))
         else:
-            assert v, f"{k} value is missing"
+            assert v or isinstance(v, (int, float, bool)), f"{k} value is missing"

--- a/tests/meta/report/helper.py
+++ b/tests/meta/report/helper.py
@@ -2,7 +2,7 @@
 
 
 def recursive_assert(data):
-    """Dictionary recursive assert test"""
+    """Dictionary recursive assert test."""
 
     for key, value in data.items():
         if isinstance(value, dict):

--- a/tests/meta/report/test_balsamic_api.py
+++ b/tests/meta/report/test_balsamic_api.py
@@ -2,7 +2,7 @@ import copy
 
 
 def test_get_sample_metadata(report_api_balsamic, case_balsamic, helpers, sample_store):
-    """Tests sample metadata extraction"""
+    """Tests sample metadata extraction."""
 
     # GIVEN a mock tumor sample and the latest metadata
     sample = helpers.add_sample(sample_store)
@@ -37,7 +37,7 @@ def test_get_sample_metadata(report_api_balsamic, case_balsamic, helpers, sample
 
 
 def test_get_variant_callers(report_api_balsamic, case_id):
-    """Test variant callers extraction for TN-PANEL analysis"""
+    """Test variant callers extraction for TN-PANEL analysis."""
 
     # GIVEN a mock metadata object
     balsamic_metadata = report_api_balsamic.analysis_api.get_latest_metadata(case_id)
@@ -63,7 +63,7 @@ def test_get_variant_callers(report_api_balsamic, case_id):
 
 
 def test_get_variant_caller_version(report_api_balsamic, case_id):
-    """Tests variant caller version extraction"""
+    """Tests variant caller version extraction."""
 
     # GIVEN a tool name and a mock variant caller versions dictionary
     var_caller_name = "manta"
@@ -82,7 +82,7 @@ def test_get_variant_caller_version(report_api_balsamic, case_id):
 
 
 def test_get_report_accreditation(report_api_balsamic, case_id):
-    """Tests report accreditation for a specific BALSAMIC analysis"""
+    """Tests report accreditation for a specific BALSAMIC analysis."""
 
     # GIVEN a mock metadata object and an accredited one
     balsamic_metadata = report_api_balsamic.analysis_api.get_latest_metadata(case_id)

--- a/tests/meta/report/test_field_validators.py
+++ b/tests/meta/report/test_field_validators.py
@@ -1,10 +1,14 @@
 """Tests report data validation"""
 
-from cg.meta.report.field_validators import get_missing_report_data, get_empty_report_data
+from cg.meta.report.field_validators import (
+    get_missing_report_data,
+    get_empty_report_data,
+    get_million_read_pairs,
+)
 
 
 def test_get_empty_report_data(report_api_mip_dna, case_mip_dna):
-    """Tests the empty report fields retrieval"""
+    """Tests the empty report fields retrieval."""
 
     # GIVEN a report data model
     report_data = report_api_mip_dna.get_report_data(
@@ -36,7 +40,7 @@ def test_get_empty_report_data(report_api_mip_dna, case_mip_dna):
 
 
 def test_get_missing_report_data(report_api_mip_dna, case_mip_dna):
-    """Checks the missing report fields retrieval"""
+    """Checks the missing report fields retrieval."""
 
     # GIVEN a report data model
     report_data = report_api_mip_dna.get_report_data(
@@ -72,3 +76,30 @@ def test_get_missing_report_data(report_api_mip_dna, case_mip_dna):
     assert "bait_set" not in missing_fields["metadata"]["ADM1"]
     assert "bait_set" in missing_fields["metadata"]["ADM2"]
     assert "ADM3" not in missing_fields["metadata"]
+
+
+def test_get_million_read_pairs():
+    """Tests millions read pairs computation."""
+
+    # GIVEN a number os sequencing reads and its representation in millions of read pairs
+    sample_reads = 1_200_000_000
+    mrp = 600.0
+
+    # WHEN obtaining the number of reds in millions of read pairs
+    million_read_pairs = get_million_read_pairs(sample_reads)
+
+    # THEN the expected value should match the calculated one
+    assert million_read_pairs == mrp
+
+
+def test_get_million_read_pairs_zero_input():
+    """Tests millions read pairs computation when the sample reads number is zero."""
+
+    # GIVEN zero as number of reads
+    sample_reads = 0
+
+    # WHEN retrieving the number of reds in millions of read pairs
+    million_read_pairs = get_million_read_pairs(sample_reads)
+
+    # THEN the obtained value should be zero
+    assert million_read_pairs == 0.0

--- a/tests/meta/report/test_mip_dna_api.py
+++ b/tests/meta/report/test_mip_dna_api.py
@@ -9,6 +9,7 @@ def test_get_sample_metadata(
     # GIVEN a mock sample and the latest metadata
     sample = helpers.add_sample(sample_store)
     sample.internal_id = "ADM1"
+    sample.reads = None
     mip_metadata = mip_analysis_api.get_latest_metadata(case_mip_dna.internal_id)
 
     # GIVEN the expected output

--- a/tests/meta/report/test_mip_dna_api.py
+++ b/tests/meta/report/test_mip_dna_api.py
@@ -4,7 +4,7 @@ from cg.constants import REPORT_GENDER
 def test_get_sample_metadata(
     report_api_mip_dna, mip_analysis_api, case_mip_dna, sample_store, helpers
 ):
-    """Tests sample metadata extraction"""
+    """Tests sample metadata extraction."""
 
     # GIVEN a mock sample and the latest metadata
     sample = helpers.add_sample(sample_store)
@@ -31,7 +31,7 @@ def test_get_sample_metadata(
 
 
 def test_get_sample_coverage(report_api_mip_dna, sample_store, helpers, case_mip_dna):
-    """Checks the sample coverage retrieval from Chanjo"""
+    """Checks the sample coverage retrieval from Chanjo."""
 
     # GIVEN a case and a sample with a specific ID
     case_mip_dna.panels = []
@@ -46,7 +46,7 @@ def test_get_sample_coverage(report_api_mip_dna, sample_store, helpers, case_mip
 
 
 def test_get_report_accreditation(report_api_mip_dna, mip_analysis_api, case_mip_dna):
-    """Verifies the report accreditation extraction workflow"""
+    """Verifies the report accreditation extraction workflow."""
 
     # GIVEN a list of accredited samples
     mip_metadata = mip_analysis_api.get_latest_metadata(case_mip_dna.internal_id)
@@ -60,7 +60,7 @@ def test_get_report_accreditation(report_api_mip_dna, mip_analysis_api, case_mip
 
 
 def test_get_report_accreditation_false(report_api_mip_dna, mip_analysis_api, case_mip_dna):
-    """Verifies that the report is not accredited if it contains a sample application that is not accredited"""
+    """Verifies that the report is not accredited if it contains a sample application that is not accredited."""
 
     # GIVEN a list of samples when one of them is not accredited
     mip_metadata = mip_analysis_api.get_latest_metadata(case_mip_dna.internal_id)

--- a/tests/meta/report/test_report_api.py
+++ b/tests/meta/report/test_report_api.py
@@ -8,7 +8,7 @@ from tests.meta.report.helper import recursive_assert
 
 
 def test_create_delivery_report(report_api_mip_dna, case_mip_dna):
-    """Tests the creation of the rendered delivery report"""
+    """Tests the creation of the rendered delivery report."""
 
     # GIVEN a pre-built case
 
@@ -24,7 +24,7 @@ def test_create_delivery_report(report_api_mip_dna, case_mip_dna):
 
 
 def test_create_delivery_report_file(report_api_mip_dna, case_mip_dna, tmp_path):
-    """Tests file generation containing the delivery report data"""
+    """Tests file generation containing the delivery report data."""
 
     # GIVEN a pre-built case
 
@@ -41,7 +41,7 @@ def test_create_delivery_report_file(report_api_mip_dna, case_mip_dna, tmp_path)
 
 
 def test_render_delivery_report(report_api_mip_dna, case_mip_dna):
-    """Tests delivery report rendering"""
+    """Tests delivery report rendering."""
 
     # GIVEN a generated report
     report_data = report_api_mip_dna.get_report_data(
@@ -57,7 +57,7 @@ def test_render_delivery_report(report_api_mip_dna, case_mip_dna):
 
 
 def test_get_validated_report_data(report_api_mip_dna, case_mip_dna):
-    """Tests report data retrieval"""
+    """Tests report data retrieval."""
 
     # GIVEN a valid case
     assert case_mip_dna
@@ -77,7 +77,7 @@ def test_get_validated_report_data(report_api_mip_dna, case_mip_dna):
 
 
 def test_validate_report_empty_fields(report_api_mip_dna, case_mip_dna, caplog):
-    """Tests the validations of allowed empty report fields"""
+    """Tests the validations of allowed empty report fields."""
 
     caplog.set_level(logging.INFO)
 
@@ -102,7 +102,7 @@ def test_validate_report_empty_fields(report_api_mip_dna, case_mip_dna, caplog):
 
 
 def test_validate_report_missing_fields(report_api_mip_dna, case_mip_dna, caplog):
-    """Tests the validations of empty required report fields"""
+    """Tests the validations of empty required report fields."""
 
     # GIVEN a delivery report
     report_data = report_api_mip_dna.get_report_data(
@@ -126,7 +126,7 @@ def test_validate_report_missing_fields(report_api_mip_dna, case_mip_dna, caplog
 
 
 def test_get_validated_report_data_external_sample(report_api_mip_dna, case_mip_dna):
-    """Tests report data retrieval"""
+    """Tests report data retrieval."""
 
     # GIVEN a delivery report with external sample data
     report_data = report_api_mip_dna.get_report_data(
@@ -145,7 +145,7 @@ def test_get_validated_report_data_external_sample(report_api_mip_dna, case_mip_
 
 
 def test_get_customer_data(report_api_mip_dna, case_mip_dna):
-    """Checks that the retrieved customer data is the expected one"""
+    """Checks that the retrieved customer data is the expected one."""
 
     # GIVEN a pre-built case
 
@@ -165,7 +165,7 @@ def test_get_customer_data(report_api_mip_dna, case_mip_dna):
 
 
 def test_get_report_version_version(report_api_mip_dna, store, helpers, timestamp_yesterday):
-    """Validates the extracted report versions of two analyses"""
+    """Validates the extracted report versions of two analyses."""
 
     # GIVEN a specific set of analyses
     last_analysis = helpers.add_analysis(store, completed_at=datetime.now())
@@ -183,7 +183,7 @@ def test_get_report_version_version(report_api_mip_dna, store, helpers, timestam
 
 
 def test_get_case_data(report_api_mip_dna, mip_analysis_api, case_mip_dna, family_name):
-    """Tests the extracted case data"""
+    """Tests the extracted case data."""
 
     # GIVEN a pre-built case
 
@@ -205,7 +205,7 @@ def test_get_case_data(report_api_mip_dna, mip_analysis_api, case_mip_dna, famil
 def test_get_samples_data(
     report_api_mip_dna, mip_analysis_api, case_mip_dna, case_samples_data, lims_samples
 ):
-    """Validates the retrieved sample data"""
+    """Validates the retrieved sample data."""
 
     # GIVEN a pre-built case
 
@@ -234,7 +234,7 @@ def test_get_samples_data(
 
 
 def test_get_lims_sample(report_api_mip_dna, case_samples_data, lims_samples):
-    """Tests lims data extraction"""
+    """Tests lims data extraction."""
 
     # GIVEN a family samples instance
 
@@ -249,7 +249,7 @@ def test_get_lims_sample(report_api_mip_dna, case_samples_data, lims_samples):
 
 
 def test_get_sample_application_data(report_api_mip_dna, case_samples_data, lims_samples):
-    """Tests sample application data extraction"""
+    """Tests sample application data extraction."""
 
     # GIVEN a lims sample instance
 
@@ -269,7 +269,7 @@ def test_get_sample_application_data(report_api_mip_dna, case_samples_data, lims
 
 
 def test_get_unique_applications(report_api_mip_dna, mip_analysis_api, case_mip_dna):
-    """Tests unique applications filtering"""
+    """Tests unique applications filtering."""
 
     # GIVEN a list of samples sharing the same application
     mip_metadata = mip_analysis_api.get_latest_metadata(case_mip_dna.internal_id)
@@ -283,7 +283,7 @@ def test_get_unique_applications(report_api_mip_dna, mip_analysis_api, case_mip_
 
 
 def test_get_sample_methods_data(report_api_mip_dna, case_samples_data):
-    """Tests sample methods retrieval from lims"""
+    """Tests sample methods retrieval from lims."""
 
     # GIVEN a sample ID
     sample_id = case_samples_data[0].sample.to_dict().get("internal_id")
@@ -302,7 +302,7 @@ def test_get_sample_methods_data(report_api_mip_dna, case_samples_data):
 
 
 def test_get_case_analysis_data(report_api_mip_dna, mip_analysis_api, case_mip_dna):
-    """Tests data analysis parameters retrieval"""
+    """Tests data analysis parameters retrieval."""
 
     # GIVEN a pre-built case
 
@@ -321,7 +321,7 @@ def test_get_case_analysis_data(report_api_mip_dna, mip_analysis_api, case_mip_d
 
 
 def test_get_sample_timestamp_data(report_api_mip_dna, case_samples_data, timestamp_yesterday):
-    """Checks that the sample timestamp information is correctly retrieved from StatusDB"""
+    """Checks that the sample timestamp information is correctly retrieved from StatusDB."""
 
     # GIVEN a mock sample data
 

--- a/tests/meta/report/test_report_api.py
+++ b/tests/meta/report/test_report_api.py
@@ -125,6 +125,23 @@ def test_validate_report_missing_fields(report_api_mip_dna, case_mip_dna, caplog
         assert "accredited" in caplog.text
 
 
+def test_get_validated_report_data_external_sample(report_api_mip_dna, case_mip_dna):
+    """Tests report data retrieval"""
+
+    # GIVEN a delivery report with external sample data
+    report_data = report_api_mip_dna.get_report_data(
+        case_mip_dna.internal_id, case_mip_dna.analyses[0].started_at
+    )
+    report_data.case.samples[0].timestamps.received_at = None
+    report_data.case.samples[0].application.external = True
+
+    # THEN check the generation
+    report_data = report_api_mip_dna.validate_report_fields(
+        case_mip_dna.internal_id, report_data, force_report=False
+    )
+    assert report_data
+
+
 def test_get_customer_data(report_api_mip_dna, case_mip_dna):
     """Checks that the retrieved customer data is the expected one"""
 

--- a/tests/meta/report/test_report_api.py
+++ b/tests/meta/report/test_report_api.py
@@ -135,10 +135,12 @@ def test_get_validated_report_data_external_sample(report_api_mip_dna, case_mip_
     report_data.case.samples[0].timestamps.received_at = None
     report_data.case.samples[0].application.external = True
 
-    # THEN check the generation
+    # WHEN validating report fields
     report_data = report_api_mip_dna.validate_report_fields(
         case_mip_dna.internal_id, report_data, force_report=False
     )
+
+    # THEN the validation should have been completed successfully
     assert report_data
 
 

--- a/tests/models/report/test_validators.py
+++ b/tests/models/report/test_validators.py
@@ -63,6 +63,22 @@ def test_validate_float():
     assert validated_str_value == "12.35"
 
 
+def test_validate_float_zero_input():
+    """Tests the validation of a float value"""
+
+    # GIVEN a valid float input (float and string format)
+    float_value = 0.0
+    str_value = "0.0"
+
+    # WHEN performing the validation
+    validated_float_value = validate_float(float_value)
+    validated_str_value = validate_float(str_value)
+
+    # THEN check if the input values were formatted correctly
+    assert validated_float_value == "0.0"
+    assert validated_str_value == "0.0"
+
+
 def test_validate_list():
     """Tests if a list is transformed into a string of comma separated values"""
 


### PR DESCRIPTION
## Description

### Fixed
- Delivery report complaining about a missing `received_at` field
- Float zero values appearing as `N/A` in the delivery report


### How to prepare for test
- [ ] ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] paxa the environment: `paxa`
- [ ] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh fix-delivery-report-external-samples`

### Test

External case `cleanhare` failing for an empty `received_at` field and a zero value for `million_read_pairs`:

<img width="543" alt="Screen Shot 2022-09-07 at 16 58 02" src="https://user-images.githubusercontent.com/26309194/188910925-65b684ee-478b-4b7d-a3bb-0d3d969691ce.png">

Successful upload deploying this branch:

`cg upload -f cleanhare`

<img width="693" alt="Screen Shot 2022-09-07 at 16 53 46" src="https://user-images.githubusercontent.com/26309194/188909894-f2bfa6b4-5f1b-4cfe-9fc5-aed404f88eab.png">

<img width="1095" alt="Screen Shot 2022-09-07 at 16 54 35" src="https://user-images.githubusercontent.com/26309194/188910101-b7bfbaeb-a7f5-4e66-915b-d43cf15e02da.png">

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
