### PR TITLE
(Delivery) Handle error when hard link for file already exists

### DIFF
--- a/cg/exc.py
+++ b/cg/exc.py
@@ -251,3 +251,7 @@ class LoqusdbDuplicateRecordError(LoqusdbError):
 
 class PdcNoFilesMatchingSearchError(CgError):
     """Exception raised when PDC API returns no files matching the search criteria."""
+
+
+class MissingFilesError(CgError):
+    """Exception raised when there are missing files."""

--- a/cg/meta/deliver.py
+++ b/cg/meta/deliver.py
@@ -175,7 +175,7 @@ class DeliverAPI:
         if not self.dry_run:
             delivery_base.mkdir(parents=True, exist_ok=True)
         file_path: Path
-        number_linked_files: int = 0
+        number_reviewed_files: int = 0
         for file_path in self.get_sample_files_from_version(
             version_obj=version_obj, sample_id=sample_id
         ):
@@ -186,18 +186,21 @@ class DeliverAPI:
             out_path: Path = delivery_base / file_name
             if self.dry_run:
                 LOG.info(f"Would hard link file {file_path} to {out_path}")
-                number_linked_files += 1
+                number_reviewed_files += 1
                 continue
             LOG.info(f"Hard link file {file_path} to {out_path}")
             try:
                 os.link(file_path, out_path)
-                number_linked_files += 1
+                number_reviewed_files += 1
             except FileExistsError:
-                LOG.info(f"Path {out_path} exists, skipping")
-        if number_linked_files == 0:
+                LOG.info(
+                    f"Warning: Path {out_path} exists, no hard link was made for file {file_name}"
+                )
+                number_reviewed_files += 1
+        if number_reviewed_files == 0:
             raise DeliveryReportError(f"No files were linked for sample {sample_name}")
 
-        LOG.info(f"Linked {number_linked_files} files for sample {sample_id}, case {case_id}")
+        LOG.info(f"Linked {number_reviewed_files} files for sample {sample_id}, case {case_id}")
 
     def get_case_files_from_version(
         self, version_obj: hk_models.Version, sample_ids: Set[str]

--- a/cg/meta/deliver.py
+++ b/cg/meta/deliver.py
@@ -10,7 +10,7 @@ from housekeeper.store import models as hk_models
 from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.constants import delivery as constants
 from cg.constants.constants import DataDelivery
-from cg.exc import DeliveryReportError
+from cg.exc import MissingFilesError
 from cg.store import Store
 from cg.store.models import Family, FamilySample, Sample
 
@@ -198,7 +198,7 @@ class DeliverAPI:
                 )
                 number_reviewed_files += 1
         if number_reviewed_files == 0:
-            raise DeliveryReportError(f"No files were linked for sample {sample_name}")
+            raise MissingFilesError(f"No files were linked for sample {sample_name}")
 
         LOG.info(f"Linked {number_reviewed_files} files for sample {sample_id}, case {case_id}")
 

--- a/cg/meta/deliver.py
+++ b/cg/meta/deliver.py
@@ -175,7 +175,7 @@ class DeliverAPI:
         if not self.dry_run:
             delivery_base.mkdir(parents=True, exist_ok=True)
         file_path: Path
-        number_currently_linked_files: int = 0
+        number_linked_files_now: int = 0
         number_previously_linked_files: int = 0
         for file_path in self.get_sample_files_from_version(
             version_obj=version_obj, sample_id=sample_id
@@ -187,22 +187,22 @@ class DeliverAPI:
             out_path: Path = delivery_base / file_name
             if self.dry_run:
                 LOG.info(f"Would hard link file {file_path} to {out_path}")
-                number_currently_linked_files += 1
+                number_linked_files_now += 1
                 continue
             LOG.info(f"Hard link file {file_path} to {out_path}")
             try:
                 os.link(file_path, out_path)
-                number_currently_linked_files += 1
+                number_linked_files_now += 1
             except FileExistsError:
                 LOG.info(
                     f"Warning: Path {out_path} exists, no hard link was made for file {file_name}"
                 )
                 number_previously_linked_files += 1
-        if number_previously_linked_files == 0 and number_currently_linked_files == 0:
+        if number_previously_linked_files == 0 and number_linked_files_now == 0:
             raise MissingFilesError(f"No files were linked for sample {sample_name}")
 
         LOG.info(
-            f"There were {number_previously_linked_files} previously linked files and {number_currently_linked_files} were linked for sample {sample_id}, case {case_id}"
+            f"There were {number_previously_linked_files} previously linked files and {number_linked_files_now} were linked for sample {sample_id}, case {case_id}"
         )
 
     def get_case_files_from_version(


### PR DESCRIPTION
## Description

`cg deliver` raises an error if files are already linked for a case.

### Added

- Counter variable `number_previously_linked_files`.

### Changed

- The error type when no files are found to `MissingFilesError`.
- The name of the counter `number_linked_files` to `number_linked_files_now`.
- When the file already exists, increase the counter `number_previously_linked_files` by one after warning the user.
- The guard checks if both `number_previously_linked_files`. and `number_linked_files_now` is zero.


### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b delivery-patch -a
    ```

### How to test

- [x] run `cg deliver analysis -d fastq -c busyhorse` 

### Expected test outcome

- [x] Raise warnings about the existence of the files, state that no new files were linked but finish without raising errors
(See output below)

## Review

- [x] Tests executed by SD
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Deploy this branch on 
  - [ ] Stage
  - [ ] Production
