### PR TITLE
Copy specific files instead of entire build context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,9 @@ ENV GOOGLE_OAUTH_CLIENT_SECRET="1"
 
 
 WORKDIR /home/src/app
-COPY cg MANIFEST.in pyproject.toml requirements* setup.py templates ./
+COPY cg ./cg
+COPY templates ./templates
+COPY MANIFEST.in pyproject.toml requirements* setup.py ./
 
 
 RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ ENV GOOGLE_OAUTH_CLIENT_SECRET="1"
 
 
 WORKDIR /home/src/app
-COPY . /home/src/app
+COPY cg MANIFEST.in pyproject.toml requirements* setup.py templates ./
 
 
 RUN pip install -r requirements.txt


### PR DESCRIPTION
## Description
SonarCloud flagged the recursive copy in our Dockerfile. It does not really matter since the build context is our public repository, but this might change over time or it might happen that it is done locally for some reason. It is better to explicitly specify which directories/files that should be copied to the container.

### Fixed

- Replace recursive copy in Dockerfile


### How to prepare for test

- [x] Paxa the environment: `paxa` cg-stage vm1

### How to test

- [x] Deploy to the stage environment.

### Expected test outcome

- [x] Check that the deploy is successful, that the image is built and the container runs as expected.

## Review

- [x] Tests executed by SA
- [x] "Merge and deploy" approved by HS
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Deploy this branch on cg prod
