### PR TITLE
Filter cases in past x days

### DIFF
--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -184,7 +184,7 @@ def submit_order(order_type):
 @BLUEPRINT.route("/cases")
 def parse_cases():
     """Fetch cases."""
-    cases: List[Family] = db.get_cases_in_past_days(days=31)
+    cases: List[Family] = db.get_cases_created_within_days(days=31)
     return jsonify(cases=cases, total=len(cases))
 
 

--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -184,7 +184,7 @@ def submit_order(order_type):
 @BLUEPRINT.route("/cases")
 def parse_cases():
     """Fetch cases."""
-    cases: List[Family] = db.cases(days=31)
+    cases: List[Family] = db.get_cases_in_past_days(days=31)
     return jsonify(cases=cases, total=len(cases))
 
 

--- a/cg/store/api/find_business_data.py
+++ b/cg/store/api/find_business_data.py
@@ -144,6 +144,15 @@ class FindBusinessDataHandler(BaseHandler):
         """Fetch all deliveries."""
         return self.Delivery.query
 
+    def get_cases_in_past_days(self, days: int) -> List[Family]:
+        """Fetch all cases newer than a given date."""
+        newer_than_date = dt.datetime.now() - dt.timedelta(days=days)
+        return apply_case_filter(
+            filter_functions=[CaseFilter.GET_NEW],
+            cases=self.get_query(table=Family),
+            date=newer_than_date,
+        ).all()
+
     def get_cases_by_customer_and_case_name_search(
         self, customer: Customer, case_name_search: str
     ) -> List[Family]:

--- a/cg/store/api/find_business_data.py
+++ b/cg/store/api/find_business_data.py
@@ -144,12 +144,12 @@ class FindBusinessDataHandler(BaseHandler):
         """Fetch all deliveries."""
         return self.Delivery.query
 
-    def get_cases_in_past_days(self, days: int) -> List[Family]:
-        """Fetch all cases newer than a given date."""
+    def get_cases_created_within_days(self, days: int) -> List[Family]:
+        """Fetch all cases created within the past days."""
         newer_than_date = dt.datetime.now() - dt.timedelta(days=days)
         return apply_case_filter(
             filter_functions=[CaseFilter.GET_NEW],
-            cases=self.get_query(table=Family),
+            cases=self._get_query(table=Family),
             date=newer_than_date,
         ).all()
 

--- a/cg/store/api/status.py
+++ b/cg/store/api/status.py
@@ -233,7 +233,7 @@ class StatusHandler(BaseHandler):
         """Return all cases that are ready to be compressed by SPRING."""
         case_filter_functions: List[CaseFilter] = [
             CaseFilter.GET_HAS_INACTIVE_ANALYSIS,
-            CaseFilter.GET_NEW,
+            CaseFilter.GET_OLD,
         ]
         return apply_case_filter(
             filter_functions=case_filter_functions,

--- a/cg/store/filters/status_case_filters.py
+++ b/cg/store/filters/status_case_filters.py
@@ -220,7 +220,7 @@ class CaseFilter(Enum):
     GET_HAS_SEQUENCE: Callable = get_cases_has_sequence
     GET_HAS_INACTIVE_ANALYSIS: Callable = get_inactive_analysis_cases
     GET_OLD: Callable = get_older_cases
-    GET_NEW: callable = get_newer_cases
+    GET_NEW: Callable = get_newer_cases
     GET_WITH_PIPELINE: Callable = get_cases_with_pipeline
     GET_WITH_LOQUSDB_SUPPORTED_PIPELINE: Callable = get_cases_with_loqusdb_supported_pipeline
     GET_WITH_LOQUSDB_SUPPORTED_SEQUENCING_METHOD: Callable = (

--- a/cg/store/filters/status_case_filters.py
+++ b/cg/store/filters/status_case_filters.py
@@ -35,9 +35,15 @@ def get_running_cases(cases: Query, **kwargs) -> Query:
     return cases.filter(Family.action == CaseActions.RUNNING)
 
 
-def get_new_cases(cases: Query, date: datetime, **kwargs) -> Query:
-    """Return old cases compared to date."""
+def get_older_cases(cases: Query, date: datetime, **kwargs) -> Query:
+    """Return older cases compared to date."""
     cases = cases.filter(Family.created_at < date)
+    return cases.order_by(Family.created_at.asc())
+
+
+def get_newer_cases(cases: Query, date: datetime, **kwargs) -> Query:
+    """Return newer cases compared to date."""
+    cases = cases.filter(Family.created_at > date)
     return cases.order_by(Family.created_at.asc())
 
 
@@ -213,7 +219,8 @@ class CaseFilter(Enum):
 
     GET_HAS_SEQUENCE: Callable = get_cases_has_sequence
     GET_HAS_INACTIVE_ANALYSIS: Callable = get_inactive_analysis_cases
-    GET_NEW: Callable = get_new_cases
+    GET_OLD: Callable = get_older_cases
+    GET_NEW: callable = get_newer_cases
     GET_WITH_PIPELINE: Callable = get_cases_with_pipeline
     GET_WITH_LOQUSDB_SUPPORTED_PIPELINE: Callable = get_cases_with_loqusdb_supported_pipeline
     GET_WITH_LOQUSDB_SUPPORTED_SEQUENCING_METHOD: Callable = (

--- a/tests/store/api/find/test_find_business_data.py
+++ b/tests/store/api/find/test_find_business_data.py
@@ -745,3 +745,18 @@ def test_fetch_cases_newer_than_date_no_cases(store_with_multiple_cases_and_samp
 
     # THEN no cases should be returned
     assert len(cases) == 0
+
+
+def test_fetch_cases_newer_than_date_all_cases(store_with_multiple_cases_and_samples: Store):
+    """Test that all cases are returned when all cases newer than the given date."""
+    # GIVEN a store with cases newer than 7 days
+    older_than_date = datetime.now() - timedelta(days=5)
+    all_cases = store_with_multiple_cases_and_samples._get_query(table=Family).all()
+    for case in all_cases:
+        case.created_at = older_than_date
+
+    # WHEN fetching cases newer than 7 days
+    cases = store_with_multiple_cases_and_samples.get_cases_created_within_days(days=7)
+
+    # THEN all cases should be returned
+    assert len(cases) == len(all_cases)

--- a/tests/store/api/find/test_find_business_data.py
+++ b/tests/store/api/find/test_find_business_data.py
@@ -1,6 +1,6 @@
 """Tests the findbusinessdata part of the Cg store API."""
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import List
 
 from sqlalchemy.orm import Query
@@ -731,3 +731,17 @@ def test_get_case_by_name_and_customer_case_found(store_with_multiple_cases_and_
     assert filtered_case is not None
     assert filtered_case.customer_id == customer.id
     assert filtered_case.name == case.name
+
+
+def test_fetch_cases_newer_than_date_no_cases(store_with_multiple_cases_and_samples: Store):
+    """Test that no cases are returned when there are no cases newer than the given date."""
+    # GIVEN a store with cases older than 7 days
+    older_than_date = datetime.now() - timedelta(days=10)
+    for case in store_with_multiple_cases_and_samples._get_query(table=Family).all():
+        case.created_at = older_than_date
+
+    # WHEN fetching cases newer than 7 days
+    cases = store_with_multiple_cases_and_samples.get_cases_created_within_days(days=7)
+
+    # THEN no cases should be returned
+    assert len(cases) == 0

--- a/tests/store/api/find/test_find_business_data.py
+++ b/tests/store/api/find/test_find_business_data.py
@@ -737,7 +737,7 @@ def test_fetch_cases_newer_than_date_no_cases(store_with_multiple_cases_and_samp
     """Test that no cases are returned when there are no cases newer than the given date."""
     # GIVEN a store with cases older than 7 days
     older_than_date = datetime.now() - timedelta(days=10)
-    for case in store_with_multiple_cases_and_samples._get_query(table=Family).all():
+    for case in store_with_multiple_cases_and_samples._get_query(table=Family):
         case.created_at = older_than_date
 
     # WHEN fetching cases newer than 7 days

--- a/tests/store/filters/test_status_cases_filters.py
+++ b/tests/store/filters/test_status_cases_filters.py
@@ -25,7 +25,7 @@ from cg.store.filters.status_case_filters import (
     get_cases_with_loqusdb_supported_pipeline,
     get_cases_with_loqusdb_supported_sequencing_method,
     get_inactive_analysis_cases,
-    get_new_cases,
+    get_older_cases,
 )
 from tests.store_helpers import StoreHelpers
 
@@ -526,7 +526,7 @@ def test_get_new_cases(base_store: Store, helpers: StoreHelpers, timestamp_in_2_
     cases: Query = base_store._get_query(table=Family)
 
     # WHEN getting completed cases
-    cases: Query = get_new_cases(cases=cases, date=timestamp_in_2_weeks)
+    cases: Query = get_older_cases(cases=cases, date=timestamp_in_2_weeks)
 
     # ASSERT that cases is a query
     assert isinstance(cases, Query)
@@ -549,7 +549,7 @@ def test_get_new_cases_when_too_new(
     cases: Query = base_store._get_query(table=Family)
 
     # WHEN getting completed cases
-    cases: Query = get_new_cases(cases=cases, date=timestamp_yesterday)
+    cases: Query = get_older_cases(cases=cases, date=timestamp_yesterday)
 
     # ASSERT that cases is a query
     assert isinstance(cases, Query)

--- a/tests/store/filters/test_status_cases_filters.py
+++ b/tests/store/filters/test_status_cases_filters.py
@@ -15,6 +15,7 @@ from cg.store.filters.status_case_filters import (
     filter_cases_by_entry_id,
     filter_case_by_internal_id,
     filter_cases_by_name,
+    get_newer_cases,
     get_running_cases,
     filter_cases_by_ticket_id,
     get_cases_with_pipeline,
@@ -516,7 +517,7 @@ def test_get_inactive_analysis_cases_when_not_completed(base_store: Store, helpe
     assert not cases.all()
 
 
-def test_get_new_cases(base_store: Store, helpers: StoreHelpers, timestamp_in_2_weeks: datetime):
+def test_get_old_cases(base_store: Store, helpers: StoreHelpers, timestamp_in_2_weeks: datetime):
     """Test that an old case is returned when a future date is supplied."""
 
     # GIVEN a case
@@ -537,10 +538,10 @@ def test_get_new_cases(base_store: Store, helpers: StoreHelpers, timestamp_in_2_
     assert cases.all()[0].internal_id == test_case.internal_id
 
 
-def test_get_new_cases_when_too_new(
+def test_get_old_cases_none_when_all_cases_are_too_new(
     base_store: Store, helpers: StoreHelpers, timestamp_yesterday: datetime
 ):
-    """Test that old case is returned when a past date is supplied."""
+    """No cases are returned when all cases in the store are too new."""
 
     # GIVEN a case
     helpers.add_case(base_store)
@@ -556,6 +557,43 @@ def test_get_new_cases_when_too_new(
 
     # THEN cases should not contain the test case
     assert not cases.all()
+
+
+def test_get_newer_cases_none_when_all_cases_older(
+    base_store: Store, helpers: StoreHelpers, timestamp_in_2_weeks: datetime
+):
+    """Test that no cases are returned when all cases are older than the given date."""
+
+    # GIVEN a cases Query
+    helpers.add_case(base_store)
+    cases: Query = base_store._get_query(table=Family)
+
+    # WHEN getting newer cases
+    cases: Query = get_newer_cases(cases=cases, date=timestamp_in_2_weeks)
+
+    # ASSERT that cases is a query
+    assert isinstance(cases, Query)
+
+    # THEN no cases should be returned
+    assert not cases.all()
+
+
+def test_get_newer_cases_all_when_all_cases_newer(
+    base_store: Store, helpers: StoreHelpers, timestamp_yesterday: datetime
+):
+    """Test that all cases are returned when all cases are newer than the given date."""
+    # GIVEN a cases Query
+    helpers.add_case(base_store)
+    cases: Query = base_store._get_query(table=Family)
+
+    # WHEN getting newer cases
+    filtered_cases: Query = get_newer_cases(cases=cases, date=timestamp_yesterday)
+
+    # ASSERT that cases is a query
+    assert isinstance(filtered_cases, Query)
+
+    # THEN all cases should be returned
+    assert filtered_cases.count() == cases.count()
 
 
 def test_filter_case_by_existing_entry_id(store_with_multiple_cases_and_samples: Store):


### PR DESCRIPTION
## Description
Replace call to gigantic and complex
```python
cases: List[Family] = db.cases(days=31)
```
With
```python
cases: List[Family] = db.get_cases_created_within_days(days=31)
```

The goal is to reduce the number of places the cases function is used in order to be able to simplify and refactor it more easily.

### Added
- get_cases_in_past_days(days: int) -> List[Family]
- GET_NEW filter

### Changed
- Replaced call to cases with get_cases_in_past_days(days=31)
- Rename GET_OLD to GET_NEW


## Review
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

