### PR TITLE
fix(Clean-up MIP folders)

### DIFF
--- a/cg/cli/clean.py
+++ b/cg/cli/clean.py
@@ -18,7 +18,8 @@ from cg.apps.tb import TrailblazerAPI
 from cg.cli.workflow.commands import (
     balsamic_past_run_dirs,
     fluffy_past_run_dirs,
-    mip_past_run_dirs,
+    mip_dna_past_run_dirs,
+    mip_rna_past_run_dirs,
     mutant_past_run_dirs,
     rnafusion_past_run_dirs,
     rsync_past_run_dirs,
@@ -61,7 +62,8 @@ def clean():
 for sub_cmd in [
     balsamic_past_run_dirs,
     fluffy_past_run_dirs,
-    mip_past_run_dirs,
+    mip_dna_past_run_dirs,
+    mip_rna_past_run_dirs,
     mutant_past_run_dirs,
     rnafusion_past_run_dirs,
     rsync_past_run_dirs,

--- a/cg/cli/workflow/commands.py
+++ b/cg/cli/workflow/commands.py
@@ -20,6 +20,7 @@ from cg.meta.workflow.rnafusion import RnafusionAnalysisAPI
 from cg.meta.workflow.fluffy import FluffyAnalysisAPI
 from cg.meta.workflow.microsalt import MicrosaltAnalysisAPI
 from cg.meta.workflow.mip_dna import MipDNAAnalysisAPI
+from cg.meta.workflow.mip_rna import MipRNAAnalysisAPI
 from cg.meta.workflow.mutant import MutantAnalysisAPI
 from cg.models.cg_config import CGConfig
 from cg.store import Store
@@ -239,17 +240,32 @@ def fluffy_past_run_dirs(
     context.invoke(past_run_dirs, yes=yes, dry_run=dry_run, before_str=before_str)
 
 
-@click.command("mip-past-run-dirs")
+@click.command("mip-dna-past-run-dirs")
 @OPTION_YES
 @OPTION_DRY
 @ARGUMENT_BEFORE_STR
 @click.pass_context
-def mip_past_run_dirs(
+def mip_dna_past_run_dirs(
     context: click.Context, before_str: str, yes: bool = False, dry_run: bool = False
 ):
-    """Clean up of "old" MIP case run dirs."""
+    """Clean up of "old" MIP_DNA case run dirs."""
 
     context.obj.meta_apis["analysis_api"] = MipDNAAnalysisAPI(context.obj)
+
+    context.invoke(past_run_dirs, yes=yes, dry_run=dry_run, before_str=before_str)
+
+
+@click.command("mip-rna-past-run-dirs")
+@OPTION_YES
+@OPTION_DRY
+@ARGUMENT_BEFORE_STR
+@click.pass_context
+def mip_rna_past_run_dirs(
+    context: click.Context, before_str: str, yes: bool = False, dry_run: bool = False
+):
+    """Clean up of "old" MIP_RNA case run dirs."""
+
+    context.obj.meta_apis["analysis_api"] = MipRNAAnalysisAPI(context.obj)
 
     context.invoke(past_run_dirs, yes=yes, dry_run=dry_run, before_str=before_str)
 

--- a/cg/meta/workflow/mip.py
+++ b/cg/meta/workflow/mip.py
@@ -33,7 +33,6 @@ CLI_OPTIONS = {
     "start_with": {"option": "--start_with_recipe"},
     "use_bwa_mem": {"option": "--bwa_mem 1 --bwa_mem2 0"},
 }
-##TODO test this option above
 LOG = logging.getLogger(__name__)
 
 

--- a/tests/cli/workflow/test_cli_workflow_clean.py
+++ b/tests/cli/workflow/test_cli_workflow_clean.py
@@ -4,7 +4,8 @@ from cg.cli.workflow.commands import (
     balsamic_past_run_dirs,
     fluffy_past_run_dirs,
     microsalt_past_run_dirs,
-    mip_past_run_dirs,
+    mip_dna_past_run_dirs,
+    mip_rna_past_run_dirs,
     mutant_past_run_dirs,
     rnafusion_past_run_dirs,
 )
@@ -40,7 +41,7 @@ def test_cli_workflow_clean_fluffy(
     assert result.exit_code == EXIT_SUCCESS
 
 
-def test_cli_workflow_clean_mip(
+def test_cli_workflow_clean_mip_dna(
     cli_runner: CliRunner,
     base_context: CGConfig,
     before_date: str,
@@ -48,11 +49,24 @@ def test_cli_workflow_clean_mip(
     # GIVEN a before string
 
     # WHEN running command in dry-run
-    result = cli_runner.invoke(mip_past_run_dirs, [before_date], obj=base_context)
+    result = cli_runner.invoke(mip_dna_past_run_dirs, [before_date], obj=base_context)
 
     # THEN command should terminate successfully
     assert result.exit_code == EXIT_SUCCESS
 
+
+def test_cli_workflow_clean_mip_rna(
+    cli_runner: CliRunner,
+    base_context: CGConfig,
+    before_date: str,
+):
+    # GIVEN a before string
+
+    # WHEN running command in dry-run
+    result = cli_runner.invoke(mip_rna_past_run_dirs, [before_date], obj=base_context)
+
+    # THEN command should terminate successfully
+    assert result.exit_code == EXIT_SUCCESS
 
 def test_cli_workflow_clean_mutant(
     cli_runner: CliRunner,

--- a/tests/cli/workflow/test_cli_workflow_clean.py
+++ b/tests/cli/workflow/test_cli_workflow_clean.py
@@ -68,6 +68,7 @@ def test_cli_workflow_clean_mip_rna(
     # THEN command should terminate successfully
     assert result.exit_code == EXIT_SUCCESS
 
+
 def test_cli_workflow_clean_mutant(
     cli_runner: CliRunner,
     base_context: CGConfig,


### PR DESCRIPTION
## Description
**Clean up MIP folders**: The function to clean MIP folders only cleans MIP DNA folders. The implemented changes create functions that clean MIP DNA and MIP RNA cases separately. 
**IMPORTANT**
The MIP RNA are still not cleaned with this fix, as the *update at* date in statusdb is not updated automatically, which is required to create the list of cases to be cleaned. This will be fixed in another PR.

### Added

- The function `mip_rna_past_run_dirs` in `/cg/cli/workflow/commands.py` to clean old MIP RNA cases
- The test function `test_cli_workflow_clean_mip_rna`

### Changed

- Renamed the function `mip_past_run_dirs`  in `/cg/cli/workflow/commands.py` to `mip_dna_past_run_dirs` as it was only cleaning MIP DNA cases
- Renamed the test function `test_cli_workflow_clean_mip` to `test_cli_workflow_clean_mip_dna`
- Added `mip_dna_past_run_dirs` and `mip_rna_past_run_dirs` to the `click.group` in `cg/cli/clean.py` and removed `mip_past_run_dirs`

### Fixed

- Removed a forgotten TODO comment in MIP

### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b clean_mip_cases -a
    ```

### How to test

- [ ] Verify that the old MIP function does not exist by running 
```bash
cg clean mip-past-run-dirs --help
```

#### 1. MIP DNA

- [ ] Verify that the new MIP DNA function exists by running
```bash
cg clean mip-dna-past-run-dirs --help
```
- [ ] run the new MIP DNA function in dry-run mode with a recent date
```bash
cg clean mip-dna-past-run-dirs --dry-run 2023-02-09
```

#### 2. MIP RNA
- [ ] Verify that the new MIP RNA function exists by running
```bash
cg clean mip-rna-past-run-dirs --help
```
- [ ] In [statusdb staged](https://cg-statusdb-stage.scilifelab.se/admin/), manually add an *uploaded at* date for an old sample with a single analysis, e.g. trueowl (This is necessary to test the function with an expected statusdb when the upload bug is fixed)
- [ ] run the new MIP RNA function in dry-run mode with a recent date
```bash
cg clean mip-rna-past-run-dirs --dry-run 2023-02-09
```

### Expected test outcome
- Verification that the old function does not exist

![image](https://user-images.githubusercontent.com/57712924/218056931-9361ae31-d27e-4afe-8bd5-f11fd72bdee1.png)


#### 1. MIP DNA

- Verification of the new function's existence and documentation

![image](https://user-images.githubusercontent.com/57712924/217821034-3a4f4e4b-9b04-444a-8faa-bce812bee2f2.png)


- Verification of the expected output of the new function (finding a number of cases to clean)

![image](https://user-images.githubusercontent.com/57712924/217791443-72c2ca5c-294f-40bd-a4d7-71e757e70c6d.png)

#### 2. MIP RNA
- Verification of the new function's existence and documentation

![image](https://user-images.githubusercontent.com/57712924/218044256-56dc8ff9-9c0f-489f-bfa3-0c71fd61f8d9.png)

- Verification of the expected output of the new function (finding one case to clean, the one which had its upload date modified manually)

![image](https://user-images.githubusercontent.com/57712924/218050762-b41ea0f1-0e7d-40d1-a03c-8f9c0065a32e.png)


## Review

- [ ] Tests executed by 
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
