### PR TITLE
Parsing and correctly summerizing  meanQscore

### DIFF
--- a/cg/apps/cgstats/parsers/quality_metrics.py
+++ b/cg/apps/cgstats/parsers/quality_metrics.py
@@ -43,6 +43,7 @@ class QualityMetrics:
             for value in parsed_metrics[lane].values():
                 value["YieldQ30"] = int(value["YieldQ30"])
                 value["Mean Quality Score (PF)"] = float(value["Mean Quality Score (PF)"])
+                value["QualityScoreSum"] = int(value["QualityScoreSum"])
                 sample_id = value.get("SampleID")
                 if sample_id not in summarized_metrics[lane]:
                     summarized_metrics[lane][sample_id] = value
@@ -51,4 +52,8 @@ class QualityMetrics:
                 summarized_metrics[lane][sample_id]["Mean Quality Score (PF)"] += value.get(
                     "Mean Quality Score (PF)"
                 )
+                summarized_metrics[lane][sample_id]["QualityScoreSum"] += value.get(
+                    "QualityScoreSum"
+                )
+
         return summarized_metrics

--- a/cg/apps/cgstats/parsers/quality_metrics.py
+++ b/cg/apps/cgstats/parsers/quality_metrics.py
@@ -42,9 +42,13 @@ class QualityMetrics:
             summarized_metrics[lane] = summarized_metrics.get(lane, {})
             for value in parsed_metrics[lane].values():
                 value["YieldQ30"] = int(value["YieldQ30"])
+                value["Mean Quality Score (PF)"] = float(value["Mean Quality Score (PF)"])
                 sample_id = value.get("SampleID")
                 if sample_id not in summarized_metrics[lane]:
                     summarized_metrics[lane][sample_id] = value
                     continue
                 summarized_metrics[lane][sample_id]["YieldQ30"] += value.get("YieldQ30")
+                summarized_metrics[lane][sample_id]["Mean Quality Score (PF)"] += value.get(
+                    "Mean Quality Score (PF)"
+                )
         return summarized_metrics


### PR DESCRIPTION
## Description

### Fixed
- Correctly summarizing `Mean Quality Score (PF)` in the `Quality_Metrics.csv` file so its correct in the `stats_<project>_<Flowcell>` file where its named `meanQscore`
- Correctly summarizing `QualityScoreSum` in the `Quality_Metrics.csv` file even though its not used in the stats file



### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
