### PR TITLE
Add multiQC report to rna delivery

### DIFF
--- a/cg/constants/delivery.py
+++ b/cg/constants/delivery.py
@@ -99,6 +99,7 @@ MIP_RNA_ANALYSIS_CASE_TAGS = [
     {"vcf-snv-clinical-index"},
     {"vcf-snv-research"},
     {"vcf-snv-research-index"},
+    {"multiqc-html"},
 ]
 
 MIP_RNA_ANALYSIS_SAMPLE_TAGS = [


### PR DESCRIPTION
## Description

### Added

- Include multiQC report in RNA delivery

### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b add_qc_report_to_delivery -a
    ```

### How to test

- [x] Do `cg deliver analysis -d mip-rna -c tenderhen`

### Expected test outcome

- [x] Check that the multiQC report is included in the delivery.
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [x] Tests executed by @moahaegglund 
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [X] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
