### PR TITLE
Fix(Flask UI) Fixes Family action options

### DIFF
--- a/cg/constants/constants.py
+++ b/cg/constants/constants.py
@@ -35,7 +35,7 @@ class CaseActions(StrEnum):
     RUNNING: str = "running"
 
 
-CASE_ACTIONS = (CaseActions.ANALYZE, CaseActions.RUNNING, CaseActions.HOLD)
+CASE_ACTIONS = (action.value for action in CaseActions)
 
 COLLABORATORS = ("cust000", "cust002", "cust003", "cust004", "cust042")
 

--- a/cg/constants/constants.py
+++ b/cg/constants/constants.py
@@ -35,7 +35,7 @@ class CaseActions(StrEnum):
     RUNNING: str = "running"
 
 
-CASE_ACTIONS = (action.value for action in CaseActions)
+CASE_ACTIONS = [action.value for action in CaseActions]
 
 COLLABORATORS = ("cust000", "cust002", "cust003", "cust004", "cust042")
 

--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -246,8 +246,8 @@ class FamilyView(BaseView):
 
     @action(
         "set_hold",
-        "Set action to HOLD",
-        "Are you sure you want to set the action for selected families to HOLD?",
+        "Set action to hold",
+        "Are you sure you want to set the action for selected families to hold?",
     )
     def action_set_hold(self, ids: List[str]):
         self.set_action_for_batch(action=CaseActions.HOLD, entry_ids=ids)
@@ -255,7 +255,7 @@ class FamilyView(BaseView):
     @action(
         "set_empty",
         "Set action to Empty",
-        "Are you sure you want to set the action for selected families to empty?",
+        "Are you sure you want to set the action for selected families to Empty?",
     )
     def action_set_empty(self, ids: List[str]):
         self.set_action_for_batch(action=None, entry_ids=ids)


### PR DESCRIPTION
## Description
When recent changes to the tuple defining CASE_ACTIONS were deployed to the front end it was discovered that one could no longer change the case action manually

### Changed

- CASE_ACTIONS is still defined via the CaseActions StrEnum but now only contains its values.



### How to prepare for test

- [ ] Deploy branch on staging VM

### How to test

- [ ] Attempt to change the action of a case

### Expected test outcome

- [ ] Check that the action is changed.
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
