### PR TITLE
fix(upload fastq) Set upload_started_at

### DIFF
--- a/cg/cli/upload/clinical_delivery.py
+++ b/cg/cli/upload/clinical_delivery.py
@@ -96,8 +96,6 @@ def auto_fastq(context: click.Context, dry_run: bool):
                     dt.datetime.now(),
                 )
                 analysis_obj.uploaded_at = dt.datetime.now()
-                if not dry_run:
-                    status_db.commit()
             else:
                 LOG.warning(
                     "Upload to clinical-delivery for %s has already started, skipping",
@@ -106,5 +104,7 @@ def auto_fastq(context: click.Context, dry_run: bool):
             continue
         case: models.Family = analysis_obj.family
         LOG.info("Uploading family: %s", case.internal_id)
+        analysis_obj.upload_started_at = dt.datetime.now()
         context.invoke(clinical_delivery, case_id=case.internal_id, dry_run=dry_run)
-        status_db.commit()
+        if not dry_run:
+            status_db.commit()


### PR DESCRIPTION
## Description
After #1537 the automatic upload to caesar uses a new function which does not set upload_started_at, and hence breaks the automation since the same case is started every time. This PR fixes that.

### Fixed

- Set upload_started_at for fastq cases


### How to prepare for test
- [x] ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh fix-fastq-upload`

### How to test
- [x] do remove uploaded at and upload_started_at from a fastq case
- [x] run `cg upload all-fastq`

### Expected test outcome
- [x] check the upload_started_at is filled in
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
