### PR TITLE
Patch the cli command family

### DIFF
--- a/cg/cli/set/families.py
+++ b/cg/cli/set/families.py
@@ -78,7 +78,7 @@ def families(
             family,
             action=action,
             priority=priority,
-            panels=panel_abbreviations,
+            panel_abbreviations=panel_abbreviations,
             family_id=case.internal_id,
             customer_id=customer_id,
         )


### PR DESCRIPTION
## Description

### Added

-

### Changed

-

### Fixed

- the name of the parameter `panels` to `panel_abbreviations` when calling the cli command `family`. 


### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b fix-set-families -a
    ```

### How to test

- [x] `cg get case --customer-id cust003 --name 20014`
- [x] `cg set families --sample-identifier name 20014-I-2A --priority research`

### Expected test outcome

- [ ] See comments below

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
