### PR TITLE
Fix set crunchy mem

### DIFF
--- a/cg/cli/compress/helpers.py
+++ b/cg/cli/compress/helpers.py
@@ -166,7 +166,7 @@ def compress_sample_fastqs_in_cases(
                 LOG.info(f"skipping individual {case_link.sample.internal_id}")
                 continue
             individuals_conversion_count += 1
-            sample_process = None
+            sample_process_mem = None
         if case_converted:
             case_conversion_count += 1
             LOG.info(f"Considering case {case.internal_id} converted")

--- a/cg/cli/compress/helpers.py
+++ b/cg/cli/compress/helpers.py
@@ -56,18 +56,18 @@ def is_case_ignored(case_id: str) -> bool:
     return False
 
 
-def set_mem_according_to_reads(
-    sample_id: str, sample_reads: Optional[int] = None, mem: Optional[int] = None
+def set_memory_according_to_reads(
+    sample_id: str, sample_reads: Optional[int] = None, sample_process_mem: Optional[int] = None
 ) -> Optional[int]:
-    """Set SLURM memory depending on number of sample reads if mem is not set."""
-    if mem:
-        return mem
+    """Set SLURM sample process memory depending on number of sample reads if sample_process_mem is not set."""
+    if sample_process_mem:
+        return sample_process_mem
     if not sample_reads:
         LOG.debug(f"No reads recorded for sample: {sample_id}")
         return
-    mem: int = ceil((sample_reads / MAX_READS_PER_GB))
-    if 1 <= mem < Slurm.MAX_NODE_MEMORY.value:
-        return mem
+    sample_process_mem: int = ceil((sample_reads / MAX_READS_PER_GB))
+    if 1 <= sample_process_mem < Slurm.MAX_NODE_MEMORY.value:
+        return sample_process_mem
     return Slurm.MAX_NODE_MEMORY.value
 
 
@@ -151,8 +151,10 @@ def compress_sample_fastqs_in_cases(
         if not case.links:
             continue
         for case_link in case.links:
-            mem: Optional[int] = set_mem_according_to_reads(
-                mem=mem, sample_id=case_link.sample.internal_id, sample_reads=case_link.sample.reads
+            sample_process_mem: Optional[int] = set_memory_according_to_reads(
+                sample_process_mem=mem,
+                sample_id=case_link.sample.internal_id,
+                sample_reads=case_link.sample.reads,
             )
             update_compress_api(
                 compress_api=compress_api, dry_run=dry_run, hours=hours, mem=mem, ntasks=ntasks
@@ -164,6 +166,7 @@ def compress_sample_fastqs_in_cases(
                 LOG.info(f"skipping individual {case_link.sample.internal_id}")
                 continue
             individuals_conversion_count += 1
+            sample_process = None
         if case_converted:
             case_conversion_count += 1
             LOG.info(f"Considering case {case.internal_id} converted")

--- a/cg/cli/compress/helpers.py
+++ b/cg/cli/compress/helpers.py
@@ -157,7 +157,11 @@ def compress_sample_fastqs_in_cases(
                 sample_reads=case_link.sample.reads,
             )
             update_compress_api(
-                compress_api=compress_api, dry_run=dry_run, hours=hours, mem=mem, ntasks=ntasks
+                compress_api=compress_api,
+                dry_run=dry_run,
+                hours=hours,
+                mem=sample_process_mem,
+                ntasks=ntasks,
             )
             case_converted: bool = compress_api.compress_fastq(
                 sample_id=case_link.sample.internal_id
@@ -166,7 +170,6 @@ def compress_sample_fastqs_in_cases(
                 LOG.info(f"skipping individual {case_link.sample.internal_id}")
                 continue
             individuals_conversion_count += 1
-            sample_process_mem = None
         if case_converted:
             case_conversion_count += 1
             LOG.info(f"Considering case {case.internal_id} converted")

--- a/tests/cli/compress/test_cli_compress_fastq.py
+++ b/tests/cli/compress/test_cli_compress_fastq.py
@@ -12,7 +12,7 @@ from cg.store.models import Family
 
 from tests.store_helpers import StoreHelpers
 
-MOCK_SET_MEM_ACCORDING_TO_READS_PATH: str = "cg.cli.compress.helpers.set_mem_according_to_reads"
+MOCK_SET_MEM_ACCORDING_TO_READS_PATH: str = "cg.cli.compress.helpers.set_memory_according_to_reads"
 
 
 def test_get_cases_to_process(

--- a/tests/cli/compress/test_compress_helpers.py
+++ b/tests/cli/compress/test_compress_helpers.py
@@ -8,19 +8,19 @@ from housekeeper.store.models import Version
 
 from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.cli.compress import helpers
-from cg.cli.compress.helpers import set_mem_according_to_reads
+from cg.cli.compress.helpers import set_memory_according_to_reads
 from cg.constants.compression import MAX_READS_PER_GB
 from cg.constants.slurm import Slurm
 
 
-def test_set_mem_according_to_reads_when_no_reads(caplog, sample_id: str):
+def test_set_memory_according_to_reads_when_no_reads(caplog, sample_id: str):
     """Test setting memory according to reads when no sample reads."""
     caplog.set_level(logging.DEBUG)
 
     # GIVEN a sample id and no reads supplied
 
     # WHEN setting memory according to reads
-    memory: int = set_mem_according_to_reads(sample_id=sample_id, sample_reads=0)
+    memory: int = set_memory_according_to_reads(sample_id=sample_id, sample_reads=0)
 
     # THEN we should log
     assert f"No reads recorded for sample: {sample_id}" in caplog.text
@@ -29,23 +29,23 @@ def test_set_mem_according_to_reads_when_no_reads(caplog, sample_id: str):
     assert memory is None
 
 
-def test_set_mem_according_to_reads_when_few_reads(sample_id: str):
+def test_set_memory_according_to_reads_when_few_reads(sample_id: str):
     """Test setting memory according to reads when few reads."""
     # GIVEN a sample id and reads
 
     # WHEN setting memory according to reads
-    memory: int = set_mem_according_to_reads(sample_id=sample_id, sample_reads=1)
+    memory: int = set_memory_according_to_reads(sample_id=sample_id, sample_reads=1)
 
     # THEN memory should be 1
     assert memory == 1
 
 
-def test_set_mem_according_to_reads_when_many_reads(sample_id: str):
+def test_set_memory_according_to_reads_when_many_reads(sample_id: str):
     """Test setting memory according to reads when many reads."""
     # GIVEN a sample id and reads
 
     # WHEN setting memory according to reads
-    memory: int = set_mem_according_to_reads(
+    memory: int = set_memory_according_to_reads(
         sample_id=sample_id, sample_reads=MAX_READS_PER_GB**10
     )
 
@@ -53,12 +53,12 @@ def test_set_mem_according_to_reads_when_many_reads(sample_id: str):
     assert memory == 180
 
 
-def test_set_mem_according_to_reads(sample_id: str):
+def test_set_memory_according_to_reads(sample_id: str):
     """Test setting memory according to reads."""
     # GIVEN a sample id and reads
 
     # WHEN setting memory according to reads
-    memory: int = set_mem_according_to_reads(
+    memory: int = set_memory_according_to_reads(
         sample_id=sample_id, sample_reads=MAX_READS_PER_GB * 10
     )
 


### PR DESCRIPTION
## Description
Change the dynamic setting of SLURM memory so that it is calculated for all samples in all cases if not supplied on CLI. Previously this was just done for the first sample in the loop.

### Fixed

- Set memory for each sample. Not just once.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b fix_set_crunchy_mem -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [x] Tests executed by HS
- [x] "Merge and deploy" approved by HS
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
