### PR TITLE
Fix database session management

### DIFF
--- a/cg/server/app.py
+++ b/cg/server/app.py
@@ -55,6 +55,10 @@ def _configure_extensions(app: Flask):
         ext.osticket.init_app(app)
     ext.admin.init_app(app, index_view=AdminIndexView(endpoint="admin"))
 
+    @app.teardown_appcontext
+    def shutdown_session(exception=None):
+        ext.db.session.remove()
+
 
 def _initialize_logging(app):
     coloredlogs.install(level="DEBUG" if app.debug else "INFO")

--- a/cg/server/app.py
+++ b/cg/server/app.py
@@ -56,10 +56,6 @@ def _configure_extensions(app: Flask):
         ext.osticket.init_app(app)
     ext.admin.init_app(app, index_view=AdminIndexView(endpoint="admin"))
 
-    @app.teardown_appcontext
-    def shutdown_session(exception=None):
-        ext.db.session.remove()
-
 
 def _initialize_logging(app):
     coloredlogs.install(level="DEBUG" if app.debug else "INFO")

--- a/cg/server/app.py
+++ b/cg/server/app.py
@@ -34,6 +34,7 @@ def create_app():
     _load_config(app)
     _configure_extensions(app)
     _register_blueprints(app)
+    _register_teardowns(app)
 
     return app
 
@@ -121,3 +122,11 @@ def _register_admin_views():
     ext.admin.add_view(admin.AnalysisView(Analysis, ext.db.session))
     ext.admin.add_view(admin.DeliveryView(Delivery, ext.db.session))
     ext.admin.add_view(admin.InvoiceView(Invoice, ext.db.session))
+
+
+def _register_teardowns(app: Flask):
+    """Register teardown functions."""
+
+    @app.teardown_appcontext
+    def remove_database_session(exception=None):
+        ext.db.session.remove()

--- a/cg/server/ext.py
+++ b/cg/server/ext.py
@@ -1,8 +1,6 @@
 from flask_admin import Admin
-from sqlalchemy.orm import scoped_session, sessionmaker
 from flask_cors import CORS
 from flask_wtf.csrf import CSRFProtect
-from flask_sqlalchemy import SQLAlchemy
 from cg.apps.lims import LimsAPI
 from cg.apps.osticket import OsTicket
 from cg.store.api.core import Store

--- a/cg/server/ext.py
+++ b/cg/server/ext.py
@@ -2,7 +2,7 @@ from flask_admin import Admin
 from sqlalchemy.orm import scoped_session, sessionmaker
 from flask_cors import CORS
 from flask_wtf.csrf import CSRFProtect
-
+from flask_sqlalchemy import SQLAlchemy
 from cg.apps.lims import LimsAPI
 from cg.apps.osticket import OsTicket
 from cg.store.api.core import Store

--- a/cg/store/api/core.py
+++ b/cg/store/api/core.py
@@ -1,6 +1,6 @@
 import logging
 from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import scoped_session, sessionmaker
 
 from cg.store.models import Model
 from cg.store.api.delete import DeleteDataHandler
@@ -9,6 +9,7 @@ from cg.store.api.find_business_data import FindBusinessDataHandler
 from .add import AddHandler
 from .find_basic_data import FindBasicDataHandler
 from .status import StatusHandler
+
 
 LOG = logging.getLogger(__name__)
 
@@ -35,8 +36,7 @@ class Store(CoreHandler):
     def __init__(self, uri):
         self.uri = uri
         self.engine = create_engine(uri)
-        session_factory = sessionmaker(bind=self.engine)
-        self.session = session_factory()
+        self.session = scoped_session(sessionmaker(bind=self.engine))
         super().__init__(session=self.session)
 
     def create_all(self):

--- a/cg/store/api/core.py
+++ b/cg/store/api/core.py
@@ -10,7 +10,6 @@ from .add import AddHandler
 from .find_basic_data import FindBasicDataHandler
 from .status import StatusHandler
 
-
 LOG = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## Description
This PR addresses the issue of incorrect database session management in the store following the removal of alchy, which likely caused status db errors in the stage and prod environment.

### Background
At present, a single session is instantiated during app creation and reused throughout the applications lifecycle. However, as stated in the [SQLAlchemy documentation](https://docs.sqlalchemy.org/en/13/orm/session_basics.html#when-do-i-construct-a-session-when-do-i-commit-it-and-when-do-i-close-it), in a web application, the session scope should be tied to the request. The session should be torn down once the request ends.

### Solution
The [documentation for SQLAlchemy](https://docs.sqlalchemy.org/en/13/orm/session_basics.html#when-do-i-construct-a-session-when-do-i-commit-it-and-when-do-i-close-it) suggests two approaches for managing session scope

1. Use a library like Flask-SQLAlchemy, which abstracts session handling complexity.
2. Use the helper class [scoped_session](https://docs.sqlalchemy.org/en/13/orm/contextual.html#sqlalchemy.orm.scoping.scoped_session) if Flask-SQLAlchemy is insufficient.

Due to the current use and implementation of the Store, opting for the first approach is difficult. Therefore, this PR implements the second option, following the guidelines provided in the [Flask documentation](https://flask.palletsprojects.com/en/2.2.x/patterns/sqlalchemy/#declarative).

The `scoped_session` returns the current [Session](https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.Session), creating it using the [scoped_session.session_factory](https://docs.sqlalchemy.org/en/20/orm/contextual.html#sqlalchemy.orm.scoped_session.session_factory) if not present.



### Added
- Teardown method to remove the database session after processing a request

### Changed
- Session instantiation now uses the scoped_session helper class



### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
