### PR TITLE
refactor(get_analyses_before)

### DIFF
--- a/cg/cli/clean.py
+++ b/cg/cli/clean.py
@@ -40,7 +40,7 @@ from cg.meta.clean.demultiplexed_flow_cells import DemultiplexedRunsFlowCell
 from cg.meta.clean.flow_cell_run_directories import RunDirFlowCell
 from cg.models.cg_config import CGConfig
 from cg.store import Store
-from cg.store.models import Sample, Flowcell
+from cg.store.models import Sample, Flowcell, Analysis
 
 CHECK_COLOR = {True: "green", False: "red"}
 LOG = logging.getLogger(__name__)
@@ -197,10 +197,15 @@ def hk_bundle_files(
     status_db: Store = context.status_db
 
     date_threshold: datetime = get_date_days_ago(days_ago=days_old)
+    if case_id:
+        analyses: List[Analysis] = status_db.get_analyses_for_case_and_pipeline_started_at_before(
+            case_internal_id=case_id, started_at_before=date_threshold, pipeline=pipeline
+        )
+    elif pipeline:
+        analyses: List[Analysis] = status_db.get_analyses_for_case_and_pipeline_started_at_before(
+            case_internal_id=case_id, started_at_before=date_threshold, pipeline=pipeline
+        )
 
-    analyses: Query = status_db.get_analyses_before_date(
-        case_id=case_id, before=date_threshold, pipeline=pipeline
-    )
     size_cleaned: int = 0
     for analysis in analyses:
         LOG.info(f"Cleaning analysis {analysis}")

--- a/cg/cli/clean.py
+++ b/cg/cli/clean.py
@@ -206,10 +206,14 @@ def hk_bundle_files(
             status_db.get_analyses_for_pipeline_started_at_before,
             status_db.get_analyses_for_case_started_at_before,
         ],
-        input_dict={"case_id": case_id, "pipeline": pipeline, "date_threshold": date_threshold},
+        input_dict={
+            "case_internal_id": case_id,
+            "pipeline": pipeline,
+            "started_at_before": date_threshold,
+        },
     )
     analyses: List[Analysis] = function_dispatcher(
-        {"case_id": case_id, "pipeline": pipeline, "date_threshold": date_threshold}
+        {"case_internal_id": case_id, "pipeline": pipeline, "started_at_before": date_threshold}
     )
 
     size_cleaned: int = 0

--- a/cg/meta/clean/api.py
+++ b/cg/meta/clean/api.py
@@ -24,10 +24,12 @@ class CleanAPI:
 
         analysis: Analysis
         LOG.debug(
-            f"number of {pipeline} analyses before: {before} : {self.status_db.get_analyses_before_date(pipeline=pipeline, before=before).count()}"
+            f"number of {pipeline} analyses before: {before} : {len(self.status_db.get_analyses_for_pipeline_started_at_before(pipeline=pipeline, started_at_before=before))}"
         )
 
-        for analysis in self.status_db.get_analyses_before_date(pipeline=pipeline, before=before):
+        for analysis in self.status_db.get_analyses_for_pipeline_started_at_before(
+            pipeline=pipeline, started_at_before=before
+        ):
             bundle_name = analysis.family.internal_id
 
             hk_bundle_version: Optional[Version] = self.housekeeper_api.version(

--- a/cg/store/api/status.py
+++ b/cg/store/api/status.py
@@ -626,7 +626,8 @@ class StatusHandler(BaseHandler):
         pipeline: Pipeline,
     ) -> List[Analysis]:
         """Return all analyses older than certain date."""
-        case_entry_id: int = self.get_case_by_internal_id(internal_id=case_internal_id).id
+        case = self.get_case_by_internal_id(internal_id=case_internal_id)
+        case_entry_id: int = case.id if case else None
         filter_functions: List[AnalysisFilter] = [
             AnalysisFilter.FILTER_BY_CASE_ENTRY_ID,
             AnalysisFilter.FILTER_WITH_PIPELINE,
@@ -646,7 +647,8 @@ class StatusHandler(BaseHandler):
         started_at_before: datetime,
     ) -> List[Analysis]:
         """Return all analyses for a case older than certain date."""
-        case_entry_id: int = self.get_case_by_internal_id(internal_id=case_internal_id).id
+        case = self.get_case_by_internal_id(internal_id=case_internal_id)
+        case_entry_id: int = case.id if case else None
         filter_functions: List[AnalysisFilter] = [
             AnalysisFilter.FILTER_BY_CASE_ENTRY_ID,
             AnalysisFilter.FILTER_STARTED_AT_BEFORE,

--- a/cg/store/api/status.py
+++ b/cg/store/api/status.py
@@ -640,6 +640,24 @@ class StatusHandler(BaseHandler):
             pipeline=pipeline,
         ).all()
 
+    def get_analyses_for_case_started_at_before(
+        self,
+        case_internal_id: str,
+        started_at_before: datetime,
+    ) -> List[Analysis]:
+        """Return all analyses for a case older than certain date."""
+        case_entry_id: int = self.get_case_by_internal_id(internal_id=case_internal_id).id
+        filter_functions: List[AnalysisFilter] = [
+            AnalysisFilter.FILTER_BY_CASE_ENTRY_ID,
+            AnalysisFilter.FILTER_STARTED_AT_BEFORE,
+        ]
+        return apply_analysis_filter(
+            analyses=self._get_query(table=Analysis),
+            filter_functions=filter_functions,
+            case_entry_id=case_entry_id,
+            started_at_date=started_at_before,
+        ).all()
+
     def get_analyses_for_pipeline_started_at_before(
         self, pipeline: Pipeline, started_at_before: datetime
     ) -> List[Analysis]:

--- a/cg/store/api/status.py
+++ b/cg/store/api/status.py
@@ -622,8 +622,8 @@ class StatusHandler(BaseHandler):
     def get_analyses_for_case_and_pipeline_started_at_before(
         self,
         case_internal_id: str,
-        started_at_before: datetime,
         pipeline: Pipeline,
+        started_at_before: datetime,
     ) -> List[Analysis]:
         """Return all analyses older than certain date."""
         case = self.get_case_by_internal_id(internal_id=case_internal_id)

--- a/cg/store/api/status.py
+++ b/cg/store/api/status.py
@@ -621,9 +621,9 @@ class StatusHandler(BaseHandler):
 
     def get_analyses_for_case_and_pipeline_started_at_before(
         self,
-        case_internal_id: str,
         pipeline: Pipeline,
         started_at_before: datetime,
+        case_internal_id: str,
     ) -> List[Analysis]:
         """Return all analyses older than certain date."""
         case = self.get_case_by_internal_id(internal_id=case_internal_id)

--- a/cg/utils/dispatcher.py
+++ b/cg/utils/dispatcher.py
@@ -11,6 +11,7 @@ class Dispatcher:
         key, values = self._parse_input_dict(input_dict)
         if key not in self.dispatch_table:
             raise ValueError(f"No matching function found for arguments: {input_dict.keys()}")
+        vals = [*values]
         return self.dispatch_table[key](*values)
 
     def _parse_input_dict(self, input_dict: Dict[str, Any]) -> [Tuple[str], Tuple[Any]]:

--- a/cg/utils/dispatcher.py
+++ b/cg/utils/dispatcher.py
@@ -8,15 +8,18 @@ class Dispatcher:
         self.dispatch_table: Dict[Tuple[str], Callable] = self._generate_dispatch_table()
 
     def __call__(self, input_dict: Dict[str, Any]):
-        key, values = self._parse_input_dict(input_dict)
-        if key not in self.dispatch_table:
+        parameters_not_none, parameter_values_not_none = self._parse_input_dict(input_dict)
+        if parameters_not_none not in self.dispatch_table:
             raise ValueError(f"No matching function found for arguments: {input_dict.keys()}")
-        return self.dispatch_table[key](**input_dict)
+        return self.dispatch_table[parameters_not_none](
+            **dict(zip(parameters_not_none, parameter_values_not_none))
+        )
 
     def _parse_input_dict(self, input_dict: Dict[str, Any]) -> [Tuple[str], Tuple[Any]]:
         parameters_not_none: List[str] = []
         values_not_none: List[Any] = []
         for parameter in sorted(input_dict.keys()):
+
             value = input_dict[parameter]
             if value is not None:
                 parameters_not_none.append(parameter)

--- a/cg/utils/dispatcher.py
+++ b/cg/utils/dispatcher.py
@@ -26,7 +26,9 @@ class Dispatcher:
     def _generate_dispatch_table(self) -> Dict[Tuple[str], Callable]:
         dispatch_table = {}
         for func in self.functions:
-            func_arg_names: List[str] = func.__code__.co_varnames[: func.__code__.co_argcount]
+            func_arg_names: List[str] = sorted(
+                func.__code__.co_varnames[: func.__code__.co_argcount]
+            )
             func_arg_names: List[str] = [arg for arg in func_arg_names if arg != "self"]
             if len(set(func_arg_names)) != len(func_arg_names):
                 raise ValueError(f"Duplicate argument names in function: {func.__name__}")

--- a/cg/utils/dispatcher.py
+++ b/cg/utils/dispatcher.py
@@ -16,7 +16,7 @@ class Dispatcher:
     def _parse_input_dict(self, input_dict: Dict[str, Any]) -> [Tuple[str], Tuple[Any]]:
         parameters_not_none: List[str] = []
         values_not_none: List[Any] = []
-        for parameter in input_dict.keys():
+        for parameter in sorted(input_dict.keys()):
             value = input_dict[parameter]
             if value is not None:
                 parameters_not_none.append(parameter)

--- a/cg/utils/dispatcher.py
+++ b/cg/utils/dispatcher.py
@@ -11,8 +11,7 @@ class Dispatcher:
         key, values = self._parse_input_dict(input_dict)
         if key not in self.dispatch_table:
             raise ValueError(f"No matching function found for arguments: {input_dict.keys()}")
-        vals = [*values]
-        return self.dispatch_table[key](*values)
+        return self.dispatch_table[key](**input_dict)
 
     def _parse_input_dict(self, input_dict: Dict[str, Any]) -> [Tuple[str], Tuple[Any]]:
         parameters_not_none: List[str] = []

--- a/cg/utils/dispatcher.py
+++ b/cg/utils/dispatcher.py
@@ -3,11 +3,13 @@ from typing import Any, List, Tuple, Callable, Dict
 
 class Dispatcher:
     def __init__(self, functions: List[Callable], input_dict: Dict[str, Any]):
+        """Initialize the dispatcher with a list of functions and an input dict"""
         self.functions: List[Callable] = functions
         self.input_dict: Dict[str, any] = input_dict
         self.dispatch_table: Dict[Tuple[str], Callable] = self._generate_dispatch_table()
 
     def __call__(self, input_dict: Dict[str, Any]):
+        """Call the dispatcher with the input dict"""
         parameters_not_none, parameter_values_not_none = self._parse_input_dict(input_dict)
         if parameters_not_none not in self.dispatch_table:
             raise ValueError(f"No matching function found for arguments: {input_dict.keys()}")
@@ -16,10 +18,10 @@ class Dispatcher:
         )
 
     def _parse_input_dict(self, input_dict: Dict[str, Any]) -> [Tuple[str], Tuple[Any]]:
+        """Parse the input dict and return a tuple of parameters and values that are not None"""
         parameters_not_none: List[str] = []
         values_not_none: List[Any] = []
         for parameter in sorted(input_dict.keys()):
-
             value = input_dict[parameter]
             if value is not None:
                 parameters_not_none.append(parameter)
@@ -27,6 +29,7 @@ class Dispatcher:
         return tuple(parameters_not_none), tuple(values_not_none)
 
     def _generate_dispatch_table(self) -> Dict[Tuple[str], Callable]:
+        """Generate a dispatch table from the list of functions"""
         dispatch_table = {}
         for func in self.functions:
             func_arg_names: List[str] = sorted(

--- a/tests/cli/clean/test_hk_bundle_files.py
+++ b/tests/cli/clean/test_hk_bundle_files.py
@@ -11,7 +11,7 @@ def test_clean_hk_bundle_files_no_files(cli_runner: CliRunner, cg_context: CGCon
     # GIVEN a housekeeper api and a bundle without files
     bundle_name = "non_existing"
     assert not cg_context.housekeeper_api.bundle(bundle_name)
-
+    case = cg_context.status_db.get_case_by_internal_id(bundle_name)
     # WHEN running the clean hk alignment files command
     caplog.set_level(logging.INFO)
     result = cli_runner.invoke(

--- a/tests/cli/clean/test_hk_case_bundle_files.py
+++ b/tests/cli/clean/test_hk_case_bundle_files.py
@@ -42,7 +42,9 @@ def test_clean_hk_case_files_too_old(cli_runner: CliRunner, clean_context: CGCon
     days_ago = 365 * 100
     date_one_year_ago = get_date_days_ago(days_ago)
     context = clean_context
-    assert not context.status_db.get_analyses_before_date(before=date_one_year_ago).all()
+    assert not context.status_db.get_analyses_for_case_and_pipeline_started_at_before(
+        started_at_before=date_one_year_ago
+    )
 
     # WHEN running the clean command
     caplog.set_level(logging.DEBUG)

--- a/tests/cli/clean/test_hk_case_bundle_files.py
+++ b/tests/cli/clean/test_hk_case_bundle_files.py
@@ -42,9 +42,7 @@ def test_clean_hk_case_files_too_old(cli_runner: CliRunner, clean_context: CGCon
     days_ago = 365 * 100
     date_one_year_ago = get_date_days_ago(days_ago)
     context = clean_context
-    assert not context.status_db.get_analyses_for_case_and_pipeline_started_at_before(
-        started_at_before=date_one_year_ago
-    )
+    assert not context.status_db.get_analyses_started_at_before(started_at_before=date_one_year_ago)
 
     # WHEN running the clean command
     caplog.set_level(logging.DEBUG)

--- a/tests/store/api/status/test_store_api_status_analysis.py
+++ b/tests/store/api/status/test_store_api_status_analysis.py
@@ -352,6 +352,29 @@ def test_get_analyses_for_case_and_pipeline_before(
         assert analysis.pipeline == pipeline
 
 
+def test_get_analyses_for_case_before(
+    store_with_analyses_for_cases_not_uploaded_fluffy: Store,
+    timestamp_now: datetime,
+    case_id: str = "yellowhog",
+):
+    """Test to get all analyses before a given date"""
+
+    # GIVEN a database with a number of analyses
+
+    # WHEN getting all analyses before a given date
+    analyses: List[
+        Analysis
+    ] = store_with_analyses_for_cases_not_uploaded_fluffy.get_analyses_for_case_started_at_before(
+        case_internal_id=case_id,
+        started_at_before=timestamp_now,
+    )
+
+    # THEN assert that the analyses before the given date are returned
+    for analysis in analyses:
+        assert analysis.started_at < timestamp_now
+        assert analysis.family.internal_id == case_id
+
+
 def test_get_analyses_for_pipeline_before(
     store_with_analyses_for_cases_not_uploaded_fluffy: Store,
     timestamp_now: datetime,

--- a/tests/store/api/status/test_store_api_status_analysis.py
+++ b/tests/store/api/status/test_store_api_status_analysis.py
@@ -326,3 +326,69 @@ def test_one_of_one_sequenced_samples(
 
     # THEN cases should contain the test case
     assert test_case in cases
+
+
+def test_get_analyses_for_case_and_pipeline_before(
+    store_with_analyses_for_cases_not_uploaded_fluffy: Store,
+    timestamp_now: datetime,
+    pipeline: Pipeline = Pipeline.FLUFFY,
+    case_id: str = "yellowhog",
+):
+    """Test to get all analyses before a given date"""
+
+    # GIVEN a database with a number of analyses
+
+    # WHEN getting all analyses before a given date
+    analyses: List[
+        Analysis
+    ] = store_with_analyses_for_cases_not_uploaded_fluffy.get_analyses_for_case_and_pipeline_started_at_before(
+        case_internal_id=case_id, started_at_before=timestamp_now, pipeline=pipeline
+    )
+
+    # THEN assert that the analyses before the given date are returned
+    for analysis in analyses:
+        assert analysis.started_at < timestamp_now
+        assert analysis.family.internal_id == case_id
+        assert analysis.pipeline == pipeline
+
+
+def test_get_analyses_for_pipeline_before(
+    store_with_analyses_for_cases_not_uploaded_fluffy: Store,
+    timestamp_now: datetime,
+    pipeline: Pipeline = Pipeline.FLUFFY,
+):
+    """Test to get all analyses for a pipeline before a given date"""
+
+    # GIVEN a database with a number of analyses
+
+    # WHEN getting all analyses before a given date
+    analyses: List[
+        Analysis
+    ] = store_with_analyses_for_cases_not_uploaded_fluffy.get_analyses_for_pipeline_started_at_before(
+        started_at_before=timestamp_now, pipeline=pipeline
+    )
+
+    # THEN assert that the analyses before the given date are returned
+    for analysis in analyses:
+        assert analysis.started_at < timestamp_now
+        assert analysis.pipeline == pipeline
+
+
+def test_get_analyses_before(
+    store_with_analyses_for_cases_not_uploaded_fluffy: Store,
+    timestamp_now: datetime,
+):
+    """Test to get all analyses for a pipeline before a given date"""
+
+    # GIVEN a database with a number of analyses
+
+    # WHEN getting all analyses before a given date
+    analyses: List[
+        Analysis
+    ] = store_with_analyses_for_cases_not_uploaded_fluffy.get_analyses_started_at_before(
+        started_at_before=timestamp_now
+    )
+
+    # THEN assert that the analyses before the given date are returned
+    for analysis in analyses:
+        assert analysis.started_at < timestamp_now

--- a/tests/store/api/status/test_store_api_status_analysis.py
+++ b/tests/store/api/status/test_store_api_status_analysis.py
@@ -15,7 +15,7 @@ from tests.store_helpers import StoreHelpers
 def test_get_families_with_extended_models(
     base_store: Store, helpers: StoreHelpers, timestamp_now: datetime
 ):
-    """Test that a query is returned from the database"""
+    """Test that a query is returned from the database."""
 
     # GIVEN a sequenced sample
     test_sample: Sample = helpers.add_sample(base_store, sequenced_at=timestamp_now)
@@ -44,7 +44,7 @@ def test_get_families_with_extended_models(
 
 
 def test_get_families_with_extended_models_when_no_case(base_store: Store):
-    """test that no case is returned from the database when no cases"""
+    """test that no case is returned from the database when no cases."""
 
     # GIVEN an empty database
 
@@ -82,7 +82,7 @@ def test_get_cases_with_samples_query(
 def test_that_many_cases_can_have_one_sample_each(
     base_store: Store, helpers: StoreHelpers, max_nr_of_cases: int, timestamp_now: datetime
 ):
-    """Test that tests that cases are returned even if there are many result rows in the query"""
+    """Test that tests that cases are returned even if there are many result rows in the query."""
 
     # GIVEN a database with max_nr_of_cases cases
     test_cases: List[Family] = helpers.add_cases_with_samples(
@@ -99,7 +99,7 @@ def test_that_many_cases_can_have_one_sample_each(
 def test_that_cases_can_have_many_samples(
     base_store: Store, helpers, max_nr_of_samples: int, timestamp_now: datetime
 ):
-    """Test that tests that cases are returned even if there are many result rows in the query"""
+    """Test that tests that cases are returned even if there are many result rows in the query."""
 
     # GIVEN a cases with max_nr_of_samples sequenced samples
     case_with_50: Family = helpers.add_case_with_samples(
@@ -159,7 +159,7 @@ def test_external_sample_to_re_analyse(
 
 
 def test_new_external_case_not_in_result(base_store: Store, helpers: StoreHelpers):
-    """Test that a case with one external sample that has no specified data_analysis does not show up"""
+    """Test that a case with one external sample that has no specified data_analysis does not show up."""
 
     # GIVEN an externally sequenced sample
     test_sample: Sample = helpers.add_sample(base_store, sequenced_at=None, is_external=True)
@@ -179,7 +179,7 @@ def test_new_external_case_not_in_result(base_store: Store, helpers: StoreHelper
 
 def test_case_to_re_analyse(base_store: Store, helpers: StoreHelpers, timestamp_now: datetime):
     """Test that a case marked for re-analyse with one sample that has been sequenced and
-    with completed analysis do show up among the cases to analyse"""
+    with completed analysis do show up among the cases to analyse."""
 
     # GIVEN a sequenced sample
     test_sample: Sample = helpers.add_sample(base_store, sequenced_at=timestamp_now)
@@ -209,7 +209,7 @@ def test_all_samples_and_analysis_completed(
     base_store: Store, helpers: StoreHelpers, timestamp_now: datetime
 ):
     """Test that a case with one sample that has been sequenced and with completed
-    analysis don't show up among the cases to analyse"""
+    analysis don't show up among the cases to analyse."""
 
     # GIVEN a sequenced sample
     test_sample: Sample = helpers.add_sample(base_store, sequenced_at=timestamp_now)
@@ -233,7 +233,7 @@ def test_all_samples_and_analysis_completed(
 def test_specified_analysis_in_result(
     base_store: Store, helpers: StoreHelpers, timestamp_now: datetime
 ):
-    """Test that a case with one sample that has specified data_analysis does show up"""
+    """Test that a case with one sample that has specified data_analysis does show up."""
 
     # GIVEN a sequenced sample
     test_sample: Sample = helpers.add_sample(base_store, sequenced_at=timestamp_now)
@@ -258,7 +258,7 @@ def test_exclude_other_pipeline_analysis_from_result(
     base_store: Store, helpers: StoreHelpers, timestamp_now: datetime
 ):
     """Test that a case with specified analysis and with one sample does not show up among
-    others"""
+    others."""
 
     # GIVEN a sequenced sample
     test_sample: Sample = helpers.add_sample(base_store, sequenced_at=timestamp_now)
@@ -280,7 +280,7 @@ def test_one_of_two_sequenced_samples(
     base_store: Store, helpers: StoreHelpers, timestamp_now: datetime
 ):
     """Test that a case with one sequenced samples and one not sequenced sample do not shows up among the
-    cases to analyse"""
+    cases to analyse."""
 
     # GIVEN a case
     test_case: Family = helpers.add_case(base_store)
@@ -306,7 +306,7 @@ def test_one_of_one_sequenced_samples(
     base_store: Store, helpers: StoreHelpers, timestamp_now: datetime
 ):
     """Test that a case with one of one samples that has been sequenced shows up among the
-    cases to analyse"""
+    cases to analyse."""
 
     # GIVEN a case
     test_case: Family = helpers.add_case(base_store)
@@ -334,7 +334,7 @@ def test_get_analyses_for_case_and_pipeline_before(
     pipeline: Pipeline = Pipeline.FLUFFY,
     case_id: str = "yellowhog",
 ):
-    """Test to get all analyses before a given date"""
+    """Test to get all analyses before a given date."""
 
     # GIVEN a database with a number of analyses
 
@@ -357,7 +357,7 @@ def test_get_analyses_for_case_before(
     timestamp_now: datetime,
     case_id: str = "yellowhog",
 ):
-    """Test to get all analyses before a given date"""
+    """Test to get all analyses before a given date."""
 
     # GIVEN a database with a number of analyses
 
@@ -380,7 +380,7 @@ def test_get_analyses_for_pipeline_before(
     timestamp_now: datetime,
     pipeline: Pipeline = Pipeline.FLUFFY,
 ):
-    """Test to get all analyses for a pipeline before a given date"""
+    """Test to get all analyses for a pipeline before a given date."""
 
     # GIVEN a database with a number of analyses
 
@@ -401,7 +401,7 @@ def test_get_analyses_before(
     store_with_analyses_for_cases_not_uploaded_fluffy: Store,
     timestamp_now: datetime,
 ):
-    """Test to get all analyses for a pipeline before a given date"""
+    """Test to get all analyses for a pipeline before a given date."""
 
     # GIVEN a database with a number of analyses
 

--- a/tests/utils/test_dispatcher.py
+++ b/tests/utils/test_dispatcher.py
@@ -187,9 +187,9 @@ def test_dispatcher_on_other_functions(
             store.get_analyses_for_case_started_at_before,
         ],
         input_dict={
-            "case_internal_id": case_internal_id,
             "pipeline": pipeline,
             "started_at_before": timestamp_now,
+            "case_internal_id": case_internal_id,
         },
     )
     analyses: List[Analysis] = function_dispatcher(

--- a/tests/utils/test_dispatcher.py
+++ b/tests/utils/test_dispatcher.py
@@ -169,7 +169,7 @@ def test_dispatcher_on_other_functions(
     helpers: StoreHelpers,
     timestamp_now: datetime,
     timestamp_yesterday: datetime,
-    pipeline: str = str(Pipeline.MIP_DNA),
+    pipeline: str = Pipeline.MIP_DNA,
     case_internal_id: str = "test_case",
 ):
     """Test that the dispatcher can be used to call functions in the status db"""
@@ -187,9 +187,9 @@ def test_dispatcher_on_other_functions(
             store.get_analyses_for_case_started_at_before,
         ],
         input_dict={
+            "case_internal_id": case_internal_id,
             "pipeline": pipeline,
             "started_at_before": timestamp_now,
-            "case_internal_id": case_internal_id,
         },
     )
     analyses: List[Analysis] = function_dispatcher(
@@ -202,6 +202,7 @@ def test_dispatcher_on_other_functions(
 
     # THEN the dispatcher should return the correct analyses
     for analysis in analyses:
-        assert analysis.case.internal_id == case_internal_id
+        assert analysis
+        assert analysis.family.internal_id == case_internal_id
         assert analysis.pipeline == pipeline
         assert analysis.started_at < timestamp_now

--- a/tests/utils/test_dispatcher.py
+++ b/tests/utils/test_dispatcher.py
@@ -188,14 +188,14 @@ def test_dispatcher_on_other_functions(
         ],
         input_dict={
             "case_internal_id": case_internal_id,
-            "pipeline": pipeline,
+            "pipeline": Pipeline,
             "started_at_before": timestamp_now,
         },
     )
     analyses: List[Analysis] = function_dispatcher(
         {
             "case_internal_id": case_internal_id,
-            "pipeline": pipeline,
+            "pipeline": Pipeline,
             "started_at_before": timestamp_now,
         }
     )


### PR DESCRIPTION
## Description

Refactoring of the get analyses before function

### Added

- `get_analyses_for_case_and_pipeline_started_at_before`
- `get_analyses_for_pipeline_started_at_before`
-`get_analyses_started_at_before`
- Tests for these functions

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do cg clean hk-bundle-files

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
