### PR TITLE
Remove queries from tests

### DIFF
--- a/tests/cli/add/test_cli_add.py
+++ b/tests/cli/add/test_cli_add.py
@@ -4,6 +4,8 @@ from cg.models.cg_config import CGConfig
 from cg.store import Store
 from click.testing import CliRunner
 
+from cg.store.models import User
+
 
 def test_add_user(cli_runner: CliRunner, base_context: CGConfig):
     # GIVEN a database with a customer in it that we can connect the user to
@@ -18,7 +20,8 @@ def test_add_user(cli_runner: CliRunner, base_context: CGConfig):
     )
     disk_store.add_commit(customer)
     # GIVEN that there is a certain number of users
-    nr_users = disk_store.User.query.count()
+    user_query = disk_store._get_query(table=User)
+    nr_users = user_query.count()
 
     # WHEN adding a new user
     name, email = "Paul T. Anderson", "paul.anderson@magnolia.com"
@@ -26,4 +29,4 @@ def test_add_user(cli_runner: CliRunner, base_context: CGConfig):
 
     # THEN exit successfully
     assert result.exit_code == EXIT_SUCCESS
-    assert disk_store.User.query.count() == nr_users + 1
+    assert user_query.count() == nr_users + 1

--- a/tests/cli/add/test_cli_add_family.py
+++ b/tests/cli/add/test_cli_add_family.py
@@ -4,7 +4,7 @@ from cg.cli.add import add
 from cg.constants import DataDelivery, Pipeline
 from cg.models.cg_config import CGConfig
 from cg.store import Store
-from cg.store.models import Customer, Panel
+from cg.store.models import Customer, Family, Panel
 from click.testing import CliRunner
 from tests.store_helpers import StoreHelpers
 
@@ -46,9 +46,10 @@ def test_add_case_required(
 
     # THEN it should be added
     assert result.exit_code == 0
-    assert disk_store.Family.query.count() == 1
-    assert disk_store.Family.query.first().name == name
-    assert disk_store.Family.query.first().panels == [panel_id]
+    case_query = disk_store._get_query(table=Family)
+    assert case_query.count() == 1
+    assert case_query.first().name == name
+    assert case_query.first().panels == [panel_id]
 
 
 def test_add_case_bad_pipeline(
@@ -86,7 +87,7 @@ def test_add_case_bad_pipeline(
 
     # THEN it should not be added
     assert result.exit_code != 0
-    assert disk_store.Family.query.count() == 0
+    assert disk_store._get_query(table=Family).count() == 0
 
 
 def test_add_case_bad_data_delivery(
@@ -123,7 +124,7 @@ def test_add_case_bad_data_delivery(
 
     # THEN it should not be added
     assert result.exit_code != 0
-    assert disk_store.Family.query.count() == 0
+    assert disk_store._get_query(table=Family).count() == 0
 
 
 def test_add_case_bad_customer(cli_runner: CliRunner, base_context: CGConfig, ticket_id: str):
@@ -154,7 +155,7 @@ def test_add_case_bad_customer(cli_runner: CliRunner, base_context: CGConfig, ti
 
     # THEN it should complain about missing customer instead of adding a case
     assert result.exit_code == 1
-    assert disk_store.Family.query.count() == 0
+    assert disk_store._get_query(table=Family).count() == 0
 
 
 def test_add_case_bad_panel(
@@ -188,7 +189,7 @@ def test_add_case_bad_panel(
 
     # THEN it should complain about missing panel instead of adding a case
     assert result.exit_code == 1
-    assert disk_store.Family.query.count() == 0
+    assert disk_store._get_query(table=Family).count() == 0
 
 
 def test_add_case_priority(
@@ -227,5 +228,7 @@ def test_add_case_priority(
 
     # THEN it should be added
     assert result.exit_code == 0
-    assert disk_store.Family.query.count() == 1
-    assert disk_store.Family.query.first().priority_human == priority
+    case_query = disk_store._get_query(table=Family)
+
+    assert case_query.count() == 1
+    assert case_query.first().priority_human == priority

--- a/tests/cli/add/test_cli_add_relationship.py
+++ b/tests/cli/add/test_cli_add_relationship.py
@@ -3,6 +3,7 @@
 from cg.cli.add import add
 from cg.store import Store
 from click.testing import CliRunner
+from cg.store.models import FamilySample
 from tests.store_helpers import StoreHelpers
 from cg.models.cg_config import CGConfig
 
@@ -24,9 +25,11 @@ def test_add_relationship_required(cli_runner: CliRunner, base_context: CGConfig
 
     # THEN it should be added
     assert result.exit_code == 0
-    assert disk_store.FamilySample.query.count() == 1
-    assert disk_store.FamilySample.query.first().family.internal_id == case_id
-    assert disk_store.FamilySample.query.first().sample.internal_id == sample_id
+    family_sample_query = disk_store._get_query(table=FamilySample)
+
+    assert family_sample_query.count() == 1
+    assert family_sample_query.first().family.internal_id == case_id
+    assert family_sample_query.first().sample.internal_id == sample_id
 
 
 def test_add_relationship_bad_sample(cli_runner: CliRunner, base_context: CGConfig, helpers):
@@ -52,7 +55,7 @@ def test_add_relationship_bad_sample(cli_runner: CliRunner, base_context: CGConf
 
     # THEN it should complain on missing sample instead of adding a relationship
     assert result.exit_code == 1
-    assert disk_store.FamilySample.query.count() == 0
+    assert disk_store._get_query(table=FamilySample).count() == 0
 
 
 def test_add_relationship_bad_family(cli_runner: CliRunner, base_context: CGConfig, helpers):
@@ -79,7 +82,7 @@ def test_add_relationship_bad_family(cli_runner: CliRunner, base_context: CGConf
 
     # THEN it should complain in missing case instead of adding a relationship
     assert result.exit_code == 1
-    assert disk_store.FamilySample.query.count() == 0
+    assert disk_store._get_query(table=FamilySample).count() == 0
 
 
 def test_add_relationship_bad_status(cli_runner: CliRunner, base_context: CGConfig, helpers):
@@ -108,7 +111,7 @@ def test_add_relationship_bad_status(cli_runner: CliRunner, base_context: CGConf
 
     # THEN it should complain on bad status instead of adding a relationship
     assert result.exit_code == 2
-    assert disk_store.FamilySample.query.count() == 0
+    assert disk_store._get_query(table=FamilySample).count() == 0
 
 
 def test_add_relationship_mother(
@@ -142,8 +145,9 @@ def test_add_relationship_mother(
 
     # THEN it should be added
     assert result.exit_code == 0
-    assert disk_store.FamilySample.query.count() == 1
-    assert disk_store.FamilySample.query.first().mother.internal_id == mother_id
+    family_sample_query = disk_store._get_query(table=FamilySample)
+    assert family_sample_query.count() == 1
+    assert family_sample_query.first().mother.internal_id == mother_id
 
 
 def test_add_relationship_bad_mother(
@@ -176,7 +180,7 @@ def test_add_relationship_bad_mother(
 
     # THEN it should not be added
     assert result.exit_code == 1
-    assert disk_store.FamilySample.query.count() == 0
+    assert disk_store._get_query(table=FamilySample).count() == 0
 
 
 def test_add_relationship_father(
@@ -213,8 +217,9 @@ def test_add_relationship_father(
 
     # THEN it should be added
     assert result.exit_code == 0
-    assert disk_store.FamilySample.query.count() == 1
-    assert disk_store.FamilySample.query.first().father.internal_id == father_id
+    family_sample_query = disk_store._get_query(table=FamilySample)
+    assert family_sample_query.count() == 1
+    assert family_sample_query.first().father.internal_id == father_id
 
 
 def test_add_relationship_bad_father(
@@ -249,4 +254,4 @@ def test_add_relationship_bad_father(
 
     # THEN it should not be added
     assert result.exit_code == 1
-    assert disk_store.FamilySample.query.count() == 0
+    assert disk_store._get_query(table=FamilySample).count() == 0

--- a/tests/cli/add/test_cli_add_sample.py
+++ b/tests/cli/add/test_cli_add_sample.py
@@ -5,7 +5,7 @@ from cg.models.cg_config import CGConfig
 from cg.store import Store
 from click.testing import CliRunner
 
-from cg.store.models import Customer
+from cg.store.models import Customer, Sample
 from tests.store_helpers import StoreHelpers
 
 
@@ -34,7 +34,7 @@ def test_add_sample_missing_customer(cli_runner: CliRunner, base_context: CGConf
 
     # THEN it should complain about missing customer instead of adding a sample
     assert result.exit_code == 1
-    assert disk_store.Sample.query.count() == 0
+    assert disk_store._get_query(table=Sample).count() == 0
 
 
 def test_add_sample_bad_application(
@@ -64,7 +64,7 @@ def test_add_sample_bad_application(
 
     # THEN it should complain about missing application instead of adding a sample
     assert result.exit_code == 1
-    assert disk_store.Sample.query.count() == 0
+    assert disk_store._get_query(table=Sample).count() == 0
 
 
 def test_add_sample_required(cli_runner: CliRunner, base_context: CGConfig, helpers: StoreHelpers):
@@ -94,9 +94,10 @@ def test_add_sample_required(cli_runner: CliRunner, base_context: CGConfig, help
 
     # THEN it should be added
     assert result.exit_code == EXIT_SUCCESS
-    assert disk_store.Sample.query.count() == 1
-    assert disk_store.Sample.query.first().name == name
-    assert disk_store.Sample.query.first().sex == Gender.MALE
+    sample_query = disk_store._get_query(table=Sample)
+    assert sample_query.count() == 1
+    assert sample_query.first().name == name
+    assert sample_query.first().sex == Gender.MALE
 
 
 def test_add_sample_lims_id(cli_runner: CliRunner, base_context: CGConfig, helpers: StoreHelpers):
@@ -129,8 +130,9 @@ def test_add_sample_lims_id(cli_runner: CliRunner, base_context: CGConfig, helpe
 
     # THEN it should be added
     assert result.exit_code == EXIT_SUCCESS
-    assert disk_store.Sample.query.count() == 1
-    assert disk_store.Sample.query.first().internal_id == lims_id
+    sample_query = disk_store._get_query(table=Sample)
+    assert sample_query.count() == 1
+    assert sample_query.first().internal_id == lims_id
 
 
 def test_add_sample_order(
@@ -167,8 +169,9 @@ def test_add_sample_order(
 
     # THEN it should be added
     assert result.exit_code == EXIT_SUCCESS
-    assert disk_store.Sample.query.count() == 1
-    assert disk_store.Sample.query.first().order == order
+    sample_query = disk_store._get_query(table=Sample)
+    assert sample_query.count() == 1
+    assert sample_query.first().order == order
 
 
 def test_add_sample_when_down_sampled(
@@ -205,8 +208,9 @@ def test_add_sample_when_down_sampled(
 
     # THEN it should be added
     assert result.exit_code == EXIT_SUCCESS
-    assert disk_store.Sample.query.count() == 1
-    assert str(disk_store.Sample.query.first().downsampled_to) == down_sampled_to
+    sample_query = disk_store._get_query(table=Sample)
+    assert sample_query.count() == 1
+    assert str(sample_query.first().downsampled_to) == down_sampled_to
 
 
 def test_add_sample_priority(
@@ -242,5 +246,6 @@ def test_add_sample_priority(
 
     # THEN it should be added
     assert result.exit_code == EXIT_SUCCESS
-    assert disk_store.Sample.query.count() == 1
-    assert disk_store.Sample.query.first().priority_human == Priority.priority.name
+    sample_query = disk_store._get_query(table=Sample)
+    assert sample_query.count() == 1
+    assert sample_query.first().priority_human == Priority.priority.name

--- a/tests/cli/get/test_cli_get_analysis.py
+++ b/tests/cli/get/test_cli_get_analysis.py
@@ -28,7 +28,7 @@ def test_get_analysis_required(
     # GIVEN a database with an analysis
     analysis: Analysis = helpers.add_analysis(disk_store, pipeline_version="9.3")
     internal_id = analysis.family.internal_id
-    assert disk_store.Analysis.query.count() == 1
+    assert disk_store._get_query(table=Analysis).count() == 1
 
     # WHEN getting a analysis
     result = cli_runner.invoke(get, ["analysis", internal_id], obj=base_context)

--- a/tests/cli/get/test_cli_get_sample.py
+++ b/tests/cli/get/test_cli_get_sample.py
@@ -31,7 +31,7 @@ def test_get_sample_required(
     # GIVEN a database with a sample
     sample = helpers.add_sample(disk_store)
     sample_id = sample.internal_id
-    assert disk_store.Sample.query.count() == 1
+    assert disk_store._get_query(table=Sample).count() == 1
 
     # WHEN getting a sample
     result = cli_runner.invoke(get, ["sample", sample_id], obj=base_context)
@@ -51,7 +51,7 @@ def test_get_samples_required(
     sample_id2 = "2"
     helpers.add_sample(store=disk_store, internal_id=sample_id2)
 
-    assert disk_store.Sample.query.count() == 2
+    assert disk_store._get_query(table=Sample).count() == 2
 
     # WHEN getting a sample
     result = cli_runner.invoke(get, ["sample", sample_id1, sample_id2], obj=base_context)
@@ -154,7 +154,7 @@ def test_get_sample_no_cases_with_case(
 
     # THEN all related cases should be listed in the output
     assert result.exit_code == EXIT_SUCCESS
-    for family_sample in disk_store.Sample.query.first().links:
+    for family_sample in disk_store._get_query(table=Sample).first().links:
         assert family_sample.family.internal_id not in result.output
 
 
@@ -164,7 +164,7 @@ def test_get_sample_cases_without_case(
     """Test that the --cases flag works without cases"""
     # GIVEN a database with a sample without related samples
     sample: Sample = helpers.add_sample(disk_store)
-    assert not disk_store.Sample.query.first().links
+    assert not disk_store._get_query(table=Sample).first().links
 
     # WHEN getting a sample with the --cases flag
     result = cli_runner.invoke(get, ["sample", sample.internal_id, "--cases"], obj=base_context)
@@ -187,7 +187,7 @@ def test_get_sample_cases_with_case(
 
     # THEN all related families should be listed in the output
     assert result.exit_code == EXIT_SUCCESS
-    for link in disk_store.Sample.query.first().links:
+    for link in disk_store._get_query(table=Sample).first().links:
         assert link.family.internal_id in result.output
 
 

--- a/tests/cli/set/test_cli_set_case.py
+++ b/tests/cli/set/test_cli_set_case.py
@@ -18,7 +18,7 @@ def test_set_case_without_options(
     """Test to set a case using only the required arguments."""
     # GIVEN a database with a case
     case_id: str = helpers.add_case(store=base_store).internal_id
-    assert base_store.Family.query.count() == 1
+    assert base_store._get_query(table=Family).count() == 1
 
     # WHEN setting a case
     result = cli_runner.invoke(case, [case_id], obj=base_context)
@@ -53,7 +53,7 @@ def test_set_case_bad_panel(
 
     # THEN it should complain in missing panel instead of setting a value
     assert result.exit_code != EXIT_SUCCESS
-    assert panel_id not in base_store.Family.query.first().panels
+    assert panel_id not in base_store._get_query(table=Family).first().panels
 
 
 def test_set_case_panel(
@@ -63,14 +63,16 @@ def test_set_case_panel(
     # GIVEN a database with a case and a panel not yet added to the case
     panel_id: str = helpers.ensure_panel(store=base_store, panel_abbreviation="a_panel").name
     case_id: str = helpers.add_case(store=base_store).internal_id
-    assert panel_id not in base_store.Family.query.first().panels
+    case_query = base_store._get_query(table=Family)
+
+    assert panel_id not in case_query.first().panels
 
     # WHEN setting a panel of a case
     result = cli_runner.invoke(case, [case_id, "--panel", panel_id], obj=base_context)
 
     # THEN it should set panel on the case
     assert result.exit_code == EXIT_SUCCESS
-    assert panel_id in base_store.Family.query.first().panels
+    assert panel_id in case_query.first().panels
 
 
 def test_set_case_priority(
@@ -80,7 +82,9 @@ def test_set_case_priority(
     # GIVEN a database with a case
     case_id: str = helpers.add_case(base_store).internal_id
     priority: str = "priority"
-    assert base_store.Family.query.first().priority_human != priority
+    case_query = base_store._get_query(table=Family)
+
+    assert case_query.first().priority_human != priority
 
     # WHEN setting a case
     result = cli_runner.invoke(
@@ -89,8 +93,8 @@ def test_set_case_priority(
 
     # THEN it should have been set
     assert result.exit_code == EXIT_SUCCESS
-    assert base_store.Family.query.count() == 1
-    assert base_store.Family.query.first().priority_human == priority
+    assert case_query.count() == 1
+    assert case_query.first().priority_human == priority
 
 
 def test_set_case_customer(
@@ -127,7 +131,7 @@ def test_set_case_bad_data_analysis(
 
     # THEN it should complain in invalid data_analysis instead of setting a value
     assert result.exit_code != EXIT_SUCCESS
-    assert str(data_analysis) != base_store.Family.query.first().data_analysis
+    assert str(data_analysis) != base_store._get_query(table=Family).first().data_analysis
 
 
 def test_set_case_data_analysis(
@@ -165,7 +169,7 @@ def test_set_case_bad_data_delivery(
 
     # THEN it should complain in invalid data_delivery instead of setting a value
     assert result.exit_code != EXIT_SUCCESS
-    assert str(data_delivery) != base_store.Family.query.first().data_delivery
+    assert str(data_delivery) != base_store._get_query(table=Family).first().data_delivery
 
 
 def test_set_case_data_delivery(

--- a/tests/cli/set/test_cli_set_flowcell.py
+++ b/tests/cli/set/test_cli_set_flowcell.py
@@ -5,6 +5,8 @@ from cg.models.cg_config import CGConfig
 from cg.store import Store
 from click.testing import CliRunner
 
+from cg.store.models import Flowcell
+
 SUCCESS = 0
 
 
@@ -26,7 +28,7 @@ def test_set_flowcell_required(
     """Test to set a flow cell using only the required arguments."""
     # GIVEN a database with a flow cell
     flow_cell_name = helpers.add_flowcell(base_store).name
-    assert base_store.Flowcell.query.count() == 1
+    assert base_store._get_query(table=Flowcell).count() == 1
 
     # WHEN setting a flowcell
     result = cli_runner.invoke(flowcell, [flow_cell_name], obj=base_context)
@@ -42,12 +44,13 @@ def test_set_flowcell_status(
     # GIVEN a database with a flow cell
     flow_cell_name = helpers.add_flowcell(base_store).name
     status = FLOWCELL_STATUS[2]
-    assert base_store.Flowcell.query.first().status != status
+    flow_cell_query = base_store._get_query(table=Flowcell)
+    assert flow_cell_query.first().status != status
 
     # WHEN setting a flowcell
     result = cli_runner.invoke(flowcell, ["--status", status, flow_cell_name], obj=base_context)
 
     # THEN it should have been set
     assert result.exit_code == SUCCESS
-    assert base_store.Flowcell.query.count() == 1
-    assert base_store.Flowcell.query.first().status == status
+    assert flow_cell_query.count() == 1
+    assert flow_cell_query.first().status == status

--- a/tests/cli/set/test_cli_set_sample.py
+++ b/tests/cli/set/test_cli_set_sample.py
@@ -8,6 +8,8 @@ from cg.models.cg_config import CGConfig
 from cg.store import Store
 from click.testing import CliRunner
 
+from cg.store.models import Sample
+
 
 def test_invalid_sample(cli_runner: CliRunner, base_context: CGConfig):
     # GIVEN an empty database
@@ -192,7 +194,9 @@ def test_invalid_customer(
     # GIVEN a database with a sample
     sample_id = helpers.add_sample(base_store).internal_id
     customer_id = "dummy_customer_id"
-    assert base_store.Sample.query.first().customer.internal_id != customer_id
+    sample_query = base_store._get_query(table=Sample)
+
+    assert sample_query.first().customer.internal_id != customer_id
 
     # WHEN calling set sample with an invalid customer
     result = cli_runner.invoke(
@@ -201,14 +205,16 @@ def test_invalid_customer(
 
     # THEN it should error about missing customer instead of setting the value
     assert result.exit_code != EXIT_SUCCESS
-    assert base_store.Sample.query.first().customer.internal_id != customer_id
+    assert sample_query.first().customer.internal_id != customer_id
 
 
 def test_customer(cli_runner: CliRunner, base_context: CGConfig, base_store: Store, helpers):
     # GIVEN a database with a sample and two customers
     sample_id = helpers.add_sample(base_store).internal_id
     customer_id = helpers.ensure_customer(base_store, "another_customer").internal_id
-    assert base_store.Sample.query.first().customer.internal_id != customer_id
+    sample_query = base_store._get_query(table=Sample)
+
+    assert sample_query.first().customer.internal_id != customer_id
 
     # WHEN calling set sample with a valid customer
     result = cli_runner.invoke(
@@ -217,7 +223,7 @@ def test_customer(cli_runner: CliRunner, base_context: CGConfig, base_store: Sto
 
     # THEN it should set the customer of the sample
     assert result.exit_code == EXIT_SUCCESS
-    assert base_store.Sample.query.first().customer.internal_id == customer_id
+    assert sample_query.first().customer.internal_id == customer_id
 
 
 def test_invalid_downsampled_to(cli_runner: CliRunner, base_context: CGConfig):
@@ -237,7 +243,9 @@ def test_downsampled_to(cli_runner: CliRunner, base_context: CGConfig, base_stor
     # GIVEN a database with a sample
     sample_id = helpers.add_sample(base_store).internal_id
     downsampled_to = 111111
-    assert base_store.Sample.query.first().downsampled_to != downsampled_to
+    sample_query = base_store._get_query(table=Sample)
+
+    assert sample_query.first().downsampled_to != downsampled_to
 
     # WHEN calling set sample with a valid value of downsampled to
     result = cli_runner.invoke(
@@ -246,7 +254,7 @@ def test_downsampled_to(cli_runner: CliRunner, base_context: CGConfig, base_stor
 
     # THEN the value should have been set on the sample
     assert result.exit_code == EXIT_SUCCESS
-    assert base_store.Sample.query.first().downsampled_to == downsampled_to
+    assert sample_query.first().downsampled_to == downsampled_to
 
 
 def test_reset_downsampled_to(
@@ -255,7 +263,9 @@ def test_reset_downsampled_to(
     # GIVEN a database with a sample
     sample_id = helpers.add_sample(base_store).internal_id
     downsampled_to = 0
-    assert base_store.Sample.query.first().downsampled_to != downsampled_to
+    sample_query = base_store._get_query(table=Sample)
+
+    assert sample_query.first().downsampled_to != downsampled_to
 
     # WHEN calling set sample with a valid reset value of downsampled to
     result = cli_runner.invoke(
@@ -264,7 +274,7 @@ def test_reset_downsampled_to(
 
     # THEN the value should have been set on the sample
     assert result.exit_code == EXIT_SUCCESS
-    assert not base_store.Sample.query.first().downsampled_to
+    assert not sample_query.first().downsampled_to
 
 
 def test_invalid_application(
@@ -273,7 +283,9 @@ def test_invalid_application(
     # GIVEN a database with a sample
     sample_id = helpers.add_sample(base_store).internal_id
     application_tag = "dummy_application"
-    assert base_store.Sample.query.first().application_version.application.tag != application_tag
+    sample_query = base_store._get_query(table=Sample)
+
+    assert sample_query.first().application_version.application.tag != application_tag
 
     # WHEN calling set sample with an invalid application
     result = cli_runner.invoke(
@@ -284,7 +296,7 @@ def test_invalid_application(
 
     # THEN it should error about missing application instead of setting the value
     assert result.exit_code != EXIT_SUCCESS
-    assert base_store.Sample.query.first().application_version.application.tag != application_tag
+    assert sample_query.first().application_version.application.tag != application_tag
 
 
 def test_application(cli_runner: CliRunner, base_context: CGConfig, base_store: Store, helpers):
@@ -293,7 +305,9 @@ def test_application(cli_runner: CliRunner, base_context: CGConfig, base_store: 
     application_tag = helpers.ensure_application_version(
         base_store, "another_application"
     ).application.tag
-    assert base_store.Sample.query.first().application_version.application.tag != application_tag
+    sample_query = base_store._get_query(table=Sample)
+
+    assert sample_query.first().application_version.application.tag != application_tag
 
     # WHEN calling set sample with an invalid application
     result = cli_runner.invoke(

--- a/tests/meta/demultiplex/test_delete_demultiplex_api.py
+++ b/tests/meta/demultiplex/test_delete_demultiplex_api.py
@@ -3,6 +3,7 @@ import pytest
 
 from pathlib import Path
 from typing import List, Optional
+from sqlalchemy.orm import Query
 
 from cg.apps.cgstats.db import models
 from cg.apps.cgstats.stats import StatsAPI
@@ -110,13 +111,13 @@ def test_no_active_samples_on_flow_cell(
     """Test if the function to find no active samples works correctly"""
 
     # GIVEN a flow cell with no active samples related to it
-    store_: Store = populated_wipe_demultiplex_api.status_db
-    samples_on_flow_cell: List[Sample] = (
-        store_.query(Flowcell).filter(Flowcell.name == flow_cell_id).first().samples
-    )
+    store: Store = populated_wipe_demultiplex_api.status_db
+    flow_cell = store.get_flow_cell_by_name(flow_cell_name=flow_cell_id)
+    samples_on_flow_cell: List[Sample] = flow_cell.samples
+
     assert samples_on_flow_cell
     for sample in samples_on_flow_cell:
-        active: bool = store_.has_active_cases_for_sample(internal_id=sample.internal_id)
+        active: bool = store.has_active_cases_for_sample(internal_id=sample.internal_id)
         assert not active
 
     # WHEN checking for active samples on flowcell
@@ -136,15 +137,13 @@ def test_active_samples_on_flow_cell(
 ):
     """Test if the function to find active samples works correctly"""
     # GIVEN a flow cell with active samples related to it
-    store_: Store = active_flow_cell_store
-
-    samples_on_flow_cell: List[Sample] = (
-        store_.query(Flowcell).filter(Flowcell.name == flow_cell_id).first().samples
-    )
+    store: Store = active_flow_cell_store
+    flow_cell = store.get_flow_cell_by_name(flow_cell_name=flow_cell_id)
+    samples_on_flow_cell: List[Sample] = flow_cell.samples
 
     assert samples_on_flow_cell
     for sample in samples_on_flow_cell:
-        active: bool = store_.has_active_cases_for_sample(internal_id=sample.internal_id)
+        active: bool = store.has_active_cases_for_sample(internal_id=sample.internal_id)
         assert active
 
     # WHEN checking for active samples on flowcell
@@ -267,34 +266,21 @@ def test_delete_flow_cell_statusdb(
     caplog.set_level(logging.INFO)
 
     # GIVEN a context, with a status db filled with a flow cell object
-
     wipe_demux_api: DeleteDemuxAPI = populated_wipe_demultiplex_api
     wipe_demux_api.set_dry_run(dry_run=False)
+    store = populated_wipe_demux_context.status_db
+    flow_cell: Flowcell = store.get_flow_cell_by_name(flow_cell_name=flow_cell_id)
+    assert flow_cell
 
-    existing_object: Flowcell = (
-        populated_wipe_demux_context.status_db.query(Flowcell)
-        .filter(Flowcell.name == flow_cell_id)
-        .first()
-    )
-    assert existing_object
-
-    # WHEN removing the object from the database
-
+    # WHEN removing the flow cell from the database
     wipe_demux_api.delete_flow_cell_in_status_db()
 
-    # THEN the user should be informed that the object was removed
-
+    # THEN the user should be informed that the flow cell was removed
     assert f"StatusDB: Deleted flowcell {wipe_demux_api.flow_cell_name}" in caplog.text
 
-    # AND the object should no longer exist in status db
-
-    existing_object: Flowcell = (
-        populated_wipe_demux_context.status_db.query(Flowcell)
-        .filter(Flowcell.name == flow_cell_id)
-        .first()
-    )
-
-    assert not existing_object
+    # AND the flow cell should no longer exist in status db
+    flow_cell: Flowcell = store.get_flow_cell_by_name(flow_cell_name=flow_cell_id)
+    assert not flow_cell
 
 
 def test_delete_flow_cell_hasta(

--- a/tests/meta/upload/nipt/conftest.py
+++ b/tests/meta/upload/nipt/conftest.py
@@ -36,11 +36,9 @@ def fixture_nipt_upload_api_failed_fc_context(
         .values(readcounts=10)
     )
     stats_api.session.commit()
-    application = (
-        status_db.Sample.query.filter(Sample.internal_id == sample_id)
-        .first()
-        .application_version.application
-    )
+    application = status_db.get_sample_by_internal_id(
+        internal_id=sample_id
+    ).application_version.application
     status_db.session.execute(
         update(Application).where(Application.id == application.id).values({"target_reads": 20})
     )

--- a/tests/store/api/add/test_store_add_base.py
+++ b/tests/store/api/add/test_store_add_base.py
@@ -1,12 +1,13 @@
 from datetime import datetime as dt
 
 from cg.store import Store
-from cg.store.models import Customer
+from cg.store.models import ApplicationVersion, Collaboration, Customer, Organism, Sample, User
 
 
 def test_add_collaboration(store: Store):
     # GIVEN an empty database
-    assert store.Collaboration.query.first() is None
+    collaboration_query = store._get_query(table=Collaboration)
+    assert collaboration_query.first() is None
     internal_id, name = "cust_group", "Test customer group"
 
     # WHEN adding a new customer group
@@ -14,7 +15,7 @@ def test_add_collaboration(store: Store):
     store.add_commit(new_collaboration)
 
     # THEN it should be stored in the database
-    assert store.Collaboration.query.first() == new_collaboration
+    assert collaboration_query.first() == new_collaboration
 
 
 def test_add_user(store: Store):
@@ -35,12 +36,13 @@ def test_add_user(store: Store):
     store.add_commit(new_user)
 
     # THEN it should be stored in the database
-    assert store.User.query.first() == new_user
+    assert store._get_query(table=User).first() == new_user
 
 
 def test_add_microbial_sample(base_store: Store, helpers):
     # GIVEN an empty database
-    assert base_store.Sample.query.first() is None
+    sample_query = base_store._get_query(table=Sample)
+    assert sample_query.first() is None
     customer_obj = helpers.ensure_customer(base_store)
     assert customer_obj
     name = "microbial_sample"
@@ -48,9 +50,9 @@ def test_add_microbial_sample(base_store: Store, helpers):
     internal_id = "lims-id"
     reference_genome = "ref_gen"
     priority = "research"
-    application_version = base_store.ApplicationVersion.query.first()
+    application_version = base_store._get_query(table=ApplicationVersion).first()
     base_store.add_organism(organism_name, organism_name, reference_genome)
-    organism = base_store.Organism.query.first()
+    organism = base_store._get_query(table=Organism).first()
 
     # WHEN adding a new microbial sample
     new_sample = base_store.add_sample(
@@ -66,8 +68,8 @@ def test_add_microbial_sample(base_store: Store, helpers):
     base_store.add_commit(new_sample)
 
     # THEN it should be stored in the database
-    assert base_store.Sample.query.first() == new_sample
-    stored_microbial_sample = base_store.Sample.query.first()
+    assert sample_query.first() == new_sample
+    stored_microbial_sample = sample_query.first()
     assert stored_microbial_sample.name == name
     assert stored_microbial_sample.internal_id == internal_id
     assert stored_microbial_sample.reference_genome == reference_genome

--- a/tests/store/api/add/test_store_add_customer.py
+++ b/tests/store/api/add/test_store_add_customer.py
@@ -6,7 +6,7 @@ from cg.store.models import Customer
 @pytest.mark.parametrize("contact_type", ["delivery", "primary", "invoice"])
 def test_contact_storing(store: Store, contact_type, helpers):
     # GIVEN an empty database
-    assert store.Customer.query.first() is None
+    assert store._get_query(table=Customer).first() is None
     internal_id, name, scout_access = "cust000", "Test customer", True
     contact_email = f"{contact_type}.contact@customer.se"
     contact_name = contact_type

--- a/tests/store/api/find/test_find_business_data.py
+++ b/tests/store/api/find/test_find_business_data.py
@@ -222,9 +222,9 @@ def test_get_latest_flow_cell_on_case(
     """Test returning the latest sequenced flow cell on a case."""
 
     # GIVEN a store with two flow cells in it, one being the latest sequenced of the two
-    latest_flow_cell: Flowcell = re_sequenced_sample_store.Flowcell.query.filter(
-        Flowcell.name == flow_cell_id
-    ).first()
+    latest_flow_cell: Flowcell = re_sequenced_sample_store.get_flow_cell_by_name(
+        flow_cell_name=flow_cell_id
+    )
 
     # WHEN fetching the latest flow cell on a case with a sample that has been sequenced on both flow cells
     latest_flow_cell_on_case: Flowcell = re_sequenced_sample_store.get_latest_flow_cell_on_case(

--- a/tests/store/api/status/test_store_api_status.py
+++ b/tests/store/api/status/test_store_api_status.py
@@ -178,13 +178,14 @@ def test_analyses_to_upload_when_filtering_with_missing_pipeline(helpers, sample
 def test_set_case_action(analysis_store, case_id):
     """Tests if actions of cases are changed to analyze."""
     # Given a store with a case with action None
-    action = analysis_store.Family.query.filter(Family.internal_id == case_id).first().action
+    case_query = analysis_store._get_query(table=Family)
+    action = case_query.filter(Family.internal_id == case_id).first().action
 
     assert action == None
 
     # When setting the case to "analyze"
     analysis_store.set_case_action(case_internal_id=case_id, action="analyze")
-    new_action = analysis_store.Family.query.filter(Family.internal_id == case_id).first().action
+    new_action = case_query.filter(Family.internal_id == case_id).first().action
 
     # Then the action should be set to analyze
     assert new_action == "analyze"

--- a/tests/store/api/status/test_store_api_status.py
+++ b/tests/store/api/status/test_store_api_status.py
@@ -175,17 +175,16 @@ def test_analyses_to_upload_when_filtering_with_missing_pipeline(helpers, sample
     assert len(records) == 0
 
 
-def test_set_case_action(analysis_store, case_id):
+def test_set_case_action(analysis_store: Store, case_id):
     """Tests if actions of cases are changed to analyze."""
     # Given a store with a case with action None
-    case_query = analysis_store._get_query(table=Family)
-    action = case_query.filter(Family.internal_id == case_id).first().action
+    action = analysis_store.get_case_by_internal_id(internal_id=case_id).action
 
     assert action == None
 
     # When setting the case to "analyze"
     analysis_store.set_case_action(case_internal_id=case_id, action="analyze")
-    new_action = case_query.filter(Family.internal_id == case_id).first().action
+    new_action = analysis_store.get_case_by_internal_id(internal_id=case_id).action
 
     # Then the action should be set to analyze
     assert new_action == "analyze"

--- a/tests/store/conftest.py
+++ b/tests/store/conftest.py
@@ -396,7 +396,7 @@ def fixture_store_with_older_and_newer_analyses(
     old_timestamp: dt.datetime,
 ) -> Store:
     """Return a store with  older and newer analyses."""
-    analysis = base_store.Analysis.query.first()
+    analysis = base_store._get_query(table=Analysis).first()
     analysis.uploaded_at = timestamp_now
     analysis.uploaded_to_vogue_at = timestamp_now
     analysis.cleaned_at = timestamp_now


### PR DESCRIPTION
## Description
Remove all instances of direct interactions with queries in the tests (exception of stats api queries which still need to be refactored).

### Fixed
- Remove queries from tests

### This [version](https://semver.org/) is a
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
