### PR TITLE
Replace undefined function call

### DIFF
--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -13,7 +13,7 @@ from urllib3.exceptions import MaxRetryError, NewConnectionError
 from cg.apps.orderform.excel_orderform_parser import ExcelOrderformParser
 from cg.apps.orderform.json_orderform_parser import JsonOrderformParser
 from cg.constants import ANALYSIS_SOURCES, METAGENOME_SOURCES
-from cg.constants.constants import FileFormat
+from cg.constants.constants import FileFormat, Pipeline
 from cg.exc import OrderError, OrderFormError, TicketCreationError
 from cg.server.ext import db, lims, osticket
 from cg.io.controller import WriteStream
@@ -154,7 +154,7 @@ def parse_cases():
 def parse_families():
     """Return families."""
     if request.args.get("status") == "analysis":
-        records = db.cases_to_mip_analyze()
+        records = db.cases_to_analyze(pipeline=Pipeline.MIP_DNA)
         count = len(records)
     else:
         customers: Optional[List[Customer]] = (


### PR DESCRIPTION
## Description
The ```cases_to_mip_analyze``` function has been removed but is still used in the /families endpoint.
Not sure where the endpoint is used

### Fixed
- Replaced undefined function

### This [version](https://semver.org/) is a
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
