### PR TITLE
Extract function for filtering not analysed cases associated with sample

### DIFF
--- a/cg/meta/transfer/external_data.py
+++ b/cg/meta/transfer/external_data.py
@@ -183,7 +183,9 @@ class ExternalDataAPI(MetaAPI):
         cases_to_start: List[dict] = []
         for sample in available_samples:
             cases_to_start.extend(
-                self.status_db.get_cases_not_analysed_by_sample_internal_id(sample.internal_id)
+                self.status_db.get_cases_not_analysed_by_sample_internal_id(
+                    sample_internal_id=sample.internal_id
+                )
             )
             last_version: Version = self.housekeeper_api.get_create_version(
                 bundle_name=sample.internal_id

--- a/cg/meta/transfer/external_data.py
+++ b/cg/meta/transfer/external_data.py
@@ -183,7 +183,7 @@ class ExternalDataAPI(MetaAPI):
         cases_to_start: List[dict] = []
         for sample in available_samples:
             cases_to_start.extend(
-                self.status_db.get_cases_not_analysed_by_sample_internal_id(
+                self.status_db.get_not_analysed_cases_by_sample_internal_id(
                     sample_internal_id=sample.internal_id
                 )
             )

--- a/cg/meta/transfer/external_data.py
+++ b/cg/meta/transfer/external_data.py
@@ -183,7 +183,7 @@ class ExternalDataAPI(MetaAPI):
         cases_to_start: List[dict] = []
         for sample in available_samples:
             cases_to_start.extend(
-                self.status_db.cases(sample_id=sample.internal_id, exclude_analysed=True)
+                self.status_db.get_cases_not_analysed_by_sample_internal_id(sample.internal_id)
             )
             last_version: Version = self.housekeeper_api.get_create_version(
                 bundle_name=sample.internal_id

--- a/cg/store/api/base.py
+++ b/cg/store/api/base.py
@@ -80,6 +80,10 @@ class BaseHandler:
         """Return join case sample query."""
         return self._get_query(table=FamilySample).join(FamilySample.family, FamilySample.sample)
 
+    def _get_join_case_and_sample_query(self) -> Query:
+        """Return join case sample query."""
+        return self._get_query(table=Family).join(Family.links, FamilySample.sample)
+
     def _get_join_sample_and_customer_query(self) -> Query:
         """Return join sample and customer query."""
         return self._get_query(table=Sample).join(Customer)

--- a/cg/store/api/find_business_data.py
+++ b/cg/store/api/find_business_data.py
@@ -723,11 +723,11 @@ class FindBusinessDataHandler(BaseHandler):
             pipeline=pipeline,
         ).all()
 
-    def get_cases_not_analysed_by_sample_internal_id(
+    def get_not_analysed_cases_by_sample_internal_id(
         self,
         sample_internal_id: str,
     ) -> List[Family]:
-        """Get cases to analyse by sample internal id."""
+        """Get not analysed cases by sample internal id."""
 
         query: Query = self._get_join_case_and_sample_query()
 

--- a/cg/store/api/find_business_data.py
+++ b/cg/store/api/find_business_data.py
@@ -720,9 +720,9 @@ class FindBusinessDataHandler(BaseHandler):
     ) -> List[Family]:
         """Get cases to analyse by sample internal id."""
 
-        query = self._get_join_case_and_sample_query()
+        query: Query = self._get_join_case_and_sample_query()
 
-        not_analysed_cases = apply_case_filter(
+        not_analysed_cases: Query = apply_case_filter(
             cases=query,
             filter_functions=[
                 CaseFilter.GET_NOT_ANALYSED,

--- a/cg/store/api/find_business_data.py
+++ b/cg/store/api/find_business_data.py
@@ -713,3 +713,24 @@ class FindBusinessDataHandler(BaseHandler):
             cases=self._get_query(table=Family),
             pipeline=pipeline,
         ).all()
+
+    def get_cases_not_analysed_by_sample_internal_id(
+        self,
+        sample_internal_id: str,
+    ) -> List[Family]:
+        """Get cases to analyse by sample internal id."""
+
+        query = self._get_join_case_and_sample_query()
+
+        not_analysed_cases = apply_case_filter(
+            cases=query,
+            filter_functions=[
+                CaseFilter.GET_NOT_ANALYSED,
+            ],
+        )
+
+        return apply_sample_filter(
+            samples=not_analysed_cases,
+            filter_functions=[SampleFilter.FILTER_BY_INTERNAL_ID],
+            internal_id=sample_internal_id,
+        ).all()

--- a/cg/store/filters/status_case_filters.py
+++ b/cg/store/filters/status_case_filters.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Optional, List, Callable
 from enum import Enum
 from cgmodels.cg.constants import Pipeline
-from sqlalchemy import and_, or_
+from sqlalchemy import and_, not_, or_
 from sqlalchemy.orm import Query
 
 from cg.constants import REPORT_SUPPORTED_DATA_DELIVERY
@@ -94,6 +94,14 @@ def get_cases_for_analysis(cases: Query, **kwargs) -> Query:
             ),
         )
     )
+
+
+def filter_cases_not_analysed(cases: Query, **kwargs) -> Query:
+    """Filter cases that have not been analysed and are not currently being analysed."""
+    not_analyzed_condition = Family.analyses.all(Analysis.completed_at.is_(None))
+    not_in_progress_condition = Family.action != CaseActions.ANALYZE
+
+    return cases.filter(and_(not_analyzed_condition, not_in_progress_condition))
 
 
 def get_cases_with_scout_data_delivery(cases: Query, **kwargs) -> Query:
@@ -220,6 +228,7 @@ class CaseFilter(Enum):
         get_cases_with_loqusdb_supported_sequencing_method
     )
     GET_FOR_ANALYSIS: Callable = get_cases_for_analysis
+    GET_NOT_ANALYSED: Callable = filter_cases_not_analysed
     GET_WITH_SCOUT_DELIVERY: Callable = get_cases_with_scout_data_delivery
     GET_REPORT_SUPPORTED: Callable = get_report_supported_data_delivery_cases
     FILTER_BY_ENTRY_ID: Callable = filter_cases_by_entry_id

--- a/cg/store/filters/status_case_filters.py
+++ b/cg/store/filters/status_case_filters.py
@@ -98,7 +98,7 @@ def get_cases_for_analysis(cases: Query, **kwargs) -> Query:
 
 def filter_cases_not_analysed(cases: Query, **kwargs) -> Query:
     """Filter cases that have not been analysed and are not currently being analysed."""
-    not_analyzed_condition = Family.analyses.all(Analysis.completed_at.is_(None))
+    not_analyzed_condition = not_(Family.analyses.any(Analysis.completed_at.isnot(None)))
     not_in_progress_condition = Family.action != CaseActions.ANALYZE
 
     return cases.filter(and_(not_analyzed_condition, not_in_progress_condition))

--- a/cg/store/filters/status_sample_filters.py
+++ b/cg/store/filters/status_sample_filters.py
@@ -9,12 +9,12 @@ from cg.store.models import Sample, Customer
 
 def filter_samples_by_internal_id(internal_id: str, samples: Query, **kwargs) -> Query:
     """Return sample by internal id."""
-    return samples.filter_by(internal_id=internal_id)
+    return samples.filter(Sample.internal_id == internal_id)
 
 
 def filter_samples_by_name(name: str, samples: Query, **kwargs) -> Query:
     """Return sample with sample name."""
-    return samples.filter_by(name=name)
+    return samples.filter(Sample.name == name)
 
 
 def filter_samples_with_type(samples: Query, tissue_type: SampleType, **kwargs) -> Query:

--- a/tests/store/api/find/test_find_business_data.py
+++ b/tests/store/api/find/test_find_business_data.py
@@ -741,7 +741,7 @@ def test_get_cases_not_analysed_by_sample_internal_id_empty_query(
     """Test that an empty query is returned if no cases match the sample internal id."""
     # GIVEN a store
     # WHEN getting cases not analysed by the sample internal id
-    cases = store_with_multiple_cases_and_samples.get_cases_not_analysed_by_sample_internal_id(
+    cases = store_with_multiple_cases_and_samples.get_not_analysed_cases_by_sample_internal_id(
         sample_internal_id=non_existent_id
     )
 
@@ -762,7 +762,7 @@ def test_get_cases_not_analysed_by_sample_internal_id_multiple_cases(
         case.action = CaseActions.HOLD
 
     # WHEN getting cases not analysed by the shared sample internal id
-    cases = store_with_multiple_cases_and_samples.get_cases_not_analysed_by_sample_internal_id(
+    cases = store_with_multiple_cases_and_samples.get_not_analysed_cases_by_sample_internal_id(
         sample_id_in_multiple_cases
     )
 

--- a/tests/store/api/find/test_find_business_data.py
+++ b/tests/store/api/find/test_find_business_data.py
@@ -736,15 +736,13 @@ def test_get_case_by_name_and_customer_case_found(store_with_multiple_cases_and_
 
 
 def test_get_cases_not_analysed_by_sample_internal_id_empty_query(
-    store_with_multiple_cases_and_samples: Store,
+    store_with_multiple_cases_and_samples: Store, non_existent_id: str
 ):
     """Test that an empty query is returned if no cases match the sample internal id."""
-    # GIVEN a store with no cases matching the sample internal id
-    sample_internal_id = "nonexistent_sample_internal_id"
-
+    # GIVEN a store
     # WHEN getting cases not analysed by the sample internal id
     cases = store_with_multiple_cases_and_samples.get_cases_not_analysed_by_sample_internal_id(
-        sample_internal_id
+        sample_internal_id=non_existent_id
     )
 
     # THEN an empty list should be returned

--- a/tests/store/api/find/test_find_business_data.py
+++ b/tests/store/api/find/test_find_business_data.py
@@ -802,4 +802,3 @@ def test_fetch_cases_newer_than_date_all_cases(store_with_multiple_cases_and_sam
 
     # THEN all cases should be returned
     assert len(cases) == len(all_cases)
-

--- a/tests/store/api/find/test_find_business_data.py
+++ b/tests/store/api/find/test_find_business_data.py
@@ -6,9 +6,11 @@ from typing import List
 from sqlalchemy.orm import Query
 
 from cg.constants import FlowCellStatus
+from cg.constants.constants import CaseActions
 from cg.store import Store
 from cg.constants.indexes import ListIndexes
 from cg.store.models import (
+    Analysis,
     Application,
     ApplicationVersion,
     Flowcell,
@@ -731,3 +733,45 @@ def test_get_case_by_name_and_customer_case_found(store_with_multiple_cases_and_
     assert filtered_case is not None
     assert filtered_case.customer_id == customer.id
     assert filtered_case.name == case.name
+
+
+def test_get_cases_not_analysed_by_sample_internal_id_empty_query(
+    store_with_multiple_cases_and_samples: Store,
+):
+    """Test that an empty query is returned if no cases match the sample internal id."""
+    # GIVEN a store with no cases matching the sample internal id
+    sample_internal_id = "nonexistent_sample_internal_id"
+
+    # WHEN getting cases not analysed by the sample internal id
+    cases = store_with_multiple_cases_and_samples.get_cases_not_analysed_by_sample_internal_id(
+        sample_internal_id
+    )
+
+    # THEN an empty list should be returned
+    assert cases == []
+
+
+def test_get_cases_not_analysed_by_sample_internal_id_multiple_cases(
+    store_with_multiple_cases_and_samples: Store,
+    sample_id_in_multiple_cases: str,
+):
+    """Test that multiple cases are returned when more than one case matches the sample internal id."""
+    # GIVEN a store with multiple cases having the same sample internal id
+    cases_query: Query = store_with_multiple_cases_and_samples._get_query(table=Family)
+
+    # Set all cases to not analysed and HOLD action
+    for case in cases_query.all():
+        case.action = CaseActions.HOLD
+
+    # WHEN getting cases not analysed by the shared sample internal id
+    cases = store_with_multiple_cases_and_samples.get_cases_not_analysed_by_sample_internal_id(
+        sample_id_in_multiple_cases
+    )
+
+    # THEN multiple cases should be returned
+    assert len(cases) > 1
+
+    # Check that all returned cases have the matching sample and are not analysed
+    for case in cases:
+        assert not case.analyses
+        assert any(sample.internal_id == sample_id_in_multiple_cases for sample in case.samples)


### PR DESCRIPTION
## Description
Replace function call to gigantic and super complex
```python
self.status_db.cases(sample_id=sample.internal_id, exclude_analysed=True)
```

With a more specialised function
```python
self.status_db.get_cases_not_analysed_by_sample_internal_id(
    sample_internal_id=sample.internal_id
)
```

I implemented et_cases_not_analysed_by_sample_internal_id based on the logic in the cases function when called like
```python
cases(sample_id=sample.internal_id, exclude_analysed=True)
```

### Added
- ```python
  CaseFilter.GET_NOT_ANALYSED
  ```
- ```python
  filter_cases_not_analysed(cases: Query, **kwargs) -> Query
    ```
- ```python
    get_not_analysed_cases_by_sample_internal_id(
        sample_internal_id: str,
    ) -> List[Family]
  ```
- ```python
  _get_join_case_and_sample_query() -> Query
  ```

### Changed
- Replaced call to cases() with get_not_analysed_cases_by_sample_internal_id()

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

