### PR TITLE
feat(crunchy): Add option to use a "--login" shell in SLURMAPI

### DIFF
--- a/cg/apps/crunchy/crunchy.py
+++ b/cg/apps/crunchy/crunchy.py
@@ -229,6 +229,7 @@ class CrunchyAPI:
             pending_path=compression_obj.pending_path,
         )
         sbatch_parameters: Sbatch = Sbatch(
+            use_login_shell="--login",
             job_name="_".join([sample_id, compression_obj.run_name, "fastq_to_spring"]),
             account=self.slurm_account,
             number_tasks=12,

--- a/cg/apps/slurm/sbatch.py
+++ b/cg/apps/slurm/sbatch.py
@@ -1,4 +1,4 @@
-SBATCH_HEADER_TEMPLATE = """#! /bin/bash
+SBATCH_HEADER_TEMPLATE = """#! /bin/bash {use_login_shell}
 #SBATCH --job-name={job_name}
 #SBATCH --account={account}
 #SBATCH --ntasks={number_tasks}

--- a/cg/models/slurm/sbatch.py
+++ b/cg/models/slurm/sbatch.py
@@ -7,6 +7,7 @@ from cg.constants.priority import SlurmQos
 
 
 class Sbatch(BaseModel):
+    use_login_shell: Optional[str] = ""
     job_name: str
     account: str
     log_dir: str


### PR DESCRIPTION
## Description

### Added

- Add option to use a "--login" shell in SLURMAPI

### How to prepare for test
- [x] ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh fix_crunchy_env`

### How to test
- [x] See below

### Expected test outcome
- [x] check that the fastq files are compressed to spring
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [x] code approved by VI
- [x] tests executed by HS
- [x] "Merge and deploy" approved by HS
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
