### PR TITLE
refactor(get_pools_- and get_samples_to_invoice)

### DIFF
--- a/cg/constants/invoice.py
+++ b/cg/constants/invoice.py
@@ -6,6 +6,7 @@ class CustomerNames(StrEnum):
     cust032: str = "cust032"
     cust001: str = "cust001"
     cust132: str = "cust132"
+    cust000: str = "cust000"
 
 
 class CostCenters(StrEnum):

--- a/cg/server/invoices/views.py
+++ b/cg/server/invoices/views.py
@@ -139,12 +139,14 @@ def new(record_type):
     customer_id = request.args.get("customer", "cust002")
     customer: Customer = db.get_customer_by_customer_id(customer_id=customer_id)
     if record_type == "Sample":
-        records: List[Pool or Sample] = db.get_samples_to_invoice_for_customer(customer=customer)
+        records: List[Union[Pool, Sample]] = db.get_samples_to_invoice_for_customer(
+            customer=customer
+        )
         customers_to_invoice: List[Customer] = db.get_customers_to_invoice(
             records=db.get_samples_to_invoice_query()
         )
     elif record_type == "Pool":
-        records: List[Pool or Sample] = db.get_pools_to_invoice_for_customer(customer=customer)
+        records: List[Union[Pool, Sample]] = db.get_pools_to_invoice_for_customer(customer=customer)
         customers_to_invoice: List[Customer] = db.get_customers_to_invoice(
             records=db.get_pools_to_invoice_query()
         )

--- a/cg/server/invoices/views.py
+++ b/cg/server/invoices/views.py
@@ -138,11 +138,16 @@ def new(record_type):
     count = request.args.get("total", 0)
     customer_id = request.args.get("customer", "cust002")
     customer: Customer = db.get_customer_by_customer_id(customer_id=customer_id)
-
     if record_type == "Sample":
-        records, customers_to_invoice = db.get_samples_to_invoice(customer=customer)
+        records: List[Pool or Sample] = db.get_samples_to_invoice_for_customer(customer=customer)
+        customers_to_invoice: List[Customer] = db.get_customers_to_invoice(
+            records=db.get_samples_to_invoice()
+        )
     elif record_type == "Pool":
-        records, customers_to_invoice = db.get_pools_to_invoice(customer=customer)
+        records: List[Pool or Sample] = db.get_pools_to_invoice_for_customer(customer=customer)
+        customers_to_invoice: List[Customer] = db.get_customers_to_invoice(
+            records=db.get_pools_to_invoice()
+        )
     return render_template(
         "invoices/new.html",
         customers_to_invoice=customers_to_invoice,

--- a/cg/server/invoices/views.py
+++ b/cg/server/invoices/views.py
@@ -141,12 +141,12 @@ def new(record_type):
     if record_type == "Sample":
         records: List[Pool or Sample] = db.get_samples_to_invoice_for_customer(customer=customer)
         customers_to_invoice: List[Customer] = db.get_customers_to_invoice(
-            records=db.get_samples_to_invoice()
+            records=db.get_samples_to_invoice_query()
         )
     elif record_type == "Pool":
         records: List[Pool or Sample] = db.get_pools_to_invoice_for_customer(customer=customer)
         customers_to_invoice: List[Customer] = db.get_customers_to_invoice(
-            records=db.get_pools_to_invoice()
+            records=db.get_pools_to_invoice_query()
         )
     return render_template(
         "invoices/new.html",

--- a/cg/store/api/status.py
+++ b/cg/store/api/status.py
@@ -2,11 +2,13 @@ from datetime import datetime, timedelta
 from types import SimpleNamespace
 from typing import List, Optional, Tuple
 
+
 from sqlalchemy.orm import Query
 from typing_extensions import Literal
 
 from cg.constants import CASE_ACTIONS, Pipeline, FlowCellStatus
 from cg.constants.constants import CaseActions
+from cg.constants.invoice import CustomerNames
 from cg.store.models import (
     Analysis,
     Application,
@@ -829,7 +831,9 @@ class StatusHandler(BaseHandler):
 
     def get_customers_to_invoice(self, records: Query) -> List[Customer]:
         customers_to_invoice: List[Customer] = [
-            record.customer for record in records.all() if record.customer.internal_id != "cust000"
+            record.customer
+            for record in records.all()
+            if record.customer.internal_id != CustomerNames.cust000
         ]
         return list(set(customers_to_invoice))
 

--- a/cg/store/filters/status_pool_filters.py
+++ b/cg/store/filters/status_pool_filters.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import List, Optional, Callable
 from alchy import Query
-from cg.store.models import Pool
+from cg.store.models import Pool, Customer
 
 
 def filter_pools_by_customer_id(pools: Query, customer_ids: List[int], **kwargs) -> Query:
@@ -69,6 +69,11 @@ def filter_pools_do_not_invoice(pools: Query, **kwargs) -> Query:
     return pools.filter(Pool.no_invoice.is_(True))
 
 
+def filter_pools_by_customer(pools: Query, customer: Customer, **kwargs) -> Query:
+    """Return pools by customer id."""
+    return pools.filter(Pool.customer == customer)
+
+
 def apply_pool_filter(
     filter_functions: List[Callable],
     pools: Query,
@@ -78,6 +83,7 @@ def apply_pool_filter(
     customer_ids: Optional[List[int]] = None,
     name_enquiry: Optional[str] = None,
     order_enquiry: Optional[str] = None,
+    customer: Optional[Customer] = None,
 ) -> Query:
     """Apply filtering functions to the pool queries and return filtered results"""
 
@@ -90,6 +96,7 @@ def apply_pool_filter(
             customer_ids=customer_ids,
             name_enquiry=name_enquiry,
             order_enquiry=order_enquiry,
+            customer=customer,
         )
     return pools
 
@@ -110,3 +117,4 @@ class PoolFilter(Enum):
     FILTER_BY_CUSTOMER_ID: Callable = filter_pools_by_customer_id
     FILTER_BY_NAME_ENQUIRY: Callable = filter_pools_by_name_enquiry
     FILTER_BY_ORDER_ENQUIRY: Callable = filter_pools_by_order_enquiry
+    FILTER_BY_CUSTOMER: Callable = filter_pools_by_customer

--- a/tests/store/api/conftest.py
+++ b/tests/store/api/conftest.py
@@ -436,7 +436,9 @@ def fixture_three_pool_names() -> List[str]:
 
 
 @pytest.fixture(name="store_with_samples_for_multiple_customers")
-def fixture_store_with_samples_for_multiple_customers(store: Store, helpers: StoreHelpers) -> Store:
+def fixture_store_with_samples_for_multiple_customers(
+    store: Store, helpers: StoreHelpers, timestamp_now: dt.datetime
+) -> Store:
     """Return a store with two samples for three different customers."""
     for number in range(3):
         helpers.add_sample(
@@ -444,13 +446,15 @@ def fixture_store_with_samples_for_multiple_customers(store: Store, helpers: Sto
             internal_id="_".join(["test_sample", str(number)]),
             customer_id="".join(["cust00", str(number)]),
             no_invoice=False,
-            delivered_at=dt.datetime.now(),
+            delivered_at=timestamp_now,
         )
     yield store
 
 
 @pytest.fixture(name="store_with_pools_for_multiple_customers")
-def fixture_store_with_pools_for_multiple_customers(store: Store, helpers: StoreHelpers) -> Store:
+def fixture_store_with_pools_for_multiple_customers(
+    store: Store, helpers: StoreHelpers, timestamp_now: dt.datetime
+) -> Store:
     """Return a store with two samples for three different customers."""
     for number in range(3):
         helpers.ensure_pool(
@@ -458,6 +462,6 @@ def fixture_store_with_pools_for_multiple_customers(store: Store, helpers: Store
             name="_".join(["test_pool", str(number)]),
             customer_id="".join(["cust00", str(number)]),
             no_invoice=False,
-            delivered_at=dt.datetime.now(),
+            delivered_at=timestamp_now,
         )
     yield store

--- a/tests/store/api/conftest.py
+++ b/tests/store/api/conftest.py
@@ -417,3 +417,43 @@ def fixture_store_with_active_sample_running(store: Store, helpers: StoreHelpers
     helpers.add_relationship(store=store, sample=sample, case=case)
 
     yield store
+
+
+@pytest.fixture(name="three_customer_ids")
+def fixture_three_customer_ids() -> List[str]:
+    """Return three customer ids."""
+    yield ["".join(["cust00", str(number)]) for number in range(3)]
+
+
+@pytest.fixture(name="three_pool_names")
+def fixture_three_pool_names() -> List[str]:
+    """Return three customer ids."""
+    yield ["_".join(["test_pool", str(number)]) for number in range(3)]
+
+
+@pytest.fixture(name="store_with_samples_for_multiple_customers")
+def fixture_store_with_samples_for_multiple_customers(store: Store, helpers: StoreHelpers) -> Store:
+    """Return a store with two samples for three different customers."""
+    for number in range(3):
+        helpers.add_sample(
+            store=store,
+            internal_id="_".join(["test_sample", str(number)]),
+            customer_id="".join(["cust00", str(number)]),
+            no_invoice=False,
+            delivered_at=dt.datetime.now(),
+        )
+    yield store
+
+
+@pytest.fixture(name="store_with_pools_for_multiple_customers")
+def fixture_store_with_pools_for_multiple_customers(store: Store, helpers: StoreHelpers) -> Store:
+    """Return a store with two samples for three different customers."""
+    for number in range(3):
+        helpers.ensure_pool(
+            store=store,
+            name="_".join(["test_pool", str(number)]),
+            customer_id="".join(["cust00", str(number)]),
+            no_invoice=False,
+            delivered_at=dt.datetime.now(),
+        )
+    yield store

--- a/tests/store/api/status/test_store_api_status_customer.py
+++ b/tests/store/api/status/test_store_api_status_customer.py
@@ -1,0 +1,30 @@
+"""Tests for the functions in the store api status related to the customer module."""
+from cg.store import Store
+from cg.store.models import Customer, Sample
+from tests.store_helpers import StoreHelpers
+from typing import List
+from sqlalchemy.orm import Query
+
+
+def test_get_customers_to_invoice(
+    store_with_samples_for_multiple_customers: Store,
+    helpers: StoreHelpers,
+    three_customer_ids: List[str],
+):
+    """Test that customers to invoice can be fetched."""
+    # GIVEN a database with samples for a customer
+
+    # WHEN getting the customers to invoice
+    customers: List[Customer] = store_with_samples_for_multiple_customers.get_customers_to_invoice(
+        records=store_with_samples_for_multiple_customers.get_samples_to_invoice_query()
+    )
+
+    # THEN the customers should be returned
+    assert customers
+    assert len(customers) == 2
+    for customer in customers:
+        assert customer.internal_id in three_customer_ids
+
+    # THEN the customers to invoice should not contain cust000
+    for customer in customers:
+        assert customer.internal_id != "cust000"

--- a/tests/store/api/status/test_store_api_status_customer.py
+++ b/tests/store/api/status/test_store_api_status_customer.py
@@ -3,7 +3,7 @@ from cg.store import Store
 from cg.store.models import Customer, Sample
 from tests.store_helpers import StoreHelpers
 from typing import List
-from sqlalchemy.orm import Query
+from cg.constants.invoice import CustomerNames
 
 
 def test_get_customers_to_invoice(
@@ -11,7 +11,7 @@ def test_get_customers_to_invoice(
     helpers: StoreHelpers,
     three_customer_ids: List[str],
 ):
-    """Test that customers to invoice can be fetched."""
+    """Test that customers to invoice can be returned."""
     # GIVEN a database with samples for a customer
 
     # WHEN getting the customers to invoice
@@ -27,4 +27,4 @@ def test_get_customers_to_invoice(
 
     # THEN the customers to invoice should not contain cust000
     for customer in customers:
-        assert customer.internal_id != "cust000"
+        assert customer.internal_id != CustomerNames.cust000

--- a/tests/store/api/status/test_store_api_status_pool.py
+++ b/tests/store/api/status/test_store_api_status_pool.py
@@ -1,0 +1,43 @@
+from typing import List
+from cg.store import Store
+from cg.store.models import Pool, Customer
+
+
+def test_get_pools_to_invoice_query(
+    store_with_pools_for_multiple_customers: Store,
+    three_pool_names: List[str],
+):
+    """Test fetching pools to invoice."""
+    # GIVEN a store with multiple pools for multiple customers
+    assert len(store_with_pools_for_multiple_customers.get_pools()) > 1
+
+    # WHEN finding samples to invoice
+    pools: List[Pool] = store_with_pools_for_multiple_customers.get_pools_to_invoice_query().all()
+
+    # THEN it should return all pools that are not invoiced
+    for pool in pools:
+        assert pool.name in three_pool_names
+        assert isinstance(pool, Pool)
+
+
+def test_get_pools_to_invoice_for_customer(
+    store_with_pools_for_multiple_customers: Store,
+    three_customer_ids: List[str],
+):
+    """Test fetching pools to invoice for a customer."""
+    # GIVEN a store with multiple pools for multiple customers
+    assert len(store_with_pools_for_multiple_customers.get_pools()) > 1
+
+    # THEN the one customer can be retrieved
+    customer: Customer = store_with_pools_for_multiple_customers.get_customer_by_customer_id(
+        customer_id=three_customer_ids[1]
+    )
+    assert customer
+
+    # WHEN finding samples to invoice for a customer
+    pools: List[Pool] = store_with_pools_for_multiple_customers.get_pools_to_invoice_for_customer(
+        customer=customer
+    )
+
+    # THEN it should return all pools that are not invoiced for the customer
+    assert pools[0].customer == customer

--- a/tests/store/api/status/test_store_api_status_pool.py
+++ b/tests/store/api/status/test_store_api_status_pool.py
@@ -7,7 +7,7 @@ def test_get_pools_to_invoice_query(
     store_with_pools_for_multiple_customers: Store,
     three_pool_names: List[str],
 ):
-    """Test fetching pools to invoice."""
+    """Test return pools to invoice."""
     # GIVEN a store with multiple pools for multiple customers
     assert len(store_with_pools_for_multiple_customers.get_pools()) > 1
 
@@ -24,7 +24,7 @@ def test_get_pools_to_invoice_for_customer(
     store_with_pools_for_multiple_customers: Store,
     three_customer_ids: List[str],
 ):
-    """Test fetching pools to invoice for a customer."""
+    """Test return pools to invoice for a customer."""
     # GIVEN a store with multiple pools for multiple customers
     assert len(store_with_pools_for_multiple_customers.get_pools()) > 1
 

--- a/tests/store/api/status/test_store_api_status_sample.py
+++ b/tests/store/api/status/test_store_api_status_sample.py
@@ -3,7 +3,7 @@
 
 from typing import List
 from cg.store import Store
-from cg.store.models import Sample
+from cg.store.models import Sample, Customer
 from tests.store_helpers import StoreHelpers
 
 
@@ -135,13 +135,13 @@ def test_get_samples_to_deliver(sample_store):
     assert {sample.name for sample in samples} == set(["to-deliver", "sequenced"])
 
 
-def test_get_samples_to_invoice(sample_store):
+def test_get_samples_to_invoice_query(sample_store):
     """Test fetching samples to invoice."""
     # GIVEN a store with a sample
     assert len(sample_store.get_samples()) > 1
 
     # WHEN finding samples to invoice
-    sample = sample_store.get_samples_to_invoice()[0].first()
+    sample = sample_store.get_samples_to_invoice_query().first()
 
     # THEN samples should be a list of samples
     assert isinstance(sample, Sample)
@@ -181,3 +181,31 @@ def test_get_samples_not_down_sampled(sample_store: Store, helpers: StoreHelpers
 
     # THEN it should return all samples in the store
     assert len(samples) == len(sample_store.get_samples())
+
+
+def test_get_samples_to_invoice_for_customer(
+    store_with_samples_for_multiple_customers: Store,
+    helpers: StoreHelpers,
+    three_customer_ids: List[str],
+):
+    """Test that samples to invoice can be fetched for a customer."""
+    # GIVEN a database with samples for a customer
+
+    # THEN the one customer can be retrieved
+    customer: Customer = store_with_samples_for_multiple_customers.get_customer_by_customer_id(
+        customer_id=three_customer_ids[1]
+    )
+    assert customer
+
+    # WHEN getting the samples to invoice for a customer
+    samples: List[
+        Sample
+    ] = store_with_samples_for_multiple_customers.get_samples_to_invoice_for_customer(
+        customer=customer,
+    )
+
+    # THEN the samples should be returned
+    assert samples
+    assert len(samples) == 1
+
+    assert samples[0].customer.internal_id == three_customer_ids[1]

--- a/tests/store/api/status/test_store_api_status_sample.py
+++ b/tests/store/api/status/test_store_api_status_sample.py
@@ -152,7 +152,7 @@ def test_get_samples_to_invoice_query(sample_store):
 
 
 def test_get_samples_not_invoiced(sample_store):
-    """Test fetching samples not invoiced."""
+    """Test getting samples not invoiced."""
     # GIVEN a store with a sample
     assert len(sample_store.get_samples()) > 1
 
@@ -168,7 +168,7 @@ def test_get_samples_not_invoiced(sample_store):
 
 
 def test_get_samples_not_down_sampled(sample_store: Store, helpers: StoreHelpers, sample_id: int):
-    """Test fetching samples not down sampled."""
+    """Test getting samples not down sampled."""
     # GIVEN a store with a sample
     assert len(sample_store.get_samples()) > 1
 
@@ -188,7 +188,7 @@ def test_get_samples_to_invoice_for_customer(
     helpers: StoreHelpers,
     three_customer_ids: List[str],
 ):
-    """Test that samples to invoice can be fetched for a customer."""
+    """Test that samples to invoice can be returned for a customer."""
     # GIVEN a database with samples for a customer
 
     # THEN the one customer can be retrieved


### PR DESCRIPTION
## Description

Refactoring of two functions related to the views.py invoice statusDB

### Added

- New functions and tests for them:
    - `get_pools_to_invoice_query`
    - `get_samples_to_invoice_query`
    - `get_customers_to_invoice`

- New tests for:
    - `get_samples_to_invoice_for_customer`
    - `get_pools_to_invoice_for_customer`


### Changed

- `get_samples_to_invoice` to `get_samples_to_invoice_for_customer`
- `get_pools_to_invoice` to `get_pools_to_invoice_for_customer`
`

### Fixed

- Functionality adapted to new function format


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
