### PR TITLE
refactor(latest_analyses)

### DIFF
--- a/cg/cli/workflow/microsalt/base.py
+++ b/cg/cli/workflow/microsalt/base.py
@@ -277,7 +277,7 @@ def upload_vogue_latest(context: click.Context, dry_run: bool) -> None:
     EXIT_CODE: int = EXIT_SUCCESS
     analysis_api: MicrosaltAnalysisAPI = context.obj.meta_apis["analysis_api"]
     latest_analyses = list(
-        analysis_api.status_db.latest_analyses()
+        analysis_api.status_db.get_analyses_by_case_entry_id_and_latest_started_at_date()
         .filter(Analysis.pipeline == Pipeline.MICROSALT)
         .filter(Analysis.uploaded_at.is_(None))
     )

--- a/cg/meta/upload/nipt/nipt.py
+++ b/cg/meta/upload/nipt/nipt.py
@@ -94,8 +94,10 @@ class NiptUploadAPI:
     def get_all_upload_analyses(self) -> Iterable[Analysis]:
         """Gets all nipt analyses that are ready to be uploaded"""
 
-        latest_nipt_analyses = self.status_db.latest_analyses().filter(
-            Analysis.pipeline == Pipeline.FLUFFY
+        latest_nipt_analyses = (
+            self.status_db.get_analyses_by_case_entry_id_and_latest_started_at_date().filter(
+                Analysis.pipeline == Pipeline.FLUFFY
+            )
         )
 
         return latest_nipt_analyses.filter(Analysis.uploaded_at.is_(None))

--- a/tests/store/api/status/test_store_api_status.py
+++ b/tests/store/api/status/test_store_api_status.py
@@ -190,11 +190,48 @@ def test_multiple_analyses(analysis_store, helpers, timestamp_now, timestamp_yes
     )
 
     # WHEN calling the analyses_to_delivery_report
-    analyses = analysis_store.latest_analyses().all()
+    analyses = analysis_store.get_analyses_by_case_entry_id_and_latest_started_at_date()
 
     # THEN only the newest analysis should be returned
     assert analysis_newest in analyses
     assert analysis_oldest not in analyses
+
+
+def test_multiple_analyses_and_cases(analysis_store, helpers, timestamp_now, timestamp_yesterday):
+    """Tests that analyses that are not latest are not returned."""
+
+    # GIVEN an analysis that is not delivery reported but there exists a newer analysis
+    case_one = analysis_store.get_case_by_internal_id("yellowhog")
+    case_two = helpers.add_case(analysis_store, internal_id="test_case_1")
+
+    cases = [case_one, case_two]
+    for case in cases:
+        oldest_analysis = helpers.add_analysis(
+            analysis_store,
+            case=case,
+            started_at=timestamp_yesterday,
+            uploaded_at=timestamp_yesterday,
+            delivery_reported_at=None,
+        )
+        helpers.add_analysis(
+            analysis_store,
+            case=case,
+            started_at=timestamp_now,
+            uploaded_at=timestamp_now,
+            delivery_reported_at=None,
+        )
+        sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
+        analysis_store.relate_sample(
+            family=oldest_analysis.family, sample=sample, status=PhenotypeStatus.UNKNOWN
+        )
+
+    # WHEN calling the analyses_to_delivery_report
+    analyses = analysis_store.get_analyses_by_case_entry_id_and_latest_started_at_date()
+
+    # THEN only the newest analysis should be returned
+    for analysis in analyses:
+        assert analysis.family.internal_id in ["test_case_1", "yellowhog"]
+        assert analysis.started_at == timestamp_now
 
 
 def test_set_case_action(analysis_store, case_id):


### PR DESCRIPTION
## Description

Refactor of the latest analyses function

### Changed

- function name `latest_analyses` renamed to `get_analyses_by_case_entry_id_and_latest_started_at_date`

### Added

- filter function `filter_analyses_by_started_at`
- Test for filter function
- test for `get_analyses_by_case_entry_id_and_latest_started_at_date`


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
