### PR TITLE
Fix(Balsamic PON): removed method

### DIFF
--- a/cg/meta/workflow/balsamic_pon.py
+++ b/cg/meta/workflow/balsamic_pon.py
@@ -2,7 +2,7 @@
 
 import logging
 from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 from cg.store.models import Family
 
@@ -42,11 +42,13 @@ class BalsamicPonAnalysisAPI(BalsamicAnalysisAPI):
     ) -> None:
         """Creates a config file for BALSAMIC PON analysis."""
         case: Family = self.status_db.get_case_by_internal_id(internal_id=case_id)
-        sample_data: dict = self.get_sample_params(case_id=case_id, panel_bed=panel_bed)
-        if len(sample_data) == 0:
+        sample_parameters: dict = self.get_sample_params(case_id=case_id, panel_bed=panel_bed)
+        if not sample_parameters:
             LOG.error(f"{case_id} has no samples tagged for Balsamic PON analysis")
             raise BalsamicStartError()
-        verified_panel_bed: str = self.get_verified_bed(panel_bed, sample_data)
+        verified_panel_bed: str = self.get_verified_bed(
+            panel_bed=panel_bed, sample_data=sample_parameters
+        )
         options: List[str] = build_command_from_dict(
             {
                 "--case-id": case.internal_id,
@@ -67,7 +69,7 @@ class BalsamicPonAnalysisAPI(BalsamicAnalysisAPI):
 
     def get_next_pon_version(self, panel_bed: str) -> str:
         """Returns the next PON version to be generated."""
-        latest_pon_file: str = self.get_latest_pon_file(panel_bed)
+        latest_pon_file: str = self.get_latest_pon_file(panel_bed=panel_bed)
         next_version = (
             int(Path(latest_pon_file).stem.split("_v")[ListIndexes.LAST.value]) + 1
             if latest_pon_file


### PR DESCRIPTION
## Description

A method to build the command line has been updated in https://github.com/Clinical-Genomics/cg/pull/1797, but the PON workflow hasn't been updated accordingly.

### Fixed
- Removed  `__build_command_str` method and not updated for Balsamic PON workflow


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] `cg workflow balsamic-pon start <case-id>`

### Expected test outcome

Current outcome:

<img width="800" alt="Screenshot 2023-04-11 at 18 12 48" src="https://user-images.githubusercontent.com/26309194/231224456-65dc9e92-e6e7-4e3d-9175-d1784b9faa4f.png">

Fixed:

<img width="800" alt="Screenshot 2023-04-11 at 18 19 28" src="https://user-images.githubusercontent.com/26309194/231226119-4f7b7cac-81b1-4389-aeca-23c48015e676.png">


## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
