### PR TITLE
(fix) Breaking change in Housekeeper package

### DIFF
--- a/cg/apps/housekeeper/hk.py
+++ b/cg/apps/housekeeper/hk.py
@@ -103,13 +103,13 @@ class HousekeeperAPI:
         if isinstance(tags, str):
             tags: List[str] = [tags]
         for tag_name in tags:
-            if not self.tag(tag_name):
+            if not self.get_tag(tag_name):
                 self.add_tag(tag_name)
 
         new_file: File = self.new_file(
             path=str(Path(path).absolute()),
             to_archive=to_archive,
-            tags=[self.tag(tag_name) for tag_name in tags],
+            tags=[self.get_tag(tag_name) for tag_name in tags],
         )
 
         new_file.version: Version = version_obj
@@ -260,7 +260,7 @@ class HousekeeperAPI:
         self.add_commit(tag_obj)
         return tag_obj
 
-    def tag(self, name: str) -> models.Tag:
+    def get_tag(self, name: str) -> models.Tag:
         """Fetch a tag."""
         return self._store.get_tag(name)
 

--- a/cg/apps/housekeeper/hk.py
+++ b/cg/apps/housekeeper/hk.py
@@ -262,7 +262,7 @@ class HousekeeperAPI:
 
     def tag(self, name: str) -> models.Tag:
         """Fetch a tag."""
-        return self._store.tag(name)
+        return self._store.get_tag(name)
 
     @staticmethod
     def get_tag_names_from_file(file: File) -> List[str]:

--- a/cg/meta/transfer/flowcell.py
+++ b/cg/meta/transfer/flowcell.py
@@ -81,7 +81,7 @@ class TransferFlowCell:
     def _add_tags_to_housekeeper(self, store: bool, tags: List[str]) -> None:
         """Add and commit tag(s) to Housekeeper if not already exists in database."""
         for tag in tags:
-            if store and self.hk.tag(name=tag) is None:
+            if store and self.hk.get_tag(name=tag) is None:
                 self.hk.add_commit(self.hk.new_tag(tag))
 
     def _parse_flow_cell_samples(

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,4 +46,4 @@ wtforms<3.0.0          # wtforms.compat missing in 3.0.0
 
 # apps
 genologics
-housekeeper>=2.5
+housekeeper>3.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,4 +46,4 @@ wtforms<3.0.0          # wtforms.compat missing in 3.0.0
 
 # apps
 genologics
-housekeeper>3.2.1
+housekeeper

--- a/tests/apps/hk/test_add_file.py
+++ b/tests/apps/hk/test_add_file.py
@@ -15,11 +15,11 @@ def test_add_file_with_flat_tag(
 ):
     """Test that we can call hk with one existing tag."""
 
-    # GIVEN an hk api populated with a version obj
+    # GIVEN a hk api populated with a version obj
     version_obj = helpers.ensure_hk_version(housekeeper_api, hk_bundle_data)
 
     # GIVEN a tag that is just a string that exists
-    assert housekeeper_api.tag(hk_tag)
+    assert housekeeper_api.get_tag(hk_tag)
 
     # WHEN we call add_file
     new_file = housekeeper_api.add_file(fastq_file, version_obj, hk_tag)
@@ -37,13 +37,13 @@ def test_add_file_with_list_of_tags(
 ):
     """Test that we can call Housekeeper with more than one tag."""
 
-    # GIVEN an hk api populated with a version obj
+    # GIVEN a hk api populated with a version obj
     version_obj = helpers.ensure_hk_version(housekeeper_api, hk_bundle_data)
 
     # GIVEN a list of tags that does not exist
     tags = [not_existing_hk_tag, not_existing_hk_tag + "_2"]
     for tag_name in tags:
-        assert housekeeper_api.tag(tag_name) is None
+        assert housekeeper_api.get_tag(tag_name) is None
 
     # WHEN we call add_file
     new_file = housekeeper_api.add_file(fastq_file, version_obj, tags)

--- a/tests/apps/hk/test_file.py
+++ b/tests/apps/hk/test_file.py
@@ -63,7 +63,7 @@ def test_add_new_file(
     assert madeline_output.exists() is True
 
     # GIVEN a tag that does not exist
-    assert populated_housekeeper_api.tag(name=not_existing_hk_tag) is None
+    assert populated_housekeeper_api.get_tag(name=not_existing_hk_tag) is None
 
     # GIVEN a known number of files in the db
     nr_files_in_db = small_helpers.length_of_iterable(populated_housekeeper_api.files())

--- a/tests/meta/transfer/test_meta_transfer_flowcell.py
+++ b/tests/meta/transfer/test_meta_transfer_flowcell.py
@@ -25,7 +25,7 @@ def test_add_tags_to_housekeeper(
     # GIVEN transfer flow cell API
 
     # GIVEN no flow cell id tag in Housekeeper
-    assert transfer_flow_cell_api.hk.tag(name=flow_cell_id) is None
+    assert transfer_flow_cell_api.hk.get_tag(name=flow_cell_id) is None
 
     # WHEN adding tags to Housekeeper
     transfer_flow_cell_api._add_tags_to_housekeeper(
@@ -33,7 +33,7 @@ def test_add_tags_to_housekeeper(
     )
 
     # THEN tha tags should be added
-    assert transfer_flow_cell_api.hk.tag(name=flow_cell_id) is not None
+    assert transfer_flow_cell_api.hk.get_tag(name=flow_cell_id) is not None
 
 
 def test_add_flow_cell_to_status_db(

--- a/tests/mocks/hk_mock.py
+++ b/tests/mocks/hk_mock.py
@@ -266,14 +266,14 @@ class MockHousekeeperAPI:
         tags = {}
         for tag_name in tag_names:
             if self.tag_exists(tag_name):
-                tag_obj = self.tag(tag_name)
+                tag_obj = self.get_tag(tag_name)
             else:
                 tag_obj = self.new_tag(tag_name)
                 self._tags.append(tag_obj)
             tags[tag_name] = tag_obj
         return tags
 
-    def tag(self, name: str):
+    def get_tag(self, name: str):
         """Fetch a tag"""
         for tag_obj in self._tags:
             if tag_obj.name == name:
@@ -443,13 +443,13 @@ class MockHousekeeperAPI:
         if isinstance(tags, str):
             tags = [tags]
         for tag_name in tags:
-            if not self.tag(tag_name):
+            if not self.get_tag(tag_name):
                 self.add_tag(tag_name)
 
         new_file = self.new_file(
             path=str(Path(path).absolute()),
             to_archive=to_archive,
-            tags=[self.tag(tag_name) for tag_name in tags],
+            tags=[self.get_tag(tag_name) for tag_name in tags],
         )
         if not version_obj:
             version_obj = self.new_version(created_at=datetime.datetime.now())


### PR DESCRIPTION
## Description
Crontabs failed to upload a case because the function `tag` in housekeeper was renamed to `get_tag`.

### Changed

- The reference to the function `store.tag` now points to `store.get_tag`.

### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b tag-patch -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ x ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
