### PR TITLE
Remove unused imports

### DIFF
--- a/cg/apps/cgstats/db/models/project.py
+++ b/cg/apps/cgstats/db/models/project.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from sqlalchemy import Column, ForeignKey, UniqueConstraint, orm, types
+from sqlalchemy import Column, orm, types
 from sqlalchemy.orm.exc import NoResultFound
 
 from .base import Model

--- a/cg/apps/gens.py
+++ b/cg/apps/gens.py
@@ -3,9 +3,6 @@
 import logging
 from typing import Dict, List
 
-from cg.constants.constants import FileFormat
-from cg.exc import CaseNotFoundError
-from cg.io.controller import ReadStream
 from cg.utils import Process
 from cg.utils.dict import get_list_from_dictionary
 

--- a/cg/apps/gens.py
+++ b/cg/apps/gens.py
@@ -1,9 +1,7 @@
 """Module for Gens API."""
 
 import logging
-from pathlib import Path
-from subprocess import CalledProcessError
-from typing import Optional, Dict, List
+from typing import Dict, List
 
 from cg.constants.constants import FileFormat
 from cg.exc import CaseNotFoundError

--- a/cg/apps/housekeeper/hk.py
+++ b/cg/apps/housekeeper/hk.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import Iterable, List, Optional, Set, Tuple, Dict
 
 from alchy import Query
-from housekeeper.exc import VersionIncludedError
 from housekeeper.include import checksum as hk_checksum
 from housekeeper.include import include_version
 from housekeeper.store import Store, models

--- a/cg/apps/lims/batch.py
+++ b/cg/apps/lims/batch.py
@@ -1,8 +1,7 @@
 from functools import partial
 from typing import Any, Dict, List
 
-from genologics.entities import Artifact, Container, Containertype, Project, Researcher
-from lxml import etree
+from genologics.entities import Artifact, Container, Containertype, Project
 from lxml.objectify import ElementMaker, ObjectifiedElement
 
 SMP_MAKER = ElementMaker(

--- a/cg/apps/tb/api.py
+++ b/cg/apps/tb/api.py
@@ -4,7 +4,6 @@ import datetime as dt
 import logging
 from typing import Any, Optional
 
-import requests
 from google.auth import jwt
 from google.auth.crypt import RSASigner
 

--- a/cg/cli/add.py
+++ b/cg/cli/add.py
@@ -27,6 +27,7 @@ LOG = logging.getLogger(__name__)
 @click.group()
 def add():
     """Add new things to the database."""
+    pass
 
 
 @add.command()

--- a/cg/cli/add.py
+++ b/cg/cli/add.py
@@ -27,7 +27,6 @@ LOG = logging.getLogger(__name__)
 @click.group()
 def add():
     """Add new things to the database."""
-    pass
 
 
 @add.command()

--- a/cg/cli/backup.py
+++ b/cg/cli/backup.py
@@ -24,7 +24,6 @@ LOG = logging.getLogger(__name__)
 @click.pass_obj
 def backup(context: CGConfig):
     """Backup utilities"""
-    pass
 
 
 @backup.command("fetch-flow-cell")

--- a/cg/cli/backup.py
+++ b/cg/cli/backup.py
@@ -24,6 +24,7 @@ LOG = logging.getLogger(__name__)
 @click.pass_obj
 def backup(context: CGConfig):
     """Backup utilities"""
+    pass
 
 
 @backup.command("fetch-flow-cell")

--- a/cg/cli/compress/helpers.py
+++ b/cg/cli/compress/helpers.py
@@ -16,7 +16,7 @@ from cg.exc import CaseNotFoundError
 from cg.meta.compress import CompressAPI
 from cg.meta.compress.files import get_spring_paths
 from cg.store import Store
-from cg.store.models import Family, Sample
+from cg.store.models import Family
 
 LOG = logging.getLogger(__name__)
 

--- a/cg/cli/import_cmd.py
+++ b/cg/cli/import_cmd.py
@@ -18,6 +18,7 @@ LOG = logging.getLogger(__name__)
 @click.group("import")
 def import_cmd():
     """Import information into the database."""
+    pass
 
 
 @import_cmd.command("application")

--- a/cg/cli/import_cmd.py
+++ b/cg/cli/import_cmd.py
@@ -18,7 +18,6 @@ LOG = logging.getLogger(__name__)
 @click.group("import")
 def import_cmd():
     """Import information into the database."""
-    pass
 
 
 @import_cmd.command("application")

--- a/cg/cli/set/base.py
+++ b/cg/cli/set/base.py
@@ -43,7 +43,6 @@ LOG = logging.getLogger(__name__)
 @click.group("set")
 def set_cmd():
     """Update information in the database."""
-    pass
 
 
 @set_cmd.command()

--- a/cg/cli/set/base.py
+++ b/cg/cli/set/base.py
@@ -43,6 +43,7 @@ LOG = logging.getLogger(__name__)
 @click.group("set")
 def set_cmd():
     """Update information in the database."""
+    pass
 
 
 @set_cmd.command()

--- a/cg/cli/status.py
+++ b/cg/cli/status.py
@@ -53,6 +53,7 @@ for header in CASE_HEADERS_LONG:
 @click.group()
 def status():
     """View status of things."""
+    pass
 
 
 @status.command()

--- a/cg/cli/status.py
+++ b/cg/cli/status.py
@@ -4,7 +4,7 @@ import click
 from cg.constants import CASE_ACTIONS, Pipeline
 from cg.models.cg_config import CGConfig
 from cg.store import Store
-from cg.store.models import Family, Sample, Customer, ApplicationVersion, Analysis
+from cg.store.models import Family, Sample
 from ansi.colour import fg
 from ansi.colour.fx import reset
 from tabulate import tabulate
@@ -53,7 +53,6 @@ for header in CASE_HEADERS_LONG:
 @click.group()
 def status():
     """View status of things."""
-    pass
 
 
 @status.command()

--- a/cg/cli/status.py
+++ b/cg/cli/status.py
@@ -1,4 +1,4 @@
-from typing import Iterable, List
+from typing import List
 
 import click
 from cg.constants import CASE_ACTIONS, Pipeline
@@ -53,7 +53,6 @@ for header in CASE_HEADERS_LONG:
 @click.group()
 def status():
     """View status of things."""
-    pass
 
 
 @status.command()

--- a/cg/cli/upload/base.py
+++ b/cg/cli/upload/base.py
@@ -2,7 +2,7 @@
 import logging
 import sys
 import traceback
-from typing import Dict, Optional
+from typing import Optional
 
 import click
 

--- a/cg/cli/upload/coverage.py
+++ b/cg/cli/upload/coverage.py
@@ -2,7 +2,6 @@
 
 import click
 from cg.meta.upload.coverage import UploadCoverageApi
-from cg.meta.workflow.mip_dna import MipDNAAnalysisAPI
 from cg.models.cg_config import CGConfig
 from cg.store import Store
 from cg.store.models import Family

--- a/cg/cli/upload/gens.py
+++ b/cg/cli/upload/gens.py
@@ -9,8 +9,8 @@ from cg.constants.gene_panel import GENOME_BUILD_37
 from cg.constants.housekeeper_tags import GensAnalysisTag
 from cg.models.cg_config import CGConfig
 from cg.store import Store
-from cg.store.models import Family, Sample
-from housekeeper.store.models import File, Version
+from cg.store.models import Family
+from housekeeper.store.models import File
 
 from cg.cli.upload.utils import suggest_cases_to_upload
 from cg.cli.workflow.commands import (

--- a/cg/cli/upload/nipt/base.py
+++ b/cg/cli/upload/nipt/base.py
@@ -20,7 +20,6 @@ LOG = logging.getLogger(__name__)
 @click.group()
 def nipt():
     """Upload NIPT result files"""
-    pass
 
 
 @nipt.command("case")

--- a/cg/cli/upload/nipt/base.py
+++ b/cg/cli/upload/nipt/base.py
@@ -20,6 +20,7 @@ LOG = logging.getLogger(__name__)
 @click.group()
 def nipt():
     """Upload NIPT result files"""
+    pass
 
 
 @nipt.command("case")

--- a/cg/cli/upload/nipt/ftp.py
+++ b/cg/cli/upload/nipt/ftp.py
@@ -14,6 +14,7 @@ LOG = logging.getLogger(__name__)
 @click.group()
 def ftp():
     """Upload NIPT result files to ftp-server"""
+    pass
 
 
 @ftp.command("case")

--- a/cg/cli/upload/nipt/ftp.py
+++ b/cg/cli/upload/nipt/ftp.py
@@ -14,7 +14,6 @@ LOG = logging.getLogger(__name__)
 @click.group()
 def ftp():
     """Upload NIPT result files to ftp-server"""
-    pass
 
 
 @ftp.command("case")

--- a/cg/cli/upload/nipt/statina.py
+++ b/cg/cli/upload/nipt/statina.py
@@ -14,7 +14,6 @@ LOG = logging.getLogger(__name__)
 @click.group()
 def statina():
     """Upload NIPT result files to Statina"""
-    pass
 
 
 @statina.command("case")

--- a/cg/cli/upload/nipt/statina.py
+++ b/cg/cli/upload/nipt/statina.py
@@ -14,6 +14,7 @@ LOG = logging.getLogger(__name__)
 @click.group()
 def statina():
     """Upload NIPT result files to Statina"""
+    pass
 
 
 @statina.command("case")

--- a/cg/cli/upload/utils.py
+++ b/cg/cli/upload/utils.py
@@ -1,7 +1,6 @@
 """Utility functions for the upload cli commands."""
 
 import logging
-from pathlib import Path
 from typing import Optional
 
 import click

--- a/cg/cli/upload/utils.py
+++ b/cg/cli/upload/utils.py
@@ -8,7 +8,6 @@ import click
 from cg.constants import Pipeline
 from cg.constants.constants import MAX_ITEMS_TO_RETRIEVE
 from cg.store import Store
-from cg.store.models import Family
 
 LOG = logging.getLogger(__name__)
 

--- a/cg/cli/workflow/commands.py
+++ b/cg/cli/workflow/commands.py
@@ -7,7 +7,6 @@ import shutil
 
 from pathlib import Path
 
-from cgmodels.cg.constants import Pipeline
 
 from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.constants import EXIT_FAIL, EXIT_SUCCESS

--- a/cg/cli/workflow/fluffy/base.py
+++ b/cg/cli/workflow/fluffy/base.py
@@ -2,7 +2,7 @@ import logging
 
 import click
 from cg.cli.workflow.commands import link, resolve_compression, store, store_available
-from cg.constants import EXIT_FAIL, EXIT_SUCCESS, Pipeline
+from cg.constants import EXIT_FAIL, EXIT_SUCCESS
 from cg.exc import CgError, DecompressionNeededError
 from cg.meta.workflow.fluffy import FluffyAnalysisAPI
 from cg.models.cg_config import CGConfig

--- a/cg/cli/workflow/rnafusion/base.py
+++ b/cg/cli/workflow/rnafusion/base.py
@@ -6,7 +6,7 @@ import click
 from pydantic import ValidationError
 
 from cg.apps.housekeeper.hk import HousekeeperAPI
-from cg.cli.workflow.commands import ARGUMENT_CASE_ID, link, resolve_compression
+from cg.cli.workflow.commands import ARGUMENT_CASE_ID, resolve_compression
 from cg.cli.workflow.nextflow.options import (
     OPTION_CONFIG,
     OPTION_LOG,

--- a/cg/constants/constants.py
+++ b/cg/constants/constants.py
@@ -1,5 +1,4 @@
 """Constants for cg."""
-from enum import Enum
 
 import click
 from cgmodels.cg.constants import StrEnum

--- a/cg/constants/housekeeper_tags.py
+++ b/cg/constants/housekeeper_tags.py
@@ -1,5 +1,4 @@
 """File tags for files in Housekeeper."""
-from enum import Enum
 from typing import List
 
 from cgmodels.cg.constants import Pipeline, StrEnum

--- a/cg/constants/rnafusion.py
+++ b/cg/constants/rnafusion.py
@@ -1,6 +1,5 @@
 """RNAfusion related constants."""
 
-from cgmodels.cg.constants import StrEnum
 
 from cg.constants.nextflow import NFX_SAMPLESHEET_HEADERS
 

--- a/cg/meta/encryption/encryption.py
+++ b/cg/meta/encryption/encryption.py
@@ -1,5 +1,4 @@
 """API for encryption on Hasta"""
-import hashlib
 import logging
 import subprocess
 from io import TextIOWrapper

--- a/cg/meta/encryption/encryption.py
+++ b/cg/meta/encryption/encryption.py
@@ -8,7 +8,6 @@ from typing import List
 
 from cg.constants import FileExtensions
 from cg.constants.encryption import GPGParameters
-from cg.constants.extraction import FlowCellExtractionParameters
 from cg.exc import ChecksumFailedError
 from cg.utils import Process
 from cg.utils.checksum.checksum import sha512_checksum

--- a/cg/meta/orders/microbial_submitter.py
+++ b/cg/meta/orders/microbial_submitter.py
@@ -4,7 +4,6 @@ from typing import List
 from cgmodels.cg.constants import Pipeline
 
 from cg.constants import DataDelivery
-from cg.exc import OrderError
 from cg.meta.orders.lims import process_lims
 from cg.meta.orders.submitter import Submitter
 from cg.models.orders.order import OrderIn

--- a/cg/meta/transfer/flowcell.py
+++ b/cg/meta/transfer/flowcell.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import List, Optional
 
-from housekeeper.store.models import Bundle, Version, Tag, File
+from housekeeper.store.models import Bundle, Version
 from cg.apps.cgstats.stats import StatsAPI
 from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.constants import FlowCellStatus

--- a/cg/meta/transfer/flowcell.py
+++ b/cg/meta/transfer/flowcell.py
@@ -3,7 +3,7 @@
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import List, Dict, Optional
+from typing import List, Optional
 
 from housekeeper.store.models import Bundle, Version, Tag, File
 from cg.apps.cgstats.stats import StatsAPI

--- a/cg/meta/upload/gisaid/models.py
+++ b/cg/meta/upload/gisaid/models.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Optional
 from pydantic import BaseModel, validator
-from datetime import date, datetime
+from datetime import datetime
 
 from cg.meta.upload.gisaid.constants import AUTHORS
 

--- a/cg/meta/upload/mip/mip_dna.py
+++ b/cg/meta/upload/mip/mip_dna.py
@@ -5,7 +5,6 @@ import logging
 
 import click
 
-from cg.apps.tb import TrailblazerAPI
 from cg.cli.generate.report.base import delivery_report
 from cg.cli.upload.clinical_delivery import clinical_delivery
 from cg.cli.upload.coverage import coverage

--- a/cg/meta/upload/nipt/models.py
+++ b/cg/meta/upload/nipt/models.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from typing import Optional
 from pydantic import BaseModel
 

--- a/cg/meta/upload/scout/uploadscoutapi.py
+++ b/cg/meta/upload/scout/uploadscoutapi.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import Dict, List, Optional, Set
 
 from housekeeper.store.models import File, Version
-from sqlalchemy.orm import Query
 
 from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.apps.lims import LimsAPI

--- a/cg/meta/upload/scout/uploadscoutapi.py
+++ b/cg/meta/upload/scout/uploadscoutapi.py
@@ -2,7 +2,7 @@
 
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set
+from typing import Dict, List, Optional, Set
 
 from housekeeper.store.models import File, Version
 from sqlalchemy.orm import Query

--- a/cg/meta/workflow/fastq.py
+++ b/cg/meta/workflow/fastq.py
@@ -14,7 +14,6 @@ import shutil
 from pathlib import Path
 from typing import List, Optional
 
-from pydantic.main import BaseModel
 
 LOG = logging.getLogger(__name__)
 

--- a/cg/meta/workflow/microsalt.py
+++ b/cg/meta/workflow/microsalt.py
@@ -9,9 +9,8 @@ import logging
 import os
 import re
 import shutil
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
-from subprocess import CalledProcessError
 from typing import Any, Dict, List, Optional, Tuple, Union
 import glob
 

--- a/cg/meta/workflow/microsalt.py
+++ b/cg/meta/workflow/microsalt.py
@@ -18,7 +18,7 @@ import click
 from cg.constants import Pipeline
 from cg.constants.constants import MicrosaltQC, MicrosaltAppTags
 from cg.constants.tb import AnalysisStatus
-from cg.exc import CgDataError, CgError
+from cg.exc import CgDataError
 from cg.meta.workflow.analysis import AnalysisAPI
 from cg.meta.workflow.fastq import MicrosaltFastqHandler
 from cg.models.cg_config import CGConfig
@@ -26,7 +26,7 @@ from cg.models.orders.sample_base import ControlEnum
 from cg.store.models import Family, Sample
 from cg.utils import Process
 from cg.constants import EXIT_FAIL, EXIT_SUCCESS
-from cg.io.json import read_json, write_json_stream, write_json
+from cg.io.json import read_json, write_json
 
 from cg.constants import Priority
 

--- a/cg/meta/workflow/mip.py
+++ b/cg/meta/workflow/mip.py
@@ -1,7 +1,7 @@
 import logging
 
 from pathlib import Path
-from typing import Any, List, Optional, Type, Dict, Union
+from typing import Any, List, Optional, Dict, Union
 
 from pydantic import ValidationError
 

--- a/cg/models/cgstats/stats_sample.py
+++ b/cg/models/cgstats/stats_sample.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Set
+from typing import List, Set
 
 from pydantic import BaseModel, Field, validator
 

--- a/cg/models/email.py
+++ b/cg/models/email.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from typing import Optional
 
-from pydantic import EmailStr
 
 from cg.models.cg_config import EmailBaseSettings
 

--- a/cg/models/invoice/invoice.py
+++ b/cg/models/invoice/invoice.py
@@ -1,7 +1,7 @@
 """Module for defining invoice models."""
 from pydantic import BaseModel
 from typing import List, Optional, Any
-from cg.constants.priority import PriorityTerms, Priority
+from cg.constants.priority import PriorityTerms
 from cg.constants.sequencing import RecordType
 
 

--- a/cg/models/lims/sample.py
+++ b/cg/models/lims/sample.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import Optional
 
 from pydantic import BaseModel, validator

--- a/cg/models/orders/sample_base.py
+++ b/cg/models/orders/sample_base.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import List, Optional
 
 from cg.constants import DataDelivery, Pipeline
-from pydantic import BaseModel, constr, NonNegativeInt, validator
+from pydantic import BaseModel, constr, validator
 
 from cg.store.models import Application, Family, Customer, Pool, Sample
 

--- a/cg/server/invoices/views.py
+++ b/cg/server/invoices/views.py
@@ -214,6 +214,5 @@ def modified_invoice(invoice_id, cost_center):
             file_object.write(invoice_obj.excel_kth)
         elif cost_center == "KI":
             file_object.write(invoice_obj.excel_ki)
-        pass
 
     return send_from_directory(directory=temp_dir, filename=file_name, as_attachment=True)

--- a/cg/server/invoices/views.py
+++ b/cg/server/invoices/views.py
@@ -21,7 +21,7 @@ from cg.apps.invoice.render import render_xlsx
 from cg.meta.invoice import InvoiceAPI
 from cg.server.ext import db, lims
 from typing import List, Union
-from cg.store.models import Customer, Invoice, Pool, Sample, User
+from cg.store.models import Customer, Invoice, Pool, Sample
 
 
 BLUEPRINT = Blueprint("invoices", __name__, template_folder="templates")

--- a/cg/server/invoices/views.py
+++ b/cg/server/invoices/views.py
@@ -214,5 +214,4 @@ def modified_invoice(invoice_id, cost_center):
             file_object.write(invoice_obj.excel_kth)
         elif cost_center == "KI":
             file_object.write(invoice_obj.excel_ki)
-
     return send_from_directory(directory=temp_dir, filename=file_name, as_attachment=True)

--- a/cg/store/api/base.py
+++ b/cg/store/api/base.py
@@ -1,5 +1,5 @@
 """All models aggregated in a base class"""
-from typing import Any, Type
+from typing import Type
 
 from alchy import Query, ModelBase
 from dataclasses import dataclass

--- a/cg/store/api/core.py
+++ b/cg/store/api/core.py
@@ -22,7 +22,6 @@ class CoreHandler(
 ):
     """Aggregating class for the store api handlers."""
 
-    pass
 
 
 class Store(alchy.Manager, CoreHandler):

--- a/cg/store/api/core.py
+++ b/cg/store/api/core.py
@@ -22,6 +22,8 @@ class CoreHandler(
 ):
     """Aggregating class for the store api handlers."""
 
+    pass
+
 
 class Store(alchy.Manager, CoreHandler):
     uri: str = ""

--- a/cg/store/api/core.py
+++ b/cg/store/api/core.py
@@ -23,7 +23,6 @@ class CoreHandler(
     """Aggregating class for the store api handlers."""
 
 
-
 class Store(alchy.Manager, CoreHandler):
     uri: str = ""
 

--- a/cg/store/api/core.py
+++ b/cg/store/api/core.py
@@ -22,6 +22,7 @@ class CoreHandler(
 ):
     """Aggregating class for the store api handlers."""
 
+    pass
 
 
 class Store(alchy.Manager, CoreHandler):

--- a/cg/store/api/import_func.py
+++ b/cg/store/api/import_func.py
@@ -9,7 +9,6 @@ import openpyxl
 from openpyxl.workbook import Workbook
 from openpyxl.worksheet.worksheet import Worksheet
 
-from cg.exc import CgError
 from cg.store import Store
 from cg.store.models import Application, ApplicationVersion
 

--- a/cg/store/api/status.py
+++ b/cg/store/api/status.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 from types import SimpleNamespace
-from typing import List, Optional, Tuple, Callable
+from typing import List, Optional, Tuple
 
 from sqlalchemy.orm import Query
 from typing_extensions import Literal

--- a/cg/store/filters/status_flow_cell_filters.py
+++ b/cg/store/filters/status_flow_cell_filters.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Optional, List, Union, Callable
+from typing import Optional, List, Callable
 
 from sqlalchemy.orm import Query
 

--- a/cg/utils/commands.py
+++ b/cg/utils/commands.py
@@ -5,7 +5,6 @@ Code to handle communications to the shell from CG.
 import copy
 import logging
 import subprocess
-from pathlib import Path
 from subprocess import CalledProcessError
 from typing import Dict, List
 

--- a/tests/apps/conftest.py
+++ b/tests/apps/conftest.py
@@ -1,6 +1,5 @@
 """Fixtures for testing apps"""
 
-from pathlib import Path
 
 import pytest
 import requests

--- a/tests/apps/gens/conftest.py
+++ b/tests/apps/gens/conftest.py
@@ -1,5 +1,4 @@
 """Conftest for Gens."""
 
-from pathlib import Path
 
 import pytest

--- a/tests/apps/hk/test_file.py
+++ b/tests/apps/hk/test_file.py
@@ -8,7 +8,7 @@ from cg.constants import SequencingFileTag
 from tests.meta.compress.conftest import MockCompressionData
 from tests.mocks.hk_mock import MockHousekeeperAPI
 
-from housekeeper.store.models import Version, File, Bundle
+from housekeeper.store.models import Version, File
 
 from tests.small_helpers import SmallHelpers
 

--- a/tests/apps/lims/test_api.py
+++ b/tests/apps/lims/test_api.py
@@ -3,7 +3,6 @@ import datetime as dt
 
 from requests.exceptions import HTTPError
 
-import cg
 from cg.apps.lims.api import LimsAPI
 
 

--- a/tests/apps/orderform/test_excel_sample_schema.py
+++ b/tests/apps/orderform/test_excel_sample_schema.py
@@ -1,4 +1,3 @@
-
 import pytest
 from pydantic import ValidationError
 

--- a/tests/apps/orderform/test_excel_sample_schema.py
+++ b/tests/apps/orderform/test_excel_sample_schema.py
@@ -1,4 +1,3 @@
-import datetime
 
 import pytest
 from pydantic import ValidationError

--- a/tests/apps/scout/test_scout_load_config.py
+++ b/tests/apps/scout/test_scout_load_config.py
@@ -1,5 +1,4 @@
 """Tests for the models in scout load config"""
-from pathlib import Path
 from typing import Any
 
 import pytest

--- a/tests/cli/add/test_cli_add_sample.py
+++ b/tests/cli/add/test_cli_add_sample.py
@@ -71,7 +71,6 @@ def test_add_sample_required(cli_runner: CliRunner, base_context: CGConfig, help
     """Test adding a sample."""
     # GIVEN a database with a customer and an application
     disk_store: Store = base_context.status_db
-    sex = "male"
     application_tag = "dummy_tag"
     helpers.ensure_application(store=disk_store, tag=application_tag)
     helpers.ensure_application_version(store=disk_store, application_tag=application_tag)

--- a/tests/cli/clean/test_hk_bundle_files.py
+++ b/tests/cli/clean/test_hk_bundle_files.py
@@ -1,6 +1,5 @@
 import logging
 from datetime import datetime
-from pathlib import Path
 
 from cg.cli.clean import hk_bundle_files
 from cg.models.cg_config import CGConfig

--- a/tests/cli/clean/test_microbial_clean.py
+++ b/tests/cli/clean/test_microbial_clean.py
@@ -2,7 +2,6 @@ import datetime as dt
 import logging
 from pathlib import Path
 
-import pytest
 
 from cg.apps.tb import TrailblazerAPI
 from cg.cli.workflow.commands import clean_run_dir

--- a/tests/cli/compress/test_cli_decompress_spring.py
+++ b/tests/cli/compress/test_cli_decompress_spring.py
@@ -4,9 +4,6 @@ import logging
 
 from cg.cli.compress.fastq import (
     decompress_case,
-    decompress_flowcell,
-    decompress_sample,
-    decompress_ticket,
 )
 from cg.models.cg_config import CGConfig
 from click.testing import CliRunner

--- a/tests/cli/compress/test_compress_helpers.py
+++ b/tests/cli/compress/test_compress_helpers.py
@@ -1,7 +1,6 @@
 """Tests for helper functions in Cg Compress CLI."""
 
 import logging
-import os
 from pathlib import Path
 
 from housekeeper.store.models import Version

--- a/tests/cli/compress/test_compress_helpers.py
+++ b/tests/cli/compress/test_compress_helpers.py
@@ -9,7 +9,6 @@ from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.cli.compress import helpers
 from cg.cli.compress.helpers import set_memory_according_to_reads
 from cg.constants.compression import MAX_READS_PER_GB, CRUNCHY_MIN_GB_PER_PROCESS
-from cg.constants.slurm import Slurm
 
 
 def test_set_memory_according_to_reads_when_no_reads(caplog, sample_id: str):

--- a/tests/cli/demultiplex/test_create_sample_sheet.py
+++ b/tests/cli/demultiplex/test_create_sample_sheet.py
@@ -5,7 +5,6 @@ from click import testing
 
 from cg.apps.demultiplex.demultiplex_api import DemultiplexingAPI
 from cg.apps.lims.samplesheet import (
-    LimsFlowcellSample,
     LimsFlowcellSampleBcl2Fastq,
     LimsFlowcellSampleDragen,
 )

--- a/tests/cli/get/test_cli_get_sample.py
+++ b/tests/cli/get/test_cli_get_sample.py
@@ -7,7 +7,7 @@ from cg.models.cg_config import CGConfig
 from cg.store import Store
 from click.testing import CliRunner
 
-from cg.store.models import Flowcell, Sample, Family, FamilySample
+from cg.store.models import Flowcell, Sample, Family
 from tests.store_helpers import StoreHelpers
 
 

--- a/tests/cli/set/test_list_keys.py
+++ b/tests/cli/set/test_list_keys.py
@@ -1,9 +1,8 @@
 """Test methods for cg cli set list_keys"""
 import logging
 
-import pytest
 from cg.cli.set.base import list_keys
-from cg.constants import EXIT_SUCCESS, Priority
+from cg.constants import EXIT_SUCCESS
 from cg.constants.subject import Gender
 from cg.models.cg_config import CGConfig
 from cg.store import Store

--- a/tests/cli/set/test_sample.py
+++ b/tests/cli/set/test_sample.py
@@ -1,5 +1,4 @@
 """Test methods for cg cli set sample"""
-import logging
 
 import pytest
 from cg.cli.set.base import sample

--- a/tests/cli/store/test_fastq.py
+++ b/tests/cli/store/test_fastq.py
@@ -2,7 +2,6 @@ import logging
 
 from click.testing import CliRunner
 
-from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.cli.store.fastq import (
     store_case,
     store_demultiplexed_flow_cell,

--- a/tests/cli/upload/test_cli_upload.py
+++ b/tests/cli/upload/test_cli_upload.py
@@ -1,7 +1,6 @@
 """Test CG CLI upload module."""
 from datetime import datetime, timedelta
 
-from cgmodels.cg.constants import Pipeline
 from click.testing import CliRunner
 
 from cg.cli.upload.base import upload

--- a/tests/cli/upload/test_cli_upload.py
+++ b/tests/cli/upload/test_cli_upload.py
@@ -1,5 +1,4 @@
 """Test CG CLI upload module."""
-import logging
 from datetime import datetime, timedelta
 
 from cgmodels.cg.constants import Pipeline

--- a/tests/cli/workflow/balsamic/test_cli_balsamic_config_case.py
+++ b/tests/cli/workflow/balsamic/test_cli_balsamic_config_case.py
@@ -3,13 +3,11 @@
 import logging
 from pathlib import Path
 
-import pytest
 from _pytest.logging import LogCaptureFixture
 
 from cg.cli.workflow.balsamic.base import config_case
 from click.testing import CliRunner
 
-from cg.exc import BalsamicStartError
 from cg.models.cg_config import CGConfig
 
 EXIT_SUCCESS = 0

--- a/tests/cli/workflow/balsamic/test_link.py
+++ b/tests/cli/workflow/balsamic/test_link.py
@@ -1,5 +1,4 @@
 import logging
-from pathlib import Path
 
 from cg.cli.workflow.balsamic.base import link
 from cg.models.cg_config import CGConfig

--- a/tests/cli/workflow/fluffy/test_cli_start.py
+++ b/tests/cli/workflow/fluffy/test_cli_start.py
@@ -1,4 +1,3 @@
-
 from cg.cli.workflow.fluffy.base import start_available
 from cg.constants import EXIT_SUCCESS
 from cg.meta.workflow.fluffy import FluffyAnalysisAPI

--- a/tests/cli/workflow/fluffy/test_cli_start.py
+++ b/tests/cli/workflow/fluffy/test_cli_start.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 
 from cg.cli.workflow.fluffy.base import start_available
 from cg.constants import EXIT_SUCCESS

--- a/tests/cli/workflow/microsalt/conftest.py
+++ b/tests/cli/workflow/microsalt/conftest.py
@@ -1,6 +1,5 @@
 """ Fixtures for microsalt CLI test """
 
-from pathlib import Path
 
 import pytest
 from cg.apps.hermes.hermes_api import HermesApi

--- a/tests/cli/workflow/mip/conftest.py
+++ b/tests/cli/workflow/mip/conftest.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import Any, Callable
 
 import pytest
 

--- a/tests/cli/workflow/mip/test_cli_mip_dna_panel.py
+++ b/tests/cli/workflow/mip/test_cli_mip_dna_panel.py
@@ -1,5 +1,4 @@
 """ Test the CLI for mip-dna panel"""
-import logging
 
 from cg.cli.workflow.mip_dna.base import panel
 

--- a/tests/cli/workflow/mip/test_cli_mip_dna_run.py
+++ b/tests/cli/workflow/mip/test_cli_mip_dna_run.py
@@ -1,9 +1,7 @@
 """ Test the CLI for run mip-dna """
 import logging
-import pytest
 
 from cg.cli.workflow.mip_dna.base import run
-from cg.exc import CgError
 from cg.meta.workflow.mip_dna import MipDNAAnalysisAPI
 
 

--- a/tests/cli/workflow/mip/test_cli_mip_dna_start.py
+++ b/tests/cli/workflow/mip/test_cli_mip_dna_start.py
@@ -1,7 +1,7 @@
 """This script tests the cli methods to create prerequisites and start a mip-dna analysis"""
 import logging
 
-from cg.cli.workflow.mip_dna.base import start, start_available
+from cg.cli.workflow.mip_dna.base import start_available
 from cg.constants import EXIT_SUCCESS, Pipeline
 from cg.meta.workflow.prepare_fastq import PrepareFastqAPI
 

--- a/tests/cli/workflow/rnafusion/test_cli_rnafusion_compound_commands.py
+++ b/tests/cli/workflow/rnafusion/test_cli_rnafusion_compound_commands.py
@@ -2,7 +2,6 @@ import logging
 
 from _pytest.logging import LogCaptureFixture
 from click.testing import CliRunner
-from pytest_mock import MockFixture
 
 from cg.apps.hermes.hermes_api import HermesApi
 from cg.apps.hermes.models import CGDeliverables
@@ -13,7 +12,6 @@ from cg.cli.workflow.rnafusion.base import (
     start_available,
     store,
     store_available,
-    store_housekeeper,
 )
 from cg.constants import EXIT_SUCCESS
 from cg.meta.workflow.rnafusion import RnafusionAnalysisAPI

--- a/tests/cli/workflow/rnafusion/test_cli_rnafusion_report_deliver.py
+++ b/tests/cli/workflow/rnafusion/test_cli_rnafusion_report_deliver.py
@@ -1,7 +1,6 @@
 """Tests for the report-deliver cli command"""
 
 import logging
-from pathlib import Path
 
 from _pytest.logging import LogCaptureFixture
 from click.testing import CliRunner

--- a/tests/cli/workflow/rnafusion/test_cli_rnafusion_run.py
+++ b/tests/cli/workflow/rnafusion/test_cli_rnafusion_run.py
@@ -1,6 +1,5 @@
 """This script tests the run cli command"""
 import logging
-from pathlib import Path
 
 from _pytest.logging import LogCaptureFixture
 from click.testing import CliRunner

--- a/tests/meta/encryption/test_encryption.py
+++ b/tests/meta/encryption/test_encryption.py
@@ -1,7 +1,6 @@
 """Tests for the meta EncryptionAPI and SpringEncryptionAPI"""
 import logging
 import pathlib
-from pathlib import Path
 
 import mock
 import pytest

--- a/tests/meta/upload/gisaid/conftest.py
+++ b/tests/meta/upload/gisaid/conftest.py
@@ -1,4 +1,3 @@
-from datetime import datetime, date
 from pathlib import Path
 from typing import List
 

--- a/tests/meta/upload/gisaid/test_gisaid_api.py
+++ b/tests/meta/upload/gisaid/test_gisaid_api.py
@@ -1,8 +1,6 @@
 """
     Tests for GisaidAPI
 """
-from pathlib import Path
-from typing import List
 
 import pytest
 from cg.apps.housekeeper.hk import HousekeeperAPI

--- a/tests/meta/upload/test_meta_upload_coverage.py
+++ b/tests/meta/upload/test_meta_upload_coverage.py
@@ -45,7 +45,7 @@ def test_upload(chanjo_config, populated_housekeeper_api, analysis_store, mocker
     # GIVEN a coverage api and a data dictionary
     mock_upload = mocker.patch.object(ChanjoAPI, "upload")
     mock_sample = mocker.patch.object(ChanjoAPI, "sample")
-    mock_remove = mocker.patch.object(ChanjoAPI, "delete_sample")
+    mocker.patch.object(ChanjoAPI, "delete_sample")
     hk_api = populated_housekeeper_api
     chanjo_api = ChanjoAPI(config=chanjo_config)
     coverage_api = UploadCoverageApi(status_api=None, hk_api=hk_api, chanjo_api=chanjo_api)

--- a/tests/meta/workflow/test_balsamic.py
+++ b/tests/meta/workflow/test_balsamic.py
@@ -1,7 +1,5 @@
 """Tests for BALSAMIC analysis"""
-import logging
 from pathlib import Path
-from typing import Dict
 
 import pytest
 from _pytest.logging import LogCaptureFixture

--- a/tests/mocks/hk_mock.py
+++ b/tests/mocks/hk_mock.py
@@ -5,7 +5,7 @@ import logging
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
-from typing import List, Optional, Dict, Iterable
+from typing import List, Optional, Dict
 
 from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.constants import SequencingFileTag

--- a/tests/mocks/osticket.py
+++ b/tests/mocks/osticket.py
@@ -2,7 +2,7 @@
 
 import logging
 import os.path
-from typing import Optional, List
+from typing import Optional
 
 from flask import Flask
 

--- a/tests/mocks/scout.py
+++ b/tests/mocks/scout.py
@@ -2,9 +2,8 @@
 
 import logging
 from pathlib import Path
-from datetime import datetime
 from pydantic import BaseModel, validator
-from typing import List, Optional
+from typing import List
 from typing_extensions import Literal
 
 from cg.apps.scout.scoutapi import ScoutAPI

--- a/tests/models/demultiplexing/test_flowcell_model.py
+++ b/tests/models/demultiplexing/test_flowcell_model.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-from cg.constants.demultiplexing import DemultiplexingDirsAndFiles
 from cg.models.demultiplex.flow_cell import FlowCell
 
 

--- a/tests/store/api/status/test_analyses_to_delivery_report.py
+++ b/tests/store/api/status/test_analyses_to_delivery_report.py
@@ -1,5 +1,4 @@
 """This file tests the analyses_to_delivery_report part of the status api"""
-from datetime import datetime, timedelta
 
 from cg.constants import Pipeline, DataDelivery
 from cg.constants.subject import PhenotypeStatus

--- a/tests/store/filters/test_status_application_filters.py
+++ b/tests/store/filters/test_status_application_filters.py
@@ -11,7 +11,6 @@ from cg.store.filters.status_application_filters import (
 from cg.store import Store
 from cg.store.models import Application
 from tests.store_helpers import StoreHelpers
-from typing import List
 from sqlalchemy.orm import Query
 from tests.store.conftest import StoreConftestFixture
 

--- a/tests/store/filters/test_status_application_filters.py
+++ b/tests/store/filters/test_status_application_filters.py
@@ -10,7 +10,6 @@ from cg.store.filters.status_application_filters import (
 
 from cg.store import Store
 from cg.store.models import Application
-from tests.store_helpers import StoreHelpers
 from sqlalchemy.orm import Query
 from tests.store.conftest import StoreConftestFixture
 

--- a/tests/store/filters/test_status_pool_filters.py
+++ b/tests/store/filters/test_status_pool_filters.py
@@ -1,8 +1,6 @@
 from alchy import Query
 from cg.store import Store
 from cg.store.models import Pool
-from tests.store_helpers import StoreHelpers
-from cg.constants.invoice import CustomerNames
 from cg.store.filters.status_pool_filters import (
     filter_pools_is_received,
     filter_pools_is_not_received,

--- a/tests/store/filters/test_status_pool_filters.py
+++ b/tests/store/filters/test_status_pool_filters.py
@@ -1,5 +1,4 @@
 from alchy import Query
-from typing import List
 from cg.store import Store
 from cg.store.models import Pool
 from tests.store_helpers import StoreHelpers
@@ -17,7 +16,6 @@ from cg.store.filters.status_pool_filters import (
     filter_pools_by_name_enquiry,
     filter_pools_by_customer_id,
 )
-from datetime import datetime
 from tests.store.conftest import StoreConftestFixture
 
 

--- a/tests/store/filters/test_status_samples_filters.py
+++ b/tests/store/filters/test_status_samples_filters.py
@@ -4,7 +4,6 @@ from cg.constants.constants import SampleType
 from cg.store import Store
 from cg.store.models import Sample
 
-from tests.store_helpers import StoreHelpers
 from cg.store.filters.status_sample_filters import (
     filter_samples_with_loqusdb_id,
     filter_samples_without_loqusdb_id,

--- a/tests/store/filters/test_status_samples_filters.py
+++ b/tests/store/filters/test_status_samples_filters.py
@@ -1,5 +1,4 @@
 from alchy import Query
-from typing import List
 from cg.constants.subject import PhenotypeStatus
 from cg.constants.constants import SampleType
 from cg.store import Store
@@ -29,7 +28,6 @@ from cg.store.filters.status_sample_filters import (
     filter_samples_by_name,
     filter_samples_by_subject_id,
 )
-from datetime import datetime
 from tests.store.conftest import StoreConftestFixture
 
 

--- a/tests/test_store_helpers.py
+++ b/tests/test_store_helpers.py
@@ -1,7 +1,6 @@
 """
 Tests for command module
 """
-from subprocess import CalledProcessError
 
 import pytest
 

--- a/tests/test_store_helpers.py
+++ b/tests/test_store_helpers.py
@@ -2,9 +2,7 @@
 Tests for command module
 """
 
-import pytest
 
-from cg.utils import Process
 
 
 def test_add_microbial_sample(base_store, helpers):

--- a/tests/test_store_helpers.py
+++ b/tests/test_store_helpers.py
@@ -3,8 +3,6 @@ Tests for command module
 """
 
 
-
-
 def test_add_microbial_sample(base_store, helpers):
     # GIVEN a base_store
 

--- a/tests/utils/test_dict.py
+++ b/tests/utils/test_dict.py
@@ -1,7 +1,6 @@
 """Tests for the dict module."""
 from pathlib import Path
 
-from housekeeper.store.models import File
 
 from cg.utils.dict import get_list_from_dictionary, get_full_path_dictionary
 

--- a/tests/utils/test_dict.py
+++ b/tests/utils/test_dict.py
@@ -1,6 +1,5 @@
 """Tests for the dict module."""
 from pathlib import Path
-from typing import Dict
 
 from housekeeper.store.models import File
 


### PR DESCRIPTION
Removed all unused imports using autoflake:

```bash
autoflake --recursive --exclude=__init__.py --remove-all-unused-imports -i cg
autoflake --recursive --exclude=conftest.py --remove-all-unused-imports -i tests
```

Upside: less clutter and time spent importing unnecessary libraries.

## Description

### Fixed
- Remove all unused imports

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
