### PR TITLE
Adjust crunchy mem according to reads

### DIFF
--- a/cg/cli/compress/fastq.py
+++ b/cg/cli/compress/fastq.py
@@ -12,9 +12,8 @@ from cg.cli.compress.helpers import (
     update_compress_api,
     is_case_ignored,
     get_cases_to_process,
-    set_mem_according_to_reads,
+    compress_sample_fastqs_in_cases,
 )
-from cg.constants.compression import CASES_TO_IGNORE
 from cg.constants.constants import DRY_RUN
 from cg.exc import CaseNotFoundError
 from cg.meta.compress import CompressAPI
@@ -57,39 +56,14 @@ def fastq_cmd(
     cases: List[Family] = get_cases_to_process(case_id=case_id, days_back=days_back, store=store)
     if not cases:
         return
-
-    case_conversion_count = 0
-    individuals_conversion_count = 0
-    for case in cases:
-        case_converted = True
-        if case_conversion_count >= number_of_conversions:
-            break
-        if is_case_ignored(case_id=case.internal_id):
-            continue
-
-        LOG.info(f"Searching for FASTQ files in case {case.internal_id}")
-        if not case.links:
-            continue
-        for case_link in case.links:
-            sample_id: str = case_link.sample.internal_id
-            if not mem:
-                mem: Optional[int] = set_mem_according_to_reads(
-                    sample_id=sample_id, sample_reads=case_link.sample.reads
-                )
-            update_compress_api(
-                compress_api=compress_api, dry_run=dry_run, hours=hours, mem=mem, ntasks=ntasks
-            )
-            case_converted: bool = compress_api.compress_fastq(sample_id=sample_id)
-            if not case_converted:
-                LOG.info(f"skipping individual {sample_id}")
-                continue
-            individuals_conversion_count += 1
-        if case_converted:
-            case_conversion_count += 1
-            LOG.info(f"Considering case {case.internal_id} converted")
-
-    LOG.info(
-        f"{individuals_conversion_count} individuals in {case_conversion_count} (completed) cases where compressed"
+    compress_sample_fastqs_in_cases(
+        compress_api=compress_api,
+        cases=cases,
+        dry_run=dry_run,
+        number_of_conversions=number_of_conversions,
+        hours=hours,
+        mem=mem,
+        ntasks=ntasks,
     )
 
 

--- a/cg/cli/compress/fastq.py
+++ b/cg/cli/compress/fastq.py
@@ -73,7 +73,7 @@ def fastq_cmd(
         for case_link in case.links:
             sample_id: str = case_link.sample.internal_id
             if not mem:
-                mem: int = set_mem_according_to_reads(
+                mem: Optional[int] = set_mem_according_to_reads(
                     sample_id=sample_id, sample_reads=case_link.sample.reads
                 )
             update_compress_api(

--- a/cg/cli/compress/helpers.py
+++ b/cg/cli/compress/helpers.py
@@ -57,7 +57,7 @@ def is_case_ignored(case_id: str) -> bool:
     return False
 
 
-def set_mem_according_to_reads(sample_id: str, sample_reads: Optional[int] = None) -> int:
+def set_mem_according_to_reads(sample_id: str, sample_reads: Optional[int] = None) -> Optional[int]:
     """Set SLURM memory depending on number of sample reads."""
     if not sample_reads:
         LOG.debug(f"No reads recorded for sample: {sample_id}")

--- a/cg/constants/compression.py
+++ b/cg/constants/compression.py
@@ -5,7 +5,7 @@ import datetime
 FASTQ_FIRST_READ_SUFFIX: str = "_R1_001.fastq.gz"
 FASTQ_SECOND_READ_SUFFIX: str = "_R2_001.fastq.gz"
 FLAG_PATH_SUFFIX: str = ".crunchy.txt"
-MAX_READS_PER_GB: int = 18000000
+MAX_READS_PER_GB: int = 18_000_000
 PENDING_PATH_SUFFIX: str = ".crunchy.pending.txt"
 
 

--- a/cg/constants/compression.py
+++ b/cg/constants/compression.py
@@ -2,10 +2,11 @@
 import datetime
 
 # Constants for crunchy
-FASTQ_FIRST_READ_SUFFIX = "_R1_001.fastq.gz"
-FASTQ_SECOND_READ_SUFFIX = "_R2_001.fastq.gz"
-FLAG_PATH_SUFFIX = ".crunchy.txt"
-PENDING_PATH_SUFFIX = ".crunchy.pending.txt"
+FASTQ_FIRST_READ_SUFFIX: str = "_R1_001.fastq.gz"
+FASTQ_SECOND_READ_SUFFIX: str = "_R2_001.fastq.gz"
+FLAG_PATH_SUFFIX: str = ".crunchy.txt"
+MAX_READS_PER_GB: int = 18000000
+PENDING_PATH_SUFFIX: str = ".crunchy.pending.txt"
 
 
 # Number of days until FASTQs counts as old

--- a/cg/constants/slurm.py
+++ b/cg/constants/slurm.py
@@ -1,5 +1,6 @@
 from enum import Enum
 
 
-class Slurm(str, Enum):
-    PARTITION = "partition"
+class Slurm(Enum):
+    PARTITION: str = "partition"
+    MAX_NODE_MEMORY: int = 180

--- a/tests/cli/compress/test_cli_compress_fastq.py
+++ b/tests/cli/compress/test_cli_compress_fastq.py
@@ -106,6 +106,7 @@ def test_compress_fastq_cli_case_id(
     caplog,
     cli_runner: CliRunner,
     helpers: StoreHelpers,
+    mocker,
     populated_compress_context: CGConfig,
 ):
     """Test to run the compress command with a specified case id."""
@@ -136,10 +137,12 @@ def test_compress_fastq_cli_case_id(
     )
     status_db.commit()
 
+    # GIVEN no adjusting according to readsa
+    mocker.patch("cg.cli.compress.fastq.set_mem_according_to_reads", return_value=None)
+
     # WHEN running the compress command
     res = cli_runner.invoke(fastq_cmd, ["--case-id", case_id], obj=populated_compress_context)
 
-    print(res.output)
     # THEN assert the program exits since no cases where found
     assert res.exit_code == 0
 
@@ -148,13 +151,16 @@ def test_compress_fastq_cli_case_id(
 
 
 def test_compress_fastq_cli_multiple_family(
-    populated_multiple_compress_context: CGConfig, cli_runner: CliRunner, caplog
+    caplog, cli_runner: CliRunner, mocker, populated_multiple_compress_context: CGConfig
 ):
     """Test to run the compress command with multiple families."""
     caplog.set_level(logging.DEBUG)
     # GIVEN a database with multiple families
     nr_cases = populated_multiple_compress_context.status_db.families().count()
     assert nr_cases > 1
+
+    # GIVEN no adjusting according to readsa
+    mocker.patch("cg.cli.compress.fastq.set_mem_according_to_reads", return_value=None)
 
     # WHEN running the compress command
     res = cli_runner.invoke(
@@ -168,7 +174,7 @@ def test_compress_fastq_cli_multiple_family(
 
 
 def test_compress_fastq_cli_multiple_set_limit(
-    populated_multiple_compress_context: CGConfig, cli_runner: CliRunner, caplog
+    caplog, cli_runner: CliRunner, mocker, populated_multiple_compress_context: CGConfig
 ):
     """Test to run the compress command with multiple families and use a limit."""
     compress_context = populated_multiple_compress_context
@@ -177,6 +183,9 @@ def test_compress_fastq_cli_multiple_set_limit(
     nr_cases = compress_context.status_db.families().count()
     limit = 5
     assert nr_cases > limit
+
+    # GIVEN no adjusting according to readsa
+    mocker.patch("cg.cli.compress.fastq.set_mem_according_to_reads", return_value=None)
 
     # WHEN running the compress command
     res = cli_runner.invoke(fastq_cmd, ["--number-of-conversions", limit], obj=compress_context)

--- a/tests/cli/compress/test_cli_compress_fastq.py
+++ b/tests/cli/compress/test_cli_compress_fastq.py
@@ -12,6 +12,8 @@ from cg.store.models import Family
 
 from tests.store_helpers import StoreHelpers
 
+MOCK_SET_MEM_ACCORDING_TO_READS_PATH: str = "cg.cli.compress.helpers.set_mem_according_to_reads"
+
 
 def test_get_cases_to_process(
     case_id: str,
@@ -138,7 +140,7 @@ def test_compress_fastq_cli_case_id(
     status_db.commit()
 
     # GIVEN no adjusting according to readsa
-    mocker.patch("cg.cli.compress.fastq.set_mem_according_to_reads", return_value=None)
+    mocker.patch(MOCK_SET_MEM_ACCORDING_TO_READS_PATH, return_value=None)
 
     # WHEN running the compress command
     res = cli_runner.invoke(fastq_cmd, ["--case-id", case_id], obj=populated_compress_context)
@@ -160,7 +162,7 @@ def test_compress_fastq_cli_multiple_family(
     assert nr_cases > 1
 
     # GIVEN no adjusting according to readsa
-    mocker.patch("cg.cli.compress.fastq.set_mem_according_to_reads", return_value=None)
+    mocker.patch(MOCK_SET_MEM_ACCORDING_TO_READS_PATH, return_value=None)
 
     # WHEN running the compress command
     res = cli_runner.invoke(
@@ -185,7 +187,7 @@ def test_compress_fastq_cli_multiple_set_limit(
     assert nr_cases > limit
 
     # GIVEN no adjusting according to readsa
-    mocker.patch("cg.cli.compress.fastq.set_mem_according_to_reads", return_value=None)
+    mocker.patch(MOCK_SET_MEM_ACCORDING_TO_READS_PATH, return_value=None)
 
     # WHEN running the compress command
     res = cli_runner.invoke(fastq_cmd, ["--number-of-conversions", limit], obj=compress_context)

--- a/tests/cli/compress/test_compress_helpers.py
+++ b/tests/cli/compress/test_compress_helpers.py
@@ -1,15 +1,36 @@
-"""Tests for helper functions in Cg Compress cli."""
+"""Tests for helper functions in Cg Compress CLI."""
 
+import logging
 import os
 from pathlib import Path
+
+from housekeeper.store.models import Version
 
 from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.cli.compress import helpers
 from cg.cli.compress.helpers import set_mem_according_to_reads
+from cg.constants.compression import MAX_READS_PER_GB
+from cg.constants.slurm import Slurm
 
 
-def test_set_mem_according_to_reads(sample_id: str):
-    """Test setting memory according to reads"""
+def test_set_mem_according_to_reads_when_no_reads(caplog, sample_id: str):
+    """Test setting memory according to reads when no sample reads."""
+    caplog.set_level(logging.DEBUG)
+
+    # GIVEN a sample id and no reads supplied
+
+    # WHEN setting memory according to reads
+    memory: int = set_mem_according_to_reads(sample_id=sample_id, sample_reads=0)
+
+    # THEN we should log
+    assert f"No reads recorded for sample: {sample_id}" in caplog.text
+
+    # THEN None should be returned
+    assert memory is None
+
+
+def test_set_mem_according_to_reads_when_few_reads(sample_id: str):
+    """Test setting memory according to reads when few reads."""
     # GIVEN a sample id and reads
 
     # WHEN setting memory according to reads
@@ -19,32 +40,61 @@ def test_set_mem_according_to_reads(sample_id: str):
     assert memory == 1
 
 
+def test_set_mem_according_to_reads_when_many_reads(sample_id: str):
+    """Test setting memory according to reads when many reads"""
+    # GIVEN a sample id and reads
+
+    # WHEN setting memory according to reads
+    memory: int = set_mem_according_to_reads(
+        sample_id=sample_id, sample_reads=MAX_READS_PER_GB**10
+    )
+
+    # THEN memory should be limited to what is available on the node
+    assert memory == 180
+
+
+def test_set_mem_according_to_reads(sample_id: str):
+    """Test setting memory according to reads when many reads"""
+    # GIVEN a sample id and reads
+
+    # WHEN setting memory according to reads
+    memory: int = set_mem_according_to_reads(
+        sample_id=sample_id, sample_reads=MAX_READS_PER_GB * 10
+    )
+
+    # THEN memory should be adjusted
+    assert memory == 10
+
+
 def test_get_true_dir_no_symlinks(project_dir: Path):
-    """Test to get a true dir when there are no symlinks"""
+    """Test to get a true dir when there are no symlinks."""
     # GIVEN a directory with some files but no symlinked files
-    a_file = project_dir / "hello.txt"
+    a_file: Path = Path(project_dir, "hello.txt")
     a_file.touch()
     assert a_file.exists()
+
     # WHEN fetching the true dir for the files in fixture dir
     true_dir = helpers.get_true_dir(a_file.parent)
+
     # THEN assert that the true_dir is None since there where no symbolic links in the project_dir
     assert true_dir is None
 
 
 def test_get_true_dir_when_symlinks(project_dir: Path):
-    """Test to get a true dir when there are symlinks to another directory
+    """Test to get a true dir when there are symlinks to another directory.
 
-    The function should return the path to another directory when there are symlinks in one
+    The function should return the path to another directory when there are symlinks in one.
     """
     # GIVEN a directory with a file with some content
     content = "hello world"
-    a_file = project_dir / "hello.txt"
+    a_file: Path = Path(project_dir, "hello.txt")
     a_file.write_text(content)
     assert a_file.exists()
+
     # GIVEN a subdirectory with a link to the above file
-    new_dir = project_dir / "new_dir/"
+    new_dir: Path = Path(project_dir, "new_dir/")
     new_dir.mkdir()
-    a_link = new_dir / "link_to_hello"
+    a_link: Path = Path(new_dir, "link_to_hello")
     a_link.symlink_to(a_file)
     assert a_link.read_text() == content
     assert a_link.parent == new_dir
@@ -58,18 +108,18 @@ def test_get_true_dir_when_symlinks(project_dir: Path):
 
 
 def test_get_versions_no_bundle(housekeeper_api: HousekeeperAPI):
-    """Test to get latest versions of bundles when no bundles exists"""
+    """Test to get latest versions of bundles when no bundles exists."""
     # GIVEN a empty housekeeper_api
 
     # WHEN fetching versions
-    versions = helpers.get_versions(housekeeper_api)
+    versions: Iterator[Version] = helpers.get_versions(housekeeper_api)
 
     # THEN assert no versions was returned
     assert sum(1 for version in versions) == 0
 
 
 def test_get_versions_one_bundle(housekeeper_api: HousekeeperAPI, spring_bundle: dict):
-    """Test to get latest versions of bundles when no bundles exists"""
+    """Test to get latest versions of bundles when no bundles exists."""
     # GIVEN a populated housekeeper_api
     housekeeper_api.add_bundle(spring_bundle)
 
@@ -86,12 +136,12 @@ def test_correct_spring_paths(
     symlinked_fastqs: dict,
     new_dir: Path,
 ):
-    """docstring for test_correct_spring_paths"""
+    """Test for correct_spring_paths."""
     # GIVEN a populated housekeeper_api
     housekeeper_api.add_bundle(spring_bundle_symlink_problem)
     # GIVEN that the spring files exists in the wrong location
-    versions = helpers.get_versions(housekeeper_api)
-    version = next(versions)
+    versions: Iterator[Version] = helpers.get_versions(housekeeper_api)
+    version: Version = next(versions)
     for file_path in version.files:
         assert not Path(file_path.full_path).exists()
 

--- a/tests/cli/compress/test_compress_helpers.py
+++ b/tests/cli/compress/test_compress_helpers.py
@@ -1,10 +1,22 @@
-"""Tests for helper functions in cg compress cli"""
+"""Tests for helper functions in Cg Compress cli."""
 
 import os
 from pathlib import Path
 
 from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.cli.compress import helpers
+from cg.cli.compress.helpers import set_mem_according_to_reads
+
+
+def test_set_mem_according_to_reads(sample_id: str):
+    """Test setting memory according to reads"""
+    # GIVEN a sample id and reads
+
+    # WHEN setting memory according to reads
+    memory: int = set_mem_according_to_reads(sample_id=sample_id, sample_reads=1)
+
+    # THEN memory should be 1
+    assert memory == 1
 
 
 def test_get_true_dir_no_symlinks(project_dir: Path):

--- a/tests/cli/compress/test_compress_helpers.py
+++ b/tests/cli/compress/test_compress_helpers.py
@@ -41,7 +41,7 @@ def test_set_mem_according_to_reads_when_few_reads(sample_id: str):
 
 
 def test_set_mem_according_to_reads_when_many_reads(sample_id: str):
-    """Test setting memory according to reads when many reads"""
+    """Test setting memory according to reads when many reads."""
     # GIVEN a sample id and reads
 
     # WHEN setting memory according to reads
@@ -54,7 +54,7 @@ def test_set_mem_according_to_reads_when_many_reads(sample_id: str):
 
 
 def test_set_mem_according_to_reads(sample_id: str):
-    """Test setting memory according to reads when many reads"""
+    """Test setting memory according to reads."""
     # GIVEN a sample id and reads
 
     # WHEN setting memory according to reads


### PR DESCRIPTION
## Description

The current Crunchy Fastq to SPRING compression seems to run out of RAM memory for samples with many reads (3 288 109 294,00; WGSPCFS120 (1))

| Case                         | Job_id                             | Status    | Apptag         | sample     | reads            | is_tumour | SLURM_mem (GB) | reads / 18 000 000 |
|------------------------------|------------------------------------|-----------|----------------|------------|------------------|-----------|----------------|--------------------|
| Successful in current system |                                    |           |                |            |                  |           |                |                    |
| awakemarlin                  | na                                 | completed | WGSPCFC030 (4) | ACC10386A2 | 732 260 066,00   | no        | 50             | 14645201,3         |
| Failed and handled manually  |                                    |           |                |            |                  |           |                |                    |
| awakemarlin                  | 4256759, 4256760                   | completed | WGSPCFS120 (1) | ACC10386A1 | 3 288 109 294,00 | yes       | 180            | 18267273,9         |
| awakemarlin                  | 4256760                            | completed | WGSPCFS120 (1) | ACC10386A1 | 3 288 109 294,00 | yes       | 180            | 18267273,9         |
| usefulmammal                 | 4247954                            | completed | WGSPCFS120 (1) |  	ACC9997A1 | 3 109 912 262,00 | yes       | 180            | 17277290,3         |
| selectprawn                  | 4257055                            | failed    | WGSLIFS120 (1) | ACC8984A1  | 3 168 258 312,00 | yes       | 120            | 26402152,6         |
| selectprawn                  | 4257395                            | failed    | WGSLIFS120 (1) | ACC8984A1  | 3 168 258 312,00 | yes       | 150            | 21121722,1         |
| selectprawn                  | 4259331                            | failed    | WGSLIFS120 (1) | ACC8984A1  | 3 168 258 312,00 | yes       | 170            | 18636813,6         |
| selectprawn                  | 4271797                            | failed    | WGSLIFS120 (1) | ACC8984A1  | 3 168 258 312,00 | yes       | 177            | 17899764,5         |
| selectprawn                  | 4272359                            | running   | WGSLIFS120 (1) | ACC8984A1  | 3 168 258 312,00 | yes       | 180            | 17601435,1         |
| vocalghost                   | 4259336, 4259337, 4259338, 4259339 | completed | WGSPCFS120 (1) | ACC9659A1  | 2 780 015 064,00 | yes       | 150            | 18533433,8         |
|                              |                                    |           |                |            |                  |           |                |                    |
|                              |                                    |           |                |            |                  |           |                |                    |
### Added

- Tests

### Fixed

- Set SLURM memory according to number of reads


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b adjust_crunchy_mem -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
