### PR TITLE
fix(SampleSheet creation for fluffy, update SampleSheet fixture)

### DIFF
--- a/cg/cli/demultiplex/sample_sheet.py
+++ b/cg/cli/demultiplex/sample_sheet.py
@@ -78,7 +78,6 @@ def create_sheet(context: CGConfig, flowcell_name: str, bcl_converter: str, dry_
     if not lims_samples:
         LOG.warning("Could not find any samples in lims for %s", flowcell_object.flowcell_id)
         raise click.Abort
-
     try:
         sample_sheet: str = create_sample_sheet(
             flowcell=flowcell_object, lims_samples=lims_samples, bcl_converter=bcl_converter

--- a/cg/meta/workflow/fluffy.py
+++ b/cg/meta/workflow/fluffy.py
@@ -140,7 +140,7 @@ class FluffyAnalysisAPI(AnalysisAPI):
         """
 
         samplesheet_df = pd.read_csv(
-            samplesheet_housekeeper_path, index_col=None, header=0, skiprows=1
+            samplesheet_housekeeper_path, index_col=None, header=0, skiprows=4
         )
         LOG.info(samplesheet_df)
         sample_id_column_alias = (

--- a/tests/fixtures/data/SampleSheet.csv
+++ b/tests/fixtures/data/SampleSheet.csv
@@ -1,3 +1,6 @@
+[Settings]
+BarcodeMismatchesIndex1,0
+BarcodeMismatchesIndex2,0
 [Data]
 FCID,Lane,SampleID,SampleRef,index,index2,SampleName,Control,Recipe,Operator,Project
 HWJFTDRXX,1,ACC7534A1,hg19,AATCGTTA,ACGTTATT,342712,N,R1,script,342712


### PR DESCRIPTION
## Description

When creating the sample sheet for fluffy, using the new sample sheet settings, the creation crashed.

### Changed

- Updated SamplSheet Fixture to include settings

### Fixed

- Number of rows skipped when reading ins sample sheet 

### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] `cg workflow fluffy create-samplesheet <case_id>`

### Expected test outcome

- [ ] Sample sheet read successfully

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on `hasta`
- [ ] Inform to @Clinical-Genomics/data-analysis 
