### PR TITLE
Add csrf protection

### DIFF
--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -7,6 +7,7 @@ from cgmodels.cg.constants import Pipeline
 from flask import redirect, request, session, url_for, flash
 from flask_admin.actions import action
 from flask_admin.contrib.sqla import ModelView
+from flask_admin.form import SecureForm
 from flask_dance.contrib.google import google
 from markupsafe import Markup
 from sqlalchemy.orm import Query
@@ -19,6 +20,8 @@ from cg.utils.flask.enum import SelectEnumField
 
 class BaseView(ModelView):
     """Base for the specific views."""
+
+    form_base_class = SecureForm  # Protect against CSRF
 
     def is_accessible(self):
         user_obj = db.user(session.get("user_email"))

--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -7,7 +7,6 @@ from cgmodels.cg.constants import Pipeline
 from flask import redirect, request, session, url_for, flash
 from flask_admin.actions import action
 from flask_admin.contrib.sqla import ModelView
-from flask_admin.form import SecureForm
 from flask_dance.contrib.google import google
 from markupsafe import Markup
 from sqlalchemy.orm import Query
@@ -20,8 +19,6 @@ from cg.utils.flask.enum import SelectEnumField
 
 class BaseView(ModelView):
     """Base for the specific views."""
-
-    form_base_class = SecureForm  # Protect against CSRF
 
     def is_accessible(self):
         user_obj = db.user(session.get("user_email"))

--- a/cg/server/app.py
+++ b/cg/server/app.py
@@ -30,6 +30,7 @@ def _configure_extensions(app: Flask):
     app.config["GOOGLE_OAUTH_CERTS"] = certs_resp.json()
 
     ext.cors.init_app(app)
+    ext.csrf.init_app(app)
     ext.db.init_app(app)
     ext.lims.init_app(app)
     if app.config["OSTICKET_API_KEY"]:
@@ -60,10 +61,11 @@ def _register_blueprints(app: Flask):
         session["user_email"] = user_data["email"]
 
     app.register_blueprint(api.BLUEPRINT)
-    _register_admin_views()
     app.register_blueprint(invoices.BLUEPRINT, url_prefix="/invoices")
-
     app.register_blueprint(oauth_bp, url_prefix="/login")
+    _register_admin_views()
+
+    ext.csrf.exempt(api.BLUEPRINT)  # Protected with Auth header already
 
     @app.route("/")
     def index():

--- a/cg/server/ext.py
+++ b/cg/server/ext.py
@@ -1,6 +1,7 @@
 from flask_admin import Admin
 from flask_alchy import Alchy
 from flask_cors import CORS
+from flask_wtf.csrf import CSRFProtect
 
 from cg.apps.lims import LimsAPI
 from cg.apps.osticket import OsTicket
@@ -28,6 +29,7 @@ class FlaskLims(LimsAPI):
 
 
 cors = CORS(resources={r"/api/*": {"origins": "*"}}, supports_credentials=True)
+csrf = CSRFProtect()
 db = CgAlchy(Model=models.Model)
 admin = Admin(name="Clinical Genomics")
 lims = FlaskLims()

--- a/cg/server/invoices/templates/invoices/invoice.html
+++ b/cg/server/invoices/templates/invoices/invoice.html
@@ -13,6 +13,7 @@
         <br>
         <form action="{{ url_for('invoices.index') }}" method="POST" enctype="multipart/form-data">
           <div class="form-group">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
             <input type="hidden" name="new_invoice_updates" value=1>
             <input type="hidden" name="invoice_id" value={{invoice.id}}>
             <div class="row">
@@ -112,6 +113,7 @@
                   <form action="{{ url_for('invoices.index') }}" method="POST" enctype="multipart/form-data">
                     <div class="col-sm-9">
                     <button class="btn btn-primary" type="submit">Undo Invoice</button> 
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
                     <input type="hidden" name="samples" value={{ invoice_dict.records }}>
                     <input type="hidden" name="invoice_id" value={{ invoice.id }}>
                     <input type="hidden" name="record_type" value={{ record_type }}>

--- a/cg/server/invoices/templates/invoices/new.html
+++ b/cg/server/invoices/templates/invoices/new.html
@@ -5,6 +5,7 @@
   <h1>Make new invoice ({{record_type}})</h1>
   <br>
   <form action="{{ url_for('invoices.new', record_type=record_type) }}">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
     <input type="hidden" name="record_type" value="{{ record_type }}">
     <div class="row">
       <div class="col">
@@ -23,6 +24,7 @@
     </div>
   </form>
   <form name="listForm" action="{{ url_for('invoices.index')}}" method="POST" class="mt-3">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
     <input type="hidden" name="customer" value="{{ args.customer }}">
     <input type="hidden" name="record_type" value="{{record_type}}">
     <label>Discount (%)</label>

--- a/cg/server/invoices/views.py
+++ b/cg/server/invoices/views.py
@@ -147,7 +147,7 @@ def new(record_type):
     )
 
 
-@BLUEPRINT.route("/<int:invoice_id>", methods=["POST"])
+@BLUEPRINT.route("/<int:invoice_id>", methods=["GET"])
 def invoice(invoice_id):
     """Save comments and uploaded modified invoices."""
     invoice_obj = db.invoice(invoice_id)

--- a/cg/server/invoices/views.py
+++ b/cg/server/invoices/views.py
@@ -24,6 +24,12 @@ from cg.server.ext import db, lims
 BLUEPRINT = Blueprint("invoices", __name__, template_folder="templates")
 
 
+@BLUEPRINT.before_request
+def before_request():
+    if not logged_in():
+        return redirect(url_for("admin.index"))
+
+
 def logged_in():
     user_obj = db.user(session.get("user_email"))
     return google.authorized and user_obj and user_obj.is_admin
@@ -97,9 +103,6 @@ def upload_invoice_news_to_db():
 @BLUEPRINT.route("/", methods=["GET", "POST"])
 def index():
     """Show invoices."""
-    if not logged_in():
-        return redirect(url_for("admin.index"))
-
     if request.form.get("new_invoice_updates"):
         url = upload_invoice_news_to_db()
         return redirect(url)
@@ -121,9 +124,6 @@ def index():
 @BLUEPRINT.route("/new/<record_type>")
 def new(record_type):
     """Generate a new invoice."""
-    if not logged_in():
-        return redirect(url_for("admin.index"))
-
     count = request.args.get("total", 0)
     customer_id = request.args.get("customer", "cust002")
     customer_obj = db.customer(customer_id)
@@ -146,9 +146,6 @@ def new(record_type):
 @BLUEPRINT.route("/<int:invoice_id>", methods=["GET", "POST"])
 def invoice(invoice_id):
     """Save comments and uploaded modified invoices."""
-    if not logged_in():
-        return redirect(url_for("admin.index"))
-
     invoice_obj = db.invoice(invoice_id)
     api = InvoiceAPI(db, lims, invoice_obj)
     kth_inv = api.prepare("KTH")
@@ -177,9 +174,6 @@ def invoice(invoice_id):
 @BLUEPRINT.route("/<int:invoice_id>/excel")
 def invoice_template(invoice_id):
     """Generate invoice template"""
-    if not logged_in():
-        return redirect(url_for("admin.index"))
-
     cost_center = request.args.get("cost_center", "KTH")
     invoice_obj = db.invoice(invoice_id)
     api = InvoiceAPI(db, lims, invoice_obj)
@@ -198,9 +192,6 @@ def invoice_template(invoice_id):
 @BLUEPRINT.route("/<int:invoice_id>/invoice_file/<cost_center>")
 def modified_invoice(invoice_id, cost_center):
     """Enables download of modified invoices saved in the database."""
-    if not logged_in():
-        return redirect(url_for("admin.index"))
-
     if cost_center not in ["KTH", "KI"]:
         return abort(http.HTTPStatus.BAD_REQUEST)
 

--- a/cg/server/invoices/views.py
+++ b/cg/server/invoices/views.py
@@ -100,9 +100,19 @@ def upload_invoice_news_to_db():
     return url_for("invoices.invoice", invoice_id=invoice_id)
 
 
-@BLUEPRINT.route("/", methods=["GET", "POST"])
+@BLUEPRINT.route("/")
 def index():
-    """Show invoices."""
+    """Retrieve invoices."""
+    invoices = {
+        "sent_invoices": db.invoices(invoiced=True),
+        "pending_invoices": db.invoices(invoiced=False),
+    }
+    return render_template("invoices/index.html", invoices=invoices)
+
+
+@BLUEPRINT.route("/", methods=["POST"])
+def update_invoices():
+    """Update invoices."""
     if request.form.get("new_invoice_updates"):
         url = upload_invoice_news_to_db()
         return redirect(url)
@@ -110,15 +120,9 @@ def index():
         invoice_id = request.form.get("invoice_id")
         url = undo_invoice(invoice_id)
         return redirect(url)
-    elif request.method == "POST":
+    else:
         url = make_new_invoice()
         return redirect(url)
-    else:
-        invoices = {
-            "sent_invoices": db.invoices(invoiced=True),
-            "pending_invoices": db.invoices(invoiced=False),
-        }
-        return render_template("invoices/index.html", invoices=invoices)
 
 
 @BLUEPRINT.route("/new/<record_type>")
@@ -143,7 +147,7 @@ def new(record_type):
     )
 
 
-@BLUEPRINT.route("/<int:invoice_id>", methods=["GET", "POST"])
+@BLUEPRINT.route("/<int:invoice_id>", methods=["POST"])
 def invoice(invoice_id):
     """Save comments and uploaded modified invoices."""
     invoice_obj = db.invoice(invoice_id)

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ Flask-CORS
 Flask-Dance
 Flask-SQLAlchemy==2.1
 Flask>=1.1.1                # versioned due to setup.py install misselecting Flask-SQLAlchemy otherwise
+flask_wtf
 google-auth
 gunicorn
 requests[security]


### PR DESCRIPTION
## Description
Since some of our endpoints only rely on cookies for authentication they are vulnerable to CSRF. An attacker could force a user to run arbitrary requests, for instance deleting resources (invoices, samples, customers etc.).

### Fixed
- CSRF vulnerability for the cg API (the admin and invoice endpoints).


### How to prepare for test
Use the Github action for deploying this branch to the cg-vm1 stage environment.

### How to test

- [x] Open https://cg-statusdb-stage.scilifelab.se/ and sign in.
- [x] Make sure that the order form can be filled in as usual via the order interface.
- [x] Make sure that records can be updated with legitimate requests via the admin interface.
- [x] Make sure that invoices can be updated with legitimate requests via the invoice interface.
- [x] Try to run a CSRF exploit for an admin endpoint deleting some resource.
- [x] Try to run a CSRF exploit  for an invoice endpoint changing some resource.

### Expected test outcome
- [x] Check that a `Bad Request` error is given when the CSRF exploit is run.
- [x] Take a screenshot and attach or copy/paste the output.


## Review

- [x] Tests executed by SA
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Deploy this branch on prod.
