### PR TITLE
Fix(Sequencing QC) Sequencing qc always passes for rml-samples with reads

### DIFF
--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -608,7 +608,7 @@ class Sample(Model, PriorityMixin):
         if self.priority == Priority.express:
             one_half_of_target_reads = application.target_reads / 2
             return self.reads >= one_half_of_target_reads
-        if self.application_version.application.prep_category == "rml":
+        if self.application_version.application.prep_category == PrepCategory.READY_MADE_LIBRARY:
             return bool(self.reads)
         return self.reads > application.expected_reads
 

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -608,6 +608,8 @@ class Sample(Model, PriorityMixin):
         if self.priority == Priority.express:
             one_half_of_target_reads = application.target_reads / 2
             return self.reads >= one_half_of_target_reads
+        if self.application_version.application.prep_category == "rml":
+            return bool(self.reads)
         return self.reads > application.expected_reads
 
     @property


### PR DESCRIPTION
## Description
Due to a recent change in #1650 the delivery of RML-samples now always fails unless the `--force-all` flag is used. This is due to the `sequencing_qc` property of Samples is not applicable for RML-samples. This PR makes it so that RML-samples pass sequencing qc as long as they have any reads.

### Changed

- RML samples now pass sequencing qc as long as they have reads



### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
   bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b fix-rml-qc -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
