### PR TITLE
Refactor family sample

### DIFF
--- a/cg/meta/deliver.py
+++ b/cg/meta/deliver.py
@@ -76,7 +76,7 @@ class DeliverAPI:
                 LOG.info(f"Could not find any version for {case_id}")
             elif not self.skip_missing_bundle:
                 raise SyntaxError(f"Could not find any version for {case_id}")
-        links: List[FamilySample] = self.store.get_case_samples_by_case_id(case_id=case_id)
+        links: List[FamilySample] = self.store.get_case_samples_by_case_id(case_internal_id=case_id)
         if not links:
             LOG.warning(f"Could not find any samples linked to case {case_id}")
             return

--- a/cg/meta/deliver.py
+++ b/cg/meta/deliver.py
@@ -76,7 +76,7 @@ class DeliverAPI:
                 LOG.info(f"Could not find any version for {case_id}")
             elif not self.skip_missing_bundle:
                 raise SyntaxError(f"Could not find any version for {case_id}")
-        links: List[FamilySample] = self.store.family_samples(case_id)
+        links: List[FamilySample] = self.store.get_case_samples_by_case_id(case_id=case_id)
         if not links:
             LOG.warning(f"Could not find any samples linked to case {case_id}")
             return

--- a/cg/meta/orders/case_submitter.py
+++ b/cg/meta/orders/case_submitter.py
@@ -271,7 +271,8 @@ class CaseSubmitter(Submitter):
                 sample_father: Sample = case_samples.get(sample.get(Pedigree.FATHER))
                 with self.status.session.no_autoflush:
                     case_sample: FamilySample = self.status.get_case_sample_link(
-                        case_id=status_db_case.internal_id, sample_id=sample["internal_id"]
+                        case_internal_id=status_db_case.internal_id,
+                        sample_internal_id=sample["internal_id"],
                     )
                 if not case_sample:
                     case_sample: FamilySample = self._create_link(

--- a/cg/meta/orders/case_submitter.py
+++ b/cg/meta/orders/case_submitter.py
@@ -14,7 +14,7 @@ from cg.models.orders.order import OrderIn
 from cg.models.orders.samples import Of1508Sample, OrderInSample
 
 from cg.constants import Priority
-from cg.store.models import Customer, Family, Sample, FamilySample
+from cg.store.models import Customer, Family, Sample, FamilySample, ApplicationVersion
 
 LOG = logging.getLogger(__name__)
 

--- a/cg/meta/orders/case_submitter.py
+++ b/cg/meta/orders/case_submitter.py
@@ -270,8 +270,8 @@ class CaseSubmitter(Submitter):
                 sample_mother: Sample = case_samples.get(sample.get(Pedigree.MOTHER))
                 sample_father: Sample = case_samples.get(sample.get(Pedigree.FATHER))
                 with self.status.session.no_autoflush:
-                    case_sample: FamilySample = self.status.link(
-                        family_id=status_db_case.internal_id, sample_id=sample["internal_id"]
+                    case_sample: FamilySample = self.status.get_case_sample_link(
+                        case_id=status_db_case.internal_id, sample_id=sample["internal_id"]
                     )
                 if not case_sample:
                     case_sample: FamilySample = self._create_link(

--- a/cg/meta/report/mip_dna.py
+++ b/cg/meta/report/mip_dna.py
@@ -27,7 +27,7 @@ from cg.models.report.metadata import MipDNASampleMetadataModel
 from cg.models.report.report import CaseModel
 from cg.models.report.sample import SampleModel
 from cg.models.mip.mip_metrics_deliverables import get_sample_id_metric
-from cg.store.models import Family, Sample
+from cg.store.models import Family, Sample, Application
 
 LOG = logging.getLogger(__name__)
 
@@ -83,11 +83,13 @@ class MipDNAReportAPI(ReportAPI):
     def get_data_analysis_type(self, case: Family) -> Optional[str]:
         """Retrieves the data analysis type carried out."""
 
-        case_sample = self.status_db.get_case_samples_by_case_id(case_internal_id=case.internal_id)[
-            0
-        ].sample
+        case_sample: Sample = self.status_db.get_case_samples_by_case_id(
+            case_internal_id=case.internal_id
+        )[0].sample
         lims_sample = self.get_lims_sample(case_sample.internal_id)
-        application = self.status_db.get_application_by_tag(tag=lims_sample.get("application"))
+        application: Application = self.status_db.get_application_by_tag(
+            tag=lims_sample.get("application")
+        )
 
         return application.analysis_type if application else None
 

--- a/cg/meta/report/mip_dna.py
+++ b/cg/meta/report/mip_dna.py
@@ -83,7 +83,7 @@ class MipDNAReportAPI(ReportAPI):
     def get_data_analysis_type(self, case: Family) -> Optional[str]:
         """Retrieves the data analysis type carried out."""
 
-        case_sample = self.status_db.family_samples(case.internal_id)[0].sample
+        case_sample = self.status_db.get_case_samples_by_case_id(case_id=case.internal_id)[0].sample
         lims_sample = self.get_lims_sample(case_sample.internal_id)
         application = self.status_db.get_application_by_tag(tag=lims_sample.get("application"))
 

--- a/cg/meta/report/mip_dna.py
+++ b/cg/meta/report/mip_dna.py
@@ -83,7 +83,9 @@ class MipDNAReportAPI(ReportAPI):
     def get_data_analysis_type(self, case: Family) -> Optional[str]:
         """Retrieves the data analysis type carried out."""
 
-        case_sample = self.status_db.get_case_samples_by_case_id(case_id=case.internal_id)[0].sample
+        case_sample = self.status_db.get_case_samples_by_case_id(case_internal_id=case.internal_id)[
+            0
+        ].sample
         lims_sample = self.get_lims_sample(case_sample.internal_id)
         application = self.status_db.get_application_by_tag(tag=lims_sample.get("application"))
 

--- a/cg/meta/report/report_api.py
+++ b/cg/meta/report/report_api.py
@@ -29,7 +29,7 @@ from cg.models.report.report import (
     ScoutReportFiles,
 )
 from cg.models.report.sample import SampleModel, ApplicationModel, TimestampModel, MethodsModel
-from cg.store.models import Analysis, Application, Family, Sample
+from cg.store.models import Analysis, Application, Family, Sample, FamilySample
 from jinja2 import Environment, PackageLoader, select_autoescape
 
 LOG = logging.getLogger(__name__)
@@ -254,7 +254,9 @@ class ReportAPI(MetaAPI):
         """Extracts all the samples associated to a specific case and their attributes."""
 
         samples = list()
-        case_samples: List[FamilySample] = self.status_db.family_samples(case.internal_id)
+        case_samples: List[FamilySample] = self.status_db.get_case_samples_by_case_id(
+            case_id=case.internal_id
+        )
 
         for case_sample in case_samples:
             sample: Sample = case_sample.sample

--- a/cg/meta/report/report_api.py
+++ b/cg/meta/report/report_api.py
@@ -255,7 +255,7 @@ class ReportAPI(MetaAPI):
 
         samples = list()
         case_samples: List[FamilySample] = self.status_db.get_case_samples_by_case_id(
-            case_id=case.internal_id
+            case_internal_id=case.internal_id
         )
 
         for case_sample in case_samples:

--- a/cg/store/api/find_business_data.py
+++ b/cg/store/api/find_business_data.py
@@ -3,7 +3,7 @@ import datetime as dt
 import logging
 from typing import Callable, List, Optional, Iterator, Union
 
-from sqlalchemy import and_, func, or_
+from sqlalchemy import and_, func
 from sqlalchemy.orm import Query
 
 from cg.constants import FlowCellStatus, Pipeline
@@ -489,11 +489,17 @@ class FindBusinessDataHandler(BaseHandler):
         ).all()
         return pools + samples
 
-    def link(self, family_id: str, sample_id: str) -> FamilySample:
-        """Return a link between a family and a sample."""
-        case_samples: Query = self._get_join_case_sample_query()
-        return case_samples.filter(
-            Family.internal_id == family_id, Sample.internal_id == sample_id
+    def get_case_sample_link(self, case_id: str, sample_id: str) -> FamilySample:
+        """Return a case-sample link between a family and a sample."""
+        filter_functions: List[CaseSampleFilter] = [
+            CaseSampleFilter.GET_SAMPLES_ASSOCIATED_WITH_CASE_BY_INTERNAL_ID,
+            CaseSampleFilter.GET_CASES_ASSOCIATED_WITH_SAMPLE_BY_INTERNAL_ID,
+        ]
+        return apply_case_sample_filter(
+            filter_functions=filter_functions,
+            case_samples=self._get_join_case_sample_query(),
+            case_id=case_id,
+            sample_id=sample_id,
         ).first()
 
     def new_invoice_id(self) -> int:

--- a/cg/store/api/find_business_data.py
+++ b/cg/store/api/find_business_data.py
@@ -252,11 +252,11 @@ class FindBusinessDataHandler(BaseHandler):
         """Return all cases."""
         return self._get_query(table=Family).all()
 
-    def get_case_samples_by_case_id(self, case_id: str) -> List[FamilySample]:
+    def get_case_samples_by_case_id(self, case_internal_id: str) -> List[FamilySample]:
         """Return the case-sample links associated with a case."""
         return apply_case_sample_filter(
             filter_functions=[CaseSampleFilter.GET_SAMPLES_ASSOCIATED_WITH_CASE_BY_INTERNAL_ID],
-            case_id=case_id,
+            case_internal_id=case_internal_id,
             case_samples=self._get_join_case_sample_query(),
         ).all()
 
@@ -489,7 +489,7 @@ class FindBusinessDataHandler(BaseHandler):
         ).all()
         return pools + samples
 
-    def get_case_sample_link(self, case_id: str, sample_id: str) -> FamilySample:
+    def get_case_sample_link(self, case_internal_id: str, sample_internal_id: str) -> FamilySample:
         """Return a case-sample link between a family and a sample."""
         filter_functions: List[CaseSampleFilter] = [
             CaseSampleFilter.GET_SAMPLES_ASSOCIATED_WITH_CASE_BY_INTERNAL_ID,
@@ -498,8 +498,8 @@ class FindBusinessDataHandler(BaseHandler):
         return apply_case_sample_filter(
             filter_functions=filter_functions,
             case_samples=self._get_join_case_sample_query(),
-            case_id=case_id,
-            sample_id=sample_id,
+            case_internal_id=case_internal_id,
+            sample_internal_id=sample_internal_id,
         ).first()
 
     def new_invoice_id(self) -> int:
@@ -681,7 +681,7 @@ class FindBusinessDataHandler(BaseHandler):
         samples: Query = apply_case_sample_filter(
             filter_functions=[CaseSampleFilter.GET_SAMPLES_ASSOCIATED_WITH_CASE_BY_INTERNAL_ID],
             case_samples=self._get_join_sample_family_query(),
-            case_id=case_id,
+            case_internal_id=case_id,
         )
         samples: Query = apply_sample_filter(
             filter_functions=[SampleFilter.FILTER_WITH_TYPE],

--- a/cg/store/api/find_business_data.py
+++ b/cg/store/api/find_business_data.py
@@ -260,14 +260,6 @@ class FindBusinessDataHandler(BaseHandler):
             case_samples=self._get_join_case_sample_query(),
         ).all()
 
-    def get_sample_cases(self, sample_id: str) -> Query:
-        """Return the case-sample links associated with a sample."""
-        return apply_case_sample_filter(
-            filter_functions=[CaseSampleFilter.GET_CASES_ASSOCIATED_WITH_SAMPLE],
-            sample_id=sample_id,
-            case_samples=self._get_join_case_sample_query(),
-        )
-
     def get_cases_from_sample(self, sample_entry_id: str) -> Query:
         """Return cases related to a given sample."""
         return apply_case_sample_filter(

--- a/cg/store/api/find_business_data.py
+++ b/cg/store/api/find_business_data.py
@@ -255,7 +255,7 @@ class FindBusinessDataHandler(BaseHandler):
     def get_case_samples_by_case_id(self, case_id: str) -> List[FamilySample]:
         """Return the case-sample links associated with a case."""
         return apply_case_sample_filter(
-            filter_functions=[CaseSampleFilter.GET_SAMPLES_ASSOCIATED_WITH_CASE_BY_ID],
+            filter_functions=[CaseSampleFilter.GET_SAMPLES_ASSOCIATED_WITH_CASE_BY_INTERNAL_ID],
             case_id=case_id,
             case_samples=self._get_join_case_sample_query(),
         ).all()
@@ -490,13 +490,11 @@ class FindBusinessDataHandler(BaseHandler):
         return pools + samples
 
     def link(self, family_id: str, sample_id: str) -> FamilySample:
-        """Find a link between a family and a sample."""
-        # to refactor
-        return (
-            self.FamilySample.query.join(FamilySample.family, FamilySample.sample)
-            .filter(Family.internal_id == family_id, Sample.internal_id == sample_id)
-            .first()
-        )
+        """Return a link between a family and a sample."""
+        case_samples: Query = self._get_join_case_sample_query()
+        return case_samples.filter(
+            Family.internal_id == family_id, Sample.internal_id == sample_id
+        ).first()
 
     def new_invoice_id(self) -> int:
         """Fetch invoices."""
@@ -675,7 +673,7 @@ class FindBusinessDataHandler(BaseHandler):
     def get_samples_by_type(self, case_id: str, sample_type: SampleType) -> Optional[List[Sample]]:
         """Get samples given a tissue type."""
         samples: Query = apply_case_sample_filter(
-            filter_functions=[CaseSampleFilter.GET_SAMPLES_ASSOCIATED_WITH_CASE_BY_ID],
+            filter_functions=[CaseSampleFilter.GET_SAMPLES_ASSOCIATED_WITH_CASE_BY_INTERNAL_ID],
             case_samples=self._get_join_sample_family_query(),
             case_id=case_id,
         )

--- a/cg/store/api/find_business_data.py
+++ b/cg/store/api/find_business_data.py
@@ -252,11 +252,11 @@ class FindBusinessDataHandler(BaseHandler):
         """Return all cases."""
         return self._get_query(table=Family).all()
 
-    def family_samples(self, family_id: str) -> List[FamilySample]:
+    def get_case_samples_by_case_id(self, case_id: str) -> List[FamilySample]:
         """Return the case-sample links associated with a case."""
         return apply_case_sample_filter(
             filter_functions=[CaseSampleFilter.GET_SAMPLES_ASSOCIATED_WITH_CASE],
-            case_id=family_id,
+            case_id=case_id,
             case_samples=self._get_join_case_sample_query(),
         ).all()
 

--- a/cg/store/api/find_business_data.py
+++ b/cg/store/api/find_business_data.py
@@ -255,12 +255,12 @@ class FindBusinessDataHandler(BaseHandler):
     def get_case_samples_by_case_id(self, case_id: str) -> List[FamilySample]:
         """Return the case-sample links associated with a case."""
         return apply_case_sample_filter(
-            filter_functions=[CaseSampleFilter.GET_SAMPLES_ASSOCIATED_WITH_CASE],
+            filter_functions=[CaseSampleFilter.GET_SAMPLES_ASSOCIATED_WITH_CASE_BY_ID],
             case_id=case_id,
             case_samples=self._get_join_case_sample_query(),
         ).all()
 
-    def get_cases_from_sample_entry_id(self, sample_entry_id: str) -> Query:
+    def get_case_samples_from_sample_entry_id(self, sample_entry_id: str) -> Query:
         """Return cases related to a given sample."""
         return apply_case_sample_filter(
             filter_functions=[CaseSampleFilter.GET_CASES_ASSOCIATED_WITH_SAMPLE_BY_ENTRY_ID],
@@ -491,6 +491,7 @@ class FindBusinessDataHandler(BaseHandler):
 
     def link(self, family_id: str, sample_id: str) -> FamilySample:
         """Find a link between a family and a sample."""
+        # to refactor
         return (
             self.FamilySample.query.join(FamilySample.family, FamilySample.sample)
             .filter(Family.internal_id == family_id, Sample.internal_id == sample_id)
@@ -674,7 +675,7 @@ class FindBusinessDataHandler(BaseHandler):
     def get_samples_by_type(self, case_id: str, sample_type: SampleType) -> Optional[List[Sample]]:
         """Get samples given a tissue type."""
         samples: Query = apply_case_sample_filter(
-            filter_functions=[CaseSampleFilter.GET_SAMPLES_ASSOCIATED_WITH_CASE],
+            filter_functions=[CaseSampleFilter.GET_SAMPLES_ASSOCIATED_WITH_CASE_BY_ID],
             case_samples=self._get_join_sample_family_query(),
             case_id=case_id,
         )

--- a/cg/store/api/find_business_data.py
+++ b/cg/store/api/find_business_data.py
@@ -260,7 +260,7 @@ class FindBusinessDataHandler(BaseHandler):
             case_samples=self._get_join_case_sample_query(),
         ).all()
 
-    def get_cases_from_sample(self, sample_entry_id: str) -> Query:
+    def get_cases_from_sample_entry_id(self, sample_entry_id: str) -> Query:
         """Return cases related to a given sample."""
         return apply_case_sample_filter(
             filter_functions=[CaseSampleFilter.GET_CASES_ASSOCIATED_WITH_SAMPLE_BY_ENTRY_ID],

--- a/cg/store/api/find_business_data.py
+++ b/cg/store/api/find_business_data.py
@@ -255,7 +255,7 @@ class FindBusinessDataHandler(BaseHandler):
     def get_case_samples_by_case_id(self, case_internal_id: str) -> List[FamilySample]:
         """Return the case-sample links associated with a case."""
         return apply_case_sample_filter(
-            filter_functions=[CaseSampleFilter.GET_SAMPLES_ASSOCIATED_WITH_CASE_BY_INTERNAL_ID],
+            filter_functions=[CaseSampleFilter.GET_SAMPLES_IN_CASE_BY_INTERNAL_ID],
             case_internal_id=case_internal_id,
             case_samples=self._get_join_case_sample_query(),
         ).all()
@@ -263,7 +263,7 @@ class FindBusinessDataHandler(BaseHandler):
     def get_case_samples_from_sample_entry_id(self, sample_entry_id: str) -> Query:
         """Return cases related to a given sample."""
         return apply_case_sample_filter(
-            filter_functions=[CaseSampleFilter.GET_CASES_ASSOCIATED_WITH_SAMPLE_BY_ENTRY_ID],
+            filter_functions=[CaseSampleFilter.GET_CASES_WITH_SAMPLE_BY_ENTRY_ID],
             sample_entry_id=sample_entry_id,
             case_samples=self._get_join_case_sample_query(),
         )
@@ -492,8 +492,8 @@ class FindBusinessDataHandler(BaseHandler):
     def get_case_sample_link(self, case_internal_id: str, sample_internal_id: str) -> FamilySample:
         """Return a case-sample link between a family and a sample."""
         filter_functions: List[CaseSampleFilter] = [
-            CaseSampleFilter.GET_SAMPLES_ASSOCIATED_WITH_CASE_BY_INTERNAL_ID,
-            CaseSampleFilter.GET_CASES_ASSOCIATED_WITH_SAMPLE_BY_INTERNAL_ID,
+            CaseSampleFilter.GET_SAMPLES_IN_CASE_BY_INTERNAL_ID,
+            CaseSampleFilter.GET_CASES_WITH_SAMPLE_BY_INTERNAL_ID,
         ]
         return apply_case_sample_filter(
             filter_functions=filter_functions,
@@ -679,7 +679,7 @@ class FindBusinessDataHandler(BaseHandler):
     def get_samples_by_type(self, case_id: str, sample_type: SampleType) -> Optional[List[Sample]]:
         """Get samples given a tissue type."""
         samples: Query = apply_case_sample_filter(
-            filter_functions=[CaseSampleFilter.GET_SAMPLES_ASSOCIATED_WITH_CASE_BY_INTERNAL_ID],
+            filter_functions=[CaseSampleFilter.GET_SAMPLES_IN_CASE_BY_INTERNAL_ID],
             case_samples=self._get_join_sample_family_query(),
             case_internal_id=case_id,
         )

--- a/cg/store/filters/status_application_version_filters.py
+++ b/cg/store/filters/status_application_version_filters.py
@@ -9,7 +9,7 @@ from cg.store.models import ApplicationVersion
 def filter_application_versions_by_application_entry_id(
     application_versions: Query, application_entry_id: int, **kwargs
 ) -> Query:
-    """Return the application versions given an application id."""
+    """Return the application versions given an application entry id."""
     return application_versions.filter(ApplicationVersion.application_id == application_entry_id)
 
 

--- a/cg/store/filters/status_case_sample_filters.py
+++ b/cg/store/filters/status_case_sample_filters.py
@@ -10,11 +10,6 @@ def get_samples_associated_with_case(case_samples: Query, case_id: str, **kwargs
     return case_samples.filter(Family.internal_id == case_id)
 
 
-def get_cases_associated_with_sample(case_samples: Query, sample_id: str, **kwargs) -> Query:
-    """Return cases associated with a sample."""
-    return case_samples.filter(Sample.internal_id == sample_id)
-
-
 def get_cases_associated_with_sample_by_entry_id(
     case_samples: Query, sample_entry_id: int, **kwargs
 ) -> Query:
@@ -45,7 +40,6 @@ class CaseSampleFilter(Enum):
     """Define CaseSample filter functions."""
 
     GET_SAMPLES_ASSOCIATED_WITH_CASE: Callable = get_samples_associated_with_case
-    GET_CASES_ASSOCIATED_WITH_SAMPLE: Callable = get_cases_associated_with_sample
     GET_CASES_ASSOCIATED_WITH_SAMPLE_BY_ENTRY_ID: Callable = (
         get_cases_associated_with_sample_by_entry_id
     )

--- a/cg/store/filters/status_case_sample_filters.py
+++ b/cg/store/filters/status_case_sample_filters.py
@@ -5,17 +5,22 @@ from sqlalchemy.orm import Query
 from cg.store.models import Family, Sample
 
 
-def get_samples_associated_with_case_by_case_id(
+def get_samples_associated_with_case_by_internal_id(
     case_samples: Query, case_id: str, **kwargs
 ) -> Query:
     """Return samples associated with a case."""
     return case_samples.filter(Family.internal_id == case_id)
 
 
+def get_cases_associated_with_sample_by_internal_id(case_samples: Query, sample_id: str, **kwargs):
+    """Return cases associated with a sample internal id."""
+    return case_samples.filter(Sample.internal_id == sample_id)
+
+
 def get_cases_associated_with_sample_by_entry_id(
     case_samples: Query, sample_entry_id: int, **kwargs
 ) -> Query:
-    """Return cases associated with a sample."""
+    """Return cases associated with a sample entry id."""
     return case_samples.filter(Sample.id == sample_entry_id)
 
 
@@ -41,7 +46,12 @@ def apply_case_sample_filter(
 class CaseSampleFilter(Enum):
     """Define CaseSample filter functions."""
 
-    GET_SAMPLES_ASSOCIATED_WITH_CASE_BY_ID: Callable = get_samples_associated_with_case_by_case_id
+    GET_SAMPLES_ASSOCIATED_WITH_CASE_BY_INTERNAL_ID: Callable = (
+        get_samples_associated_with_case_by_internal_id
+    )
+    GET_CASES_ASSOCIATED_WITH_SAMPLE_BY_INTERNAL_ID: Callable = (
+        get_cases_associated_with_sample_by_internal_id
+    )
     GET_CASES_ASSOCIATED_WITH_SAMPLE_BY_ENTRY_ID: Callable = (
         get_cases_associated_with_sample_by_entry_id
     )

--- a/cg/store/filters/status_case_sample_filters.py
+++ b/cg/store/filters/status_case_sample_filters.py
@@ -6,15 +6,17 @@ from cg.store.models import Family, Sample
 
 
 def get_samples_associated_with_case_by_internal_id(
-    case_samples: Query, case_id: str, **kwargs
+    case_samples: Query, case_internal_id: str, **kwargs
 ) -> Query:
     """Return samples associated with a case."""
-    return case_samples.filter(Family.internal_id == case_id)
+    return case_samples.filter(Family.internal_id == case_internal_id)
 
 
-def get_cases_associated_with_sample_by_internal_id(case_samples: Query, sample_id: str, **kwargs):
+def get_cases_associated_with_sample_by_internal_id(
+    case_samples: Query, sample_internal_id: str, **kwargs
+):
     """Return cases associated with a sample internal id."""
-    return case_samples.filter(Sample.internal_id == sample_id)
+    return case_samples.filter(Sample.internal_id == sample_internal_id)
 
 
 def get_cases_associated_with_sample_by_entry_id(
@@ -27,18 +29,18 @@ def get_cases_associated_with_sample_by_entry_id(
 def apply_case_sample_filter(
     filter_functions: List[Callable],
     case_samples: Query,
-    case_id: Optional[str] = None,
+    case_internal_id: Optional[str] = None,
     sample_entry_id: Optional[int] = None,
-    sample_id: Optional[str] = None,
+    sample_internal_id: Optional[str] = None,
 ) -> Query:
     """Apply filtering functions to the sample queries and return filtered results."""
 
     for function in filter_functions:
         case_samples: Query = function(
             case_samples=case_samples,
-            case_id=case_id,
+            case_internal_id=case_internal_id,
             sample_entry_id=sample_entry_id,
-            sample_id=sample_id,
+            sample_internal_id=sample_internal_id,
         )
     return case_samples
 

--- a/cg/store/filters/status_case_sample_filters.py
+++ b/cg/store/filters/status_case_sample_filters.py
@@ -5,23 +5,19 @@ from sqlalchemy.orm import Query
 from cg.store.models import Family, Sample
 
 
-def get_samples_associated_with_case_by_internal_id(
+def get_samples_in_case_by_internal_id(
     case_samples: Query, case_internal_id: str, **kwargs
 ) -> Query:
     """Return samples associated with a case."""
     return case_samples.filter(Family.internal_id == case_internal_id)
 
 
-def get_cases_associated_with_sample_by_internal_id(
-    case_samples: Query, sample_internal_id: str, **kwargs
-):
+def get_cases_with_sample_by_internal_id(case_samples: Query, sample_internal_id: str, **kwargs):
     """Return cases associated with a sample internal id."""
     return case_samples.filter(Sample.internal_id == sample_internal_id)
 
 
-def get_cases_associated_with_sample_by_entry_id(
-    case_samples: Query, sample_entry_id: int, **kwargs
-) -> Query:
+def get_cases_with_sample_by_entry_id(case_samples: Query, sample_entry_id: int, **kwargs) -> Query:
     """Return cases associated with a sample entry id."""
     return case_samples.filter(Sample.id == sample_entry_id)
 
@@ -48,12 +44,6 @@ def apply_case_sample_filter(
 class CaseSampleFilter(Enum):
     """Define CaseSample filter functions."""
 
-    GET_SAMPLES_ASSOCIATED_WITH_CASE_BY_INTERNAL_ID: Callable = (
-        get_samples_associated_with_case_by_internal_id
-    )
-    GET_CASES_ASSOCIATED_WITH_SAMPLE_BY_INTERNAL_ID: Callable = (
-        get_cases_associated_with_sample_by_internal_id
-    )
-    GET_CASES_ASSOCIATED_WITH_SAMPLE_BY_ENTRY_ID: Callable = (
-        get_cases_associated_with_sample_by_entry_id
-    )
+    GET_SAMPLES_IN_CASE_BY_INTERNAL_ID: Callable = get_samples_in_case_by_internal_id
+    GET_CASES_WITH_SAMPLE_BY_INTERNAL_ID: Callable = get_cases_with_sample_by_internal_id
+    GET_CASES_WITH_SAMPLE_BY_ENTRY_ID: Callable = get_cases_with_sample_by_entry_id

--- a/cg/store/filters/status_case_sample_filters.py
+++ b/cg/store/filters/status_case_sample_filters.py
@@ -5,7 +5,9 @@ from sqlalchemy.orm import Query
 from cg.store.models import Family, Sample
 
 
-def get_samples_associated_with_case(case_samples: Query, case_id: str, **kwargs) -> Query:
+def get_samples_associated_with_case_by_case_id(
+    case_samples: Query, case_id: str, **kwargs
+) -> Query:
     """Return samples associated with a case."""
     return case_samples.filter(Family.internal_id == case_id)
 
@@ -39,7 +41,7 @@ def apply_case_sample_filter(
 class CaseSampleFilter(Enum):
     """Define CaseSample filter functions."""
 
-    GET_SAMPLES_ASSOCIATED_WITH_CASE: Callable = get_samples_associated_with_case
+    GET_SAMPLES_ASSOCIATED_WITH_CASE_BY_ID: Callable = get_samples_associated_with_case_by_case_id
     GET_CASES_ASSOCIATED_WITH_SAMPLE_BY_ENTRY_ID: Callable = (
         get_cases_associated_with_sample_by_entry_id
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,25 +134,31 @@ def fixture_another_case_id() -> str:
 
 @pytest.fixture(name="sample_id")
 def fixture_sample_id() -> str:
-    """Returns a sample id."""
+    """Return a sample id."""
     return "ADM1"
 
 
 @pytest.fixture(name="father_sample_id")
 def fixture_father_sample_id() -> str:
-    """Returns the sample id of the father."""
+    """Return the sample id of the father."""
     return "ADM2"
 
 
 @pytest.fixture(name="mother_sample_id")
 def fixture_mother_sample_id() -> str:
-    """Returns the mothers sample id."""
+    """Return the mothers sample id."""
     return "ADM3"
+
+
+@pytest.fixture(name="invalid_sample_id")
+def fixture_invalid_sample_id() -> str:
+    """Return an invalid sample id."""
+    return "invalid-sample-id"
 
 
 @pytest.fixture(name="sample_ids")
 def fixture_sample_ids(sample_id: str, father_sample_id: str, mother_sample_id: str) -> List[str]:
-    """Returns a list with three samples of a family."""
+    """Return a list with three samples of a family."""
     return [sample_id, father_sample_id, mother_sample_id]
 
 

--- a/tests/meta/deliver/test_delivery_api.py
+++ b/tests/meta/deliver/test_delivery_api.py
@@ -50,7 +50,7 @@ def test_get_case_analysis_files(populated_deliver_api: DeliverAPI, case_id: str
     assert version
 
     # GIVEN that a case object exists in the database
-    link_objs: List[FamilySample] = deliver_api.store.family_samples(case_id)
+    link_objs: List[FamilySample] = deliver_api.store.get_case_samples_by_case_id(case_id=case_id)
     samples: List[Sample] = [link.sample for link in link_objs]
     sample_ids: Set[str] = set([sample.internal_id for sample in samples])
 
@@ -98,7 +98,7 @@ def test_get_case_files_from_version(
     assert len(version.files) == 2
 
     # GIVEN the sample ids of the samples
-    link_objs: List[FamilySample] = analysis_store.family_samples(case_id)
+    link_objs: List[FamilySample] = analysis_store.get_case_samples_by_case_id(case_id)
     samples: List[Sample] = [link.sample for link in link_objs]
     sample_ids: Set[str] = set([sample.internal_id for sample in samples])
 

--- a/tests/meta/deliver/test_delivery_api.py
+++ b/tests/meta/deliver/test_delivery_api.py
@@ -50,7 +50,9 @@ def test_get_case_analysis_files(populated_deliver_api: DeliverAPI, case_id: str
     assert version
 
     # GIVEN that a case object exists in the database
-    link_objs: List[FamilySample] = deliver_api.store.get_case_samples_by_case_id(case_id=case_id)
+    link_objs: List[FamilySample] = deliver_api.store.get_case_samples_by_case_id(
+        case_internal_id=case_id
+    )
     samples: List[Sample] = [link.sample for link in link_objs]
     sample_ids: Set[str] = set([sample.internal_id for sample in samples])
 

--- a/tests/meta/report/conftest.py
+++ b/tests/meta/report/conftest.py
@@ -60,7 +60,7 @@ def case_balsamic(case_id, report_api_balsamic) -> Family:
 def case_samples_data(case_id, report_api_mip_dna):
     """MIP DNA family sample object."""
 
-    return report_api_mip_dna.status_db.get_case_samples_by_case_id(case_id=case_id)
+    return report_api_mip_dna.status_db.get_case_samples_by_case_id(case_internal_id=case_id)
 
 
 @pytest.fixture(name="mip_analysis_api")
@@ -96,7 +96,9 @@ def report_store(analysis_store, helpers, timestamp_yesterday):
     helpers.add_analysis(analysis_store, case, pipeline=Pipeline.MIP_DNA, started_at=datetime.now())
 
     # Mock sample dates to calculate processing times
-    for family_sample in analysis_store.get_case_samples_by_case_id(case_id=case.internal_id):
+    for family_sample in analysis_store.get_case_samples_by_case_id(
+        case_internal_id=case.internal_id
+    ):
         family_sample.sample.ordered_at = timestamp_yesterday - timedelta(days=2)
         family_sample.sample.received_at = timestamp_yesterday - timedelta(days=1)
         family_sample.sample.prepared_at = timestamp_yesterday

--- a/tests/meta/report/conftest.py
+++ b/tests/meta/report/conftest.py
@@ -60,7 +60,7 @@ def case_balsamic(case_id, report_api_balsamic) -> Family:
 def case_samples_data(case_id, report_api_mip_dna):
     """MIP DNA family sample object."""
 
-    return report_api_mip_dna.status_db.family_samples(case_id)
+    return report_api_mip_dna.status_db.get_case_samples_by_case_id(case_id=case_id)
 
 
 @pytest.fixture(name="mip_analysis_api")
@@ -96,7 +96,7 @@ def report_store(analysis_store, helpers, timestamp_yesterday):
     helpers.add_analysis(analysis_store, case, pipeline=Pipeline.MIP_DNA, started_at=datetime.now())
 
     # Mock sample dates to calculate processing times
-    for family_sample in analysis_store.family_samples(case.internal_id):
+    for family_sample in analysis_store.get_case_samples_by_case_id(case_id=case.internal_id):
         family_sample.sample.ordered_at = timestamp_yesterday - timedelta(days=2)
         family_sample.sample.received_at = timestamp_yesterday - timedelta(days=1)
         family_sample.sample.prepared_at = timestamp_yesterday

--- a/tests/store/api/conftest.py
+++ b/tests/store/api/conftest.py
@@ -536,42 +536,6 @@ def fixture_store_with_pools_for_multiple_customers(
     yield store
 
 
-@pytest.fixture(name="store_with_analyses_for_cases")
-def fixture_store_with_analyses_for_cases(
-    analysis_store: Store,
-    helpers: StoreHelpers,
-    timestamp_now: dt.datetime,
-    timestamp_yesterday: dt.datetime,
-) -> Store:
-    """Return a store with two analyses for two cases."""
-    case_one = analysis_store.get_case_by_internal_id("yellowhog")
-    case_two = helpers.add_case(analysis_store, internal_id="test_case_1")
-
-    cases = [case_one, case_two]
-    for case in cases:
-        oldest_analysis = helpers.add_analysis(
-            analysis_store,
-            case=case,
-            started_at=timestamp_yesterday,
-            uploaded_at=timestamp_yesterday,
-            delivery_reported_at=None,
-            uploaded_to_vogue_at=timestamp_yesterday,
-        )
-        helpers.add_analysis(
-            analysis_store,
-            case=case,
-            started_at=timestamp_now,
-            uploaded_at=timestamp_now,
-            delivery_reported_at=None,
-            uploaded_to_vogue_at=timestamp_now,
-        )
-        sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
-        analysis_store.relate_sample(
-            family=oldest_analysis.family, sample=sample, status=PhenotypeStatus.UNKNOWN
-        )
-    return analysis_store
-
-
 @pytest.fixture(name="store_with_analyses_for_cases_not_uploaded_fluffy")
 def fixture_store_with_analyses_for_cases_not_uploaded_fluffy(
     analysis_store: Store,

--- a/tests/store/api/delete/test_store_api_delete.py
+++ b/tests/store/api/delete/test_store_api_delete.py
@@ -70,12 +70,12 @@ def test_store_api_delete_all_empty_cases(
     case_without_samples: List[
         FamilySample
     ] = store_with_multiple_cases_and_samples.get_case_samples_by_case_id(
-        case_id=case_id_without_samples
+        case_internal_id=case_id_without_samples
     )
     case_with_samples: List[
         FamilySample
     ] = store_with_multiple_cases_and_samples.get_case_samples_by_case_id(
-        case_id=case_id_with_multiple_samples
+        case_internal_id=case_id_with_multiple_samples
     )
 
     assert not case_without_samples
@@ -88,12 +88,12 @@ def test_store_api_delete_all_empty_cases(
 
     # THEN no entry should be found for the empty case, but the one with samples should remain.
     result: List[FamilySample] = store_with_multiple_cases_and_samples.get_case_samples_by_case_id(
-        case_id=case_id_without_samples
+        case_internal_id=case_id_without_samples
     )
     case_with_samples: List[
         FamilySample
     ] = store_with_multiple_cases_and_samples.get_case_samples_by_case_id(
-        case_id=case_id_with_multiple_samples
+        case_internal_id=case_id_with_multiple_samples
     )
 
     assert not result

--- a/tests/store/api/delete/test_store_api_delete.py
+++ b/tests/store/api/delete/test_store_api_delete.py
@@ -65,11 +65,15 @@ def test_store_api_delete_all_empty_cases(
     """Test function to delete cases that are not associated with any samples"""
 
     # GIVEN a database containing a case without samples and a case with samples
-    case_without_samples: List[FamilySample] = store_with_multiple_cases_and_samples.family_samples(
-        case_id_without_samples
+    case_without_samples: List[
+        FamilySample
+    ] = store_with_multiple_cases_and_samples.get_case_samples_by_case_id(
+        case_id=case_id_without_samples
     )
-    case_with_samples: List[FamilySample] = store_with_multiple_cases_and_samples.family_samples(
-        case_id_with_multiple_samples
+    case_with_samples: List[
+        FamilySample
+    ] = store_with_multiple_cases_and_samples.get_case_samples_by_case_id(
+        case_id=case_id_with_multiple_samples
     )
 
     assert not case_without_samples
@@ -81,11 +85,13 @@ def test_store_api_delete_all_empty_cases(
     )
 
     # THEN no entry should be found for the empty case, but the one with samples should remain.
-    result: List[FamilySample] = store_with_multiple_cases_and_samples.family_samples(
-        case_id_without_samples
+    result: List[FamilySample] = store_with_multiple_cases_and_samples.get_case_samples_by_case_id(
+        case_id=case_id_without_samples
     )
-    case_with_samples: List[FamilySample] = store_with_multiple_cases_and_samples.family_samples(
-        case_id_with_multiple_samples
+    case_with_samples: List[
+        FamilySample
+    ] = store_with_multiple_cases_and_samples.get_case_samples_by_case_id(
+        case_id=case_id_with_multiple_samples
     )
 
     assert not result

--- a/tests/store/api/delete/test_store_api_delete.py
+++ b/tests/store/api/delete/test_store_api_delete.py
@@ -44,12 +44,14 @@ def test_store_api_delete_relationships_between_sample_and_cases(
     store_with_multiple_cases_and_samples.delete_relationships_sample(sample=sample_in_single_case)
 
     # THEN it should no longer be associated with any cases, but other relationships should remain
-    results: List[FamilySample] = store_with_multiple_cases_and_samples.get_cases_from_sample(
+    results: List[
+        FamilySample
+    ] = store_with_multiple_cases_and_samples.get_cases_from_sample_entry_id(
         sample_entry_id=sample_in_single_case.id
     ).all()
     existing_relationships: List[
         FamilySample
-    ] = store_with_multiple_cases_and_samples.get_cases_from_sample(
+    ] = store_with_multiple_cases_and_samples.get_cases_from_sample_entry_id(
         sample_entry_id=sample_in_multiple_cases.id
     ).all()
 

--- a/tests/store/api/delete/test_store_api_delete.py
+++ b/tests/store/api/delete/test_store_api_delete.py
@@ -46,12 +46,12 @@ def test_store_api_delete_relationships_between_sample_and_cases(
     # THEN it should no longer be associated with any cases, but other relationships should remain
     results: List[
         FamilySample
-    ] = store_with_multiple_cases_and_samples.get_cases_from_sample_entry_id(
+    ] = store_with_multiple_cases_and_samples.get_case_samples_from_sample_entry_id(
         sample_entry_id=sample_in_single_case.id
     ).all()
     existing_relationships: List[
         FamilySample
-    ] = store_with_multiple_cases_and_samples.get_cases_from_sample_entry_id(
+    ] = store_with_multiple_cases_and_samples.get_case_samples_from_sample_entry_id(
         sample_entry_id=sample_in_multiple_cases.id
     ).all()
 

--- a/tests/store/api/find/test_find_business_data.py
+++ b/tests/store/api/find/test_find_business_data.py
@@ -405,6 +405,24 @@ def test_get_application_by_case(case_id: str, rml_pool_store: Store):
     assert application_version.application == application
 
 
+def test_get_case_samples_by_case_id(
+    store_with_analyses_for_cases: Store,
+    case_id: str,
+):
+    """Test that getting case-samples by case id returns a list of FamilySamples."""
+    # GIVEN a store with case-samples and a case id
+
+    # WHEN fetching the case-samples matching the case id
+    case_samples: List[FamilySample] = store_with_analyses_for_cases.get_case_samples_by_case_id(
+        case_id=case_id
+    )
+
+    # THEN a list of case-samples should be returned
+    assert case_samples
+    assert isinstance(case_samples, List)
+    assert isinstance(case_samples[0], FamilySample)
+
+
 def test_find_single_case_for_sample(
     sample_id_in_single_case: str, store_with_multiple_cases_and_samples: Store
 ):

--- a/tests/store/api/find/test_find_business_data.py
+++ b/tests/store/api/find/test_find_business_data.py
@@ -418,7 +418,9 @@ def test_find_single_case_for_sample(
     assert sample
 
     # WHEN the cases associated with the sample is fetched
-    cases: List[FamilySample] = store_with_multiple_cases_and_samples.get_cases_from_sample(
+    cases: List[
+        FamilySample
+    ] = store_with_multiple_cases_and_samples.get_cases_from_sample_entry_id(
         sample_entry_id=sample.id
     ).all()
 
@@ -436,7 +438,9 @@ def test_find_multiple_cases_for_sample(
     assert sample
 
     # WHEN the cases associated with the sample is fetched
-    cases: List[FamilySample] = store_with_multiple_cases_and_samples.get_cases_from_sample(
+    cases: List[
+        FamilySample
+    ] = store_with_multiple_cases_and_samples.get_cases_from_sample_entry_id(
         sample_entry_id=sample.id
     ).all()
 

--- a/tests/store/api/find/test_find_business_data.py
+++ b/tests/store/api/find/test_find_business_data.py
@@ -423,6 +423,27 @@ def test_get_case_samples_by_case_id(
     assert isinstance(case_samples[0], FamilySample)
 
 
+def test_get_case_sample_link(
+    store_with_analyses_for_cases: Store,
+    case_id: str,
+    sample_id: str,
+):
+    """Test that the returned element is a FamilySample with the correct case and sample internal ids."""
+    # GIVEN a store with case-samples and valid case and sample internal ids
+
+    # WHEN fetching a case-sample with case and sample internal ids
+    case_sample: FamilySample = store_with_analyses_for_cases.get_case_sample_link(
+        case_internal_id=case_id,
+        sample_internal_id=sample_id,
+    )
+
+    # THEN the returned element is a FamilySample object
+    assert isinstance(case_sample, FamilySample)
+    # THEN the returned family sample has teh correct case and sample internal ids
+    assert case_sample.family.internal_id == case_id
+    assert case_sample.sample.internal_id == sample_id
+
+
 def test_find_single_case_for_sample(
     sample_id_in_single_case: str, store_with_multiple_cases_and_samples: Store
 ):

--- a/tests/store/api/find/test_find_business_data.py
+++ b/tests/store/api/find/test_find_business_data.py
@@ -438,7 +438,7 @@ def test_find_single_case_for_sample(
     # WHEN the cases associated with the sample is fetched
     cases: List[
         FamilySample
-    ] = store_with_multiple_cases_and_samples.get_cases_from_sample_entry_id(
+    ] = store_with_multiple_cases_and_samples.get_case_samples_from_sample_entry_id(
         sample_entry_id=sample.id
     ).all()
 
@@ -458,7 +458,7 @@ def test_find_multiple_cases_for_sample(
     # WHEN the cases associated with the sample is fetched
     cases: List[
         FamilySample
-    ] = store_with_multiple_cases_and_samples.get_cases_from_sample_entry_id(
+    ] = store_with_multiple_cases_and_samples.get_case_samples_from_sample_entry_id(
         sample_entry_id=sample.id
     ).all()
 

--- a/tests/store/api/find/test_find_business_data.py
+++ b/tests/store/api/find/test_find_business_data.py
@@ -414,7 +414,7 @@ def test_get_case_samples_by_case_id(
 
     # WHEN fetching the case-samples matching the case id
     case_samples: List[FamilySample] = store_with_analyses_for_cases.get_case_samples_by_case_id(
-        case_id=case_id
+        case_internal_id=case_id
     )
 
     # THEN a list of case-samples should be returned

--- a/tests/store/api/find/test_find_business_data.py
+++ b/tests/store/api/find/test_find_business_data.py
@@ -439,7 +439,7 @@ def test_get_case_sample_link(
 
     # THEN the returned element is a FamilySample object
     assert isinstance(case_sample, FamilySample)
-    # THEN the returned family sample has teh correct case and sample internal ids
+    # THEN the returned family sample has the correct case and sample internal ids
     assert case_sample.family.internal_id == case_id
     assert case_sample.sample.internal_id == sample_id
 

--- a/tests/store/conftest.py
+++ b/tests/store/conftest.py
@@ -6,7 +6,7 @@ from typing import Generator, List
 import pytest
 
 from cg.constants import Pipeline
-from cg.constants.subject import Gender
+from cg.constants.subject import Gender, PhenotypeStatus
 from cg.store import Store
 from cg.store.models import Analysis, Application, Family, Sample, Customer
 from tests.store_helpers import StoreHelpers
@@ -383,3 +383,39 @@ def fixture_store_with_older_and_newer_analyses(
         )
 
     yield base_store
+
+
+@pytest.fixture(name="store_with_analyses_for_cases")
+def fixture_store_with_analyses_for_cases(
+    analysis_store: Store,
+    helpers: StoreHelpers,
+    timestamp_now: dt.datetime,
+    timestamp_yesterday: dt.datetime,
+) -> Store:
+    """Return a store with two analyses for two cases."""
+    case_one = analysis_store.get_case_by_internal_id("yellowhog")
+    case_two = helpers.add_case(analysis_store, internal_id="test_case_1")
+
+    cases = [case_one, case_two]
+    for case in cases:
+        oldest_analysis = helpers.add_analysis(
+            analysis_store,
+            case=case,
+            started_at=timestamp_yesterday,
+            uploaded_at=timestamp_yesterday,
+            delivery_reported_at=None,
+            uploaded_to_vogue_at=timestamp_yesterday,
+        )
+        helpers.add_analysis(
+            analysis_store,
+            case=case,
+            started_at=timestamp_now,
+            uploaded_at=timestamp_now,
+            delivery_reported_at=None,
+            uploaded_to_vogue_at=timestamp_now,
+        )
+        sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
+        analysis_store.relate_sample(
+            family=oldest_analysis.family, sample=sample, status=PhenotypeStatus.UNKNOWN
+        )
+    return analysis_store

--- a/tests/store/filters/test_status_case_sample_filters.py
+++ b/tests/store/filters/test_status_case_sample_filters.py
@@ -12,3 +12,58 @@ from cg.store.filters.status_case_sample_filters import (
     get_cases_associated_with_sample_by_entry_id,
 )
 from tests.store_helpers import StoreHelpers
+
+
+def test_get_samples_associated_with_case_valid_id(store_with_analyses_for_cases: Store):
+    """Test that the case id of the filtered case_sample is the correct one."""
+    # GIVEN a store with case_samples
+    case_sample_query: Query = store_with_analyses_for_cases._get_join_case_sample_query()
+    assert case_sample_query.count() > 0
+    # GIVEN a case_id from the store
+    case_id: str = case_sample_query.first().family_id
+    assert case_id
+
+    # WHEN filtering by the chosen case id
+    filtered_query: Query = get_samples_associated_with_case(
+        case_samples=case_sample_query, case_id=case_id
+    )
+
+    # THEN the filtered query has fewer elements than the original query
+    assert filtered_query.count() < case_sample_query.count()
+    # THEN the case_samples in the query have the correct case id
+    assert all(case_sample.family_id == case_id for case_sample in filtered_query.all())
+
+
+def test_get_samples_associated_with_case_unexistent_id(
+    store_with_analyses_for_cases: Store, case_id_does_not_exist: str
+):
+    """Test that an empty query is returned when filtering using an unexistent case id."""
+    # GIVEN a store with case samples
+    case_sample_query: Query = store_with_analyses_for_cases._get_join_case_sample_query()
+    assert case_sample_query.count() > 0
+
+    # WHEN filtering using an unexistent id
+    filtered_query: Query = get_samples_associated_with_case(
+        case_samples=case_sample_query, case_id=case_id_does_not_exist
+    )
+
+    # THEN the returned query is empty
+    assert filtered_query.count() == 0
+
+
+def test_get_cases_associated_with_sample():
+    """."""
+    # GIVEN
+
+    # WHEN
+
+    # THEN
+
+
+def test_get_cases_associated_with_sample_by_entry_id():
+    """."""
+    # GIVEN
+
+    # WHEN
+
+    # THEN

--- a/tests/store/filters/test_status_case_sample_filters.py
+++ b/tests/store/filters/test_status_case_sample_filters.py
@@ -8,7 +8,6 @@ from cg.store import Store
 from cg.store.models import Family, Sample, FamilySample
 from cg.store.filters.status_case_sample_filters import (
     get_samples_associated_with_case,
-    get_cases_associated_with_sample,
     get_cases_associated_with_sample_by_entry_id,
 )
 from tests.store_helpers import StoreHelpers
@@ -49,15 +48,6 @@ def test_get_samples_associated_with_case_unexistent_id(
 
     # THEN the returned query is empty
     assert filtered_query.count() == 0
-
-
-def test_get_cases_associated_with_sample():
-    """."""
-    # GIVEN
-
-    # WHEN
-
-    # THEN
 
 
 def test_get_cases_associated_with_sample_by_entry_id():

--- a/tests/store/filters/test_status_case_sample_filters.py
+++ b/tests/store/filters/test_status_case_sample_filters.py
@@ -1,0 +1,14 @@
+from typing import List
+
+from sqlalchemy.orm import Query
+
+from datetime import datetime
+
+from cg.store import Store
+from cg.store.models import Family, Sample, FamilySample
+from cg.store.filters.status_case_sample_filters import (
+    get_samples_associated_with_case,
+    get_cases_associated_with_sample,
+    get_cases_associated_with_sample_by_entry_id,
+)
+from tests.store_helpers import StoreHelpers

--- a/tests/store/filters/test_status_case_sample_filters.py
+++ b/tests/store/filters/test_status_case_sample_filters.py
@@ -29,7 +29,7 @@ def test_get_samples_associated_with_case_valid_id(store_with_analyses_for_cases
 
     # THEN the filtered query has fewer elements than the original query
     assert filtered_query.count() < case_sample_query.count()
-    # THEN the case_samples in the query have the correct case id
+    # THEN the case_samples in the filtered query have the correct case id
     assert all(
         case_sample.family.internal_id == case_internal_id for case_sample in filtered_query.all()
     )
@@ -48,14 +48,14 @@ def test_get_samples_associated_with_case_unexistent_id(
         case_samples=case_sample_query, case_id=case_id_does_not_exist
     )
 
-    # THEN the returned query is empty
+    # THEN the filtered query is empty
     assert filtered_query.count() == 0
 
 
 def test_get_cases_associated_with_sample_by_entry_id_valid_id(
     store_with_analyses_for_cases: Store,
 ):
-    """."""
+    """Test that filtering by a valid entry id returns case-samples with the desired entry id."""
     # GIVEN a store with case-samples
     case_sample_query: Query = store_with_analyses_for_cases._get_join_case_sample_query()
     assert case_sample_query.count() > 0
@@ -70,16 +70,23 @@ def test_get_cases_associated_with_sample_by_entry_id_valid_id(
 
     # THEN the filtered query has fewer elements than the original query
     assert filtered_query.count() < case_sample_query.count()
-    # THEN the case_samples in the query have the correct case id
+    # THEN the case_samples in the filtered query have the correct case id
     assert all(case_sample.sample_id == sample_entry_id for case_sample in filtered_query.all())
 
 
 def test_get_cases_associated_with_sample_by_entry_id_invalid_id(
     store_with_analyses_for_cases: Store,
+    invalid_entry_id: int = -1,
 ):
-    """."""
-    # GIVEN
+    """Test that filtering with an invalid entry id returns an empty query."""
+    # GIVEN a store with case-samples
+    case_sample_query: Query = store_with_analyses_for_cases._get_join_case_sample_query()
+    assert case_sample_query.count() > 0
 
-    # WHEN
+    # WHEN filtering using an invalid entry id
+    filtered_query: Query = get_cases_associated_with_sample_by_entry_id(
+        case_samples=case_sample_query, sample_entry_id=invalid_entry_id
+    )
 
-    # THEN
+    # THEN the filtered query is empty
+    assert filtered_query.count() == 0

--- a/tests/store/filters/test_status_case_sample_filters.py
+++ b/tests/store/filters/test_status_case_sample_filters.py
@@ -2,13 +2,13 @@ from sqlalchemy.orm import Query
 
 from cg.store import Store
 from cg.store.filters.status_case_sample_filters import (
-    get_samples_associated_with_case_by_internal_id,
-    get_cases_associated_with_sample_by_internal_id,
-    get_cases_associated_with_sample_by_entry_id,
+    get_samples_in_case_by_internal_id,
+    get_cases_with_sample_by_internal_id,
+    get_cases_with_sample_by_entry_id,
 )
 
 
-def test_get_samples_associated_with_case_by_internal_id_valid_id(
+def test_get_samples_in_case_by_internal_id_valid_id(
     store_with_analyses_for_cases: Store,
     case_id: str,
 ):
@@ -17,7 +17,7 @@ def test_get_samples_associated_with_case_by_internal_id_valid_id(
     case_sample_query: Query = store_with_analyses_for_cases._get_join_case_sample_query()
 
     # WHEN filtering by the chosen case internal id
-    filtered_query: Query = get_samples_associated_with_case_by_internal_id(
+    filtered_query: Query = get_samples_in_case_by_internal_id(
         case_samples=case_sample_query, case_internal_id=case_id
     )
 
@@ -28,16 +28,16 @@ def test_get_samples_associated_with_case_by_internal_id_valid_id(
         assert case_sample.family.internal_id == case_id
 
 
-def test_get_samples_associated_with_case_by_internal_id_unexistent_id(
+def test_get_samples_in_case_by_internal_id_nonexistent_id(
     store_with_analyses_for_cases: Store, case_id_does_not_exist: str
 ):
-    """Test that an empty query is returned when filtering using an unexistent case id."""
+    """Test that an empty query is returned when filtering using a non-existent case id."""
     # GIVEN a store with case-samples and an unexistent case internal id
     case_sample_query: Query = store_with_analyses_for_cases._get_join_case_sample_query()
     assert case_sample_query.count() > 0
 
-    # WHEN filtering using an unexistent id
-    filtered_query: Query = get_samples_associated_with_case_by_internal_id(
+    # WHEN filtering using a non-existent id
+    filtered_query: Query = get_samples_in_case_by_internal_id(
         case_samples=case_sample_query, case_internal_id=case_id_does_not_exist
     )
 
@@ -45,7 +45,7 @@ def test_get_samples_associated_with_case_by_internal_id_unexistent_id(
     assert filtered_query.count() == 0
 
 
-def test_get_cases_associated_with_sample_by_internal_id_valid_id(
+def test_get_cases_with_sample_by_internal_id_valid_id(
     store_with_analyses_for_cases: Store,
     sample_id: str,
 ):
@@ -54,7 +54,7 @@ def test_get_cases_associated_with_sample_by_internal_id_valid_id(
     case_sample_query: Query = store_with_analyses_for_cases._get_join_case_sample_query()
 
     # WHEN filtering using a sample internal id
-    filtered_query: Query = get_cases_associated_with_sample_by_internal_id(
+    filtered_query: Query = get_cases_with_sample_by_internal_id(
         case_samples=case_sample_query, sample_internal_id=sample_id
     )
 
@@ -65,7 +65,7 @@ def test_get_cases_associated_with_sample_by_internal_id_valid_id(
         assert case_sample.sample.internal_id == sample_id
 
 
-def test_get_cases_associated_with_sample_by_internal_id_invalid_id(
+def test_get_cases_with_sample_by_internal_id_invalid_id(
     store_with_analyses_for_cases: Store, invalid_sample_id: str
 ):
     """Test that an empty query is returned when filtering using an invalid sample internal id."""
@@ -74,7 +74,7 @@ def test_get_cases_associated_with_sample_by_internal_id_invalid_id(
     assert case_sample_query.count() > 0
 
     # WHEN filtering using an invalid sample internal id
-    filtered_query: Query = get_cases_associated_with_sample_by_internal_id(
+    filtered_query: Query = get_cases_with_sample_by_internal_id(
         case_samples=case_sample_query, sample_internal_id=invalid_sample_id
     )
 
@@ -82,7 +82,7 @@ def test_get_cases_associated_with_sample_by_internal_id_invalid_id(
     assert filtered_query.count() == 0
 
 
-def test_get_cases_associated_with_sample_by_entry_id_valid_id(
+def test_get_cases_with_sample_by_entry_id_valid_id(
     store_with_analyses_for_cases: Store,
     sample_entry_id: int = 1,
 ):
@@ -91,7 +91,7 @@ def test_get_cases_associated_with_sample_by_entry_id_valid_id(
     case_sample_query: Query = store_with_analyses_for_cases._get_join_case_sample_query()
 
     # WHEN filtering the query by the chosen sample entry id
-    filtered_query: Query = get_cases_associated_with_sample_by_entry_id(
+    filtered_query: Query = get_cases_with_sample_by_entry_id(
         case_samples=case_sample_query, sample_entry_id=sample_entry_id
     )
 
@@ -102,7 +102,7 @@ def test_get_cases_associated_with_sample_by_entry_id_valid_id(
         assert case_sample.sample_id == sample_entry_id
 
 
-def test_get_cases_associated_with_sample_by_entry_id_invalid_id(
+def test_get_cases_with_sample_by_entry_id_invalid_id(
     store_with_analyses_for_cases: Store,
     invalid_entry_id: int = -1,
 ):
@@ -112,7 +112,7 @@ def test_get_cases_associated_with_sample_by_entry_id_invalid_id(
     assert case_sample_query.count() > 0
 
     # WHEN filtering using an invalid sample entry id
-    filtered_query: Query = get_cases_associated_with_sample_by_entry_id(
+    filtered_query: Query = get_cases_with_sample_by_entry_id(
         case_samples=case_sample_query, sample_entry_id=invalid_entry_id
     )
 

--- a/tests/store/filters/test_status_case_sample_filters.py
+++ b/tests/store/filters/test_status_case_sample_filters.py
@@ -18,7 +18,7 @@ def test_get_samples_associated_with_case_by_internal_id_valid_id(
 
     # WHEN filtering by the chosen case internal id
     filtered_query: Query = get_samples_associated_with_case_by_internal_id(
-        case_samples=case_sample_query, case_id=case_id
+        case_samples=case_sample_query, case_internal_id=case_id
     )
 
     # THEN the filtered query has at least one element but fewer elements than the original query
@@ -38,7 +38,7 @@ def test_get_samples_associated_with_case_by_internal_id_unexistent_id(
 
     # WHEN filtering using an unexistent id
     filtered_query: Query = get_samples_associated_with_case_by_internal_id(
-        case_samples=case_sample_query, case_id=case_id_does_not_exist
+        case_samples=case_sample_query, case_internal_id=case_id_does_not_exist
     )
 
     # THEN the filtered query is empty
@@ -55,7 +55,7 @@ def test_get_cases_associated_with_sample_by_internal_id_valid_id(
 
     # WHEN filtering using a sample internal id
     filtered_query: Query = get_cases_associated_with_sample_by_internal_id(
-        case_samples=case_sample_query, sample_id=sample_id
+        case_samples=case_sample_query, sample_internal_id=sample_id
     )
 
     # THEN the filtered query has at least one element but fewer elements than the original query
@@ -75,7 +75,7 @@ def test_get_cases_associated_with_sample_by_internal_id_invalid_id(
 
     # WHEN filtering using an invalid sample internal id
     filtered_query: Query = get_cases_associated_with_sample_by_internal_id(
-        case_samples=case_sample_query, sample_id=invalid_sample_id
+        case_samples=case_sample_query, sample_internal_id=invalid_sample_id
     )
 
     # THEN the filtered query is empty

--- a/tests/store/filters/test_status_case_sample_filters.py
+++ b/tests/store/filters/test_status_case_sample_filters.py
@@ -1,51 +1,81 @@
-from typing import List
-
 from sqlalchemy.orm import Query
 
-from datetime import datetime
-
 from cg.store import Store
-from cg.store.models import Family, Sample, FamilySample
 from cg.store.filters.status_case_sample_filters import (
-    get_samples_associated_with_case_by_case_id,
+    get_samples_associated_with_case_by_internal_id,
+    get_cases_associated_with_sample_by_internal_id,
     get_cases_associated_with_sample_by_entry_id,
 )
-from tests.store_helpers import StoreHelpers
 
 
-def test_get_samples_associated_with_case_by_case_id_valid_id(store_with_analyses_for_cases: Store):
-    """Test that the case id of the filtered case-sample is the correct one."""
-    # GIVEN a store with case-samples
+def test_get_samples_associated_with_case_by_internal_id_valid_id(
+    store_with_analyses_for_cases: Store,
+    case_id: str,
+):
+    """Test that filtering by a valid case id returns case-samples with the desired case id."""
+    # GIVEN a store with case-samples and a case internal id
     case_sample_query: Query = store_with_analyses_for_cases._get_join_case_sample_query()
-    assert case_sample_query.count() > 0
-    # GIVEN a case_id from the store
-    case_internal_id: str = case_sample_query.first().family.internal_id
-    assert case_internal_id
 
-    # WHEN filtering by the chosen case id
-    filtered_query: Query = get_samples_associated_with_case_by_case_id(
-        case_samples=case_sample_query, case_id=case_internal_id
+    # WHEN filtering by the chosen case internal id
+    filtered_query: Query = get_samples_associated_with_case_by_internal_id(
+        case_samples=case_sample_query, case_id=case_id
     )
 
-    # THEN the filtered query has fewer elements than the original query
-    assert filtered_query.count() < case_sample_query.count()
-    # THEN the case_samples in the filtered query have the correct case id
-    assert all(
-        case_sample.family.internal_id == case_internal_id for case_sample in filtered_query.all()
-    )
+    # THEN the filtered query has at least one element but fewer elements than the original query
+    assert 0 < filtered_query.count() < case_sample_query.count()
+    # THEN the case_samples in the filtered query have the correct case internal id
+    for case_sample in filtered_query.all():
+        assert case_sample.family.internal_id == case_id
 
 
-def test_get_samples_associated_with_case_by_case_id_unexistent_id(
+def test_get_samples_associated_with_case_by_internal_id_unexistent_id(
     store_with_analyses_for_cases: Store, case_id_does_not_exist: str
 ):
     """Test that an empty query is returned when filtering using an unexistent case id."""
-    # GIVEN a store with case-samples
+    # GIVEN a store with case-samples and an unexistent case internal id
     case_sample_query: Query = store_with_analyses_for_cases._get_join_case_sample_query()
     assert case_sample_query.count() > 0
 
     # WHEN filtering using an unexistent id
-    filtered_query: Query = get_samples_associated_with_case_by_case_id(
+    filtered_query: Query = get_samples_associated_with_case_by_internal_id(
         case_samples=case_sample_query, case_id=case_id_does_not_exist
+    )
+
+    # THEN the filtered query is empty
+    assert filtered_query.count() == 0
+
+
+def test_get_cases_associated_with_sample_by_internal_id_valid_id(
+    store_with_analyses_for_cases: Store,
+    sample_id: str,
+):
+    """Test that filtering by a valid sample internal id returns case-samples with the desired sample internal id."""
+    # GIVEN a store with case-samples and a sample internal id
+    case_sample_query: Query = store_with_analyses_for_cases._get_join_case_sample_query()
+
+    # WHEN filtering using a sample internal id
+    filtered_query: Query = get_cases_associated_with_sample_by_internal_id(
+        case_samples=case_sample_query, sample_id=sample_id
+    )
+
+    # THEN the filtered query has at least one element but fewer elements than the original query
+    assert 0 < filtered_query.count() < case_sample_query.count()
+    # THEN the case_samples in the filtered query have the correct sample internal id
+    for case_sample in filtered_query.all():
+        assert case_sample.sample.internal_id == sample_id
+
+
+def test_get_cases_associated_with_sample_by_internal_id_invalid_id(
+    store_with_analyses_for_cases: Store, invalid_sample_id: str
+):
+    """Test that an empty query is returned when filtering using an invalid sample internal id."""
+    # GIVEN a store with case-samples and an invalid sample internal id
+    case_sample_query: Query = store_with_analyses_for_cases._get_join_case_sample_query()
+    assert case_sample_query.count() > 0
+
+    # WHEN filtering using an invalid sample internal id
+    filtered_query: Query = get_cases_associated_with_sample_by_internal_id(
+        case_samples=case_sample_query, sample_id=invalid_sample_id
     )
 
     # THEN the filtered query is empty
@@ -54,36 +84,34 @@ def test_get_samples_associated_with_case_by_case_id_unexistent_id(
 
 def test_get_cases_associated_with_sample_by_entry_id_valid_id(
     store_with_analyses_for_cases: Store,
+    sample_entry_id: int = 1,
 ):
-    """Test that filtering by a valid entry id returns case-samples with the desired entry id."""
-    # GIVEN a store with case-samples
+    """Test that filtering by a valid sample entry id returns case-samples with the desired sample entry id."""
+    # GIVEN a store with case-samples and a sample entry id
     case_sample_query: Query = store_with_analyses_for_cases._get_join_case_sample_query()
-    assert case_sample_query.count() > 0
-    # GIVEN one sample entry id in the store
-    sample_entry_id: int = case_sample_query.first().sample_id
-    assert sample_entry_id
 
     # WHEN filtering the query by the chosen sample entry id
     filtered_query: Query = get_cases_associated_with_sample_by_entry_id(
         case_samples=case_sample_query, sample_entry_id=sample_entry_id
     )
 
-    # THEN the filtered query has fewer elements than the original query
-    assert filtered_query.count() < case_sample_query.count()
+    # THEN the filtered query has at least one element but fewer elements than the original query
+    assert 0 < filtered_query.count() < case_sample_query.count()
     # THEN the case_samples in the filtered query have the correct case id
-    assert all(case_sample.sample_id == sample_entry_id for case_sample in filtered_query.all())
+    for case_sample in filtered_query.all():
+        assert case_sample.sample_id == sample_entry_id
 
 
 def test_get_cases_associated_with_sample_by_entry_id_invalid_id(
     store_with_analyses_for_cases: Store,
     invalid_entry_id: int = -1,
 ):
-    """Test that filtering with an invalid entry id returns an empty query."""
-    # GIVEN a store with case-samples
+    """Test that filtering with an invalid sample entry id returns an empty query."""
+    # GIVEN a store with case-samples and an invalid sample entry id
     case_sample_query: Query = store_with_analyses_for_cases._get_join_case_sample_query()
     assert case_sample_query.count() > 0
 
-    # WHEN filtering using an invalid entry id
+    # WHEN filtering using an invalid sample entry id
     filtered_query: Query = get_cases_associated_with_sample_by_entry_id(
         case_samples=case_sample_query, sample_entry_id=invalid_entry_id
     )

--- a/tests/store/filters/test_status_case_sample_filters.py
+++ b/tests/store/filters/test_status_case_sample_filters.py
@@ -14,30 +14,32 @@ from tests.store_helpers import StoreHelpers
 
 
 def test_get_samples_associated_with_case_valid_id(store_with_analyses_for_cases: Store):
-    """Test that the case id of the filtered case_sample is the correct one."""
-    # GIVEN a store with case_samples
+    """Test that the case id of the filtered case-sample is the correct one."""
+    # GIVEN a store with case-samples
     case_sample_query: Query = store_with_analyses_for_cases._get_join_case_sample_query()
     assert case_sample_query.count() > 0
     # GIVEN a case_id from the store
-    case_id: str = case_sample_query.first().family_id
-    assert case_id
+    case_internal_id: str = case_sample_query.first().family.internal_id
+    assert case_internal_id
 
     # WHEN filtering by the chosen case id
     filtered_query: Query = get_samples_associated_with_case(
-        case_samples=case_sample_query, case_id=case_id
+        case_samples=case_sample_query, case_id=case_internal_id
     )
 
     # THEN the filtered query has fewer elements than the original query
     assert filtered_query.count() < case_sample_query.count()
     # THEN the case_samples in the query have the correct case id
-    assert all(case_sample.family_id == case_id for case_sample in filtered_query.all())
+    assert all(
+        case_sample.family.internal_id == case_internal_id for case_sample in filtered_query.all()
+    )
 
 
 def test_get_samples_associated_with_case_unexistent_id(
     store_with_analyses_for_cases: Store, case_id_does_not_exist: str
 ):
     """Test that an empty query is returned when filtering using an unexistent case id."""
-    # GIVEN a store with case samples
+    # GIVEN a store with case-samples
     case_sample_query: Query = store_with_analyses_for_cases._get_join_case_sample_query()
     assert case_sample_query.count() > 0
 
@@ -50,7 +52,31 @@ def test_get_samples_associated_with_case_unexistent_id(
     assert filtered_query.count() == 0
 
 
-def test_get_cases_associated_with_sample_by_entry_id():
+def test_get_cases_associated_with_sample_by_entry_id_valid_id(
+    store_with_analyses_for_cases: Store,
+):
+    """."""
+    # GIVEN a store with case-samples
+    case_sample_query: Query = store_with_analyses_for_cases._get_join_case_sample_query()
+    assert case_sample_query.count() > 0
+    # GIVEN one sample entry id in the store
+    sample_entry_id: int = case_sample_query.first().sample_id
+    assert sample_entry_id
+
+    # WHEN filtering the query by the chosen sample entry id
+    filtered_query: Query = get_cases_associated_with_sample_by_entry_id(
+        case_samples=case_sample_query, sample_entry_id=sample_entry_id
+    )
+
+    # THEN the filtered query has fewer elements than the original query
+    assert filtered_query.count() < case_sample_query.count()
+    # THEN the case_samples in the query have the correct case id
+    assert all(case_sample.sample_id == sample_entry_id for case_sample in filtered_query.all())
+
+
+def test_get_cases_associated_with_sample_by_entry_id_invalid_id(
+    store_with_analyses_for_cases: Store,
+):
     """."""
     # GIVEN
 

--- a/tests/store/filters/test_status_case_sample_filters.py
+++ b/tests/store/filters/test_status_case_sample_filters.py
@@ -7,13 +7,13 @@ from datetime import datetime
 from cg.store import Store
 from cg.store.models import Family, Sample, FamilySample
 from cg.store.filters.status_case_sample_filters import (
-    get_samples_associated_with_case,
+    get_samples_associated_with_case_by_case_id,
     get_cases_associated_with_sample_by_entry_id,
 )
 from tests.store_helpers import StoreHelpers
 
 
-def test_get_samples_associated_with_case_valid_id(store_with_analyses_for_cases: Store):
+def test_get_samples_associated_with_case_by_case_id_valid_id(store_with_analyses_for_cases: Store):
     """Test that the case id of the filtered case-sample is the correct one."""
     # GIVEN a store with case-samples
     case_sample_query: Query = store_with_analyses_for_cases._get_join_case_sample_query()
@@ -23,7 +23,7 @@ def test_get_samples_associated_with_case_valid_id(store_with_analyses_for_cases
     assert case_internal_id
 
     # WHEN filtering by the chosen case id
-    filtered_query: Query = get_samples_associated_with_case(
+    filtered_query: Query = get_samples_associated_with_case_by_case_id(
         case_samples=case_sample_query, case_id=case_internal_id
     )
 
@@ -35,7 +35,7 @@ def test_get_samples_associated_with_case_valid_id(store_with_analyses_for_cases
     )
 
 
-def test_get_samples_associated_with_case_unexistent_id(
+def test_get_samples_associated_with_case_by_case_id_unexistent_id(
     store_with_analyses_for_cases: Store, case_id_does_not_exist: str
 ):
     """Test that an empty query is returned when filtering using an unexistent case id."""
@@ -44,7 +44,7 @@ def test_get_samples_associated_with_case_unexistent_id(
     assert case_sample_query.count() > 0
 
     # WHEN filtering using an unexistent id
-    filtered_query: Query = get_samples_associated_with_case(
+    filtered_query: Query = get_samples_associated_with_case_by_case_id(
         case_samples=case_sample_query, case_id=case_id_does_not_exist
     )
 


### PR DESCRIPTION
## Description

### Added

- Unit tests for case-sample filter functions in `tests/store/filters/test_status_case_sample_filters.py`.
- The distinction between entry id and internal id in the name of the filter functions in `tests/store/filters/test_status_case_sample_filters.py`
- Fixture for `invalid_sample_id`in `tests/conftest.py`.
- Tests for `get_case_samples_by_case_id` and `get_case_sample_link`.

### Changed

- The name of the function `family_sample` in `cg/store/find_busines_data.py` to `get_case_samples_by_case_id` and its parameters.
- Tests for `get_case_samples_by_case_id`.
- The location of the store_with_analyses_for_cases fixture, moved one level up (from `tests/store/api/conftest.py` to `tests/store/conftest.py`.
- The name of the function `get_cases_from_sample` in `cg/store/find_busines_data.py` to `get_cases_from_sample_entry_id`.
- The name of the function `link` in `cg/store/find_busines_data.py` to `get_case_sample_link`.

### Removed
- Unused function `get_sample_cases` in `cg/store/find_busines_data.py`.

### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b refactor-family-sample -a
    ```
- [x] copy production file: `cp -r /home/proj/production/housekeeper-bundles/funnygar/2022-12-05 /home/proj/stage/housekeeper-bundles/funnygar`

### How to test

- [x] `cg deliver analysis --case-id funnygar -d mip-rna`
- [x] `cg upload clinical-delivery funnygar --dry-run`
- [x] `cg generate delivery-report funnygar -f --dry-run`
- [x] `cg generate delivery-report funnygar -f`
- [x] Delete the copied folder on stage `rm -r /home/proj/stage/housekeeper-bundles/funnygar/2022-12-05`

### Expected test outcome

- [x] Check that all commands exit successfully (see Tests on stage below)

## Review

- [x] Tests executed by SD 11-04-2023
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
