### PR TITLE
Fix no click version help message in cg set sample

### DIFF
--- a/cg/cli/set/base.py
+++ b/cg/cli/set/base.py
@@ -164,12 +164,11 @@ def list_changeable_sample_attributes(
 def show_set_sample_help(sample_obj: models.Sample = "None") -> None:
     """Show help for the set sample command"""
     LOG.info("sample_id: optional, internal_id of sample to set value on")
-    show_option_help(long_name=OPTION_LONG_SKIP_LIMS, help_text=HELP_SKIP_LIMS)
-    show_option_help(short_name=OPTION_SHORT_YES, long_name=OPTION_LONG_YES, help_text=HELP_YES)
-    show_option_help(
-        short_name=OPTION_SHORT_KEY_VALUE, long_name=OPTION_LONG_KEY_VALUE, help_text=HELP_KEY_VALUE
-    )
+    LOG.info("Below is a set of changeable sample attributes, to combine with -kv flag")
+
     list_changeable_sample_attributes(sample_obj, skip_attributes=NOT_CHANGEABLE_SAMPLE_ATTRIBUTES)
+
+    LOG.info("See example below:")
     LOG.info(f"To set apptag use '{OPTION_SHORT_KEY_VALUE} application_version [APPTAG]")
     LOG.info(f"To set customer use '{OPTION_SHORT_KEY_VALUE} customer [CUSTOMER]")
     LOG.info(
@@ -177,6 +176,7 @@ def show_set_sample_help(sample_obj: models.Sample = "None") -> None:
     )
 
 
+# Below function is probably deprecated and can be removed / MJ
 def show_option_help(short_name: str = "", long_name: str = "", help_text: str = "") -> None:
     """Show help for one option"""
     help_message = f"Use "
@@ -209,7 +209,7 @@ def show_option_help(short_name: str = "", long_name: str = "", help_text: str =
 )
 @click.option(OPTION_LONG_SKIP_LIMS, is_flag=True, help=HELP_SKIP_LIMS)
 @click.option(OPTION_SHORT_YES, OPTION_LONG_YES, is_flag=True, help=HELP_YES)
-@click.option("--help", is_flag=True)
+@click.option("--lkv", is_flag=True)
 @click.pass_obj
 def sample(
     context: CGConfig,
@@ -217,12 +217,13 @@ def sample(
     kwargs: click.Tuple([str, str]),
     skip_lims: bool,
     yes: bool,
-    help: bool,
+    lkv: bool,
 ):
+    """Set key values on a sample"""
     status_db: Store = context.status_db
     sample_obj: models.Sample = status_db.sample(internal_id=sample_id)
 
-    if help:
+    if lkv:
         show_set_sample_help(sample_obj)
 
     if sample_obj is None:

--- a/cg/cli/set/base.py
+++ b/cg/cli/set/base.py
@@ -198,7 +198,7 @@ def show_option_help(short_name: str = "", long_name: str = "", help_text: str =
 @set_cmd.command()
 @click.option("-lks", "--listkeys_statusdb", is_flag=True, help="List all available modifiable sample properties in statusDB")
 @click.option("-lkl", "--listkeys_lims", is_flag=True, help="List all available modifiable sample properties in LIMS")
-def list_modifiable_keys(context: CGConfig, lks: bool, lkl: bool):
+def list_keys(context: CGConfig, lks: bool, lkl: bool):
     """List modifiable keys in statusDB and LIMS"""
     if lk:
         show_set_sample_help(sample_obj)

--- a/cg/cli/set/base.py
+++ b/cg/cli/set/base.py
@@ -206,7 +206,7 @@ def show_option_help(short_name: str = "", long_name: str = "", help_text: str =
     multiple=True,
     help=HELP_KEY_VALUE,
 )
-@click.option("--lk", is_flag=True, help="List all available modifiable sample properties")
+@click.option("-lk", "--listkeys", is_flag=True, help="List all available modifiable sample properties")
 @click.option(OPTION_LONG_SKIP_LIMS, is_flag=True, help=HELP_SKIP_LIMS)
 @click.option(OPTION_SHORT_YES, OPTION_LONG_YES, is_flag=True, help=HELP_YES)
 @click.pass_obj

--- a/cg/cli/set/base.py
+++ b/cg/cli/set/base.py
@@ -198,9 +198,9 @@ def show_option_help(short_name: str = "", long_name: str = "", help_text: str =
 @set_cmd.command()
 @click.option("-lks", "--listkeys_statusdb", is_flag=True, help="List all available modifiable sample properties in statusDB")
 @click.option("-lkl", "--listkeys_lims", is_flag=True, help="List all available modifiable sample properties in LIMS")
-def list_keys(context: CGConfig, lks: bool, lkl: bool):
+def list_keys(context: CGConfig, listkeys_statusdb: bool, listkeys_lims: bool):
     """List modifiable keys in statusDB and LIMS"""
-    if lk:
+    if listkeys_statusdb:
         show_set_sample_help(sample_obj)
 
 @set_cmd.command()

--- a/cg/cli/set/base.py
+++ b/cg/cli/set/base.py
@@ -163,7 +163,6 @@ def list_changeable_sample_attributes(
 
 def show_set_sample_help(sample_obj: models.Sample = "None") -> None:
     """Show help for the set sample command"""
-    LOG.info(f"sample_id: optional, internal_id of sample to set value on \n")
     LOG.info(f"Below is a set of changeable sample attributes, to combine with -kv flag:\n")
 
     list_changeable_sample_attributes(sample_obj, skip_attributes=NOT_CHANGEABLE_SAMPLE_ATTRIBUTES)
@@ -207,7 +206,7 @@ def show_option_help(short_name: str = "", long_name: str = "", help_text: str =
     multiple=True,
     help=HELP_KEY_VALUE,
 )
-@click.option("--lkv", is_flag=True, help="List all available modifiable sample properties")
+@click.option("--lk", is_flag=True, help="List all available modifiable sample properties")
 @click.option(OPTION_LONG_SKIP_LIMS, is_flag=True, help=HELP_SKIP_LIMS)
 @click.option(OPTION_SHORT_YES, OPTION_LONG_YES, is_flag=True, help=HELP_YES)
 @click.pass_obj
@@ -217,13 +216,13 @@ def sample(
     kwargs: click.Tuple([str, str]),
     skip_lims: bool,
     yes: bool,
-    lkv: bool,
+    lk: bool,
 ):
-    """Set key values on a sample"""
+    """Set key values on a sample: (sample_id: optional, internal_id of sample to set value on)"""
     status_db: Store = context.status_db
     sample_obj: models.Sample = status_db.sample(internal_id=sample_id)
 
-    if lkv:
+    if lk:
         show_set_sample_help(sample_obj)
 
     if sample_obj is None:

--- a/cg/cli/set/base.py
+++ b/cg/cli/set/base.py
@@ -197,11 +197,17 @@ def show_option_help(short_name: str = "", long_name: str = "", help_text: str =
 
 @set_cmd.command()
 @click.option("-lks", "--listkeys_statusdb", is_flag=True, help="List all available modifiable sample properties in statusDB")
-@click.option("-lkl", "--listkeys_lims", is_flag=True, help="List all available modifiable sample properties in LIMS")
+@click.option("-lkl", "--listkeys_lims", is_flag=True, help="List all available modifiable sample properties in LIMS (placeholder)")
+@click.pass_obj
 def list_keys(context: CGConfig, listkeys_statusdb: bool, listkeys_lims: bool):
     """List modifiable keys in statusDB and LIMS"""
+    status_db: Store = context.status_db
+    sample_obj: models.Sample = status_db.sample(internal_id=sample_id)
     if listkeys_statusdb:
         show_set_sample_help(sample_obj)
+    if listkeys_lims:
+        LOG.warning("Function lkl not implemented yet")
+        raise click.Abort
 
 @set_cmd.command()
 @click.argument("sample_id", required=False)

--- a/cg/cli/set/base.py
+++ b/cg/cli/set/base.py
@@ -163,16 +163,16 @@ def list_changeable_sample_attributes(
 
 def show_set_sample_help(sample_obj: models.Sample = "None") -> None:
     """Show help for the set sample command"""
-    LOG.info("sample_id: optional, internal_id of sample to set value on")
-    LOG.info("Below is a set of changeable sample attributes, to combine with -kv flag")
+    LOG.info(f"sample_id: optional, internal_id of sample to set value on \n")
+    LOG.info(f"Below is a set of changeable sample attributes, to combine with -kv flag:\n")
 
     list_changeable_sample_attributes(sample_obj, skip_attributes=NOT_CHANGEABLE_SAMPLE_ATTRIBUTES)
 
-    LOG.info("See example below:")
+    LOG.info(f"\nSee example below:")
     LOG.info(f"To set apptag use '{OPTION_SHORT_KEY_VALUE} application_version [APPTAG]")
     LOG.info(f"To set customer use '{OPTION_SHORT_KEY_VALUE} customer [CUSTOMER]")
     LOG.info(
-        f"To set priority use '{OPTION_SHORT_KEY_VALUE} priority [priority as text or " f"number]"
+        f"To set priority use '{OPTION_SHORT_KEY_VALUE} priority [priority as text or " f"number]\n"
     )
 
 

--- a/cg/cli/set/base.py
+++ b/cg/cli/set/base.py
@@ -207,9 +207,9 @@ def show_option_help(short_name: str = "", long_name: str = "", help_text: str =
     multiple=True,
     help=HELP_KEY_VALUE,
 )
+@click.option("--lkv", is_flag=True, help="List all available modifiable sample properties")
 @click.option(OPTION_LONG_SKIP_LIMS, is_flag=True, help=HELP_SKIP_LIMS)
 @click.option(OPTION_SHORT_YES, OPTION_LONG_YES, is_flag=True, help=HELP_YES)
-@click.option("--lkv", is_flag=True)
 @click.pass_obj
 def sample(
     context: CGConfig,

--- a/cg/cli/set/base.py
+++ b/cg/cli/set/base.py
@@ -196,6 +196,14 @@ def show_option_help(short_name: str = "", long_name: str = "", help_text: str =
 
 
 @set_cmd.command()
+@click.option("-lks", "--listkeys_statusdb", is_flag=True, help="List all available modifiable sample properties in statusDB")
+@click.option("-lkl", "--listkeys_lims", is_flag=True, help="List all available modifiable sample properties in LIMS")
+def list_modifiable_keys(context: CGConfig, lks: bool, lkl: bool):
+    """List modifiable keys in statusDB and LIMS"""
+    if lk:
+        show_set_sample_help(sample_obj)
+
+@set_cmd.command()
 @click.argument("sample_id", required=False)
 @click.option(
     OPTION_SHORT_KEY_VALUE,
@@ -206,7 +214,6 @@ def show_option_help(short_name: str = "", long_name: str = "", help_text: str =
     multiple=True,
     help=HELP_KEY_VALUE,
 )
-@click.option("-lk", "--listkeys", is_flag=True, help="List all available modifiable sample properties")
 @click.option(OPTION_LONG_SKIP_LIMS, is_flag=True, help=HELP_SKIP_LIMS)
 @click.option(OPTION_SHORT_YES, OPTION_LONG_YES, is_flag=True, help=HELP_YES)
 @click.pass_obj
@@ -216,14 +223,10 @@ def sample(
     kwargs: click.Tuple([str, str]),
     skip_lims: bool,
     yes: bool,
-    lk: bool,
 ):
     """Set key values on a sample: (sample_id: optional, internal_id of sample to set value on)"""
     status_db: Store = context.status_db
     sample_obj: models.Sample = status_db.sample(internal_id=sample_id)
-
-    if lk:
-        show_set_sample_help(sample_obj)
 
     if sample_obj is None:
         LOG.error(f"Can't find sample {sample_id}")

--- a/cg/cli/set/base.py
+++ b/cg/cli/set/base.py
@@ -196,20 +196,6 @@ def show_option_help(short_name: str = "", long_name: str = "", help_text: str =
 
 
 @set_cmd.command()
-@click.option("-lks", "--listkeys_statusdb", is_flag=True, help="List all available modifiable sample properties in statusDB")
-@click.option("-lkl", "--listkeys_lims", is_flag=True, help="List all available modifiable sample properties in LIMS (placeholder)")
-@click.pass_obj
-def list_keys(context: CGConfig, listkeys_statusdb: bool, listkeys_lims: bool):
-    """List modifiable keys in statusDB and LIMS"""
-    status_db: Store = context.status_db
-    sample_obj: models.Sample = status_db.sample(internal_id=sample_id)
-    if listkeys_statusdb:
-        show_set_sample_help(sample_obj)
-    if listkeys_lims:
-        LOG.warning("Function lkl not implemented yet")
-        raise click.Abort
-
-@set_cmd.command()
 @click.argument("sample_id", required=False)
 @click.option(
     OPTION_SHORT_KEY_VALUE,
@@ -220,6 +206,7 @@ def list_keys(context: CGConfig, listkeys_statusdb: bool, listkeys_lims: bool):
     multiple=True,
     help=HELP_KEY_VALUE,
 )
+@click.option("-lk", "--listkeys", is_flag=True, help="List all available modifiable sample properties")
 @click.option(OPTION_LONG_SKIP_LIMS, is_flag=True, help=HELP_SKIP_LIMS)
 @click.option(OPTION_SHORT_YES, OPTION_LONG_YES, is_flag=True, help=HELP_YES)
 @click.pass_obj
@@ -229,10 +216,14 @@ def sample(
     kwargs: click.Tuple([str, str]),
     skip_lims: bool,
     yes: bool,
+    lk: bool,
 ):
     """Set key values on a sample: (sample_id: optional, internal_id of sample to set value on)"""
     status_db: Store = context.status_db
     sample_obj: models.Sample = status_db.sample(internal_id=sample_id)
+
+    if lk:
+        show_set_sample_help(sample_obj)
 
     if sample_obj is None:
         LOG.error(f"Can't find sample {sample_id}")


### PR DESCRIPTION
## Description

This branch merge aims to remove the non-standard help message in cg set sample --help, which had been hijacked to display a custom-made help message that allowed for the functionality of listing the modifiable keys in statusDB. Now the standard click help message has returned, and the list modifiable keys has been made into an optional argument. 

### Added

- An argument to list modifiable keys in cg set sample 

### Changed

- Moved relevant information in the custom help message to the click help message

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
