### PR TITLE
Remove models from base handler

### DIFF
--- a/cg/store/api/base.py
+++ b/cg/store/api/base.py
@@ -40,24 +40,6 @@ class BaseHandler:
     def __init__(self, session: Session):
         self.session = session
 
-    Analysis: Type[ModelBase] = Analysis
-    Application: Type[ModelBase] = Application
-    ApplicationVersion: Type[ModelBase] = ApplicationVersion
-    Bed: Type[ModelBase] = Bed
-    BedVersion: Type[ModelBase] = BedVersion
-    Collaboration: Type[ModelBase] = Collaboration
-    Customer: Type[ModelBase] = Customer
-    Delivery: Type[ModelBase] = Delivery
-    Family: Type[ModelBase] = Family
-    FamilySample: Type[ModelBase] = FamilySample
-    Flowcell: Type[ModelBase] = Flowcell
-    Invoice: Type[ModelBase] = Invoice
-    Organism: Type[ModelBase] = Organism
-    Panel: Type[ModelBase] = Panel
-    Pool: Type[ModelBase] = Pool
-    Sample: Type[ModelBase] = Sample
-    User: Type[ModelBase] = User
-
     def _get_query(self, table: Type[ModelBase]) -> Query:
         """Return a query for the given table."""
         return self.session.query(table)
@@ -132,8 +114,8 @@ class BaseHandler:
         return analyses.join(
             case_and_date_subquery,
             and_(
-                self.Analysis.family_id == case_and_date_subquery.c.family_id,
-                self.Analysis.started_at == case_and_date_subquery.c.started_at,
+                Analysis.family_id == case_and_date_subquery.c.family_id,
+                Analysis.started_at == case_and_date_subquery.c.started_at,
             ),
         )
 

--- a/cg/store/api/base.py
+++ b/cg/store/api/base.py
@@ -2,7 +2,6 @@
 from typing import Callable, Optional, Type, List
 
 from sqlalchemy.orm import Query, Session
-from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import and_, func
 from dataclasses import dataclass
 from cg.store.filters.status_case_filters import CaseFilter, apply_case_filter
@@ -12,20 +11,11 @@ from cg.store.models import (
     Analysis,
     Application,
     ApplicationVersion,
-    Bed,
-    BedVersion,
-    Collaboration,
     Customer,
-    Delivery,
     Family,
     FamilySample,
     Flowcell,
-    Invoice,
-    Organism,
-    Panel,
-    Pool,
     Sample,
-    User,
 )
 from cg.store.filters.status_analysis_filters import AnalysisFilter, apply_analysis_filter
 from cg.utils.date import get_date_days_ago

--- a/cg/store/api/find_basic_data.py
+++ b/cg/store/api/find_basic_data.py
@@ -55,7 +55,7 @@ class FindBasicDataHandler(BaseHandler):
                 filter_functions=[ApplicationFilter.FILTER_BY_PREP_CATEGORY],
                 prep_category=prep_category,
             )
-            .order_by(self.Application.prep_category, self.Application.tag)
+            .order_by(Application.prep_category, Application.tag)
             .all()
         )
 
@@ -66,7 +66,7 @@ class FindBasicDataHandler(BaseHandler):
                 applications=self._get_query(table=Application),
                 filter_functions=[ApplicationFilter.FILTER_IS_NOT_ARCHIVED],
             )
-            .order_by(self.Application.prep_category, self.Application.tag)
+            .order_by(Application.prep_category, Application.tag)
             .all()
         )
 
@@ -83,7 +83,7 @@ class FindBasicDataHandler(BaseHandler):
                 ],
                 prep_category=prep_category,
             )
-            .order_by(self.Application.prep_category, self.Application.tag)
+            .order_by(Application.prep_category, Application.tag)
             .all()
         )
 
@@ -91,7 +91,7 @@ class FindBasicDataHandler(BaseHandler):
         """Return all applications."""
         return (
             self._get_query(table=Application)
-            .order_by(self.Application.prep_category, self.Application.tag)
+            .order_by(Application.prep_category, Application.tag)
             .all()
         )
 

--- a/tests/meta/report/test_report_api.py
+++ b/tests/meta/report/test_report_api.py
@@ -9,7 +9,7 @@ from cg.models.report.sample import SampleModel, ApplicationModel, MethodsModel,
 
 from cg.models.mip.mip_analysis import MipAnalysis
 
-from cg.store.models import Analysis
+from cg.store.models import Analysis, FamilySample
 
 from cg.constants import REPORT_GENDER
 from cg.exc import DeliveryReportError
@@ -220,7 +220,7 @@ def test_get_samples_data(
 
     # GIVEN an expected output
     expected_lims_data: dict = lims_samples[0]
-    expected_sample_data: models.FamilySample = case_samples_data[0]
+    expected_sample_data: FamilySample = case_samples_data[0]
 
     # GIVEN a mip analysis mock metadata
     mip_metadata: MipAnalysis = mip_analysis_api.get_latest_metadata(case_mip_dna.internal_id)

--- a/tests/meta/upload/balsamic/test_balsamic.py
+++ b/tests/meta/upload/balsamic/test_balsamic.py
@@ -2,7 +2,7 @@
 
 from cg.meta.upload.gt import UploadGenotypesAPI
 from cg.models.cg_config import CGConfig
-from cg.store import models
+from cg.store.models import Family
 from tests.cli.workflow.balsamic.conftest import (
     fixture_balsamic_context,
     balsamic_lims,
@@ -24,7 +24,7 @@ def test_genotype_check_wgs_normal(balsamic_context: CGConfig):
     """Test a cancer case with WGS and normal sample that is Genotype compatible."""
     # GIVEN a balsamic case with WGS tag and a normal sample
     internal_id = "balsamic_case_wgs_paired_enough_reads"
-    case_obj: models.Family = balsamic_context.status_db.get_case_by_internal_id(
+    case_obj: Family = balsamic_context.status_db.get_case_by_internal_id(
         internal_id=internal_id
     )
 
@@ -39,7 +39,7 @@ def test_genotype_check_non_wgs_normal(balsamic_context: CGConfig):
     """Test a cancer case with no WGS sample that is not Genotype compatible."""
     # GIVEN a balsamic case with a normal sample, but no WGS tag
     internal_id = "balsamic_case_tgs_paired"
-    case_obj: models.Family = balsamic_context.status_db.get_case_by_internal_id(
+    case_obj: Family = balsamic_context.status_db.get_case_by_internal_id(
         internal_id=internal_id
     )
 
@@ -54,7 +54,7 @@ def test_genotype_check_only_tumour(balsamic_context: CGConfig):
     """Test a cancer case with only a tumour sample that is not Genotype compatible."""
     # GIVEN a balsamic case with only tumour sample
     internal_id = "balsamic_case_wgs_single"
-    case_obj: models.Family = balsamic_context.status_db.get_case_by_internal_id(
+    case_obj: Family = balsamic_context.status_db.get_case_by_internal_id(
         internal_id=internal_id
     )
 

--- a/tests/meta/upload/balsamic/test_balsamic.py
+++ b/tests/meta/upload/balsamic/test_balsamic.py
@@ -24,10 +24,10 @@ def test_genotype_check_wgs_normal(balsamic_context: CGConfig):
     """Test a cancer case with WGS and normal sample that is Genotype compatible."""
     # GIVEN a balsamic case with WGS tag and a normal sample
     internal_id = "balsamic_case_wgs_paired_enough_reads"
-    case_obj: Family = balsamic_context.status_db.get_case_by_internal_id(internal_id=internal_id)
+    case: Family = balsamic_context.status_db.get_case_by_internal_id(internal_id=internal_id)
 
     # WHEN checking if the case is Genotype upload compatible
-    passed_check = UploadGenotypesAPI.is_suitable_for_genotype_upload(case_obj)
+    passed_check = UploadGenotypesAPI.is_suitable_for_genotype_upload(case)
 
     # THEN it should return True
     assert passed_check
@@ -37,10 +37,10 @@ def test_genotype_check_non_wgs_normal(balsamic_context: CGConfig):
     """Test a cancer case with no WGS sample that is not Genotype compatible."""
     # GIVEN a balsamic case with a normal sample, but no WGS tag
     internal_id = "balsamic_case_tgs_paired"
-    case_obj: Family = balsamic_context.status_db.get_case_by_internal_id(internal_id=internal_id)
+    case: Family = balsamic_context.status_db.get_case_by_internal_id(internal_id=internal_id)
 
     # WHEN checking if the case is Genotype upload compatible
-    passed_check = UploadGenotypesAPI.is_suitable_for_genotype_upload(case_obj)
+    passed_check = UploadGenotypesAPI.is_suitable_for_genotype_upload(case)
 
     # THEN it should return False
     assert not passed_check
@@ -50,10 +50,10 @@ def test_genotype_check_only_tumour(balsamic_context: CGConfig):
     """Test a cancer case with only a tumour sample that is not Genotype compatible."""
     # GIVEN a balsamic case with only tumour sample
     internal_id = "balsamic_case_wgs_single"
-    case_obj: Family = balsamic_context.status_db.get_case_by_internal_id(internal_id=internal_id)
+    case: Family = balsamic_context.status_db.get_case_by_internal_id(internal_id=internal_id)
 
     # WHEN checking if the case is Genotype upload compatible
-    passed_check = UploadGenotypesAPI.is_suitable_for_genotype_upload(case_obj)
+    passed_check = UploadGenotypesAPI.is_suitable_for_genotype_upload(case)
 
     # THEN it should return False
     assert not passed_check

--- a/tests/meta/upload/balsamic/test_balsamic.py
+++ b/tests/meta/upload/balsamic/test_balsamic.py
@@ -24,9 +24,7 @@ def test_genotype_check_wgs_normal(balsamic_context: CGConfig):
     """Test a cancer case with WGS and normal sample that is Genotype compatible."""
     # GIVEN a balsamic case with WGS tag and a normal sample
     internal_id = "balsamic_case_wgs_paired_enough_reads"
-    case_obj: Family = balsamic_context.status_db.get_case_by_internal_id(
-        internal_id=internal_id
-    )
+    case_obj: Family = balsamic_context.status_db.get_case_by_internal_id(internal_id=internal_id)
 
     # WHEN checking if the case is Genotype upload compatible
     passed_check = UploadGenotypesAPI.is_suitable_for_genotype_upload(case_obj)
@@ -39,9 +37,7 @@ def test_genotype_check_non_wgs_normal(balsamic_context: CGConfig):
     """Test a cancer case with no WGS sample that is not Genotype compatible."""
     # GIVEN a balsamic case with a normal sample, but no WGS tag
     internal_id = "balsamic_case_tgs_paired"
-    case_obj: Family = balsamic_context.status_db.get_case_by_internal_id(
-        internal_id=internal_id
-    )
+    case_obj: Family = balsamic_context.status_db.get_case_by_internal_id(internal_id=internal_id)
 
     # WHEN checking if the case is Genotype upload compatible
     passed_check = UploadGenotypesAPI.is_suitable_for_genotype_upload(case_obj)
@@ -54,9 +50,7 @@ def test_genotype_check_only_tumour(balsamic_context: CGConfig):
     """Test a cancer case with only a tumour sample that is not Genotype compatible."""
     # GIVEN a balsamic case with only tumour sample
     internal_id = "balsamic_case_wgs_single"
-    case_obj: Family = balsamic_context.status_db.get_case_by_internal_id(
-        internal_id=internal_id
-    )
+    case_obj: Family = balsamic_context.status_db.get_case_by_internal_id(internal_id=internal_id)
 
     # WHEN checking if the case is Genotype upload compatible
     passed_check = UploadGenotypesAPI.is_suitable_for_genotype_upload(case_obj)

--- a/tests/meta/upload/scout/test_generate_load_config.py
+++ b/tests/meta/upload/scout/test_generate_load_config.py
@@ -131,7 +131,7 @@ def test_generate_config_adds_sample_paths(
 
 def test_generate_config_adds_case_paths(
     sample_id: str,
-    mip_dna_analysis: Store.Analysis,
+    mip_dna_analysis: Analysis,
     upload_mip_analysis_scout_api: UploadScoutAPI,
 ):
     """Test that generate config adds case file paths"""

--- a/tests/store/api/add/test_store_add_customer.py
+++ b/tests/store/api/add/test_store_add_customer.py
@@ -40,12 +40,12 @@ def test_contact_structure(store: Store, contact_type):
     # WHEN checking the structure of Customer
 
     # THEN contact email and name should not be present
-    assert not hasattr(store.Customer, contact_type + "_contact_email")
-    assert not hasattr(store.Customer, contact_type + "_contact_name")
+    assert not hasattr(Customer, contact_type + "_contact_email")
+    assert not hasattr(Customer, contact_type + "_contact_name")
 
     # THEN deprecated attributes should not be present
-    assert hasattr(store.Customer, contact_type + "_contact_id")
-    assert hasattr(store.Customer, contact_type + "_contact")
+    assert hasattr(Customer, contact_type + "_contact_id")
+    assert hasattr(Customer, contact_type + "_contact")
 
 
 def test_add_basic(store: Store):

--- a/tests/store/conftest.py
+++ b/tests/store/conftest.py
@@ -8,7 +8,7 @@ import pytest
 from cg.constants import Pipeline
 from cg.constants.subject import Gender, PhenotypeStatus
 from cg.store import Store
-from cg.store.models import Analysis, Application, Family, Sample, Customer
+from cg.store.models import Analysis, Application, Family, Organism, Sample, Customer
 from tests.store_helpers import StoreHelpers
 
 
@@ -149,7 +149,7 @@ def fixture_microbial_store(
         application_version = base_store.get_application_by_tag(
             sample_data["application"]
         ).versions[0]
-        organism = base_store.Organism(
+        organism = Organism(
             internal_id=sample_data["organism"], name=sample_data["organism"]
         )
         base_store.session.add(organism)

--- a/tests/store/conftest.py
+++ b/tests/store/conftest.py
@@ -149,9 +149,7 @@ def fixture_microbial_store(
         application_version = base_store.get_application_by_tag(
             sample_data["application"]
         ).versions[0]
-        organism = Organism(
-            internal_id=sample_data["organism"], name=sample_data["organism"]
-        )
+        organism = Organism(internal_id=sample_data["organism"], name=sample_data["organism"])
         base_store.session.add(organism)
         sample = base_store.add_sample(
             name=sample_data["name"],

--- a/tests/store/conftest.py
+++ b/tests/store/conftest.py
@@ -149,7 +149,9 @@ def fixture_microbial_store(
         application_version = base_store.get_application_by_tag(
             sample_data["application"]
         ).versions[0]
-        organism = Organism(internal_id=sample_data["organism"], name=sample_data["organism"])
+        organism: Organism = Organism(
+            internal_id=sample_data["organism"], name=sample_data["organism"]
+        )
         base_store.session.add(organism)
         sample = base_store.add_sample(
             name=sample_data["name"],

--- a/tests/store_helpers.py
+++ b/tests/store_helpers.py
@@ -456,7 +456,7 @@ class StoreHelpers:
     ):
         """Load a case with samples and link relations from a dictionary."""
         customer_obj = StoreHelpers.ensure_customer(store)
-        case_obj = Family(
+        case = Family(
             name=case_info["name"],
             panels=case_info["panels"],
             internal_id=case_info["internal_id"],
@@ -468,8 +468,8 @@ class StoreHelpers:
             tickets=case_info["tickets"],
         )
 
-        case_obj = StoreHelpers.add_case(
-            store, case_obj=case_obj, customer_id=customer_obj.internal_id
+        case: Family = StoreHelpers.add_case(
+            store, case_obj=case, customer_id=customer_obj.internal_id
         )
 
         app_tag = app_tag or "WGSPCFC030"
@@ -502,7 +502,7 @@ class StoreHelpers:
                 mother = sample_objs[sample_data[Pedigree.MOTHER]]
             StoreHelpers.add_relationship(
                 store,
-                case=case_obj,
+                case=case,
                 sample=sample_obj,
                 status=sample_data.get("status", PhenotypeStatus.UNKNOWN),
                 father=father,
@@ -512,10 +512,10 @@ class StoreHelpers:
         StoreHelpers.add_analysis(
             store,
             pipeline=Pipeline.MIP_DNA,
-            case=case_obj,
+            case=case,
             completed_at=completed_at or datetime.now(),
         )
-        return case_obj
+        return case
 
     @staticmethod
     def add_organism(

--- a/tests/store_helpers.py
+++ b/tests/store_helpers.py
@@ -455,7 +455,7 @@ class StoreHelpers:
     ):
         """Load a case with samples and link relations from a dictionary."""
         customer_obj = StoreHelpers.ensure_customer(store)
-        case_obj = store.Family(
+        case_obj = Family(
             name=case_info["name"],
             panels=case_info["panels"],
             internal_id=case_info["internal_id"],


### PR DESCRIPTION
## Description
There is no reason to keep the models in the base handler as attributes any longer.

### Changed
- Removed all model attributes on the base handler class since they are unnecessary.

## Review
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by


### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

