### PR TITLE
Cache Google Oauth2 certificate

### DIFF
--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -41,7 +41,7 @@ def get_certificate_ttl(response_data) -> int:
     """Extract time to live in seconds for certificate from response headers."""
     expires_header = response_data.headers.get("Expires")
     expires = datetime.strptime(expires_header, "%a, %d %b %Y %H:%M:%S %Z")
-    ttl = int((expires - datetime.utcnow().replace(tzinfo=timezone.utc)).total_seconds())
+    ttl = int((expires - datetime.utcnow()).total_seconds())
 
     return ttl
 

--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -46,6 +46,8 @@ def get_certificate_ttl(response_data) -> int:
 
 def fetch_and_cache_google_oauth2_certificates():
     """Fetch and cache Google OAuth2 certificates."""
+    global cache
+
     url = "https://www.googleapis.com/oauth2/v1/certs"
     response = requests.get(url)
     response.raise_for_status()

--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -35,7 +35,7 @@ BLUEPRINT = Blueprint("api", __name__, url_prefix="/api/v1")
 cache = TTLCache(maxsize=1, ttl=3600)
 
 
-def extract_certificate_expiration_in_seconds(response_data):
+def get_certificate_ttl(response_data):
     expires_header = response_data.headers.get("Expires")
     expires = datetime.strptime(expires_header, "%a, %d %b %Y %H:%M:%S %Z")
     ttl = int((expires - datetime.utcnow().replace(tzinfo=timezone.utc)).total_seconds())
@@ -43,30 +43,30 @@ def extract_certificate_expiration_in_seconds(response_data):
     return ttl
 
 
-def extract_certificate(response_data):
+def get_certificate(response_data):
     cert_key = next(iter(response_data))
     certificate = response_data[cert_key]
     return certificate
 
 
-def update_certificate_cache():
+def fetch_and_cache_google_oauth2_certificate():
     url = "https://www.googleapis.com/oauth2/v1/certs"
     response = requests.get(url)
     response.raise_for_status()
     data = response.json()
 
-    ttl = extract_certificate_expiration_in_seconds(response_data=data)
-    cert = extract_certificate(response_data=data)
+    ttl = get_certificate_ttl(response_data=data)
+    cert = get_certificate(response_data=data)
     cache.set("cert", cert, ttl=ttl)
 
     return data
 
 
-def get_certificate_from_cache():
+def get_google_oauth2_certificate():
     cert = cache.get("cert")
 
     if not cert:
-        cert = update_certificate_cache()
+        cert = fetch_and_cache_google_oauth2_certificate()
 
     return cert
 
@@ -107,7 +107,7 @@ def before_request():
 
     jwt_token = auth_header.split("Bearer ")[-1]
     try:
-        user_data = jwt.decode(jwt_token, certs=get_certificate_from_cache())
+        user_data = jwt.decode(jwt_token, certs=get_google_oauth2_certificate())
     except ValueError:
         return abort(
             make_response(

--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -33,6 +33,8 @@ LOG = logging.getLogger(__name__)
 BLUEPRINT = Blueprint("api", __name__, url_prefix="/api/v1")
 
 cache = TTLCache(maxsize=1, ttl=3600)
+cache_certificates_key = "certs"
+cache[cache_certificates_key] = None
 
 
 def get_certificate_ttl(response_data) -> int:
@@ -56,14 +58,14 @@ def fetch_and_cache_google_oauth2_certificates():
     ttl = get_certificate_ttl(response_data=response)
 
     cache = TTLCache(maxsize=1, ttl=ttl)
-    cache["certs"] = certs
+    cache[cache_certificates_key] = certs
 
     return certs
 
 
 def get_google_oauth2_certificates():
     """Get Google OAuth2 certificates from cache or fetch and cache them."""
-    certs = cache.get("certs")
+    certs = cache.get(cache_certificates_key)
 
     if not certs:
         certs = fetch_and_cache_google_oauth2_certificates()

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ werkzeug<1.0.0              # due to breaking changes in 1.0.0
 
 # utils
 ansi
+cachetools
 cgmodels>=0.10.5
 coloredlogs
 email-validator


### PR DESCRIPTION
## Description
Instead of fetching the certificate on each received request, we can cache it. This should reduce the response time for requests against our API. Google only rotates the certificate once per day.

The current implementation does not use that two certificates are returned from Google.

### Added
- Caching of Google OAuth certificate

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

