### PR TITLE
Clean demux runs

### DIFF
--- a/cg/apps/housekeeper/hk.py
+++ b/cg/apps/housekeeper/hk.py
@@ -354,13 +354,20 @@ class HousekeeperAPI:
 
     def is_fastq_or_spring_in_all_bundles(self, bundle_names: List[str]) -> bool:
         """Return bool of fastq or spring present in all bundles."""
-        sequencing_files_in_hk: Dict[str, Iterable[File]] = {}
+        sequencing_files_in_hk: Dict[str, bool] = {}
         for bundle_name in bundle_names:
             sequencing_files_in_hk[bundle_name] = False
             for tag in [SequencingFileTag.FASTQ, SequencingFileTag.SPRING_METADATA]:
+                sample_file_in_hk: List[bool] = []
+                hk_files: Optional[List[File]] = self.get_files_from_latest_version(
+                    bundle_name=bundle_name, tags=[tag]
+                )
                 try:
-                    if self.get_file_from_latest_version(bundle_name=bundle_name, tags=[tag]):
-                        sequencing_files_in_hk[bundle_name] = True
-                except FileNotFoundError as error:
-                    LOG.warning(error)
+                    sample_file_in_hk += [True for hk_file in hk_files if hk_file.is_included]
+                    if sample_file_in_hk:
+                        break
+                finally:
+                    sequencing_files_in_hk[bundle_name] = (
+                        all(sample_file_in_hk) if sample_file_in_hk else False
+                    )
         return all(sequencing_files_in_hk.values())

--- a/cg/apps/housekeeper/hk.py
+++ b/cg/apps/housekeeper/hk.py
@@ -353,7 +353,7 @@ class HousekeeperAPI:
         return self.files(version=version.id, tags=tags)
 
     def is_fastq_or_spring_in_all_bundles(self, bundle_names: List[str]) -> bool:
-        """Return bool of fastq or spring present in all bundles."""
+        """Return whether or not all FASTQ/SPRING files are included for the given bundles."""
         sequencing_files_in_hk: Dict[str, bool] = {}
         for bundle_name in bundle_names:
             sequencing_files_in_hk[bundle_name] = False

--- a/cg/apps/housekeeper/hk.py
+++ b/cg/apps/housekeeper/hk.py
@@ -362,12 +362,10 @@ class HousekeeperAPI:
                 hk_files: Optional[List[File]] = self.get_files_from_latest_version(
                     bundle_name=bundle_name, tags=[tag]
                 )
-                try:
-                    sample_file_in_hk += [True for hk_file in hk_files if hk_file.is_included]
-                    if sample_file_in_hk:
-                        break
-                finally:
-                    sequencing_files_in_hk[bundle_name] = (
-                        all(sample_file_in_hk) if sample_file_in_hk else False
-                    )
+                sample_file_in_hk += [True for hk_file in hk_files if hk_file.is_included]
+                if sample_file_in_hk:
+                    break
+            sequencing_files_in_hk[bundle_name] = (
+                all(sample_file_in_hk) if sample_file_in_hk else False
+            )
         return all(sequencing_files_in_hk.values())

--- a/cg/apps/housekeeper/hk.py
+++ b/cg/apps/housekeeper/hk.py
@@ -359,7 +359,7 @@ class HousekeeperAPI:
             sequencing_files_in_hk[bundle_name] = False
             for tag in [SequencingFileTag.FASTQ, SequencingFileTag.SPRING_METADATA]:
                 try:
-                    if self.get_files(bundle=bundle_name, tags=[tag]):
+                    if self.get_file_from_latest_version(bundle_name=bundle_name, tags=[tag]):
                         sequencing_files_in_hk[bundle_name] = True
                 except FileNotFoundError as error:
                     LOG.warning(error)

--- a/cg/cli/clean.py
+++ b/cg/cli/clean.py
@@ -416,7 +416,7 @@ def remove_old_demutliplexed_run_dirs(context: CGConfig, days_old: int, dry_run:
         try:
             flow_cell: FlowCell = FlowCell(flow_cell_path=flow_cell_dir)
         except FlowCellError:
-            return
+            continue
         samples: List[Sample] = status_db.get_samples_from_flow_cell(flow_cell_id=flow_cell.id)
         are_sequencing_files_in_hk: bool = housekeeper_api.is_fastq_or_spring_in_all_bundles(
             bundle_names=[sample.internal_id for sample in samples]

--- a/cg/cli/clean.py
+++ b/cg/cli/clean.py
@@ -325,7 +325,7 @@ def fix_flow_cell_status(context: CGConfig, dry_run: bool):
     LOG.info(
         f"Number of flow cells with status {FlowCellStatus.ONDISK.value} or {FlowCellStatus.REMOVED} in Statusdb: {len(flow_cells_in_statusdb)}"
     )
-    physical_ondisk_flow_cell_names = [
+    flow_cells_on_disk = [
         DemultiplexedRunsFlowCell(
             flow_cell_path=flow_cell_dir,
             status_db=status_db,
@@ -337,7 +337,7 @@ def fix_flow_cell_status(context: CGConfig, dry_run: bool):
         status_db_flow_cell_status = flow_cell.status
         new_status: str = (
             FlowCellStatus.ONDISK
-            if flow_cell.name in physical_ondisk_flow_cell_names
+            if flow_cell.name in flow_cells_on_disk
             else FlowCellStatus.REMOVED
         )
         if status_db_flow_cell_status != new_status:

--- a/cg/cli/clean.py
+++ b/cg/cli/clean.py
@@ -400,7 +400,7 @@ def clean_run_directories(
         flow_cell_dir for flow_cell_dir in Path(run_directory).iterdir() if flow_cell_dir.is_dir()
     ]
     for flow_cell_dir in flow_cell_dirs:
-        LOG.info(f"Checking flow cell {flow_cell_dir.name}", flow_cell_dir.name)
+        LOG.info(f"Checking flow cell {flow_cell_dir.name}")
         run_dir_flow_cell: RunDirFlowCell = RunDirFlowCell(
             flow_cell_dir=flow_cell_dir, status_db=status_db, housekeeper_api=housekeeper_api
         )

--- a/cg/constants/housekeeper_tags.py
+++ b/cg/constants/housekeeper_tags.py
@@ -1,8 +1,22 @@
 """File tags for files in Housekeeper."""
-
+from enum import Enum
 from typing import List
 
 from cgmodels.cg.constants import Pipeline, StrEnum
+
+
+class AlignmentFileTag(str, Enum):
+    """Tags for alignment files."""
+
+    BAM: str = "bam"
+    BAM_BAI: str = "bai"
+    BAM_INDEX: str = "bam-index"
+    CRAM: str = "cram"
+    CRAM_CRAI: str = "crai"
+    CRAM_INDEX: str = "cram-index"
+
+
+ALIGNMENT_FILE_TAGS: List[str] = [tag.value for tag in AlignmentFileTag]
 
 
 class SequencingFileTag(StrEnum):

--- a/cg/constants/housekeeper_tags.py
+++ b/cg/constants/housekeeper_tags.py
@@ -5,7 +5,7 @@ from typing import List
 from cgmodels.cg.constants import Pipeline, StrEnum
 
 
-class AlignmentFileTag(str, Enum):
+class AlignmentFileTag(StrEnum):
     """Tags for alignment files."""
 
     BAM: str = "bam"
@@ -19,13 +19,13 @@ class AlignmentFileTag(str, Enum):
 ALIGNMENT_FILE_TAGS: List[str] = [tag.value for tag in AlignmentFileTag]
 
 
-class ArchiveTag(str, Enum):
+class ArchiveTag(StrEnum):
     """Tags for archived status."""
 
     ARCHIVED: str = "archived"
 
 
-class ScoutTag(str, Enum):
+class ScoutTag(StrEnum):
     """Tags for Scout."""
 
     ARCHIVED: str = "archived"

--- a/cg/constants/housekeeper_tags.py
+++ b/cg/constants/housekeeper_tags.py
@@ -19,7 +19,22 @@ class AlignmentFileTag(str, Enum):
 ALIGNMENT_FILE_TAGS: List[str] = [tag.value for tag in AlignmentFileTag]
 
 
+class ArchiveTag(str, Enum):
+    """Tags for archived status."""
+
+    ARCHIVED: str = "archived"
+
+
+class ScoutTag(str, Enum):
+    """Tags for Scout."""
+
+    ARCHIVED: str = "archived"
+    SOLVED: str = "solved"
+
+
 class SequencingFileTag(StrEnum):
+    """Tags for sequencing files."""
+
     ARCHIVED_SAMPLE_SHEET: str = "archived_sample_sheet"
     CGSTATS_LOG: str = "log"
     FASTQ: str = "fastq"

--- a/cg/constants/sequencing.py
+++ b/cg/constants/sequencing.py
@@ -5,10 +5,11 @@ from cgmodels.cg.constants import StrEnum
 class Sequencers(StrEnum):
     """Sequencer instruments."""
 
+    ALL: str = "all"
     HISEQX: str = "hiseqx"
     HISEQGA: str = "hiseqga"
     NOVASEQ: str = "novaseq"
-    ALL: str = "all"
+    OTHER: str = "other"
 
 
 sequencer_types = {

--- a/cg/constants/sequencing.py
+++ b/cg/constants/sequencing.py
@@ -31,6 +31,7 @@ sequencer_types = {
     "A00187": Sequencers.NOVASEQ,
     "A00621": Sequencers.NOVASEQ,
     "A00689": Sequencers.NOVASEQ,
+    "A01901": Sequencers.NOVASEQ,
 }
 
 

--- a/cg/datetime/utils.py
+++ b/cg/datetime/utils.py
@@ -1,0 +1,7 @@
+"""Module for datetime utility functions."""
+from datetime import datetime, timedelta
+
+
+def get_date_days_ago(days_ago: int) -> datetime:
+    """Calculate the date 'days_ago'."""
+    return datetime.now() - timedelta(days=days_ago)

--- a/cg/datetime/utils.py
+++ b/cg/datetime/utils.py
@@ -3,5 +3,10 @@ from datetime import datetime, timedelta
 
 
 def get_date_days_ago(days_ago: int) -> datetime:
-    """Calculate the date 'days_ago'."""
+    """Return the date that was number of 'days_ago'."""
     return datetime.now() - timedelta(days=days_ago)
+
+
+def get_timedelta_from_date(date: datetime) -> timedelta:
+    """Return the number of days ago from date to now."""
+    return datetime.now() - date

--- a/cg/meta/clean/demultiplexed_flow_cells.py
+++ b/cg/meta/clean/demultiplexed_flow_cells.py
@@ -26,7 +26,7 @@ SEQUENCER_IDENTIFIER_POSITION = 1
 class DemultiplexedRunsFlowCell:
     """Class to check if a given flow cell in demultiplexed-runs is valid, or can be removed. A
     valid flow cell is named correctly, has the correct status ('ondisk') in Statusdb,
-    and has FASTQ files in Housekeeper.
+    and has FASTQ and/oor SPRING files in Housekeeper.
 
     A flow cell that is correctly named has four segments divided by underscores:
     <run_date>_<sequencer>_<run_number>_<identifier>. The identifier consists of the position of
@@ -187,10 +187,9 @@ class DemultiplexedRunsFlowCell:
 
     @property
     def is_demultiplexing_ongoing_or_started_and_not_completed(self) -> bool:
-        """Checks demultiplexing status for a flow cell. A flow cell can only be deleted if
-        demultiplexing has not started or is not ongoing. Completed flow cells can be deleted."""
+        """Checks demultiplexing status for a flow cell."""
         if self._is_demultiplexing_ongoing_or_started_and_not_completed is None:
-            LOG.info(f"Checking demultiplexing status for flowcell {self.id}:")
+            LOG.info(f"Checking demultiplexing status for flow cell {self.id}:")
             self._is_demultiplexing_ongoing_or_started_and_not_completed: bool = (
                 self.tb.has_latest_analysis_started(case_id=self.id)
                 or self.tb.is_latest_analysis_ongoing(case_id=self.id)
@@ -199,7 +198,6 @@ class DemultiplexedRunsFlowCell:
                 LOG.warning(f"Demultiplexing not fully completed for flow cell {self.id}!")
             else:
                 LOG.info("Demultiplexing fully completed!")
-
         return self._is_demultiplexing_ongoing_or_started_and_not_completed
 
     @property

--- a/cg/meta/clean/demultiplexed_flow_cells.py
+++ b/cg/meta/clean/demultiplexed_flow_cells.py
@@ -26,7 +26,7 @@ SEQUENCER_IDENTIFIER_POSITION = 1
 class DemultiplexedRunsFlowCell:
     """Class to check if a given flow cell in demultiplexed-runs is valid, or can be removed. A
     valid flow cell is named correctly, has the correct status ('ondisk') in Statusdb,
-    and has FASTQ and/oor SPRING files in Housekeeper.
+    and has FASTQ and/or SPRING files in Housekeeper.
 
     A flow cell that is correctly named has four segments divided by underscores:
     <run_date>_<sequencer>_<run_number>_<identifier>. The identifier consists of the position of

--- a/cg/meta/clean/demultiplexed_flow_cells.py
+++ b/cg/meta/clean/demultiplexed_flow_cells.py
@@ -56,17 +56,17 @@ class DemultiplexedRunsFlowCell:
         self.identifier: str = self.split_name[FLOW_CELL_IDENTIFIER_POSITION]
         self.sequencer_serial_number: str = self.split_name[SEQUENCER_IDENTIFIER_POSITION]
         self.id: str = self.identifier[1:]
-        self._hk_fastq_files: list = None
-        self._hk_spring_files: list = None
-        self._is_correctly_named: bool = None
-        self._exists_in_statusdb: bool = None
-        self._fastq_files_exist_in_housekeeper: bool = None
-        self._spring_files_exist_in_housekeeper: bool = None
-        self._files_exist_in_housekeeper: bool = None
-        self._files_exist_on_disk: bool = None
-        self._passed_check: bool = None
-        self._sequencer_type: str = None
-        self._is_demultiplexing_ongoing_or_started_and_not_completed: bool = None
+        self._hk_fastq_files: Optional[list] = None
+        self._hk_spring_files: Optional[list] = None
+        self._is_correctly_named: Optional[bool] = None
+        self._exists_in_statusdb: Optional[bool] = None
+        self._fastq_files_exist_in_housekeeper: Optional[bool] = None
+        self._spring_files_exist_in_housekeeper: Optional[bool] = None
+        self._files_exist_in_housekeeper: Optional[bool] = None
+        self._files_exist_on_disk: Optional[bool] = None
+        self._passed_check: Optional[bool] = None
+        self._sequencer_type: Optional[str] = None
+        self._is_demultiplexing_ongoing_or_started_and_not_completed: Optional[bool] = None
 
     @property
     def sequencer_type(self) -> str:

--- a/cg/meta/clean/demultiplexed_flow_cells.py
+++ b/cg/meta/clean/demultiplexed_flow_cells.py
@@ -25,13 +25,13 @@ SEQUENCER_IDENTIFIER_POSITION = 1
 
 class DemultiplexedRunsFlowCell:
     """Class to check if a given flow cell in demultiplexed-runs is valid, or can be removed. A
-    valid flow cell is named correctly, has the correct status ('ondisk') in statusdb,
-    and has fastq files in Housekeeper.
+    valid flow cell is named correctly, has the correct status ('ondisk') in Statusdb,
+    and has FASTQ files in Housekeeper.
 
     A flow cell that is correctly named has four segments divided by underscores:
     <run_date>_<sequencer>_<run_number>_<identifier>. The identifier consists of the position of
     the flow cell on the sequencer in the first position (either A or B), and the flow cell id in
-    the rest of the identifier. Flow cell id is the naming convention used in statusdb and other
+    the rest of the identifier. Flow cell id is the naming convention used in Statusdb and other
     systems"""
 
     def __init__(
@@ -56,28 +56,30 @@ class DemultiplexedRunsFlowCell:
         self.identifier: str = self.split_name[FLOW_CELL_IDENTIFIER_POSITION]
         self.sequencer_serial_number: str = self.split_name[SEQUENCER_IDENTIFIER_POSITION]
         self.id: str = self.identifier[1:]
-        self._hk_fastq_files = None
-        self._hk_spring_files = None
-        self._is_correctly_named = None
-        self._exists_in_statusdb = None
-        self._fastq_files_exist_in_housekeeper = None
-        self._spring_files_exist_in_housekeeper = None
-        self._files_exist_in_housekeeper = None
-        self._files_exist_on_disk = None
-        self._passed_check = None
-        self._sequencer_type = None
-        self._is_demultiplexing_ongoing_or_started_and_not_completed = None
+        self._hk_fastq_files: list = None
+        self._hk_spring_files: list = None
+        self._is_correctly_named: bool = None
+        self._exists_in_statusdb: bool = None
+        self._fastq_files_exist_in_housekeeper: bool = None
+        self._spring_files_exist_in_housekeeper: bool = None
+        self._files_exist_in_housekeeper: bool = None
+        self._files_exist_on_disk: bool = None
+        self._passed_check: bool = None
+        self._sequencer_type: str = None
+        self._is_demultiplexing_ongoing_or_started_and_not_completed: bool = None
 
     @property
     def sequencer_type(self) -> str:
-        """The type of sequencer a flow cell has been sequenced on"""
+        """The type of sequencer a flow cell has been sequenced on."""
         if self._sequencer_type is None:
-            self._sequencer_type = sequencer_types.get(self.sequencer_serial_number, "other")
+            self._sequencer_type: str = sequencer_types.get(
+                self.sequencer_serial_number, Sequencers.OTHER
+            )
         return self._sequencer_type
 
     @property
     def hk_fastq_files(self) -> list:
-        """All fastq files in Housekeeper for a particular flow cell"""
+        """All FASTQ files in Housekeeper for a particular flow cell."""
         if self._hk_fastq_files is None:
             self._hk_fastq_files = [
                 fastq_file for fastq_file in self.all_fastq_files if self.id in fastq_file.path
@@ -96,79 +98,72 @@ class DemultiplexedRunsFlowCell:
     @property
     def is_correctly_named(self) -> bool:
         """Checks if the flow cell directory is correctly named: it should end with the flow cell
-        id"""
+        id."""
         if self._is_correctly_named is None:
             self._is_correctly_named: bool = self.split_name[-1] == self.identifier
             if not self._is_correctly_named:
-                LOG.warning("Flow cell not correctly named!: %s", self.path)
+                LOG.warning(f"Flow cell not correctly named!: {self.path}")
         return self._is_correctly_named
 
     @property
     def exists_in_statusdb(self) -> bool:
-        """Checks if flow cell exists in statusdb"""
+        """Checks if flow cell exists in Statusdb."""
         if self._exists_in_statusdb is None:
             self._exists_in_statusdb: bool = self.status_db.get_flow_cell(self.id) is not None
             if not self._exists_in_statusdb:
-                LOG.warning("Flow cell %s does not exist in statusdb!", self.id)
+                LOG.warning(f"Flow cell {self.id} does not exist in Statusdb!")
         return self._exists_in_statusdb
 
     @property
     def fastq_files_exist_in_housekeeper(self) -> bool:
-        """Checks if the flow cell has any fastq files in Housekeeper"""
+        """Checks if the flow cell has any FASTQ files in Housekeeper."""
         if self._fastq_files_exist_in_housekeeper is None:
             self._fastq_files_exist_in_housekeeper: bool = len(self.hk_fastq_files) > 0
             if not self._fastq_files_exist_in_housekeeper:
-                LOG.warning("Flow cell %s does not have any fastq files in Housekeeper!", self.id)
+                LOG.warning(f"Flow cell {self.id} does not have any FASTQ files in Housekeeper!")
         return self._fastq_files_exist_in_housekeeper
 
     @property
     def spring_files_exist_in_housekeeper(self) -> bool:
-        """Checks if the flow cell has any spring files in Housekeeper"""
+        """Checks if the flow cell has any SPRING files in Housekeeper."""
         if self._spring_files_exist_in_housekeeper is None:
             self._spring_files_exist_in_housekeeper: bool = len(self.hk_spring_files) > 0
             if not self._spring_files_exist_in_housekeeper:
-                LOG.warning("Flow cell %s does not have any spring files in Housekeeper!", self.id)
+                LOG.warning(f"Flow cell {self.id} does not have any SPRING files in Housekeeper!")
         return self._spring_files_exist_in_housekeeper
 
     @property
     def files_exist_in_housekeeper(self) -> bool:
-        """Checks if the flow cell has any files, either fastq or spring, in Housekeeper"""
+        """Checks if the flow cell has any files, either FASTQ or SPRING, in Housekeeper."""
         if self._files_exist_in_housekeeper is None:
             self._files_exist_in_housekeeper: bool = (
                 self.fastq_files_exist_in_housekeeper or self.spring_files_exist_in_housekeeper
             )
             if not self._files_exist_in_housekeeper:
                 LOG.warning(
-                    "Flow cell %s has neither fastq files nor spring files in Housekeeper!", self.id
+                    f"Flow cell {self.id} has neither FASTQ files nor SPRING files in Housekeeper!"
                 )
         return self._files_exist_in_housekeeper
 
     @staticmethod
     def _check_files_existence(files: list) -> List[bool]:
-        """Checks file existence and handles permission errors"""
+        """Checks file existence and handles permission errors."""
         files_exist: List[bool] = []
         for file in files:
             try:
                 files_exist.append(Path(file.path).exists())
             except PermissionError:
-                LOG.warning("Can't check file %s, no permission!", file)
+                LOG.warning(f"Can't check file {file}, no permission!")
                 continue
         return files_exist
 
     @property
     def files_exist_on_disk(self) -> bool:
-        """Checks if the spring or fastq files that are in Housekeeper are actually present on
-        disk"""
+        """Checks if the SPRING or FASTQ files that are in Housekeeper are actually present on
+        disk."""
 
         if self._files_exist_on_disk is None:
-            if not self.files_exist_in_housekeeper:
-                LOG.warning(
-                    "Flow cell %s has no fastq files or spring files in Housekeeper, skipping "
-                    "disk check",
-                    self.id,
-                )
-                self._files_exist_on_disk = False
-            else:
+            if self.files_exist_in_housekeeper:
                 if self.fastq_files_exist_in_housekeeper:
                     fastq_files_exist_on_disk: List[bool] = self._check_files_existence(
                         self.hk_fastq_files
@@ -180,22 +175,28 @@ class DemultiplexedRunsFlowCell:
                     )
                     self._files_exist_on_disk: bool = all(spring_files_exist_on_disk)
                 if not self._files_exist_on_disk:
-                    LOG.warning("Flow cell %s has no fastq files or spring files on disk!", self.id)
+                    LOG.warning(f"Flow cell {self.id} has no fastq files or spring files on disk!")
 
+            else:
+                LOG.warning(
+                    f"Flow cell {self.id} has no FASTQ files or SPRING files in Housekeeper, skipping "
+                    "disk check"
+                )
+                self._files_exist_on_disk = False
         return self._files_exist_on_disk
 
     @property
     def is_demultiplexing_ongoing_or_started_and_not_completed(self) -> bool:
         """Checks demultiplexing status for a flow cell. A flow cell can only be deleted if
-        demultiplexing has not started or is not ongoing. Completed flow cells can be deleted"""
+        demultiplexing has not started or is not ongoing. Completed flow cells can be deleted."""
         if self._is_demultiplexing_ongoing_or_started_and_not_completed is None:
-            LOG.info("Checking demultiplexing status for flowcell %s:", self.id)
+            LOG.info(f"Checking demultiplexing status for flowcell {self.id}:")
             self._is_demultiplexing_ongoing_or_started_and_not_completed: bool = (
                 self.tb.has_latest_analysis_started(case_id=self.id)
                 or self.tb.is_latest_analysis_ongoing(case_id=self.id)
             ) and not self.tb.is_latest_analysis_completed(case_id=self.id)
             if self._is_demultiplexing_ongoing_or_started_and_not_completed:
-                LOG.warning("Demultiplexing not fully completed for flow cell %s!", self.id)
+                LOG.warning(f"Demultiplexing not fully completed for flow cell {self.id}!")
             else:
                 LOG.info("Demultiplexing fully completed!")
 
@@ -203,9 +204,9 @@ class DemultiplexedRunsFlowCell:
 
     @property
     def passed_check(self) -> bool:
-        """Indicates if all checks have passed"""
+        """Indicates if all checks have passed."""
         if self._passed_check is None:
-            LOG.info("Checking %s:", self.path)
+            LOG.info(f"Checking {self.path}:")
             self._passed_check = all(
                 [
                     self.is_correctly_named,
@@ -215,15 +216,13 @@ class DemultiplexedRunsFlowCell:
                 ]
             )
             LOG.info(
-                "Flow cell %s has passed all checks, setting flag to True!", self.id
+                f"Flow cell {self.id} has passed all checks, setting flag to True!"
             ) if self._passed_check else LOG.error(
-                "Flow cell %s failed one or more tests, setting flag to %s!",
-                self.id,
-                self._passed_check,
+                f"Flow cell {self.id} failed one or more tests, setting flag to {self._passed_check}!"
             )
         return self._passed_check
 
-    def remove_files_from_housekeeper(self):
+    def remove_files_from_housekeeper(self) -> None:
         """Remove fastq files and the sample sheet from Housekeeper when deleting a
         flow cell from demultiplexed-runs."""
         if self.fastq_files_exist_in_housekeeper:
@@ -236,8 +235,8 @@ class DemultiplexedRunsFlowCell:
                 self.hk.delete_file(sample_sheet.id)
         self.hk.commit()
 
-    def remove_from_demultiplexed_runs(self):
-        """Removes a flow cell directory completely from demultiplexed-runs"""
+    def remove_from_demultiplexed_runs(self) -> None:
+        """Removes a flow cell directory completely from demultiplexed-runs."""
         if self.is_correctly_named:
             self.archive_sample_sheet()
         shutil.rmtree(self.path, ignore_errors=True)
@@ -245,24 +244,23 @@ class DemultiplexedRunsFlowCell:
             self.status_db.get_flow_cell(self.id).status = FlowCellStatus.REMOVED
         self.status_db.commit()
 
-    def remove_failed_flow_cell(self):
-        """Performs the two removal actions for failed flow cells"""
+    def remove_failed_flow_cell(self) -> None:
+        """Performs the two removal actions for failed flow cells."""
         self.remove_from_demultiplexed_runs()
         if self.files_exist_in_housekeeper and self.is_correctly_named:
             self.remove_files_from_housekeeper()
 
-    def archive_sample_sheet(self):
+    def archive_sample_sheet(self) -> None:
         """Archives a sample sheet to /home/proj/production/sample_sheets and adds it to
-        Housekeeper with an appropriate tag"""
-        LOG.info("Archiving sample sheet for flow cell %s", self.run_name)
+        Housekeeper with an appropriate tag."""
+        LOG.info(f"Archiving sample sheet for flow cell {self.run_name}")
         globbed_unaligned_paths: Path.glob = Path(self.path).glob(
             DemultiplexingDirsAndFiles.UNALIGNED_DIR_NAME + ASTERISK
         )
         globbed_unaligned_paths_list: list = list(globbed_unaligned_paths)
         if not globbed_unaligned_paths_list:
             LOG.warning(
-                "No Unaligned directory found for flow cell %s! No sample sheet to archive!",
-                self.run_name,
+                f"No Unaligned directory found for flow cell {self.run_nam}! No sample sheet to archive!"
             )
             return
         unaligned_path: Path = globbed_unaligned_paths_list[0]
@@ -281,18 +279,18 @@ class DemultiplexedRunsFlowCell:
         )
 
         sample_sheet_run_dir.mkdir(parents=True, exist_ok=True)
-        LOG.info("Sample sheet directory created for flow cell directory %s", self.run_name)
+        LOG.info(f"Sample sheet directory created for flow cell directory {self.run_name}")
 
         try:
             shutil.move(original_sample_sheet, archived_sample_sheet)
             self.add_sample_sheet_to_housekeeper(archived_sample_sheet)
             self.hk.commit()
         except FileNotFoundError:
-            LOG.warning("No sample sheet found in flow cell directory %s!", self.run_name)
+            LOG.warning(f"No sample sheet found in flow cell directory {self.run_name}!")
             shutil.rmtree(sample_sheet_run_dir, ignore_errors=True)
 
     def add_sample_sheet_to_housekeeper(self, sample_sheet_path: Path):
-        """Adds an archive sample sheet to Housekeeper"""
+        """Adds an archive sample sheet to Housekeeper."""
 
         hk_bundle: hk_models.Bundle = self.hk.bundle(self.id)
         if hk_bundle is None:

--- a/cg/meta/clean/flow_cell_run_directories.py
+++ b/cg/meta/clean/flow_cell_run_directories.py
@@ -6,14 +6,16 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Optional
 
-from housekeeper.store import models as hk_models
+from housekeeper.store.models import Bundle
 
 from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.constants import FlowCellStatus
 from cg.constants.demultiplexing import DemultiplexingDirsAndFiles
 from cg.constants.symbols import UNDERSCORE
 from cg.constants.housekeeper_tags import SequencingFileTag
+from cg.datetime.utils import get_timedelta_from_date
 from cg.store import Store
+from cg.store.models import Flowcell
 
 FLOW_CELL_DATE_POSITION = 0
 FLOW_CELL_IDENTIFIER_POSITION = 3
@@ -22,7 +24,7 @@ PDC_RETRIEVAL_STATUSES = [FlowCellStatus.PROCESSING, FlowCellStatus.RETRIEVED]
 
 
 class RunDirFlowCell:
-    """Class to check and remove flow cell run directories"""
+    """Class to check and remove flow cell run directories."""
 
     def __init__(self, flow_cell_dir: Path, status_db: Store, housekeeper_api: HousekeeperAPI):
         self.flow_cell_dir: Path = flow_cell_dir
@@ -44,23 +46,22 @@ class RunDirFlowCell:
 
     @property
     def age(self) -> int:
-        """How long ago a flow cell was sequenced, in days"""
+        """How long ago a flow cell was sequenced, in days."""
         if self._age is None:
-            self._age: int = (datetime.now() - self.sequenced_date).days
+            self._age: int = (get_timedelta_from_date(date=self.sequenced_date)).days
         return self._age
 
     @property
     def sequenced_date(self) -> datetime:
-        """The date on which the flow cell was sequenced"""
+        """The date on which the flow cell was sequenced."""
         if self._sequenced_date is None:
-            if self.status_db.get_flow_cell(flow_cell_id=self.id):
-                LOG.info("Found flow cell %s in statusdb, getting sequenced date.", self.id)
-                self._sequenced_date: datetime = self.status_db.get_flow_cell(
-                    flow_cell_id=self.id
-                ).sequenced_at
+            flow_cell: Flowcell = self.status_db.get_flow_cell(flow_cell_id=self.id)
+            if flow_cell:
+                LOG.info(f"Found flow cell {self.id} in Statusdb, getting sequenced date.")
+                self._sequenced_date: datetime = flow_cell.sequenced_at
             else:
                 LOG.info(
-                    "Flow cell %s NOT found in statusdb, deriving sequenced date from run dir name!",
+                    f"Flow cell {self.id} NOT found in Statusdb, deriving sequenced date from run dir name!",
                     self.id,
                 )
                 self._sequenced_date: datetime = self.derived_date
@@ -68,42 +69,42 @@ class RunDirFlowCell:
 
     @property
     def is_retrieved_from_pdc(self) -> bool:
-        """Flow cell is (being) retrieved from PDC"""
+        """Flow cell is (being) retrieved from PDC."""
         if self._is_retrieved_from_pdc is None:
             self._is_retrieved_from_pdc = self.flow_cell_status in PDC_RETRIEVAL_STATUSES
         return self._is_retrieved_from_pdc
 
     @property
     def flow_cell_status(self) -> str:
-        """Status of the flow cell"""
+        """Return status of the flow cell."""
         if self._flow_cell_status is None:
             self._flow_cell_status = self.status_db.get_flow_cell(flow_cell_id=self.id).status
         return self._flow_cell_status
 
     @property
     def exists_in_statusdb(self) -> bool:
-        """The flow cell exists in statusdb"""
+        """The flow cell exists in Statusdb."""
         if self._exists_in_statusdb is None:
             self._exists_in_statusdb = (
                 self.status_db.get_flow_cell(flow_cell_id=self.id) is not None
             )
         return self._exists_in_statusdb
 
-    def remove_run_directory(self):
-        """Removes the flow cell run directory"""
-        LOG.info("Removing run directory %s", self.flow_cell_dir)
+    def remove_run_directory(self) -> None:
+        """Removes the flow cell run directory."""
+        LOG.info(f"Removing run directory {self.flow_cell_dir}")
         shutil.rmtree(self.flow_cell_dir, ignore_errors=True)
 
-    def archive_sample_sheet(self):
-        """Archives a sample sheet in housekeeper-bundles"""
-        LOG.info("Start archiving sample sheet %s", self.sample_sheet_path)
+    def archive_sample_sheet(self) -> None:
+        """Archives a sample sheet in Housekeeper bundles."""
+        LOG.info(f"Start archiving sample sheet {self.sample_sheet_path}")
         if not self.sample_sheet_path.exists():
             LOG.warning("Sample sheet does not exists!")
             return
         LOG.info("Sample sheet found!")
-        hk_bundle: hk_models.Bundle = self.hk.bundle(name=self.id)
+        hk_bundle: Bundle = self.hk.bundle(name=self.id)
         if hk_bundle is None:
-            LOG.info("Creating bundle with name %s", self.id)
+            LOG.info(f"Creating bundle with name {self.id}")
             self.hk.create_new_bundle_and_version(name=self.id)
         try:
             self.hk.add_and_include_file_to_latest_version(

--- a/cg/meta/clean/flow_cell_run_directories.py
+++ b/cg/meta/clean/flow_cell_run_directories.py
@@ -61,8 +61,7 @@ class RunDirFlowCell:
                 self._sequenced_date: datetime = flow_cell.sequenced_at
             else:
                 LOG.info(
-                    f"Flow cell {self.id} NOT found in Statusdb, deriving sequenced date from run dir name!",
-                    self.id,
+                    f"Flow cell {self.id} NOT found in Statusdb, deriving sequenced date from run dir name!"
                 )
                 self._sequenced_date: datetime = self.derived_date
         return self._sequenced_date

--- a/cg/meta/clean/flow_cell_run_directories.py
+++ b/cg/meta/clean/flow_cell_run_directories.py
@@ -18,7 +18,7 @@ from cg.store import Store
 from cg.store.models import Flowcell
 
 FLOW_CELL_DATE_POSITION = 0
-FLOW_CELL_IDENTIFIER_POSITION = 3
+FLOW_CELL_IDENTIFIER_POSITION = -1
 LOG = logging.getLogger(__name__)
 PDC_RETRIEVAL_STATUSES = [FlowCellStatus.PROCESSING, FlowCellStatus.RETRIEVED]
 

--- a/tests/apps/hk/test_file.py
+++ b/tests/apps/hk/test_file.py
@@ -398,25 +398,23 @@ def test_is_fastq_or_spring_in_all_bundles_when_missing(
 
 
 def test_is_fastq_or_spring_in_all_bundles_when_multiple_bundles(
-    populated_housekeeper_api: MockHousekeeperAPI,
     case_id: str,
-    sample_id: str,
-    madeline_output: Path,
-    tags: List[str],
     compression_object: MockCompressionData,
+    populated_housekeeper_api: MockHousekeeperAPI,
+    madeline_output: Path,
+    sample_id: str,
+    tags: List[str],
 ):
     """Test checking if all FASTQ or SPRING files are present in bundles when all bundles have files present."""
     # GIVEN a populated housekeeper api with some files
-    version: Version = populated_housekeeper_api.last_version(case_id)
 
-    # GIVEN a FASTQ file tag in the bundle
     # GIVEN a FASTQ file tag with a file included the bundle
     populated_housekeeper_api.add_and_include_file_to_latest_version(
         file=madeline_output, bundle_name=case_id, tags=[SequencingFileTag.FASTQ]
     )
 
     # GIVEN an empty bundle
-    sample_bundle: Bundle = populated_housekeeper_api.create_new_bundle_and_version(name=sample_id)
+    populated_housekeeper_api.create_new_bundle_and_version(name=sample_id)
 
     # GIVEN a SPRING file tag in the bundle
     compression_object.spring_metadata_path.touch()

--- a/tests/apps/hk/test_file.py
+++ b/tests/apps/hk/test_file.py
@@ -416,7 +416,7 @@ def test_is_fastq_or_spring_in_all_bundles_when_multiple_bundles(
     # GIVEN an empty bundle
     populated_housekeeper_api.create_new_bundle_and_version(name=sample_id)
 
-    # GIVEN a SPRING file tag in the bundle
+    # GIVEN a SPRING an existing file
     compression_object.spring_metadata_path.touch()
 
     # GIVEN a SPRING file tag with a file included the bundle
@@ -424,6 +424,49 @@ def test_is_fastq_or_spring_in_all_bundles_when_multiple_bundles(
         file=compression_object.spring_metadata_path,
         bundle_name=sample_id,
         tags=[SequencingFileTag.SPRING_METADATA],
+    )
+
+    # WHEN fetching all files
+    was_true = populated_housekeeper_api.is_fastq_or_spring_in_all_bundles(
+        bundle_names=[case_id, sample_id]
+    )
+
+    # THEN assert all file were present in all bundles
+    assert was_true
+
+
+def test_is_fastq_or_spring_in_all_bundles_when_multiple_bundles_and_files(
+    case_id: str,
+    compression_object: MockCompressionData,
+    populated_housekeeper_api: MockHousekeeperAPI,
+    madeline_output: Path,
+    sample_id: str,
+    tags: List[str],
+):
+    """Test checking if all FASTQ or SPRING files are present in bundles when all bundles have files present and some both FASTQ and SPRING."""
+    # GIVEN a populated housekeeper api with some files
+
+    # GIVEN a FASTQ file tag with a file included the bundle
+    populated_housekeeper_api.add_and_include_file_to_latest_version(
+        file=madeline_output, bundle_name=case_id, tags=[SequencingFileTag.FASTQ]
+    )
+
+    # GIVEN an empty bundle
+    populated_housekeeper_api.create_new_bundle_and_version(name=sample_id)
+
+    # GIVEN a SPRING an existing file
+    compression_object.spring_metadata_path.touch()
+
+    # GIVEN a SPRING file tag with a file included the bundle
+    populated_housekeeper_api.add_and_include_file_to_latest_version(
+        file=compression_object.spring_metadata_path,
+        bundle_name=sample_id,
+        tags=[SequencingFileTag.SPRING_METADATA],
+    )
+
+    # GIVEN a FASTQ file tag with a file included the bundle
+    populated_housekeeper_api.add_and_include_file_to_latest_version(
+        file=madeline_output, bundle_name=case_id, tags=[SequencingFileTag.FASTQ]
     )
 
     # WHEN fetching all files

--- a/tests/cli/clean/test_hk_case_bundle_files.py
+++ b/tests/cli/clean/test_hk_case_bundle_files.py
@@ -8,7 +8,7 @@ from cg.store import Store
 from cg.store import models
 from cgmodels.cg.constants import Pipeline
 from click.testing import CliRunner
-from cg.cli.clean import get_date_days_ago
+from cg.datetime.utils import get_date_days_ago
 
 from tests.store_helpers import StoreHelpers
 


### PR DESCRIPTION
## Description

### Added

- New CLI command to clean old demultiplexed-runs folders

### Changed

- Reactor "clean" code


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b clean-demux-runs -a
    ```

### How to test

- [x] See below

## Review

- [x] Tests executed by HS
- [x] "Merge and deploy" approved by VJ
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
