### PR TITLE
fix(wrong return type from query caller)

### DIFF
--- a/cg/cli/compress/fastq.py
+++ b/cg/cli/compress/fastq.py
@@ -54,7 +54,8 @@ def fastq_cmd(
     store: Store = context.status_db
     cases: List[Family] = get_cases_to_process(case_id=case_id, days_back=days_back, store=store)
     if not cases:
-        return
+        LOG.info("No cases to compress")
+        return None
     compress_sample_fastqs_in_cases(
         compress_api=compress_api,
         cases=cases,

--- a/cg/store/api/status.py
+++ b/cg/store/api/status.py
@@ -255,7 +255,7 @@ class StatusHandler(BaseHandler):
         ]
         return apply_case_filter(
             functions=csse_filter_functions, cases=self._get_case_query(), date=date_threshold
-        )
+        ).all()
 
     def _get_sample_query(self) -> Query:
         """Return sample query."""

--- a/tests/cli/compress/test_cli_compress_fastq.py
+++ b/tests/cli/compress/test_cli_compress_fastq.py
@@ -84,7 +84,7 @@ def test_compress_fastq_cli_no_family(compress_context: CGConfig, cli_runner: Cl
     assert res.exit_code == 0
 
     # THEN assert it was communicated that no families where found
-    assert "individuals in 0 (completed) cases where compressed" in caplog.text
+    assert "No cases to compress" in caplog.text
 
 
 def test_compress_fastq_cli_case_id_no_family(


### PR DESCRIPTION
## Description

A query caller returned the actual query causing a None check to pass when it should not. This caused that a log message was produced that should have been reached.


### Changed

- Return of a query caller function to return the query object instead of the query

- Added a LOG input informing that there are no cases to compress in the scenario when there are no cases to compress

- Changed to test to pick up the newly added LOG input instead of the one that should not be reached.

### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b hotfix_query_bug -a
    ```

### How to test

- [x] Do `cg compress fastq` on 1) non-existing case and existing case

### Expected test outcome

- [x] Check that the log produces the expected outcome "no cases to compress"
- [x] Take a screenshot and attach or copy/paste the output.

## Review

- [x] Tests executed by @ChrOertlin 
- [x] "Merge and deploy" approved by @henrikstranneheim 
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan


- [x] Deploy this branch on production

