### PR TITLE
Add handling for LoqusdbUploadError in observations upload

### DIFF
--- a/cg/cli/upload/observations/observations.py
+++ b/cg/cli/upload/observations/observations.py
@@ -40,7 +40,7 @@ def observations(context: CGConfig, case_id: Optional[str], dry_run: bool):
     if dry_run:
         LOG.info(f"Dry run. Would upload observations for {case.internal_id}.")
         return
-    with contextlib.suppress(DuplicateRecordError, DuplicateSampleError):
+    with contextlib.suppress(DuplicateRecordError, DuplicateSampleError, LoqusdbUploadError):
         observations_api.process(case.analyses[0])
 
 

--- a/cg/cli/upload/observations/utils.py
+++ b/cg/cli/upload/observations/utils.py
@@ -42,14 +42,14 @@ def get_observations_case_to_upload(context: CGConfig, case_id: str) -> models.F
 
     case: models.Family = get_observations_case(context, case_id, upload=True)
     if not case.customer.loqus_upload:
-        LOG.error(
+        LOG.warning(
             f"Customer {case.customer.internal_id} is not whitelisted for upload to Loqusdb. Canceling upload for "
             f"case {case.internal_id}."
         )
         raise LoqusdbUploadError
 
     if not LinkHelper.is_all_samples_non_tumour(case.links):
-        LOG.error(f"Case {case.internal_id} has tumor samples. Cancelling its upload.")
+        LOG.warning(f"Case {case.internal_id} has tumor samples. Cancelling its upload.")
         raise LoqusdbUploadError
     return case
 


### PR DESCRIPTION
## Description

When uploading cases to Scout for customers that are not whitelisted for loqusdb we raise an error. The error raised is a LoqusdbUploadError, which in general should be a warning since we in all the cases want to continue with the other steps of the upload of a family. 

### Fixed

- Error handling of `LoqusdbUploadError`

### How to prepare for test
- [ ] ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] paxa the environment: `paxa`
- [ ] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
