### PR TITLE
feat(crunchy): Raise min GB per process

### DIFF
--- a/cg/cli/compress/helpers.py
+++ b/cg/cli/compress/helpers.py
@@ -9,7 +9,7 @@ from typing import Iterator, Optional, List
 from housekeeper.store.models import Version, Bundle
 
 from cg.apps.housekeeper.hk import HousekeeperAPI
-from cg.constants.compression import CASES_TO_IGNORE, MAX_READS_PER_GB
+from cg.constants.compression import CASES_TO_IGNORE, MAX_READS_PER_GB, CRUNCHY_MIN_GB_PER_PROCESS
 from cg.constants.slurm import Slurm
 from cg.exc import CaseNotFoundError
 from cg.meta.compress import CompressAPI
@@ -66,7 +66,9 @@ def set_memory_according_to_reads(
         LOG.debug(f"No reads recorded for sample: {sample_id}")
         return
     sample_process_mem: int = ceil((sample_reads / MAX_READS_PER_GB))
-    if 1 <= sample_process_mem < Slurm.MAX_NODE_MEMORY.value:
+    if sample_process_mem < CRUNCHY_MIN_GB_PER_PROCESS:
+        return CRUNCHY_MIN_GB_PER_PROCESS
+    if CRUNCHY_MIN_GB_PER_PROCESS <= sample_process_mem < Slurm.MAX_NODE_MEMORY.value:
         return sample_process_mem
     return Slurm.MAX_NODE_MEMORY.value
 

--- a/cg/constants/compression.py
+++ b/cg/constants/compression.py
@@ -6,6 +6,7 @@ FASTQ_FIRST_READ_SUFFIX: str = "_R1_001.fastq.gz"
 FASTQ_SECOND_READ_SUFFIX: str = "_R2_001.fastq.gz"
 FLAG_PATH_SUFFIX: str = ".crunchy.txt"
 MAX_READS_PER_GB: int = 18_000_000
+CRUNCHY_MIN_GB_PER_PROCESS: int = 30
 PENDING_PATH_SUFFIX: str = ".crunchy.pending.txt"
 
 

--- a/tests/cli/compress/test_compress_helpers.py
+++ b/tests/cli/compress/test_compress_helpers.py
@@ -9,7 +9,7 @@ from housekeeper.store.models import Version
 from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.cli.compress import helpers
 from cg.cli.compress.helpers import set_memory_according_to_reads
-from cg.constants.compression import MAX_READS_PER_GB
+from cg.constants.compression import MAX_READS_PER_GB, CRUNCHY_MIN_GB_PER_PROCESS
 from cg.constants.slurm import Slurm
 
 
@@ -37,7 +37,7 @@ def test_set_memory_according_to_reads_when_few_reads(sample_id: str):
     memory: int = set_memory_according_to_reads(sample_id=sample_id, sample_reads=1)
 
     # THEN memory should be 1
-    assert memory == 1
+    assert memory == CRUNCHY_MIN_GB_PER_PROCESS
 
 
 def test_set_memory_according_to_reads_when_many_reads(sample_id: str):
@@ -59,11 +59,11 @@ def test_set_memory_according_to_reads(sample_id: str):
 
     # WHEN setting memory according to reads
     memory: int = set_memory_according_to_reads(
-        sample_id=sample_id, sample_reads=MAX_READS_PER_GB * 10
+        sample_id=sample_id, sample_reads=MAX_READS_PER_GB * 100
     )
 
     # THEN memory should be adjusted
-    assert memory == 10
+    assert memory == 100
 
 
 def test_get_true_dir_no_symlinks(project_dir: Path):

--- a/tests/cli/compress/test_compress_helpers.py
+++ b/tests/cli/compress/test_compress_helpers.py
@@ -36,7 +36,7 @@ def test_set_memory_according_to_reads_when_few_reads(sample_id: str):
     # WHEN setting memory according to reads
     memory: int = set_memory_according_to_reads(sample_id=sample_id, sample_reads=1)
 
-    # THEN memory should be 1
+    # THEN memory should be set to the minimum
     assert memory == CRUNCHY_MIN_GB_PER_PROCESS
 
 


### PR DESCRIPTION
## Description
It appears Crunchy need a decent amount of memory to run independent of the actual number of reads. This PR raises the minimum memory when set dynamically to 30 GB.

### Fixed

- Raise min memory for Crunchy process


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b raise_crunchy_mem_floor -a
    ```

### How to test

- [x] See below

### Expected test outcome

- [x] Take a screenshot and attach or copy/paste the output.

## Review

- [x] Tests executed by HS
- [x] "Merge and deploy" approved by HS
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
