### PR TITLE
fix(MIP-RNA) Add evaluation of exit status for upload rna-fusion

### DIFF
--- a/cg/meta/upload/mip/mip_rna.py
+++ b/cg/meta/upload/mip/mip_rna.py
@@ -26,8 +26,8 @@ class MipRNAUploadAPI(UploadAPI):
     def upload(self, ctx: click.Context, case: Family, restart: bool) -> None:
         """Uploads MIP-RNA analysis data and files."""
 
-        analysis_obj: Analysis = case.analyses[0]
-        self.update_upload_started_at(analysis=analysis_obj)
+        analysis: Analysis = case.analyses[0]
+        self.update_upload_started_at(analysis=analysis)
 
         # Clinical delivery upload
         ctx.invoke(clinical_delivery, case_id=case.internal_id)
@@ -39,7 +39,7 @@ class MipRNAUploadAPI(UploadAPI):
                 LOG.info(
                     f"Upload of case {case.internal_id} was successful. Setting uploaded at to {dt.datetime.now()}"
                 )
-                self.update_uploaded_at(analysis_obj)
+                self.update_uploaded_at(analysis)
             else:
                 raise RuntimeError(f"Upload to Scout failed for sample {case.internal_id}")
         else:

--- a/cg/meta/upload/mip/mip_rna.py
+++ b/cg/meta/upload/mip/mip_rna.py
@@ -34,14 +34,16 @@ class MipRNAUploadAPI(UploadAPI):
 
         # Scout specific upload
         if DataDelivery.SCOUT in case.data_delivery:
-            ctx.invoke(upload_rna_to_scout, case_id=case.internal_id)
+            result: int = ctx.invoke(upload_rna_to_scout, case_id=case.internal_id)
+            if result == 0:
+                LOG.info(
+                    f"Upload of case {case.internal_id} was successful. Setting uploaded at to {dt.datetime.now()}"
+                )
+                self.update_uploaded_at(analysis_obj)
+            else:
+                raise RuntimeError(f"Upload to Scout failed for sample {case.internal_id}")
         else:
             LOG.warning(
                 f"There is nothing to upload to Scout for case {case.internal_id} and "
                 f"the specified data delivery ({case.data_delivery})"
             )
-
-        LOG.info(
-            f"Upload of case {case.internal_id} was successful. Setting uploaded at to {dt.datetime.now()}"
-        )
-        self.update_uploaded_at(analysis_obj)


### PR DESCRIPTION
## Description
See #1772 

### Added

- Evaluation of exit status of function `upload_rna_to_scout`, which raises a `RuntimeError` if exit status == 1, continue with normal execution if exit status == 0.


### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [x] Copy the files to be uploaded from production to stage:
```bash
cp -r ../proj/production/housekeeper-bundles/ACC11434A4/ ../proj/stage/housekeeper-bundles/
cp -r ../proj/production/housekeeper-bundles/closefawn/ ../proj/stage/housekeeper-bundles/
```
- [x]  Restart the upload of a MIP-RNA case with multiple DNA samples linked to with `cg upload -f closefawn -r` 

### Expected test outcome

- [x] Expect a `RuntimeError` (see below)

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Deploy this branch on hasta production
- [ ] Inform to KSV
