### PR TITLE
add new function to get samples by list of customer IDs

### DIFF
--- a/cg/store/api/find_business_data.py
+++ b/cg/store/api/find_business_data.py
@@ -516,7 +516,7 @@ class FindBusinessDataHandler(BaseHandler):
     def get_samples_by_customer_id_list_and_subject_id_and_is_tumour(
         self, customer_ids: List[int], subject_id: str
     ) -> List[Sample]:
-        """Return a list of samples matching a list of customers with given subject_id and is_tumour."""
+        """Return a list of samples matching a list of customers with given subject id and is a tumour sample."""
         samples = self._get_query(table=Sample)
         return apply_sample_filter(
             samples=samples,

--- a/cg/store/api/find_business_data.py
+++ b/cg/store/api/find_business_data.py
@@ -532,10 +532,10 @@ class FindBusinessDataHandler(BaseHandler):
         samples = self._get_query(table=Sample)
         return apply_sample_filter(
             samples=samples,
-            customer_ids=customer_ids,
+            customer_entry_ids=customer_ids,
             subject_id=subject_id,
             filter_functions=[
-                SampleFilter.FILTER_BY_CUSTOMER_ID,
+                SampleFilter.FILTER_BY_CUSTOMER_ENTRY_ID,
                 SampleFilter.FILTER_BY_SUBJECT_ID,
                 SampleFilter.FILTER_IS_TUMOUR,
             ],

--- a/cg/store/api/find_business_data.py
+++ b/cg/store/api/find_business_data.py
@@ -513,6 +513,22 @@ class FindBusinessDataHandler(BaseHandler):
                 samples=samples, filter_functions=[SampleFilter.FILTER_IS_NOT_TUMOUR]
             ).all()
 
+    def get_samples_by_customer_id_list_and_subject_id_and_is_tumour(
+        self, customer_ids: list[int], subject_id: str
+    ) -> List[Sample]:
+        """Return a list of samples matching a list of customers with given subject_id and is_tumour."""
+        samples = self._get_query(table=Sample)
+        return apply_sample_filter(
+            samples=samples,
+            customer_ids=customer_ids,
+            subject_id=subject_id,
+            filter_functions=[
+                SampleFilter.FILTER_BY_CUSTOMER_ID,
+                SampleFilter.FILTER_BY_SUBJECT_ID,
+                SampleFilter.FILTER_IS_TUMOUR,
+            ],
+        ).all()
+
     def get_samples_by_any_id(self, **identifiers: dict) -> Query:
         records = self._get_query(table=Sample)
 

--- a/cg/store/api/find_business_data.py
+++ b/cg/store/api/find_business_data.py
@@ -514,7 +514,7 @@ class FindBusinessDataHandler(BaseHandler):
             ).all()
 
     def get_samples_by_customer_id_list_and_subject_id_and_is_tumour(
-        self, customer_ids: list[int], subject_id: str
+        self, customer_ids: List[int], subject_id: str
     ) -> List[Sample]:
         """Return a list of samples matching a list of customers with given subject_id and is_tumour."""
         samples = self._get_query(table=Sample)

--- a/tests/store/api/conftest.py
+++ b/tests/store/api/conftest.py
@@ -385,7 +385,7 @@ def store_with_samples_customer_id_and_subject_id_and_tumour_status(
             is_tumour=is_tumour,
             customer_id=customer_id,
         )
-    yield store
+    return store
 
 
 @pytest.fixture(name="pool_name_1")

--- a/tests/store/api/conftest.py
+++ b/tests/store/api/conftest.py
@@ -364,6 +364,30 @@ def store_with_samples_subject_id_and_tumour_status(
     return store
 
 
+@pytest.fixture(name="store_with_samples_customer_id_and_subject_id_and_tumour_status")
+def store_with_samples_customer_id_and_subject_id_and_tumour_status(
+    store: Store, helpers: StoreHelpers
+) -> Store:
+    """Return a store with four samples with different customer IDs, and tumour status."""
+    samples_data = [
+        # customer_id, subject_id, is_tumour
+        ("1", "test_subject", True),
+        ("1", "test_subject_2", False),
+        ("2", "test_subject", True),
+        ("2", "test_subject_2", False),
+    ]
+    for customer_id, subject_id, is_tumour in samples_data:
+        helpers.add_sample(
+            store=store,
+            internal_id=f"test_sample_{customer_id}_{subject_id}",
+            name=f"sample_{customer_id}_{subject_id}",
+            subject_id=subject_id,
+            is_tumour=is_tumour,
+            customer_id=customer_id,
+        )
+    return store
+
+
 @pytest.fixture(name="pool_name_1")
 def fixture_pool_name_1() -> str:
     """Return the name of the first pool."""

--- a/tests/store/api/conftest.py
+++ b/tests/store/api/conftest.py
@@ -385,7 +385,7 @@ def store_with_samples_customer_id_and_subject_id_and_tumour_status(
             is_tumour=is_tumour,
             customer_id=customer_id,
         )
-    return store
+    yield store
 
 
 @pytest.fixture(name="pool_name_1")

--- a/tests/store/api/find/test_find_business_data_sample.py
+++ b/tests/store/api/find/test_find_business_data_sample.py
@@ -85,6 +85,40 @@ def test_get_samples_by_subject_id_and_is_tumour(
     assert samples and len(samples) == 1
 
 
+def test_get_samples_by_customer_id_list_and_subject_id_and_is_tumour(
+    store_with_samples_customer_id_and_subject_id_and_tumour_status: Store,
+    helpers: StoreHelpers,
+):
+    """Test that samples can be fetched by customer ID, subject ID, and tumour status."""
+    # GIVEN a database with four samples, two with customer ID 1 and two with customer ID 2
+    customer_ids = [1, 2]
+    subject_id = "test_subject"
+    is_tumour = True
+
+    # ASSERT that there are four samples in the store
+    assert len(store_with_samples_customer_id_and_subject_id_and_tumour_status.get_samples()) == 4
+
+    # ASSERT that there are customers with the given customer IDs
+    for customer_id in customer_ids:
+        assert store_with_samples_customer_id_and_subject_id_and_tumour_status.get_customer_by_customer_id(
+            customer_id=str(customer_id)
+        )
+
+    # WHEN fetching the samples by customer ID list, subject ID, and tumour status
+    samples = store_with_samples_customer_id_and_subject_id_and_tumour_status.get_samples_by_customer_id_list_and_subject_id_and_is_tumour(
+        customer_ids=customer_ids, subject_id=subject_id
+    )
+
+    # THEN two samples should be returned, one for each customer ID, with the specified subject ID and tumour status
+    assert isinstance(samples, list)
+    assert len(samples) == 2
+
+    for customer_id, sample in zip(customer_ids, samples):
+        assert sample.customer_id == customer_id
+        assert sample.subject_id == subject_id
+        assert sample.is_tumour == is_tumour
+
+
 def test_get_sample_by_name(store_with_samples_that_have_names: Store, name="test_sample_1"):
     """Test that samples can be fetched by name."""
     # GIVEN a database with two samples of which one has a name

--- a/tests/store/api/find/test_find_business_data_sample.py
+++ b/tests/store/api/find/test_find_business_data_sample.py
@@ -88,9 +88,9 @@ def test_get_samples_by_subject_id_and_is_tumour(
 def test_get_samples_by_customer_id_list_and_subject_id_and_is_tumour(
     store_with_samples_customer_id_and_subject_id_and_tumour_status: Store,
     helpers: StoreHelpers,
-    customer_ids = [1, 2]
-    subject_id = "test_subject"
-    is_tumour = True
+    customer_ids: List[int] = [1, 2],
+    subject_id: str = "test_subject",
+    is_tumour: bool = True
 ):
     """Test that samples can be fetched by customer ID, subject ID, and tumour status."""
     # GIVEN a database with four samples, two with customer ID 1 and two with customer ID 2
@@ -113,8 +113,10 @@ def test_get_samples_by_customer_id_list_and_subject_id_and_is_tumour(
     # THEN two samples should be returned, one for each customer ID, with the specified subject ID and tumour status
     assert isinstance(samples, list)
     assert len(samples) == 2
-for sample in samples:
-    assert isInstance(sample,Sample)
+
+    for sample in samples:
+        assert isinstance(sample, Sample)
+
     for customer_id, sample in zip(customer_ids, samples):
         assert sample.customer_id == customer_id
         assert sample.subject_id == subject_id

--- a/tests/store/api/find/test_find_business_data_sample.py
+++ b/tests/store/api/find/test_find_business_data_sample.py
@@ -90,14 +90,10 @@ def test_get_samples_by_customer_id_list_and_subject_id_and_is_tumour(
     helpers: StoreHelpers,
     customer_ids: List[int] = [1, 2],
     subject_id: str = "test_subject",
-    is_tumour: bool = True
+    is_tumour: bool = True,
 ):
     """Test that samples can be fetched by customer ID, subject ID, and tumour status."""
     # GIVEN a database with four samples, two with customer ID 1 and two with customer ID 2
-
-
-    # ASSERT that there are four samples in the store
-    assert len(store_with_samples_customer_id_and_subject_id_and_tumour_status.get_samples()) == 4
 
     # ASSERT that there are customers with the given customer IDs
     for customer_id in customer_ids:

--- a/tests/store/api/find/test_find_business_data_sample.py
+++ b/tests/store/api/find/test_find_business_data_sample.py
@@ -119,6 +119,36 @@ def test_get_samples_by_customer_id_list_and_subject_id_and_is_tumour(
         assert sample.is_tumour == is_tumour
 
 
+def test_get_samples_by_customer_id_list_and_subject_id_and_is_tumour_with_non_existing_customer_id(
+    store_with_samples_customer_id_and_subject_id_and_tumour_status: Store,
+    helpers: StoreHelpers,
+):
+    """Test that no samples are returned when filtering on non-existing customer ID."""
+    # GIVEN a database with four samples, two with customer ID 1 and two with customer ID 2
+
+    # ASSERT that there are no customers with the given customer IDs
+    customer_ids = [1, 2, 3]
+    for customer_id in customer_ids:
+        if customer_id == 3:
+            assert store_with_samples_customer_id_and_subject_id_and_tumour_status.get_customer_by_customer_id(
+                customer_id=str(customer_id)
+            ) is None
+        else:
+            assert store_with_samples_customer_id_and_subject_id_and_tumour_status.get_customer_by_customer_id(
+                customer_id=str(customer_id)
+            )
+
+    # WHEN fetching the samples by customer ID list, subject ID, and tumour status
+    non_existing_customer_id = [3]
+    samples = store_with_samples_customer_id_and_subject_id_and_tumour_status.get_samples_by_customer_id_list_and_subject_id_and_is_tumour(
+        customer_ids=non_existing_customer_id, subject_id="test_subject"
+    )
+
+    # THEN no samples should be returned
+    assert isinstance(samples, list)
+    assert len(samples) == 0
+
+
 def test_get_sample_by_name(store_with_samples_that_have_names: Store, name="test_sample_1"):
     """Test that samples can be fetched by name."""
     # GIVEN a database with two samples of which one has a name

--- a/tests/store/api/find/test_find_business_data_sample.py
+++ b/tests/store/api/find/test_find_business_data_sample.py
@@ -88,12 +88,13 @@ def test_get_samples_by_subject_id_and_is_tumour(
 def test_get_samples_by_customer_id_list_and_subject_id_and_is_tumour(
     store_with_samples_customer_id_and_subject_id_and_tumour_status: Store,
     helpers: StoreHelpers,
-):
-    """Test that samples can be fetched by customer ID, subject ID, and tumour status."""
-    # GIVEN a database with four samples, two with customer ID 1 and two with customer ID 2
     customer_ids = [1, 2]
     subject_id = "test_subject"
     is_tumour = True
+):
+    """Test that samples can be fetched by customer ID, subject ID, and tumour status."""
+    # GIVEN a database with four samples, two with customer ID 1 and two with customer ID 2
+
 
     # ASSERT that there are four samples in the store
     assert len(store_with_samples_customer_id_and_subject_id_and_tumour_status.get_samples()) == 4
@@ -112,7 +113,8 @@ def test_get_samples_by_customer_id_list_and_subject_id_and_is_tumour(
     # THEN two samples should be returned, one for each customer ID, with the specified subject ID and tumour status
     assert isinstance(samples, list)
     assert len(samples) == 2
-
+for sample in samples:
+    assert isInstance(sample,Sample)
     for customer_id, sample in zip(customer_ids, samples):
         assert sample.customer_id == customer_id
         assert sample.subject_id == subject_id

--- a/tests/store/api/find/test_find_business_data_sample.py
+++ b/tests/store/api/find/test_find_business_data_sample.py
@@ -87,7 +87,6 @@ def test_get_samples_by_subject_id_and_is_tumour(
 
 def test_get_samples_by_customer_id_list_and_subject_id_and_is_tumour(
     store_with_samples_customer_id_and_subject_id_and_tumour_status: Store,
-    helpers: StoreHelpers,
     customer_ids: List[int] = [1, 2],
     subject_id: str = "test_subject",
     is_tumour: bool = True,
@@ -130,9 +129,12 @@ def test_get_samples_by_customer_id_list_and_subject_id_and_is_tumour_with_non_e
     customer_ids = [1, 2, 3]
     for customer_id in customer_ids:
         if customer_id == 3:
-            assert store_with_samples_customer_id_and_subject_id_and_tumour_status.get_customer_by_customer_id(
-                customer_id=str(customer_id)
-            ) is None
+            assert (
+                store_with_samples_customer_id_and_subject_id_and_tumour_status.get_customer_by_customer_id(
+                    customer_id=str(customer_id)
+                )
+                is None
+            )
         else:
             assert store_with_samples_customer_id_and_subject_id_and_tumour_status.get_customer_by_customer_id(
                 customer_id=str(customer_id)


### PR DESCRIPTION
## Description
In order to filter samples using a list of customer ID's, such as in a collaborator group, a new function is needed to keep the SQL logic within the find_business_data.py.

### Added

- new function: `get_samples_by_customer_id_list_and_subject_id_and_is_tumour`

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b add-sample-filter-by-customer-list -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
