### PR TITLE
fix(sample sheet) Added force flag to sample sheet creation

### DIFF
--- a/cg/apps/demultiplex/sample_sheet/create.py
+++ b/cg/apps/demultiplex/sample_sheet/create.py
@@ -11,7 +11,10 @@ LOG = logging.getLogger(__name__)
 
 
 def create_sample_sheet(
-    flow_cell: FlowCell, lims_samples: List[LimsFlowcellSample], bcl_converter: str
+    bcl_converter: str,
+    flow_cell: FlowCell,
+    lims_samples: List[LimsFlowcellSample],
+    force: bool = False,
 ) -> str:
     """Create a sample sheet for a flow cell."""
     if flow_cell.sample_sheet_path.exists():
@@ -27,9 +30,10 @@ def create_sample_sheet(
         raise FlowCellError(message=message)
 
     sample_sheet_creator = SampleSheetCreator(
+        bcl_converter=bcl_converter,
         flowcell_id=flow_cell.id,
         lims_samples=lims_samples,
         run_parameters=run_parameters,
-        bcl_converter=bcl_converter,
+        force=force,
     )
     return sample_sheet_creator.construct_sample_sheet()

--- a/cg/apps/demultiplex/sample_sheet/novaseq_sample_sheet.py
+++ b/cg/apps/demultiplex/sample_sheet/novaseq_sample_sheet.py
@@ -25,15 +25,17 @@ class SampleSheetCreator:
 
     def __init__(
         self,
+        bcl_converter: str,
         flowcell_id: str,
         lims_samples: List[LimsFlowcellSample],
         run_parameters: RunParameters,
-        bcl_converter: str,
+        force: bool = False,
     ):
+        self.bcl_converter = bcl_converter
         self.flowcell_id: str = flowcell_id
         self.lims_samples: List[LimsFlowcellSample] = lims_samples
         self.run_parameters: RunParameters = run_parameters
-        self.bcl_converter = bcl_converter
+        self.force = force
 
     @property
     def valid_indexes(self) -> List[Index]:
@@ -128,6 +130,9 @@ class SampleSheetCreator:
             expected_index_length=self.run_parameters.index_length,
         )
         sample_sheet: str = self.convert_to_sample_sheet()
+        if self.force:
+            LOG.info("Skipping validation of sample sheet due to force flag")
+            return sample_sheet
         LOG.info("Validating sample sheet")
         get_sample_sheet(
             sample_sheet=sample_sheet,

--- a/cg/cli/demultiplex/sample_sheet.py
+++ b/cg/cli/demultiplex/sample_sheet.py
@@ -52,8 +52,11 @@ def validate_sample_sheet(sheet: click.Path, bcl_converter: str):
 @click.argument("flow-cell-name")
 @OPTION_BCL_CONVERTER
 @click.option("--dry-run", is_flag=True)
+@click.option("--force", is_flag=True, help="Skips the validation of the sample sheet")
 @click.pass_obj
-def create_sheet(context: CGConfig, flow_cell_name: str, bcl_converter: str, dry_run: bool):
+def create_sheet(
+    context: CGConfig, flow_cell_name: str, bcl_converter: str, dry_run: bool, force: bool = False
+):
     """Command to create a sample sheet.
     flow-cell-name is the flow cell run directory name, e.g. '201203_A00689_0200_AHVKJCDRXX'
 
@@ -82,7 +85,7 @@ def create_sheet(context: CGConfig, flow_cell_name: str, bcl_converter: str, dry
         raise click.Abort
     try:
         sample_sheet: str = create_sample_sheet(
-            flow_cell=flow_cell, lims_samples=lims_samples, bcl_converter=bcl_converter
+            bcl_converter=bcl_converter, flow_cell=flow_cell, lims_samples=lims_samples, force=force
         )
     except (FileNotFoundError, FileExistsError) as error:
         raise click.Abort from error


### PR DESCRIPTION
## Description
For problematic flow cells that fail the sample sheet validation it can be useful to force it through and then manually edit it.
### Added

- Force flag to sample sheet creation which then skips the validation



### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b force-ss-creation -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
