### PR TITLE
feat(ordering) Adds new delivery option and filters families on pipeline

### DIFF
--- a/cg/constants/constants.py
+++ b/cg/constants/constants.py
@@ -99,6 +99,7 @@ class DataDelivery(StrEnum):
     FASTQ_QC_ANALYSIS: str = "fastq_qc-analysis"
     FASTQ_ANALYSIS_SCOUT: str = "fastq-analysis-scout"
     NIPT_VIEWER: str = "nipt-viewer"
+    NO_DELIVERY: str = "no-delivery"
     SCOUT: str = "scout"
     STATINA: str = "statina"
 

--- a/cg/meta/orders/fastq_submitter.py
+++ b/cg/meta/orders/fastq_submitter.py
@@ -59,7 +59,7 @@ class FastqSubmitter(Submitter):
     def create_maf_case(self, sample_obj: models.Sample):
         case_obj: models.Family = self.status.add_case(
             data_analysis=Pipeline(Pipeline.MIP_DNA),
-            data_delivery=DataDelivery(DataDelivery.ANALYSIS_FILES),
+            data_delivery=DataDelivery(DataDelivery.NO_DELIVERY),
             name="_".join([sample_obj.name, "MAF"]),
             panels=[GenePanelMasterList.OMIM_AUTO],
             priority=Priority.research,

--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -168,9 +168,13 @@ def families():
 @BLUEPRINT.route("/families_in_collaboration")
 def families_in_collaboration():
     """Fetch families in collaboration."""
-    order_customer = db.customer(request.args.get("customer"))
+    order_customer: models.Customer = db.customer(request.args.get("customer"))
+    data_analysis: str = request.args.get("data_analysis")
+    print(request.args)
     families_q: Query = db.families(
-        enquiry=request.args.get("enquiry"), customers=order_customer.collaborators
+        enquiry=request.args.get("enquiry"),
+        customers=order_customer.collaborators,
+        data_analysis=data_analysis,
     )
     count = families_q.count()
     records = families_q.limit(30)

--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -170,7 +170,6 @@ def families_in_collaboration():
     """Fetch families in collaboration."""
     order_customer: models.Customer = db.customer(request.args.get("customer"))
     data_analysis: str = request.args.get("data_analysis")
-    print(request.args)
     families_q: Query = db.families(
         enquiry=request.args.get("enquiry"),
         customers=order_customer.collaborators,

--- a/cg/store/api/findbusinessdata.py
+++ b/cg/store/api/findbusinessdata.py
@@ -124,10 +124,10 @@ class FindBusinessDataHandler(BaseHandler):
     def families(
         self,
         *,
-        action: str = None,
-        data_analysis: str = None,
+        action: Optional[str] = None,
+        data_analysis: Optional[str] = None,
         customers: List[models.Customer] = None,
-        enquiry: str = None,
+        enquiry: Optional[str] = None,
     ) -> Query:
         """Fetch families."""
 
@@ -147,7 +147,6 @@ class FindBusinessDataHandler(BaseHandler):
             if enquiry
             else records
         )
-        print(data_analysis)
         records = records.filter_by(action=action) if action else records
         records = records.filter_by(data_analysis=data_analysis) if data_analysis else records
         return records.order_by(models.Family.created_at.desc())

--- a/cg/store/api/findbusinessdata.py
+++ b/cg/store/api/findbusinessdata.py
@@ -122,7 +122,12 @@ class FindBusinessDataHandler(BaseHandler):
         return self.Delivery.query
 
     def families(
-        self, *, customers: List[models.Customer] = None, enquiry: str = None, action: str = None
+        self,
+        *,
+        action: str = None,
+        data_analysis: str = None,
+        customers: List[models.Customer] = None,
+        enquiry: str = None,
     ) -> Query:
         """Fetch families."""
 
@@ -142,8 +147,9 @@ class FindBusinessDataHandler(BaseHandler):
             if enquiry
             else records
         )
-
+        print(data_analysis)
         records = records.filter_by(action=action) if action else records
+        records = records.filter_by(data_analysis=data_analysis) if data_analysis else records
         return records.order_by(models.Family.created_at.desc())
 
     def family(self, internal_id: str) -> models.Family:

--- a/tests/meta/orders/test_meta_orders_status.py
+++ b/tests/meta/orders/test_meta_orders_status.py
@@ -270,7 +270,7 @@ def test_store_samples(orders_api, base_store, fastq_status_data, ticket: str):
     for sample in new_samples:
         assert len(sample.deliveries) == 1
     assert family_link.family.data_analysis
-    assert family_link.family.data_delivery in [DataDelivery.FASTQ, DataDelivery.ANALYSIS_FILES]
+    assert family_link.family.data_delivery in [DataDelivery.FASTQ, DataDelivery.NO_DELIVERY]
 
 
 def test_store_samples_sex_stored(orders_api, base_store, fastq_status_data, ticket: str):


### PR DESCRIPTION
## Description
To prevent internal control cases to be delivered by the new automation (see issue#1633) a new delivery type was added for placing control orders.

For placing re-runs the customer can order any existing family in any type of order, which can result in issues (see #1607 ). The orderportal via the `/families_in_collaboration` will now only suggest families of the same ordertype

### Added

- New delivery option: no-delivery

### Changed

- The families function now accepts the data_delivery argument which filters on the given data_delivery

### How to prepare for test

- [x] Deploy branch on stage environment using github action

**How to test**:
- [x] login on https://clinical-stage.scilifelab.se/
- [x] on an admin account attempt to place an order with the no-delivery option
- [x] Place an RNA-order with the fastq delivery type
- [x] Verify that no mip-cases are suggested in a balsamic order and vice versa

**Expected test outcome**:
- [x] The no-delivery option can only be used when admin
- [x] RNA-orders can have fastq delivery type

**Review:**
- [x] tests executed by VJ
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
