### PR TITLE
Fix(fohm upload) Removed alive_bar

### DIFF
--- a/cg/constants/compression.py
+++ b/cg/constants/compression.py
@@ -111,7 +111,7 @@ OTHER_VALIDATION_CASES = [
     "keencalf",
     "keenviper",
     "luckyhog",
-    "maturejay",
+    "maturejay",  # sars-cov-2 case
     "meetpossum",
     "mintbaboon",
     "mintyeti",

--- a/cg/meta/upload/fohm/fohm.py
+++ b/cg/meta/upload/fohm/fohm.py
@@ -92,7 +92,8 @@ class FOHMUploadAPI:
 
     @property
     def aggregation_dataframe(self) -> pd.DataFrame:
-        """Dataframe with all 'komplettering' rows from multiple cases, and additional rows to be used for aggregation"""
+        """Dataframe with all 'komplettering' rows from multiple cases, and additional rows to be
+        used for aggregation."""
         if not isinstance(self._aggregation_dataframe, pd.DataFrame):
             self._aggregation_dataframe = self.reports_dataframe.copy()
         return self._aggregation_dataframe
@@ -129,7 +130,7 @@ class FOHMUploadAPI:
         if getpass.getuser() == self.config.fohm.valid_uploader:
             return
         raise CgError(
-            f"Cannot upload to FOHM as {getpass.getuser()}, please log in as {self.config.fohm.valid_uploader}"
+            f"Cannot upload to FOHM as {getpass.getuser()}, please log in as {self.config.fohm.valid_uploader} "
         )
 
     def set_cases_to_aggregate(self, cases: list) -> None:
@@ -164,10 +165,7 @@ class FOHMUploadAPI:
         )
 
     def link_sample_rawdata_files(self) -> None:
-        """
-        Hardlink samples rawdata files to fohm delivery folder
-        """
-        samples_to_link = len(self.aggregation_dataframe)
+        """Hardlink samples rawdata files to fohm delivery folder."""
         for sample_id in self.aggregation_dataframe["internal_id"]:
             sample_obj: models.Sample = self.status_db.sample(sample_id)
             bundle_name = sample_obj.links[0].family.internal_id
@@ -246,7 +244,6 @@ class FOHMUploadAPI:
         ed_key = paramiko.Ed25519Key.from_private_key_file(self.config.fohm.key)
         transport.connect(username=self.config.fohm.username, pkey=ed_key)
         sftp = paramiko.SFTPClient.from_transport(transport)
-        files_to_upload = len(list(self.daily_rawdata_path.iterdir()))
         for file in self.daily_rawdata_path.iterdir():
             LOG.info(f"Sending {file} via SFTP, dry-run {self.dry_run}")
             if self._dry_run:

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,6 @@ sendmail-container
 werkzeug<1.0.0              # due to breaking changes in 1.0.0
 
 # utils
-alive_progress
 ansi
 cgmodels>=0.10.5
 coloredlogs


### PR DESCRIPTION
## Description
The fohm upload crashes in production somewhere in the alive_bar function in the alive_progress package. Since this only provides a graphical view of the progress, which is not used it has been removed

### Changed

- Removed usage of alive_bar
- Removed alive_progress as a dependency


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b fix-fohm-upload -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
