### PR TITLE
Fix: MIP-DNA clinical delivery of delivery reports

### DIFF
--- a/cg/meta/upload/mip_dna/mip_dna.py
+++ b/cg/meta/upload/mip_dna/mip_dna.py
@@ -36,7 +36,6 @@ class MipDNAUploadAPI(UploadAPI):
         self.update_upload_started_at(analysis_obj)
 
         # Main upload
-        ctx.invoke(clinical_delivery, case_id=case_obj.internal_id)
         ctx.invoke(coverage, family_id=case_obj.internal_id, re_upload=restart)
         ctx.invoke(validate, family_id=case_obj.internal_id)
         ctx.invoke(genotypes, family_id=case_obj.internal_id, re_upload=restart)
@@ -45,6 +44,9 @@ class MipDNAUploadAPI(UploadAPI):
         # Delivery report generation
         if case_obj.data_delivery in REPORT_SUPPORTED_DATA_DELIVERY:
             ctx.invoke(delivery_report, case_id=case_obj.internal_id)
+
+        # Clinical delivery upload
+        ctx.invoke(clinical_delivery, case_id=case_obj.internal_id)
 
         # Scout specific upload
         if DataDelivery.SCOUT in case_obj.data_delivery:

--- a/cg/meta/workflow/balsamic_pon.py
+++ b/cg/meta/workflow/balsamic_pon.py
@@ -2,6 +2,7 @@
 
 import logging
 from pathlib import Path
+from typing import List
 
 from cg.constants.indexes import ListIndexes
 from cg.exc import BalsamicStartError
@@ -31,6 +32,7 @@ class BalsamicPonAnalysisAPI(BalsamicAnalysisAPI):
         genome_version: str,
         panel_bed: str,
         pon_cnn: str,
+        observations: List[str],
         dry_run: bool = False,
     ) -> None:
         """Creates a config file for BALSAMIC PON analysis"""


### PR DESCRIPTION
## Description

Delivery report  is not being uploaded to caesar automatically.

### Fixed
- Clinical delivery of a delivery report.
- Missing PON config case argument.

### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
```shell
bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b fix-report-clinical-delivery -a
```

### How to test

- [x] `cg upload -f ...`

<img width="800" alt="Screenshot 2023-01-16 at 09 08 48" src="https://user-images.githubusercontent.com/26309194/212628209-1f8fd139-a281-41e6-ba4c-6d150fcbaa24.png">

Customer inbox:
<img width="800" alt="Screenshot 2023-01-16 at 09 12 44" src="https://user-images.githubusercontent.com/26309194/212628909-49428218-21ea-43c2-a16e-0b889fb3b71a.png">


## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
