### PR TITLE
Fix(osTicket) Send connecting ticket email from internal address

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ ENV LIMS_USERNAME="limsadmin"
 ENV LIMS_PASSWORD="limsadminpassword"
 
 ENV MAIL_CONTAINER_URI="http://127.0.0.1:port/container"
+ENV BASE_SENDER_EMAIL="cg@email.com"
 
 ENV OSTICKET_EMAIL="support@system.email"
 ENV OSTICKET_API_KEY=None

--- a/cg/apps/osticket.py
+++ b/cg/apps/osticket.py
@@ -24,28 +24,32 @@ class OsTicket(object):
         self.url = None
         self.osticket_email = None
         self.email_uri = None
+        self.base_sender_email = None
 
     def init_app(self, app: Flask):
         """Initialize the API in Flask"""
         self.setup(
             api_key=app.config["OSTICKET_API_KEY"],
+            base_sender_email=app.config["BASE_SENDER_EMAIL"],
             domain=app.config["OSTICKET_DOMAIN"],
-            osticket_email=app.config["SUPPORT_SYSTEM_EMAIL"],
             email_uri=app.config["EMAIL_URI"],
+            osticket_email=app.config["SUPPORT_SYSTEM_EMAIL"],
         )
 
     def setup(
         self,
         api_key: str = None,
+        base_sender_email: str = None,
         domain: str = None,
-        osticket_email: str = None,
         email_uri: str = None,
+        osticket_email: str = None,
     ):
         """Initialize the API"""
         self.headers = {"X-API-Key": api_key}
         self.url = os.path.join(domain, "api/tickets.json")
         self.osticket_email = osticket_email
         self.email_uri = email_uri
+        self.base_sender_email = base_sender_email
 
     def open_ticket(
         self, attachment: dict, email: str, message: str, name: str, subject: str

--- a/cg/cli/upload/clinical_delivery.py
+++ b/cg/cli/upload/clinical_delivery.py
@@ -1,45 +1,81 @@
 """Code that handles CLI commands to upload"""
 import datetime as dt
 import logging
-
 from pathlib import Path
+from typing import Set
 
 import click
 
-from cg.constants import Pipeline, DataDelivery
-from cg.constants.constants import DRY_RUN
-from cg.meta.workflow.analysis import AnalysisAPI
-from cg.store import Store, models
-
+from cgmodels.trailblazer.constants import AnalysisTypes
 from cg.apps.tb import TrailblazerAPI
+from cg.constants import Pipeline
+from cg.constants.constants import DRY_RUN
 from cg.constants.delivery import PIPELINE_ANALYSIS_TAG_MAP
 from cg.constants.priority import PRIORITY_TO_SLURM_QOS
 from cg.meta.deliver import DeliverAPI
 from cg.meta.rsync import RsyncAPI
+from cg.store import Store, models
 
 LOG = logging.getLogger(__name__)
 
 
-@click.group()
+@click.command("clinical-delivery")
 @click.pass_context
-def fastq(context: click.Context):
-    context.obj.meta_apis["delivery_api"] = DeliverAPI(
-        store=context.obj.status_db,
-        hk_api=context.obj.housekeeper_api,
-        case_tags=PIPELINE_ANALYSIS_TAG_MAP[DataDelivery.FASTQ]["case_tags"],
-        sample_tags=PIPELINE_ANALYSIS_TAG_MAP[DataDelivery.FASTQ]["sample_tags"],
-        delivery_type=DataDelivery.FASTQ,
-        project_base_path=Path(context.obj.delivery_path),
+@click.argument("case_id", required=True)
+@DRY_RUN
+def clinical_delivery(context: click.Context, case_id: str, dry_run: bool):
+    """Links the appropriate files for a case, based on the data_delivery, to the customer folder
+    and subsequently uses rsync to upload it to caesar."""
+    case_obj: models.Family = context.obj.status_db.family(case_id)
+    delivery_types: Set[str] = case_obj.get_delivery_arguments()
+    is_sample_delivery: bool
+    is_case_delivery: bool
+    is_sample_delivery, is_case_delivery = DeliverAPI.get_delivery_scope(
+        delivery_arguments=delivery_types
     )
-    context.obj.meta_apis["rsync_api"] = RsyncAPI(context.obj)
+    if not delivery_types:
+        LOG.info(f"No delivery of files requested for case {case_id}")
+        return
+
+    LOG.debug("Delivery types are: %s", delivery_types)
+    for delivery_type in delivery_types:
+        DeliverAPI(
+            store=context.obj.status_db,
+            hk_api=context.obj.housekeeper_api,
+            case_tags=PIPELINE_ANALYSIS_TAG_MAP[delivery_type]["case_tags"],
+            sample_tags=PIPELINE_ANALYSIS_TAG_MAP[delivery_type]["sample_tags"],
+            delivery_type=delivery_type,
+            project_base_path=Path(context.obj.delivery_path),
+        ).deliver_files(case_obj=case_obj)
+
+    rsync_api: RsyncAPI = RsyncAPI(context.obj)
+    job_id: int = rsync_api.slurm_rsync_single_case(
+        case_id=case_id,
+        dry_run=dry_run,
+        sample_files_present=is_sample_delivery,
+        case_files_present=is_case_delivery,
+    )
+    RsyncAPI.write_trailblazer_config(
+        {"jobs": [str(job_id)]}, config_path=rsync_api.trailblazer_config_path
+    )
+    if not dry_run:
+        context.obj.trailblazer_api.add_pending_analysis(
+            case_id=case_id,
+            analysis_type=AnalysisTypes.OTHER,
+            config_path=rsync_api.trailblazer_config_path.as_posix(),
+            out_dir=rsync_api.log_dir.as_posix(),
+            slurm_quality_of_service=PRIORITY_TO_SLURM_QOS[case_obj.priority],
+            data_analysis=Pipeline.RSYNC,
+        )
+    LOG.info("Transfer of case %s started with SLURM job id %s", case_id, job_id)
 
 
-@fastq.command("all-available")
+@click.command("all-fastq")
 @click.pass_context
 @DRY_RUN
 def auto_fastq(context: click.Context, dry_run: bool):
     """Starts upload of all not previously uploaded cases with analysis type fastq to
-    clinical-delivery"""
+    clinical-delivery."""
 
     status_db: Store = context.obj.status_db
     trailblazer_api: TrailblazerAPI = context.obj.trailblazer_api
@@ -69,41 +105,6 @@ def auto_fastq(context: click.Context, dry_run: bool):
                 )
             continue
         case: models.Family = analysis_obj.family
-        analysis_obj.upload_started_at = dt.datetime.now()
         LOG.info("Uploading family: %s", case.internal_id)
-        context.invoke(upload_fastq, case_id=case.internal_id, dry_run=dry_run)
+        context.invoke(clinical_delivery, case_id=case.internal_id, dry_run=dry_run)
         status_db.commit()
-
-
-@fastq.command("case")
-@click.pass_context
-@click.argument("case_id", required=True)
-@DRY_RUN
-def upload_fastq(context: click.Context, case_id: str, dry_run: bool):
-    """Uploads fastq files for a case to clinical-delivery"""
-
-    status_db: Store = context.obj.status_db
-    deliver_api: DeliverAPI = context.obj.meta_apis["delivery_api"]
-    rsync_api: RsyncAPI = context.obj.meta_apis["rsync_api"]
-    trailblazer_api: TrailblazerAPI = context.obj.trailblazer_api
-
-    case: models.Family = status_db.family(internal_id=case_id)
-    deliver_api.deliver_files(case)
-    job_id: int = rsync_api.slurm_rsync_single_case(
-        case_id=case_id, dry_run=dry_run, sample_files_present=True
-    )
-    rsync_api.write_trailblazer_config(
-        {"jobs": [str(job_id)]}, config_path=rsync_api.trailblazer_config_path
-    )
-    if not dry_run:
-        trailblazer_api.add_pending_analysis(
-            case_id=case_id,
-            analysis_type=AnalysisAPI.get_application_type(
-                status_db.family(case_id).links[0].sample
-            ),
-            config_path=str(rsync_api.trailblazer_config_path),
-            out_dir=str(rsync_api.log_dir),
-            slurm_quality_of_service=PRIORITY_TO_SLURM_QOS[case.priority],
-            data_analysis=Pipeline.FASTQ,
-        )
-    LOG.info("Transfer of case %s started with SLURM job id %s", case_id, job_id)

--- a/cg/cli/upload/clinical_delivery.py
+++ b/cg/cli/upload/clinical_delivery.py
@@ -40,7 +40,6 @@ def fastq(context: click.Context):
 def auto_fastq(context: click.Context, dry_run: bool):
     """Starts upload of all not previously uploaded cases with analysis type fastq to
     clinical-delivery"""
-
     status_db: Store = context.obj.status_db
     trailblazer_api: TrailblazerAPI = context.obj.trailblazer_api
     for analysis_obj in status_db.analyses_to_upload(pipeline=Pipeline.FASTQ):

--- a/cg/meta/orders/ticket_handler.py
+++ b/cg/meta/orders/ticket_handler.py
@@ -180,7 +180,7 @@ class TicketHandler:
             order=order,
             project=project,
         )
-        base_sender, base_server = self.osticket.base_sender_email("@")
+        base_sender, base_server = self.osticket.base_sender_email.split("@")
         temp_dir: TemporaryDirectory = self.osticket.create_connecting_ticket_attachment(
             content=self.replace_empty_string_with_none(obj=order.dict())
         )

--- a/cg/meta/orders/ticket_handler.py
+++ b/cg/meta/orders/ticket_handler.py
@@ -186,7 +186,7 @@ class TicketHandler:
         )
         email_form = FormDataRequest(
             sender_prefix=sender_prefix,
-            email_server_alias=email_server_alias,
+            email_server_alias=self.osticket.base_sender_email,
             request_uri=self.osticket.email_uri,
             recipients=self.osticket.osticket_email,
             mail_title=f"[#{ticket_number}]",

--- a/cg/meta/orders/ticket_handler.py
+++ b/cg/meta/orders/ticket_handler.py
@@ -180,7 +180,7 @@ class TicketHandler:
             order=order,
             project=project,
         )
-        sender_prefix, email_server_alias = user_mail.split("@")
+        sender_prefix: str = user_mail.split("@")[0]
         temp_dir: TemporaryDirectory = self.osticket.create_connecting_ticket_attachment(
             content=self.replace_empty_string_with_none(obj=order.dict())
         )

--- a/cg/meta/orders/ticket_handler.py
+++ b/cg/meta/orders/ticket_handler.py
@@ -180,15 +180,15 @@ class TicketHandler:
             order=order,
             project=project,
         )
-        sender_prefix: str = user_mail.split("@")[0]
+        base_sender, base_server = self.osticket.base_sender_email("@")
         temp_dir: TemporaryDirectory = self.osticket.create_connecting_ticket_attachment(
             content=self.replace_empty_string_with_none(obj=order.dict())
         )
         email_form = FormDataRequest(
-            sender_prefix=sender_prefix,
-            email_server_alias=self.osticket.base_sender_email,
+            sender_prefix=base_sender,
+            email_server_alias=base_server,
             request_uri=self.osticket.email_uri,
-            recipients=self.osticket.osticket_email,
+            recipients=[self.osticket.osticket_email, user_mail],
             mail_title=f"[#{ticket_number}]",
             mail_body=message,
             attachments=[Path(f"{temp_dir.name}/order.json")],

--- a/cg/server/config.py
+++ b/cg/server/config.py
@@ -22,6 +22,7 @@ OSTICKET_API_KEY = os.environ.get("OSTICKET_API_KEY")
 OSTICKET_DOMAIN = os.environ.get("OSTICKET_DOMAIN")
 SUPPORT_SYSTEM_EMAIL = os.environ.get("SUPPORT_SYSTEM_EMAIL")
 EMAIL_URI = os.environ.get("EMAIL_URI")
+BASE_SENDER_EMAIL = os.environ.get("BASE_SENDER_EMAIL")
 
 
 # oauth

--- a/tests/mocks/osticket.py
+++ b/tests/mocks/osticket.py
@@ -25,6 +25,7 @@ class MockOsTicket(OsTicket):
         self._should_fail: bool = False
         self._return_none: bool = False
         self.email_uri = "http://localhost:0000/sendmail"
+        self.base_sender_email = "cg@email.com"
 
     def set_ticket_nr(self, ticket: str) -> None:
         self._ticket_nr = ticket

--- a/tests/mocks/osticket.py
+++ b/tests/mocks/osticket.py
@@ -39,6 +39,7 @@ class MockOsTicket(OsTicket):
         domain: str = None,
         osticket_email: str = None,
         email_uri: str = None,
+        base_sender_email=None,
     ):
         """Initialize the API."""
         self.headers = {"X-API-Key": api_key}

--- a/tests/mocks/osticket.py
+++ b/tests/mocks/osticket.py
@@ -36,10 +36,10 @@ class MockOsTicket(OsTicket):
     def setup(
         self,
         api_key: str = None,
+        base_sender_email: str = None,
         domain: str = None,
-        osticket_email: str = None,
         email_uri: str = None,
-        base_sender_email=None,
+        osticket_email: str = None,
     ):
         """Initialize the API."""
         self.headers = {"X-API-Key": api_key}


### PR DESCRIPTION
## Description
See issue #1566 
### Added

- New environment variable `BASE_SENDER_EMAIL`

### Changed

- Sends email from BASE_SENDER_EMAIL instead of the user address


### How to prepare for test
- [ ] ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] paxa the environment: `paxa`
- [ ] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
