### PR TITLE
add exception handling for duplicated cases

### DIFF
--- a/cg/cli/upload/observations/observations.py
+++ b/cg/cli/upload/observations/observations.py
@@ -1,6 +1,7 @@
 """Code for uploading observations data via CLI."""
 
 import logging
+import contextlib
 from datetime import datetime
 from typing import Optional
 
@@ -39,9 +40,8 @@ def observations(context: CGConfig, case_id: Optional[str], dry_run: bool):
     if dry_run:
         LOG.info(f"Dry run. Would upload observations for {case.internal_id}.")
         return
-
-    observations_api.process(case.analyses[0])
-    LOG.info(f"Observations uploaded for case: {case.internal_id}")
+    with contextlib.suppression(DuplicateRecordError, DuplicateSampleError):
+        observations_api.process(case.analyses[0])
 
 
 @click.command("available-observations")

--- a/cg/cli/upload/observations/observations.py
+++ b/cg/cli/upload/observations/observations.py
@@ -40,7 +40,7 @@ def observations(context: CGConfig, case_id: Optional[str], dry_run: bool):
     if dry_run:
         LOG.info(f"Dry run. Would upload observations for {case.internal_id}.")
         return
-    with contextlib.suppression(DuplicateRecordError, DuplicateSampleError):
+    with contextlib.suppress(DuplicateRecordError, DuplicateSampleError):
         observations_api.process(case.analyses[0])
 
 

--- a/cg/meta/upload/observations/observations_api.py
+++ b/cg/meta/upload/observations/observations_api.py
@@ -92,7 +92,8 @@ class UploadObservationsAPI:
         # check if some sample has already been uploaded
         for link in analysis_obj.family.links:
             if link.sample.loqusdb_id:
-                raise DuplicateRecordError(f"{link.sample.internal_id} already in LoqusDB")
+                LOG.info(f"{link.sample.internal_id} already in LoqusDB")
+                raise DuplicateRecordError
         results = self.get_input(analysis_obj)
         self.upload(results)
         case_obj = self.loqusdb.get_case(analysis_obj.family.internal_id)

--- a/cg/meta/upload/observations/observations_api.py
+++ b/cg/meta/upload/observations/observations_api.py
@@ -99,7 +99,7 @@ class UploadObservationsAPI:
         for link in analysis_obj.family.links:
             link.sample.loqusdb_id = str(case_obj["_id"])
         self.status.commit()
-        LOG.info(f"Observations uploaded for case: {case_obj.internal_id}")
+        LOG.info(f"Observations uploaded for case: {analysis_obj.family.internal_id}")
 
     @staticmethod
     def _all_samples(links: List[models.FamilySample]) -> bool:

--- a/cg/meta/upload/observations/observations_api.py
+++ b/cg/meta/upload/observations/observations_api.py
@@ -99,6 +99,7 @@ class UploadObservationsAPI:
         for link in analysis_obj.family.links:
             link.sample.loqusdb_id = str(case_obj["_id"])
         self.status.commit()
+        LOG.info(f"Observations uploaded for case: {case_obj.internal_id}")
 
     @staticmethod
     def _all_samples(links: List[models.FamilySample]) -> bool:


### PR DESCRIPTION
## Description

### Fixed

- When a sample/case has already been uploaded to loqusdb we dont want to abort, we want to continue with our process


### How to prepare for test
- [ ] ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] paxa the environment: `paxa`
- [ ] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [x] `cg upload -r -f <case_with_sample_already_in_loqusdb>`

### Expected test outcome
- [x] Case is not interrupted in the "Observations"

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
