### PR TITLE
Lock housekeeper to latest minor release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,4 +46,4 @@ wtforms<3.0.0          # wtforms.compat missing in 3.0.0
 
 # apps
 genologics
-housekeeper
+housekeeper==3.*


### PR DESCRIPTION
## Description
We don't want to use a new major version of housekeeper by mistake, so we should lock it to the most recent minor release and update the major manually together with the necessary patches.

### Fixed
- Lock housekeeper version to the latest minor version.

### This [version](https://semver.org/) is a
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
