### PR TITLE
Add missing to_dict methods

### DIFF
--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -5,7 +5,7 @@ from typing import List, Optional, Set, Dict
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, ForeignKey, Table, UniqueConstraint, orm, types
 from sqlalchemy.util import deprecated
-from sqlalchemy.orm import InstrumentedAttribute
+from sqlalchemy.orm.attributes import InstrumentedAttribute
 
 from cg.constants import (
     CASE_ACTIONS,

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -219,6 +219,9 @@ class Bed(Model):
     def __str__(self) -> str:
         return self.name
 
+    def to_dict(self):
+        return to_dict(model_instance=self)
+
 
 class BedVersion(Model):
     """Model for bed target captures versions"""
@@ -314,6 +317,9 @@ class Collaboration(Model):
             "internal_id": self.internal_id,
         }
 
+    def to_dict(self):
+        return to_dict(model_instance=self)
+
 
 class Delivery(Model):
     __tablename__ = "delivery"
@@ -324,6 +330,9 @@ class Delivery(Model):
     sample_id = Column(ForeignKey("sample.id", ondelete="CASCADE"))
     pool_id = Column(ForeignKey("pool.id", ondelete="CASCADE"))
     comment = Column(types.Text)
+
+    def to_dict(self):
+        return to_dict(model_instance=self)
 
 
 class Family(Model, PriorityMixin):
@@ -552,6 +561,9 @@ class Panel(Model):
     def __str__(self):
         return f"{self.abbrev} ({self.current_version})"
 
+    def to_dict(self):
+        return to_dict(model_instance=self)
+
 
 class Pool(Model):
     __tablename__ = "pool"
@@ -575,6 +587,9 @@ class Pool(Model):
     ordered_at = Column(types.DateTime, nullable=False)
     received_at = Column(types.DateTime)
     ticket = Column(types.String(32))
+
+    def to_dict(self):
+        return to_dict(model_instance=self)
 
 
 class Sample(Model, PriorityMixin):

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -5,6 +5,7 @@ from typing import List, Optional, Set, Dict
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, ForeignKey, Table, UniqueConstraint, orm, types
 from sqlalchemy.util import deprecated
+from sqlalchemy.orm import InstrumentedAttribute
 
 from cg.constants import (
     CASE_ACTIONS,
@@ -27,6 +28,7 @@ def to_dict(model_instance):
         return {
             column.name: getattr(model_instance, column.name)
             for column in model_instance.__table__.columns
+            if not isinstance(getattr(model_instance, column.name), InstrumentedAttribute)
         }
 
 


### PR DESCRIPTION
## Description
Patch broken to_dict method, we want to find a better solution - using some common library for serialization or defining the to_dict method on the base model.

The endpoints were failing due to trying to serialize some invalid objects in the dicts (non json serializable). 

### Fixed
- Patch broken `to_dict`

### This [version](https://semver.org/) is a
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

