### PR TITLE
Remove dead case filter functions

### DIFF
--- a/cg/meta/workflow/balsamic.py
+++ b/cg/meta/workflow/balsamic.py
@@ -604,37 +604,6 @@ class BalsamicAnalysisAPI(AnalysisAPI):
         )
         return config_data["analysis"]["BALSAMIC_version"]
 
-    def case_has_correct_number_tumour_normal_samples(self, case_internal_id: str) -> bool:
-        """Evaluates if a case has exactly one tumor and up to one normal sample in ClinicalDB.
-        This check is only applied to filter jobs which start automatically"""
-
-        samples: List[Sample] = self.status_db.get_samples_by_case_and_pipeline(
-            case_internal_id=case_internal_id, pipeline=self.pipeline
-        )
-
-        normal_samples_count: int = self.count_normal_samples(samples=samples)
-        tumour_samples_count: int = self.count_tumour_samples(samples=samples)
-
-        return normal_samples_count <= 1 and tumour_samples_count == 1
-
-    def count_normal_samples(self, samples: List[Sample]) -> int:
-        return len([sample for sample in samples if not sample.is_tumour])
-
-    def count_tumour_samples(self, samples: List[Sample]) -> int:
-        return len([sample for sample in samples if sample.is_tumour])
-
-    def get_valid_cases_to_analyze(self) -> list:
-        """Retrieve a list of balsamic cases without analysis,
-        where samples have enough reads to be analyzed"""
-
-        return [
-            case_object.internal_id
-            for case_object in self.get_cases_to_analyze()
-            if self.case_has_correct_number_tumour_normal_samples(
-                case_internal_id=case_object.internal_id
-            )
-        ]
-
     def config_case(
         self,
         case_id: str,

--- a/cg/store/api/find_business_data.py
+++ b/cg/store/api/find_business_data.py
@@ -175,22 +175,6 @@ class FindBusinessDataHandler(BaseHandler):
             case_samples=self._get_join_case_sample_query(),
         )
 
-    def get_samples_by_case_and_pipeline(
-        self, case_internal_id: str, pipeline: Pipeline
-    ) -> List[Sample]:
-        """Return all samples linked to a case and pipeline"""
-
-        linked_samples: Query = self.query(Sample).join(Family.links, FamilySample.sample)
-
-        filtered_samples: Query = apply_case_filter(
-            cases=linked_samples,
-            filter_functions=[CaseFilter.FILTER_BY_INTERNAL_ID, CaseFilter.GET_WITH_PIPELINE],
-            internal_id=case_internal_id,
-            pipeline=pipeline,
-        )
-
-        return filtered_samples.all()
-
     def filter_cases_with_samples(self, case_ids: List[str]) -> List[str]:
         """Return case id:s associated with samples."""
         cases_with_samples = set()


### PR DESCRIPTION
## Description
`family_has_correct_number_tumor_normal_samples` is only called by `get_valid_cases_to_analyze`, which in turn is not called anywhere.

### Fixed
- Remove dead functions `family_has_correct_number_tumor_normal_samples` and `get_valid_cases_to_analyze`.

### This [version](https://semver.org/) is a
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
