### PR TITLE
fix(cg/meta/backup.py Nonetype.to_archive bug)

### DIFF
--- a/cg/meta/backup/backup.py
+++ b/cg/meta/backup/backup.py
@@ -405,14 +405,15 @@ class SpringBackupAPI:
             return
         hk_spring_file: File = self.hk_api.files(path=str(spring_file_path)).first()
         LOG.info(f"Setting {spring_file_path} to archived in Housekeeper")
-        self.hk_api.set_to_archive(file=hk_spring_file, value=True)
+        if hk_spring_file:
+            self.hk_api.set_to_archive(file=hk_spring_file, value=True)
 
     def is_to_be_retrieved_and_decrypted(self, spring_file_path: Path) -> bool:
         """Determines if a spring file is archived on PDC and needs to be retrieved and decrypted."""
-        return (
-            self.hk_api.files(path=str(spring_file_path)).first().to_archive
-            and not spring_file_path.exists()
-        )
+        file = self.hk_api.files(path=str(spring_file_path)).first()
+        if file and not spring_file_path.exists():
+            return file.to_archive
+        return False
 
     def remove_archived_spring_file(self, spring_file_path: Path) -> None:
         """Removes all files related to spring PDC archiving."""
@@ -422,7 +423,10 @@ class SpringBackupAPI:
 
     def is_spring_file_archived(self, spring_file_path: Path) -> bool:
         """Checks if a spring file is marked as archived in Housekeeper."""
-        return self.hk_api.files(path=str(spring_file_path)).first().to_archive
+        file = self.hk_api.files(path=str(spring_file_path)).first()
+        if file and not spring_file_path.exists():
+            return file.to_archive
+        return False
 
     @staticmethod
     def is_compression_ongoing(spring_file_path: Path) -> bool:

--- a/cg/meta/backup/backup.py
+++ b/cg/meta/backup/backup.py
@@ -408,7 +408,7 @@ class SpringBackupAPI:
             LOG.info(f"Setting {spring_file_path} to archived in Housekeeper")
             self.hk_api.set_to_archive(file=hk_spring_file, value=True)
         else:
-            LOG.warning(f"Could not find {spring_file_path} in Housekeeper")
+            LOG.warning(f"Could not find {spring_file_path} on disk")
 
     def remove_archived_spring_file(self, spring_file_path: Path) -> None:
         """Removes all files related to spring PDC archiving."""
@@ -418,15 +418,15 @@ class SpringBackupAPI:
 
     def is_to_be_retrieved_and_decrypted(self, spring_file_path: Path) -> bool:
         """Determines if a spring file is archived on PDC and needs to be retrieved and decrypted."""
-        file = self.hk_api.files(path=str(spring_file_path)).first()
+        file: File = self.hk_api.files(path=str(spring_file_path)).first()
         if file and not spring_file_path.exists():
-            LOG.warning(f"Could not find {spring_file_path} in Housekeeper")
+            LOG.warning(f"Could not find {spring_file_path} on disk")
             return file.to_archive
         return False
 
     def is_spring_file_archived(self, spring_file_path: Path) -> bool:
         """Checks if a spring file is marked as archived in Housekeeper."""
-        file = self.hk_api.files(path=str(spring_file_path)).first()
+        file: File = self.hk_api.files(path=str(spring_file_path)).first()
         if file:
             return file.to_archive
         return False

--- a/cg/meta/backup/backup.py
+++ b/cg/meta/backup/backup.py
@@ -407,6 +407,8 @@ class SpringBackupAPI:
         if hk_spring_file:
             LOG.info(f"Setting {spring_file_path} to archived in Housekeeper")
             self.hk_api.set_to_archive(file=hk_spring_file, value=True)
+        else:
+            LOG.warning(f"Could not find {spring_file_path} in Housekeeper")
 
     def remove_archived_spring_file(self, spring_file_path: Path) -> None:
         """Removes all files related to spring PDC archiving."""
@@ -418,7 +420,7 @@ class SpringBackupAPI:
         """Checks if a spring file is marked as archived in Housekeeper."""
         file = self.hk_api.files(path=str(spring_file_path)).first()
         if file and not spring_file_path.exists():
-            LOG.info(f"Spring file {spring_file_path} does not exist")
+            LOG.warning(f"Could not find {spring_file_path} in Housekeeper")
             return file.to_archive
         return False
 

--- a/cg/meta/backup/backup.py
+++ b/cg/meta/backup/backup.py
@@ -404,17 +404,9 @@ class SpringBackupAPI:
             LOG.info(f"Dry run, no changes made to {spring_file_path}")
             return
         hk_spring_file: File = self.hk_api.files(path=str(spring_file_path)).first()
-        LOG.info(f"Setting {spring_file_path} to archived in Housekeeper")
         if hk_spring_file:
+            LOG.info(f"Setting {spring_file_path} to archived in Housekeeper")
             self.hk_api.set_to_archive(file=hk_spring_file, value=True)
-
-    def is_to_be_retrieved_and_decrypted(self, spring_file_path: Path) -> bool:
-        """Determines if a spring file is archived on PDC and needs to be retrieved and decrypted."""
-        file = self.hk_api.files(path=str(spring_file_path)).first()
-        if file and not spring_file_path.exists():
-            LOG.info(f"Spring file {spring_file_path} does not exist")
-            return file.to_archive
-        return False
 
     def remove_archived_spring_file(self, spring_file_path: Path) -> None:
         """Removes all files related to spring PDC archiving."""

--- a/cg/meta/backup/backup.py
+++ b/cg/meta/backup/backup.py
@@ -416,11 +416,18 @@ class SpringBackupAPI:
             LOG.info(f"Removing spring file {spring_file_path} from disk")
             spring_file_path.unlink()
 
-    def is_spring_file_archived(self, spring_file_path: Path) -> bool:
-        """Checks if a spring file is marked as archived in Housekeeper."""
+    def is_to_be_retrieved_and_decrypted(self, spring_file_path: Path) -> bool:
+        """Determines if a spring file is archived on PDC and needs to be retrieved and decrypted."""
         file = self.hk_api.files(path=str(spring_file_path)).first()
         if file and not spring_file_path.exists():
             LOG.warning(f"Could not find {spring_file_path} in Housekeeper")
+            return file.to_archive
+        return False
+
+    def is_spring_file_archived(self, spring_file_path: Path) -> bool:
+        """Checks if a spring file is marked as archived in Housekeeper."""
+        file = self.hk_api.files(path=str(spring_file_path)).first()
+        if file:
             return file.to_archive
         return False
 

--- a/cg/meta/backup/backup.py
+++ b/cg/meta/backup/backup.py
@@ -412,6 +412,7 @@ class SpringBackupAPI:
         """Determines if a spring file is archived on PDC and needs to be retrieved and decrypted."""
         file = self.hk_api.files(path=str(spring_file_path)).first()
         if file and not spring_file_path.exists():
+            LOG.info(f"Spring file {spring_file_path} does not exist")
             return file.to_archive
         return False
 
@@ -425,6 +426,7 @@ class SpringBackupAPI:
         """Checks if a spring file is marked as archived in Housekeeper."""
         file = self.hk_api.files(path=str(spring_file_path)).first()
         if file and not spring_file_path.exists():
+            LOG.info(f"Spring file {spring_file_path} does not exist")
             return file.to_archive
         return False
 

--- a/cg/meta/backup/backup.py
+++ b/cg/meta/backup/backup.py
@@ -420,7 +420,6 @@ class SpringBackupAPI:
         """Determines if a spring file is archived on PDC and needs to be retrieved and decrypted."""
         spring_file: File = self.hk_api.files(path=str(spring_file_path)).first()
         if spring_file and not spring_file_path.exists():
-            LOG.warning(f"Could not find {spring_file_path} on disk")
             return spring_file.to_archive
         return False
 

--- a/cg/meta/backup/backup.py
+++ b/cg/meta/backup/backup.py
@@ -418,17 +418,17 @@ class SpringBackupAPI:
 
     def is_to_be_retrieved_and_decrypted(self, spring_file_path: Path) -> bool:
         """Determines if a spring file is archived on PDC and needs to be retrieved and decrypted."""
-        file: File = self.hk_api.files(path=str(spring_file_path)).first()
-        if file and not spring_file_path.exists():
+        spring_file: File = self.hk_api.files(path=str(spring_file_path)).first()
+        if spring_file and not spring_file_path.exists():
             LOG.warning(f"Could not find {spring_file_path} on disk")
-            return file.to_archive
+            return spring_file.to_archive
         return False
 
     def is_spring_file_archived(self, spring_file_path: Path) -> bool:
         """Checks if a spring file is marked as archived in Housekeeper."""
-        file: File = self.hk_api.files(path=str(spring_file_path)).first()
-        if file:
-            return file.to_archive
+        spring_file: File = self.hk_api.files(path=str(spring_file_path)).first()
+        if spring_file:
+            return spring_file.to_archive
         return False
 
     @staticmethod

--- a/cg/meta/compress/compress.py
+++ b/cg/meta/compress/compress.py
@@ -115,6 +115,7 @@ class CompressAPI:
                 if not self.backup_api.is_to_be_retrieved_and_decrypted(
                     spring_file_path=compression.spring_path
                 ):
+                    LOG.warning(f"Could not find {compression.spring_path} on disk")
                     return False
                 LOG.info("Until the SPRING file is retrieved from PDC and decrypted")
                 self.backup_api.retrieve_and_decrypt_spring_file(

--- a/cg/meta/compress/compress.py
+++ b/cg/meta/compress/compress.py
@@ -112,7 +112,7 @@ class CompressAPI:
         for compression in compressions:
             if not self.crunchy_api.is_spring_decompression_possible(compression_obj=compression):
                 LOG.info(f"SPRING to FASTQ decompression not possible for {sample_id}")
-                if not self.backup_api.is_to_be_retrieved_and_decrypted(
+                if not self.backup_api.is_spring_file_archived(
                     spring_file_path=compression.spring_path
                 ):
                     return False

--- a/cg/meta/compress/compress.py
+++ b/cg/meta/compress/compress.py
@@ -112,7 +112,7 @@ class CompressAPI:
         for compression in compressions:
             if not self.crunchy_api.is_spring_decompression_possible(compression_obj=compression):
                 LOG.info(f"SPRING to FASTQ decompression not possible for {sample_id}")
-                if not self.backup_api.is_spring_file_archived(
+                if not self.backup_api.is_to_be_retrieved_and_decrypted(
                     spring_file_path=compression.spring_path
                 ):
                     return False


### PR DESCRIPTION
## Description

There is a bug occuring in cg/meta/backup.py where it can happen that the to_archive attribute gets accessed on a Nonetype resulting in an error.

### Added

- A none check before accessing the attribute.

### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do cg decompress case

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
