### PR TITLE
Add new LIMS API functions to fetch RNA data

### DIFF
--- a/cg/constants/lims.py
+++ b/cg/constants/lims.py
@@ -59,6 +59,9 @@ MASTER_STEPS_UDFS = {
         "Hybridize Library TWIST v2": "Bait Set",
         "Target enrichment TWIST v1": "Bait Set",
     },
+    "rna_prep_step": {
+        "A-tailing and Adapter ligation (RNA) v1": "Amount needed (ng)",
+    },
     "prep_method_step": {
         "Library Preparation (Cov) v1": {
             "method_number": "Method document",


### PR DESCRIPTION
## Description
Addition of 2 new LIMS API functions to fetch data for the creation of RNA delivery reports.

### Added
- Function to fetch a sample's RIN value from LIMS
- Function to fetch RNA prep input amount of a sample
- Necessary LIMS config updates


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
