### PR TITLE
Fix typo causing removal of failed flow cells to fail

### DIFF
--- a/cg/meta/clean/demultiplexed_flow_cells.py
+++ b/cg/meta/clean/demultiplexed_flow_cells.py
@@ -258,7 +258,7 @@ class DemultiplexedRunsFlowCell:
         globbed_unaligned_paths_list: list = list(globbed_unaligned_paths)
         if not globbed_unaligned_paths_list:
             LOG.warning(
-                f"No Unaligned directory found for flow cell {self.run_nam}! No sample sheet to archive!"
+                f"No Unaligned directory found for flow cell {self.run_name}! No sample sheet to archive!"
             )
             return
         unaligned_path: Path = globbed_unaligned_paths_list[0]


### PR DESCRIPTION
## Description
Fix typo causing commands related to removing failed flow cells to error out.

The `cg clean invalid-flow-cell-dirs -f` command fails.

### Fixed
- Typo in cleanup for failed flow cells

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions