### PR TITLE
fix(rnafusion): change default value for FUSIONREPORT_FILTER

### DIFF
--- a/cg/constants/rnafusion.py
+++ b/cg/constants/rnafusion.py
@@ -15,7 +15,7 @@ class RnafusionDefaults:
     TRIM: bool = False
     FASTP_TRIM: bool = True
     TRIM_TAIL: int = 50
-    FUSIONREPORT_FILTER: int = 1
+    FUSIONREPORT_FILTER: bool = False
     FUSIONINSPECTOR_FILTER: bool = False
     ALL: bool = False
     PIZZLY: bool = False


### PR DESCRIPTION
## Description

### Fixed

- Changes default value for FUSIONREPORT_FILTER in the rnafusion workflow. It should be a boolean set to false instead of an integer. 


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
