### PR TITLE
Replace alchy with sqlalchemy in housekeeper

### DIFF
--- a/cg/apps/housekeeper/hk.py
+++ b/cg/apps/housekeeper/hk.py
@@ -5,7 +5,7 @@ import os
 from pathlib import Path
 from typing import Iterable, List, Optional, Set, Tuple, Dict
 
-from alchy import Query
+from sqlalchemy.orm import Query
 from housekeeper.include import checksum as hk_checksum
 from housekeeper.include import include_version
 from housekeeper.store import Store, models

--- a/cg/cli/clean.py
+++ b/cg/cli/clean.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 from cg.utils.dispatcher import Dispatcher
 
 import click
-from alchy import Query
+from sqlalchemy.orm import Query
 from cgmodels.cg.constants import Pipeline
 from housekeeper.store.models import File, Version
 from tabulate import tabulate

--- a/cg/meta/clean/demultiplexed_flow_cells.py
+++ b/cg/meta/clean/demultiplexed_flow_cells.py
@@ -6,7 +6,7 @@ import shutil
 from pathlib import Path
 from typing import List, Optional
 
-from alchy import Query
+from sqlalchemy.orm import Query
 from housekeeper.store.models import Bundle, Version
 
 from cg.apps.housekeeper.hk import HousekeeperAPI

--- a/cg/meta/workflow/fluffy.py
+++ b/cg/meta/workflow/fluffy.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import List, Optional
 
 import pandas as pd
-from alchy import Query
+from sqlalchemy.orm import Query
 from cg.constants import Pipeline
 from cg.constants.demultiplexing import SAMPLE_SHEET_DATA_HEADER
 from cg.exc import CgError


### PR DESCRIPTION
## Description
Remove alchy from the housekeeper module in cg. 

### Fixed
- Replace `alchy` with `sqlalchemy` in the housekeeper module


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- Merge https://github.com/Clinical-Genomics/housekeeper/pull/112
- Merge this PR
- Deploy housekeeper
- Deploy cg