### PR TITLE
Remove unused requirements and add transitive ones

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ SQLAlchemy<1.4
 Click<7.0
 
 # server
+blinker
 Flask-Admin
 Flask-CORS
 Flask-Dance

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ pymysql
 Click<7.0
 
 # server
+blinker
 Flask-Admin
 Flask-CORS
 Flask-Dance

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,20 +1,16 @@
 # database
 Alchy
 alembic
-pymysql
 SQLAlchemy<1.4
 
 # cli
 Click<7.0
 
 # server
-blinker
 Flask-Admin
-Flask-Alchy
 Flask-CORS
 Flask-Dance
-Flask-SQLAlchemy==2.1
-Flask>=1.1.1                # versioned due to setup.py install misselecting Flask-SQLAlchemy otherwise
+Flask>=1.1.1
 flask_wtf
 google-auth
 gunicorn
@@ -28,7 +24,7 @@ ansi
 cachetools
 cgmodels>=0.11.0
 coloredlogs
-email-validator
+Jinja2
 lxml
 marshmallow>3               # due to code expects behaviour from >3
 markupsafe<2.1            # due to soft_unicode import error from markupsafe
@@ -43,7 +39,7 @@ pyyaml
 setuptools>=39.2.0      # due to WeasyPrint 45, tinycss2 1.0.1 and cairocffi file-.cairocffi-VERSION
 tabulate
 typing_extensions
-wtforms<3.0.0          # wtforms.compat missing in 3.0.0
+urllib3
 
 # apps
 genologics

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,12 +2,12 @@
 Alchy
 alembic
 SQLAlchemy<1.4
+pymysql
 
 # cli
 Click<7.0
 
 # server
-blinker
 Flask-Admin
 Flask-CORS
 Flask-Dance


### PR DESCRIPTION
## Description
Some of the requirements are no longer used and can be removed.

The outdated requirements were found by
```
pip install deptry
deptry .

Scanning 455 files...
There were 8 dependency issues found.

-----------------------------------------------------

The project contains obsolete dependencies:

	Flask-Alchy
	Flask-SQLAlchemy
	email-validator
	gunicorn
	pymysql
	wtforms

Consider removing them from your project's dependencies. If a package is used for development purposes, you should add it to your development dependencies instead.

-----------------------------------------------------

There are transitive dependencies that should be explicitly defined as dependencies:

	Jinja2
	urllib3

They are currently imported but not specified directly as your project's dependencies.

-----------------------------------------------------


```



### Added
- Jinja2 and urllib3 as dependencies

### Changed
- Removed Flask-Alchy, Flask-SQLAlchemy, email-validator and wtforms as dependencies


### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
