### PR TITLE
fix(inconsitent parameter usage)

### DIFF
--- a/cg/store/api/add.py
+++ b/cg/store/api/add.py
@@ -75,7 +75,7 @@ class AddHandler(BaseHandler):
     def add_application(
         self,
         tag: str,
-        category: str,
+        prep_category: str,
         description: str,
         percent_kth: int,
         percent_reads_guaranteed: int,
@@ -86,7 +86,7 @@ class AddHandler(BaseHandler):
 
         return self.Application(
             tag=tag,
-            prep_category=category,
+            prep_category=prep_category,
             description=description,
             is_accredited=is_accredited,
             percent_kth=percent_kth,

--- a/cg/store/api/import_func.py
+++ b/cg/store/api/import_func.py
@@ -179,7 +179,7 @@ def add_application_object(
     """Adds an application from a raw application record"""
     new_application: models.Application = store.add_application(
         tag=application.tag,
-        category=application.prep_category,
+        prep_category=application.prep_category,
         description=application.description,
         is_accredited=application.is_accredited == 1.0,
         turnaround_time=application.turnaround_time,

--- a/tests/cli/generate/report/conftest.py
+++ b/tests/cli/generate/report/conftest.py
@@ -23,7 +23,7 @@ def fixture_mip_dna_context(cg_context, helpers, case_id, real_housekeeper_api) 
     helpers.ensure_application_version(
         store=store,
         application_tag="WGSA",
-        application_type="wgs",
+        prep_category="wgs",
     )
     case = helpers.add_case(
         store=store,

--- a/tests/cli/workflow/balsamic/conftest.py
+++ b/tests/cli/workflow/balsamic/conftest.py
@@ -321,14 +321,10 @@ def fixture_balsamic_context(
     status_db: Store = cg_context.status_db
 
     # Create tgs application version
-    helpers.ensure_application_version(
-        store=status_db, application_tag="TGSA", application_type="tgs"
-    )
+    helpers.ensure_application_version(store=status_db, application_tag="TGSA", prep_category="tgs")
 
     # Create wes application version
-    helpers.ensure_application_version(
-        store=status_db, application_tag="WESA", application_type="wes"
-    )
+    helpers.ensure_application_version(store=status_db, application_tag="WESA", prep_category="wes")
 
     # Create textbook case for WGS PAIRED with enough reads
     case_wgs_paired_enough_reads = helpers.add_case(

--- a/tests/cli/workflow/mip/conftest.py
+++ b/tests/cli/workflow/mip/conftest.py
@@ -132,7 +132,7 @@ def fixture_mip_dna_context(
     mip_analysis_api = MipDNAAnalysisAPI(config=cg_context)
 
     # Add apptag to db
-    helpers.ensure_application_version(store=_store, application_tag="WGSA", application_type="wgs")
+    helpers.ensure_application_version(store=_store, application_tag="WGSA", prep_category="wgs")
 
     # Add sample, cases and relationships to db
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1147,7 +1147,7 @@ def fixture_base_store(
     applications = [
         store.add_application(
             tag="WGXCUSC000",
-            category="wgs",
+            prep_category="wgs",
             description="External WGS",
             sequencing_depth=0,
             is_external=True,
@@ -1157,7 +1157,7 @@ def fixture_base_store(
         ),
         store.add_application(
             tag="EXXCUSR000",
-            category="wes",
+            prep_category="wes",
             description="External WES",
             sequencing_depth=0,
             is_external=True,
@@ -1167,7 +1167,7 @@ def fixture_base_store(
         ),
         store.add_application(
             tag="WGSPCFC060",
-            category="wgs",
+            prep_category="wgs",
             description="WGS, double",
             sequencing_depth=30,
             accredited=True,
@@ -1177,7 +1177,7 @@ def fixture_base_store(
         ),
         store.add_application(
             tag="RMLP05R800",
-            category="rml",
+            prep_category="rml",
             description="Ready-made",
             sequencing_depth=0,
             percent_kth=80,
@@ -1186,7 +1186,7 @@ def fixture_base_store(
         ),
         store.add_application(
             tag="WGSPCFC030",
-            category="wgs",
+            prep_category="wgs",
             description="WGS trio",
             is_accredited=True,
             sequencing_depth=30,
@@ -1198,7 +1198,7 @@ def fixture_base_store(
         ),
         store.add_application(
             tag="METLIFR020",
-            category="wgs",
+            prep_category="wgs",
             description="Whole genome metagenomics",
             sequencing_depth=0,
             target_reads=400000,
@@ -1207,7 +1207,7 @@ def fixture_base_store(
         ),
         store.add_application(
             tag="METNXTR020",
-            category="wgs",
+            prep_category="wgs",
             description="Metagenomics",
             sequencing_depth=0,
             target_reads=200000,
@@ -1216,7 +1216,7 @@ def fixture_base_store(
         ),
         store.add_application(
             tag="MWRNXTR003",
-            category="mic",
+            prep_category="mic",
             description="Microbial whole genome ",
             sequencing_depth=0,
             percent_kth=80,
@@ -1225,7 +1225,7 @@ def fixture_base_store(
         ),
         store.add_application(
             tag=apptag_rna,
-            category="tgs",
+            prep_category="tgs",
             description="RNA seq, poly-A based priming",
             percent_kth=80,
             percent_reads_guaranteed=75,
@@ -1236,7 +1236,7 @@ def fixture_base_store(
         ),
         store.add_application(
             tag="VWGDPTR001",
-            category="cov",
+            prep_category="cov",
             description="Viral whole genome  ",
             sequencing_depth=0,
             percent_kth=80,

--- a/tests/store/api/conftest.py
+++ b/tests/store/api/conftest.py
@@ -193,7 +193,7 @@ def fixture_rml_pool_store(
 
     application = store.add_application(
         tag="RMLP05R800",
-        category="rml",
+        prep_category="rml",
         description="Ready-made",
         percent_kth=80,
         percent_reads_guaranteed=75,

--- a/tests/store/api/test_store_import_func.py
+++ b/tests/store/api/test_store_import_func.py
@@ -310,7 +310,7 @@ def test_sync_rml_orderform_inactivate(rml_store: Store, rml_orderform: str, hel
         store=rml_store,
         application_tag="apptag_to_inactivate",
         is_archived=False,
-        application_type=prep_category,
+        prep_category=prep_category,
     )
     active_apps_from_start = rml_store.applications(category=prep_category, archived=False).count()
     inactive_apps_from_start = rml_store.applications(category=prep_category, archived=True).count()

--- a/tests/store_helpers.py
+++ b/tests/store_helpers.py
@@ -53,7 +53,7 @@ class StoreHelpers:
     def ensure_application_version(
         store: Store,
         application_tag: str = "dummy_tag",
-        application_type: str = "wgs",
+        prep_category: str = "wgs",
         is_external: bool = False,
         is_rna: bool = False,
         description: str = None,
@@ -63,14 +63,14 @@ class StoreHelpers:
         """Utility function to return existing or create application version for tests."""
         if is_rna:
             application_tag = "rna_tag"
-            application_type = "wts"
+            prep_category = "wts"
 
         application = store.application(tag=application_tag)
         if not application:
             application = StoreHelpers.add_application(
                 store,
-                application_tag,
-                application_type,
+                application_tag=application_tag,
+                prep_category=prep_category,
                 is_external=is_external,
                 description=description,
                 is_accredited=is_accredited,
@@ -104,7 +104,7 @@ class StoreHelpers:
             application: models.Application = StoreHelpers.add_application(
                 store=store,
                 application_tag=tag,
-                application_type=application_type,
+                prep_category=application_type,
                 description=description,
                 is_archived=is_archived,
             )
@@ -114,7 +114,7 @@ class StoreHelpers:
     def add_application(
         store: Store,
         application_tag: str = "dummy_tag",
-        application_type: str = "wgs",
+        prep_category: str = "wgs",
         description: str = None,
         is_archived: bool = False,
         is_accredited: bool = False,
@@ -131,7 +131,7 @@ class StoreHelpers:
             description = "dummy_description"
         application = store.add_application(
             tag=application_tag,
-            category=application_type,
+            prep_category=prep_category,
             description=description,
             is_archived=is_archived,
             percent_kth=80,
@@ -258,7 +258,7 @@ class StoreHelpers:
         application_version = StoreHelpers.ensure_application_version(
             store=store,
             application_tag=application_tag,
-            application_type=application_type,
+            prep_category=application_type,
             is_external=is_external,
             is_rna=is_rna,
         )
@@ -684,7 +684,7 @@ class StoreHelpers:
         application_version = StoreHelpers.ensure_application_version(
             store=store,
             application_tag=application_tag,
-            application_type=application_type,
+            prep_category=application_type,
             is_external=is_external,
             is_rna=is_rna,
         )


### PR DESCRIPTION
## Description

A parameter "prep_category" of the Application model was inconsistently called: category, prep_category and application_type. 

This PR changes the code to consistently refer to the parameter as prep_category

This will make testing less confusing.

### Changed

- Parameter naming

### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
