### PR TITLE
feat(application): Add default for min seq depth

### DIFF
--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -82,7 +82,7 @@ class ApplicationView(BaseView):
     ]
     column_filters = ["prep_category", "is_accredited"]
     column_searchable_list = ["tag", "prep_category"]
-    form_excluded_columns = ["category"]
+    form_excluded_columns = ["category", "versions"]
 
     @staticmethod
     def view_application_link(unused1, unused2, model, unused3):

--- a/cg/store/api/add.py
+++ b/cg/store/api/add.py
@@ -80,15 +80,17 @@ class AddHandler(BaseHandler):
         percent_kth: int,
         percent_reads_guaranteed: int,
         is_accredited: bool = False,
+        min_sequencing_depth: int = 0,
         **kwargs,
     ) -> Application:
-        """Build a new application  record."""
+        """Build a new application record."""
 
         return self.Application(
             tag=tag,
             prep_category=prep_category,
             description=description,
             is_accredited=is_accredited,
+            min_sequencing_depth=min_sequencing_depth,
             percent_kth=percent_kth,
             percent_reads_guaranteed=percent_reads_guaranteed,
             **kwargs,

--- a/cg/store/api/import_func.py
+++ b/cg/store/api/import_func.py
@@ -183,6 +183,7 @@ def add_application_object(application: ApplicationSchema, sign: str, store: Sto
         turnaround_time=application.turnaround_time,
         minimum_order=application.minimum_order,
         sequencing_depth=application.sequencing_depth,
+        min_sequencing_depth=application.min_sequencing_depth,
         target_reads=application.target_reads,
         sample_amount=application.sample_amount,
         sample_volume=application.sample_volume,

--- a/cg/store/api/models.py
+++ b/cg/store/api/models.py
@@ -30,6 +30,7 @@ class ApplicationSchema(BaseModel):
     is_external: int
     limitations: Optional[str]
     minimum_order: int
+    min_sequencing_depth: Optional[int]
     percent_kth: Optional[int]
     percent_reads_guaranteed: Optional[int]
     prep_category: str

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -86,7 +86,7 @@ class Application(Model):
     turnaround_time = Column(types.Integer)
     minimum_order = Column(types.Integer, default=1)
     sequencing_depth = Column(types.Integer)
-    min_sequencing_depth = Column(types.Integer)
+    min_sequencing_depth = Column(types.Integer, default=0, nullable=False)
     target_reads = Column(types.BigInteger, default=0)
     percent_reads_guaranteed = Column(types.Integer, nullable=False)
     sample_amount = Column(types.Integer)


### PR DESCRIPTION
## Description

### Changed

- Add default for min seq depth in applications

### Fixed

- Fix #1728 


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [x] Tests executed by HS
- [x] "Merge and deploy" approved by @Vince-janv 
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
