### PR TITLE
Handle when version is None

### DIFF
--- a/tests/meta/deliver/test_delivery_api.py
+++ b/tests/meta/deliver/test_delivery_api.py
@@ -46,8 +46,8 @@ def test_get_case_analysis_files(populated_deliver_api: DeliverAPI, case_id: str
     """Test to fetch case specific files for a case that exists in housekeeper."""
     deliver_api: DeliverAPI = populated_deliver_api
     # GIVEN a case which exist as bundle in hk with a version
-    version_obj = deliver_api.hk_api.last_version(case_id)
-    assert version_obj
+    version = deliver_api.hk_api.last_version(case_id)
+    assert version
 
     # GIVEN that a case object exists in the database
     link_objs: List[FamilySample] = deliver_api.store.family_samples(case_id)
@@ -56,7 +56,7 @@ def test_get_case_analysis_files(populated_deliver_api: DeliverAPI, case_id: str
 
     # WHEN fetching all case files from the delivery api
     bundle_latest_files = deliver_api.get_case_files_from_version(
-        version_obj=version_obj, sample_ids=sample_ids
+        version=version, sample_ids=sample_ids
     )
 
     # THEN housekeeper files should be returned
@@ -94,8 +94,8 @@ def test_get_case_files_from_version(
     helpers.ensure_hk_bundle(real_housekeeper_api, bundle_data=case_hk_bundle_no_files)
 
     # GIVEN a version object where two file exists
-    version_obj: hk_models.Version = real_housekeeper_api.last_version(case_id)
-    assert len(version_obj.files) == 2
+    version: hk_models.Version = real_housekeeper_api.last_version(case_id)
+    assert len(version.files) == 2
 
     # GIVEN the sample ids of the samples
     link_objs: List[FamilySample] = analysis_store.family_samples(case_id)
@@ -104,7 +104,7 @@ def test_get_case_files_from_version(
 
     # WHEN fetching the case files
     case_files = deliver_api.get_case_files_from_version(
-        version_obj=version_obj, sample_ids=sample_ids
+        version=version, sample_ids=sample_ids
     )
 
     # THEN we should only get the case specific files back
@@ -138,12 +138,12 @@ def test_get_sample_files_from_version(
     ]
     helpers.ensure_hk_bundle(hk_api, bundle_data=case_hk_bundle_no_files)
     # GIVEN a version object with some files
-    version_obj: hk_models.Version = hk_api.last_version(case_id)
-    assert len(version_obj.files) == 2
+    version: hk_models.Version = hk_api.last_version(case_id)
+    assert len(version.files) == 2
 
     # WHEN fetching the sample specific files
     sample_files = deliver_api.get_sample_files_from_version(
-        version_obj=version_obj, sample_id="ADM1"
+        version_obj=version, sample_id="ADM1"
     )
 
     # THEN assert that only the sample specific file was returned


### PR DESCRIPTION
## Description
https://github.com/Clinical-Genomics/cg/issues/1808

### Fixed
- Handle when the get_case_files_from_version function is called with None.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

### This [version](https://semver.org/) is a
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

