### PR TITLE
Fix MIP-RNA upload

### DIFF
--- a/cg/cli/upload/base.py
+++ b/cg/cli/upload/base.py
@@ -73,8 +73,10 @@ def upload(context: click.Context, family_id: Optional[str], restart: bool):
         # Upload for balsamic, balsamic-umi and balsamic-qc
         if Pipeline.BALSAMIC in case.data_analysis:
             upload_api = BalsamicUploadAPI(config=config_object)
-        if case.data_analysis == Pipeline.RNAFUSION:
+        elif case.data_analysis == Pipeline.RNAFUSION:
             upload_api = RnafusionUploadAPI(config=config_object)
+        elif case.data_analysis == Pipeline.MIP_RNA:
+            upload_api: UploadAPI = MipRNAUploadAPI(config=config_object)
 
         context.obj.meta_apis["upload_api"] = upload_api
         upload_api.upload(ctx=context, case=case, restart=restart)


### PR DESCRIPTION
## Description

MIP-RNA upload was accidentally deleted in https://github.com/Clinical-Genomics/cg/pull/1693


### Fixed

- MIP-RNA upload 


### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b fix_rna_upload -a
    ```

### How to test

- [x] `cg upload -f pickedsatyr `
<img width="386" alt="image" src="https://user-images.githubusercontent.com/29628428/220593428-a53e4d85-0082-4412-8909-821dc755ab8d.png">


## Review

- [x] Tests executed by EFC
- [x] "Merge and deploy" approved by SD
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
