### PR TITLE
Replace Family query with existing methods

### DIFF
--- a/cg/store/api/status.py
+++ b/cg/store/api/status.py
@@ -91,16 +91,11 @@ class StatusHandler(BaseHandler):
 
     def get_families_with_analyses(self) -> Query:
         """Return all cases in the database with an analysis."""
-        return self.Family.query.outerjoin(Analysis).join(
-            Family.links,
-            FamilySample.sample,
-            ApplicationVersion,
-            Application,
-        )
+        return self._get_outer_join_cases_with_analyses_query()
 
     def get_families_with_samples(self) -> Query:
         """Return all cases in the database with samples."""
-        return self.Family.query.join(Family.links, FamilySample.sample, Family.customer)
+        return self._get_join_cases_with_samples_query()
 
     def cases_to_analyze(
         self, pipeline: Pipeline = None, threshold: bool = False, limit: int = None


### PR DESCRIPTION
## Description
Replace Family queries

### Changed
- Replaced direct queries on the Family table with existing get_join query methods.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

