### PR TITLE
adding mitodel to scout

### DIFF
--- a/cg/constants/scout_upload.py
+++ b/cg/constants/scout_upload.py
@@ -40,6 +40,7 @@ MIP_SAMPLE_TAGS = dict(
     reviewer_alignment={"expansionhunter", "bam"},
     reviewer_alignment_index={"expansionhunter", "bam-index"},
     reviewer_vcf={"expansionhunter", "vcf-str"},
+    mitodel_file={"mitodel"},
 )
 
 BALSAMIC_SAMPLE_TAGS = dict(

--- a/cg/meta/upload/scout/hk_tags.py
+++ b/cg/meta/upload/scout/hk_tags.py
@@ -38,3 +38,4 @@ class SampleTags(BaseModel):
     reviewer_alignment: Set[str] = None
     reviewer_alignment_index: Set[str] = None
     reviewer_vcf: Set[str] = None
+    mitodel_file: Set[str] = None

--- a/cg/meta/upload/scout/mip_config_builder.py
+++ b/cg/meta/upload/scout/mip_config_builder.py
@@ -142,6 +142,9 @@ class MipConfigBuilder(ScoutConfigBuilder):
             hk_tags=self.sample_tags.reviewer_vcf, sample_id=sample_id
         )
         config_sample.reviewer.catalog = self.fetch_file_from_hk(hk_tags=self.case_tags.str_catalog)
+        config_sample.mitodel_file = self.fetch_sample_file(
+            hk_tags=self.sample_tags.mitodel_file, sample_id=sample_id
+        )
 
     @staticmethod
     def extract_generic_filepath(file_path: Optional[str]) -> Optional[str]:

--- a/cg/models/scout/scout_load_config.py
+++ b/cg/models/scout/scout_load_config.py
@@ -58,6 +58,7 @@ class ScoutMipIndividual(ScoutIndividual):
     upd_regions_bed: Optional[str] = None
     upd_sites_bed: Optional[str] = None
     vcf2cytosure: Optional[str] = None
+    mitodel_file: Optional[str] = None
 
 
 class ScoutBalsamicIndividual(ScoutIndividual):

--- a/tests/apps/scout/conftest.py
+++ b/tests/apps/scout/conftest.py
@@ -31,6 +31,7 @@ def fixture_sample_dict() -> dict:
             "vcf": Path("path", "to", "expansionhunter.vcf").as_posix(),
             "catalog": Path("path", "to", "variant_catalog.json").as_posix(),
         },
+        "mitodel_file": Path("path", "to", "mitodel.txt").as_posix(),
         "capture_kit": None,
         Pedigree.FATHER: RelationshipStatus.HAS_NO_PARENT,
         Pedigree.MOTHER: RelationshipStatus.HAS_NO_PARENT,

--- a/tests/apps/scout/test_scout_load_config.py
+++ b/tests/apps/scout/test_scout_load_config.py
@@ -1,4 +1,5 @@
 """Tests for the models in scout load config"""
+from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
@@ -16,8 +17,13 @@ def test_validate_individual_display_name(sample_dict):
     # THEN assert that the display name is correct
     assert ind_obj.sample_name == sample["sample_name"]
 
-
-def test_validate_mt_bam(sample_dict):
+@pytest.mark.parametrize(
+    "key, value",
+    [
+        ("mt_bam", Path("path", "to", "reduced_mt.bam").as_posix(),),
+    ],
+)
+def test_validate_mt_bam(sample_dict, key, value):
     """Test to validate an individual"""
     # GIVEN some sample information
     sample = sample_dict
@@ -26,8 +32,18 @@ def test_validate_mt_bam(sample_dict):
     ind_obj = scout_load_config.ScoutMipIndividual(**sample)
 
     # THEN assert that the mt_bam path is correct
-    assert ind_obj.mt_bam == sample["mt_bam"]
+    assert getattr(ind_obj, key) == value
 
+def test_validate_mitodel_file(sample_dict):
+    """Test to validate an individual"""
+    # GIVEN some sample information
+    sample = sample_dict
+
+    # WHEN validating the sample data
+    ind_obj = scout_load_config.ScoutMipIndividual(**sample)
+
+    # THEN assert that the mmitodel path is correct
+    assert ind_obj.mitodel_file == sample["mitodel_file"]
 
 def test_validate_reviewer_alignment(sample_dict):
     """Test to validate a reviewer alignment file for an individual."""


### PR DESCRIPTION
## Description

### Added

- Mitochondrial deletion files from MIP to scout load config.
- fixes https://github.com/Clinical-Genomics/cg/issues/1586

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
