### PR TITLE
add bwa-mem option to mip analysis workflow

### DIFF
--- a/cg/cli/workflow/mip/base.py
+++ b/cg/cli/workflow/mip/base.py
@@ -7,6 +7,7 @@ from cg.cli.workflow.commands import ensure_flowcells_ondisk, link, resolve_comp
 from cg.cli.workflow.mip.options import (
     ARGUMENT_CASE_ID,
     EMAIL_OPTION,
+    OPTION_BWA_MEM,
     OPTION_DRY,
     OPTION_MIP_DRY_RUN,
     OPTION_PANEL_BED,
@@ -69,6 +70,7 @@ def panel(context: CGConfig, case_id: str, dry_run: bool):
 @START_AFTER_PROGRAM
 @START_WITH_PROGRAM
 @ARGUMENT_CASE_ID
+@OPTION_BWA_MEM
 @OPTION_DRY
 @OPTION_MIP_DRY_RUN
 @OPTION_SKIP_EVALUATION
@@ -83,6 +85,7 @@ def run(
     skip_evaluation: bool = False,
     start_after: str = None,
     start_with: str = None,
+    use_bwa_mem: bool = False,
 ):
     """Run the analysis for a case"""
 
@@ -99,6 +102,7 @@ def run(
         skip_evaluation=analysis_api.get_skip_evaluation_flag(
             case_id=case_id, skip_evaluation=skip_evaluation
         ),
+        use_bwa_mem=use_bwa_mem,
     )
 
     try:
@@ -128,6 +132,7 @@ def run(
 @click.command()
 @ARGUMENT_CASE_ID
 @EMAIL_OPTION
+@OPTION_BWA_MEM
 @OPTION_DRY
 @OPTION_MIP_DRY_RUN
 @OPTION_PANEL_BED
@@ -147,6 +152,7 @@ def start(
     skip_evaluation: bool,
     start_after: str,
     start_with: str,
+    use_bwa_mem: bool,
 ):
     """Start full MIP analysis workflow for a case"""
 
@@ -170,6 +176,7 @@ def start(
             dry_run=dry_run,
             mip_dry_run=mip_dry_run,
             skip_evaluation=skip_evaluation,
+            use_bwa_mem=use_bwa_mem,
         )
     except (FlowcellsNeededError, DecompressionNeededError) as error:
         LOG.error(error)

--- a/cg/cli/workflow/mip/options.py
+++ b/cg/cli/workflow/mip/options.py
@@ -14,6 +14,12 @@ START_AFTER_PROGRAM = click.option(
 START_WITH_PROGRAM = click.option(
     "-sw", "--start-with", help="Start mip from this program.", type=str
 )
+OPTION_BWA_MEM = click.option(
+    "--use-bwa-mem",
+    is_flag=True,
+    default=False,
+    help="Use BWA-mem instead of the default BWA-mem2"
+)
 OPTION_DRY = click.option(
     "-d",
     "--dry-run",

--- a/cg/cli/workflow/mip/options.py
+++ b/cg/cli/workflow/mip/options.py
@@ -15,10 +15,7 @@ START_WITH_PROGRAM = click.option(
     "-sw", "--start-with", help="Start mip from this program.", type=str
 )
 OPTION_BWA_MEM = click.option(
-    "--use-bwa-mem",
-    is_flag=True,
-    default=False,
-    help="Use BWA-mem instead of the default BWA-mem2"
+    "--use-bwa-mem", is_flag=True, default=False, help="Use BWA-mem instead of the default BWA-mem2"
 )
 OPTION_DRY = click.option(
     "-d",

--- a/cg/meta/workflow/mip.py
+++ b/cg/meta/workflow/mip.py
@@ -31,6 +31,7 @@ CLI_OPTIONS = {
     "skip_evaluation": {"option": "--qccollect_skip_evaluation"},
     "start_after": {"option": "--start_after_recipe"},
     "start_with": {"option": "--start_with_recipe"},
+    "use_bwa_mem": {"option": "--use_bwa_mem"},
 }
 
 LOG = logging.getLogger(__name__)

--- a/cg/meta/workflow/mip.py
+++ b/cg/meta/workflow/mip.py
@@ -31,9 +31,9 @@ CLI_OPTIONS = {
     "skip_evaluation": {"option": "--qccollect_skip_evaluation"},
     "start_after": {"option": "--start_after_recipe"},
     "start_with": {"option": "--start_with_recipe"},
-    "use_bwa_mem": {"option": "--use_bwa_mem"},
+    "use_bwa_mem": {"option": "--bwa_mem 1 --bwa_mem2 0"},
 }
-
+##TODO test this option above
 LOG = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## Description
In the coming release of MIP we have made BWA-mem2 the default aligner. It is faster but we know that it might crash on older data files. We would need an option in CG to switch aligner if we need to restart with the older aligner. This PR adds the command to cg.

### Added

- Command --use-bwa-mem to mip-dna analysis workflow

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b add-bwamem-command-to-mip -a
    ```

### How to test

- [ ] On Stage, do `cg workflow mip-dna start --help` and show the new option.
- [ ] On stage, get the new config files for mip11.1 (not in production yet) `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-servers-stage.sh update-mip-config
` (from https://github.com/Clinical-Genomics/servers/pull/843)
- [ ] Start dryrun of case funnyelf, using `cg workflow mip-dna start --mip-dry-run funnyelf`, to show it works as normal.
- [ ] Start dryrun of case funnyelf, using `cg workflow mip-dna start --mip-dry-run --use-bwa-mem funnyelf`, to test the new function.

### Expected test outcome

- [x] Check that the new option is present in the help text.
- [x]  Check that in the config files for mip11.1 the default version is bwa-mem2.
- [x]  Check that the new option is present in the mip command when starting the funnyelf case
- [x]  Check that when using the new option flag, bwa-mem2 is switched off and bwa-mem is switched on.


## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
