### PR TITLE
feat(rnafusion): Add default compute environment and revision

### DIFF
--- a/cg/cli/workflow/rnafusion/base.py
+++ b/cg/cli/workflow/rnafusion/base.py
@@ -124,8 +124,8 @@ def run(
             case_id=case_id, root_dir=analysis_api.root_dir, params_file=params_file
         ),
         "name": case_id,
-        "compute-env": compute_env,
-        "revision": revision,
+        "compute-env": compute_env or analysis_api.compute_env,
+        "revision": revision or analysis_api.revision,
         "wait": "SUBMITTED",
     }
 

--- a/cg/meta/workflow/rnafusion.py
+++ b/cg/meta/workflow/rnafusion.py
@@ -48,6 +48,8 @@ class RnafusionAnalysisAPI(AnalysisAPI):
         self.tower_pipeline: str = config.rnafusion.tower_pipeline
         self.account: str = config.rnafusion.slurm.account
         self.email: str = config.rnafusion.slurm.mail_user
+        self.compute_env: str = config.rnafusion.compute_env
+        self.revision: str = config.rnafusion.revision
 
     @property
     def root(self) -> str:


### PR DESCRIPTION
## Description

Fixes https://github.com/Clinical-Genomics/cg/issues/1905
Fixes https://github.com/Clinical-Genomics/cg/issues/1866

### Added

- Locks revision and compute environment by using defaults given in the cg config file. 

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
