### PR TITLE
refactor(move queries to findhandler)

### DIFF
--- a/cg/cli/workflow/microsalt/base.py
+++ b/cg/cli/workflow/microsalt/base.py
@@ -276,11 +276,7 @@ def upload_vogue_latest(context: click.Context, dry_run: bool) -> None:
 
     EXIT_CODE: int = EXIT_SUCCESS
     analysis_api: MicrosaltAnalysisAPI = context.obj.meta_apis["analysis_api"]
-    latest_analyses = list(
-        analysis_api.status_db.latest_analyses()
-        .filter(Analysis.pipeline == Pipeline.MICROSALT)
-        .filter(Analysis.uploaded_at.is_(None))
-    )
+    latest_analyses = list(analysis_api.status_db.get_latest_microsalt_analysis_to_upload())
     for analysis in latest_analyses:
         unique_id: str = analysis.family.internal_id
         try:

--- a/cg/meta/upload/nipt/nipt.py
+++ b/cg/meta/upload/nipt/nipt.py
@@ -93,12 +93,7 @@ class NiptUploadAPI:
 
     def get_all_upload_analyses(self) -> Iterable[Analysis]:
         """Gets all nipt analyses that are ready to be uploaded"""
-
-        latest_nipt_analyses = self.status_db.latest_analyses().filter(
-            Analysis.pipeline == Pipeline.FLUFFY
-        )
-
-        return latest_nipt_analyses.filter(Analysis.uploaded_at.is_(None))
+        return self.status_db.get_latest_nipt_analysis_to_upload()
 
     def upload_to_ftp_server(self, results_file: Path) -> None:
         """Upload the result file to the ftp server"""

--- a/cg/store/api/find_business_data.py
+++ b/cg/store/api/find_business_data.py
@@ -95,10 +95,12 @@ class FindBusinessDataHandler(BaseHandler):
         return records
 
     def get_latest_nipt_analysis_to_upload(self):
+        """Return latest nipt analysis."""
         latest_nipt_analyses = self.latest_analyses().filter(Analysis.pipeline == Pipeline.FLUFFY)
         return latest_nipt_analyses.filter(Analysis.uploaded_at.is_(None))
 
     def get_latest_microsalt_analysis_to_upload(self):
+        """Return latest mircosalt analysis."""
         return (
             self.latest_analyses()
             .filter(Analysis.pipeline == Pipeline.MICROSALT)

--- a/cg/store/api/find_business_data.py
+++ b/cg/store/api/find_business_data.py
@@ -94,6 +94,17 @@ class FindBusinessDataHandler(BaseHandler):
 
         return records
 
+    def get_latest_nipt_analysis_to_upload(self):
+        latest_nipt_analyses = self.latest_analyses().filter(Analysis.pipeline == Pipeline.FLUFFY)
+        return latest_nipt_analyses.filter(Analysis.uploaded_at.is_(None))
+
+    def get_latest_microsalt_analysis_to_upload(self):
+        return (
+            self.latest_analyses()
+            .filter(Analysis.pipeline == Pipeline.MICROSALT)
+            .filter(Analysis.uploaded_at.is_(None))
+        )
+
     def latest_analyses(self) -> Query:
         """Fetch latest analysis for all cases."""
 

--- a/tests/store/api/conftest.py
+++ b/tests/store/api/conftest.py
@@ -579,7 +579,7 @@ def fixture_store_with_analyses_for_cases_not_uploaded_fluffy(
     timestamp_now: dt.datetime,
     timestamp_yesterday: dt.datetime,
 ) -> Store:
-    """Return a store with two analyses for two cases."""
+    """Return a store with two analyses for two cases and pipeline."""
     case_one = analysis_store.get_case_by_internal_id("yellowhog")
     case_two = helpers.add_case(analysis_store, internal_id="test_case_1")
 
@@ -617,7 +617,7 @@ def fixture_store_with_analyses_for_cases_not_uploaded_microsalt(
     timestamp_now: dt.datetime,
     timestamp_yesterday: dt.datetime,
 ) -> Store:
-    """Return a store with two analyses for two cases."""
+    """Return a store with two analyses for two cases and pipeline."""
     case_one = analysis_store.get_case_by_internal_id("yellowhog")
     case_two = helpers.add_case(analysis_store, internal_id="test_case_1")
 

--- a/tests/store/api/conftest.py
+++ b/tests/store/api/conftest.py
@@ -611,7 +611,7 @@ def fixture_store_with_analyses_for_cases_not_uploaded_fluffy(
 
 
 @pytest.fixture(name="store_with_analyses_for_cases_not_uploaded_microsalt")
-def fixture_store_with_analyses_for_cases_not_uploaded_fluffy(
+def fixture_store_with_analyses_for_cases_not_uploaded_microsalt(
     analysis_store: Store,
     helpers: StoreHelpers,
     timestamp_now: dt.datetime,

--- a/tests/store/api/conftest.py
+++ b/tests/store/api/conftest.py
@@ -17,6 +17,8 @@ from tests.store_helpers import StoreHelpers
 from cg.store.models import ApplicationVersion, Pool, Sample, Invoice, Application
 from tests.meta.demultiplex.conftest import fixture_populated_flow_cell_store
 from cg.constants.invoice import CustomerNames
+from cg.constants.subject import PhenotypeStatus
+from cg.constants import Pipeline
 
 
 class StoreCheckers:
@@ -532,3 +534,115 @@ def fixture_store_with_pools_for_multiple_customers(
             delivered_at=timestamp_now,
         )
     yield store
+
+
+@pytest.fixture(name="store_with_analyses_for_cases")
+def fixture_store_with_analyses_for_cases(
+    analysis_store: Store,
+    helpers: StoreHelpers,
+    timestamp_now: dt.datetime,
+    timestamp_yesterday: dt.datetime,
+) -> Store:
+    """Return a store with two analyses for two cases."""
+    case_one = analysis_store.get_case_by_internal_id("yellowhog")
+    case_two = helpers.add_case(analysis_store, internal_id="test_case_1")
+
+    cases = [case_one, case_two]
+    for case in cases:
+        oldest_analysis = helpers.add_analysis(
+            analysis_store,
+            case=case,
+            started_at=timestamp_yesterday,
+            uploaded_at=timestamp_yesterday,
+            delivery_reported_at=None,
+            uploaded_to_vogue_at=timestamp_yesterday,
+        )
+        helpers.add_analysis(
+            analysis_store,
+            case=case,
+            started_at=timestamp_now,
+            uploaded_at=timestamp_now,
+            delivery_reported_at=None,
+            uploaded_to_vogue_at=timestamp_now,
+        )
+        sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
+        analysis_store.relate_sample(
+            family=oldest_analysis.family, sample=sample, status=PhenotypeStatus.UNKNOWN
+        )
+    return analysis_store
+
+
+@pytest.fixture(name="store_with_analyses_for_cases_not_uploaded_fluffy")
+def fixture_store_with_analyses_for_cases_not_uploaded_fluffy(
+    analysis_store: Store,
+    helpers: StoreHelpers,
+    timestamp_now: dt.datetime,
+    timestamp_yesterday: dt.datetime,
+) -> Store:
+    """Return a store with two analyses for two cases."""
+    case_one = analysis_store.get_case_by_internal_id("yellowhog")
+    case_two = helpers.add_case(analysis_store, internal_id="test_case_1")
+
+    cases = [case_one, case_two]
+    for case in cases:
+        oldest_analysis = helpers.add_analysis(
+            analysis_store,
+            case=case,
+            started_at=timestamp_yesterday,
+            uploaded_at=timestamp_yesterday,
+            delivery_reported_at=None,
+            uploaded_to_vogue_at=timestamp_yesterday,
+            pipeline=Pipeline.FLUFFY,
+        )
+        helpers.add_analysis(
+            analysis_store,
+            case=case,
+            started_at=timestamp_now,
+            uploaded_at=None,
+            delivery_reported_at=None,
+            uploaded_to_vogue_at=timestamp_now,
+            pipeline=Pipeline.FLUFFY,
+        )
+        sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
+        analysis_store.relate_sample(
+            family=oldest_analysis.family, sample=sample, status=PhenotypeStatus.UNKNOWN
+        )
+    return analysis_store
+
+
+@pytest.fixture(name="store_with_analyses_for_cases_not_uploaded_microsalt")
+def fixture_store_with_analyses_for_cases_not_uploaded_fluffy(
+    analysis_store: Store,
+    helpers: StoreHelpers,
+    timestamp_now: dt.datetime,
+    timestamp_yesterday: dt.datetime,
+) -> Store:
+    """Return a store with two analyses for two cases."""
+    case_one = analysis_store.get_case_by_internal_id("yellowhog")
+    case_two = helpers.add_case(analysis_store, internal_id="test_case_1")
+
+    cases = [case_one, case_two]
+    for case in cases:
+        oldest_analysis = helpers.add_analysis(
+            analysis_store,
+            case=case,
+            started_at=timestamp_yesterday,
+            uploaded_at=timestamp_yesterday,
+            delivery_reported_at=None,
+            uploaded_to_vogue_at=timestamp_yesterday,
+            pipeline=Pipeline.MICROSALT,
+        )
+        helpers.add_analysis(
+            analysis_store,
+            case=case,
+            started_at=timestamp_now,
+            uploaded_at=None,
+            delivery_reported_at=None,
+            uploaded_to_vogue_at=timestamp_now,
+            pipeline=Pipeline.MICROSALT,
+        )
+        sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
+        analysis_store.relate_sample(
+            family=oldest_analysis.family, sample=sample, status=PhenotypeStatus.UNKNOWN
+        )
+    return analysis_store

--- a/tests/store/api/find/test_find_business_data_analysis.py
+++ b/tests/store/api/find/test_find_business_data_analysis.py
@@ -1,11 +1,12 @@
 """Tests the findbusinessdata part of the Cg store API related to Analysis model."""
-
+from datetime import datetime
 from typing import List
 from cg.store import Store
 from cg.store.models import (
     Analysis,
 )
 from tests.store_helpers import StoreHelpers
+from cg.constants import Pipeline
 
 
 def test_get_analysis_by_case(
@@ -23,3 +24,39 @@ def test_get_analysis_by_case(
     for analysis in analyses:
         assert analysis
         assert analysis.family == case
+
+
+def test_get_latest_nipt_analysis_to_upload(
+    store_with_analyses_for_cases_not_uploaded_fluffy: Store, timestamp_now: datetime
+):
+    # GIVEN an analysis that is not delivery reported but there exists a newer analysis
+
+    # WHEN calling the analyses_to_delivery_report
+    analyses = (
+        store_with_analyses_for_cases_not_uploaded_fluffy.get_latest_nipt_analysis_to_upload()
+    )
+
+    # THEN only the newest analysis should be returned
+    for analysis in analyses:
+        assert analysis.family.internal_id in ["test_case_1", "yellowhog"]
+        assert analysis.started_at == timestamp_now
+        assert analysis.uploaded_at is None
+        assert analysis.pipeline == Pipeline.FLUFFY
+
+
+def test_get_latest_microsalt_analysis_to_upload(
+    store_with_analyses_for_cases_not_uploaded_microsalt: Store, timestamp_now: datetime
+):
+    # GIVEN an analysis that is not delivery reported but there exists a newer analysis
+
+    # WHEN calling the analyses_to_delivery_report
+    analyses = (
+        store_with_analyses_for_cases_not_uploaded_microsalt.get_latest_microsalt_analysis_to_upload()
+    )
+
+    # THEN only the newest analysis should be returned
+    for analysis in analyses:
+        assert analysis.family.internal_id in ["test_case_1", "yellowhog"]
+        assert analysis.started_at == timestamp_now
+        assert analysis.uploaded_at is None
+        assert analysis.pipeline == Pipeline.MICROSALT


### PR DESCRIPTION
## Description

In preparation for the refaction of the latest_analyses function some code needed to be moved from other apis to the fund handler.

### Added

- functions `get_latest_nipt_analysis_to_upload` and `get_latest_microsalt_analysis_to_upload`
- tests for these functions

### Changed

- Moved code from nipt.py and microsalt/base.py to find_business_data.py. The code that got moved was placed into functions which are now at those initial places. 

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
