### PR TITLE
Modify run parameter model and tests

### DIFF
--- a/cg/apps/demultiplex/sample_sheet/create.py
+++ b/cg/apps/demultiplex/sample_sheet/create.py
@@ -3,6 +3,7 @@ from typing import List
 
 from cg.apps.demultiplex.sample_sheet.novaseq_sample_sheet import SampleSheetCreator
 from cg.apps.lims.samplesheet import LimsFlowcellSample
+from cg.constants.demultiplexing import FlowCellType
 from cg.exc import FlowCellError
 from cg.models.demultiplex.flow_cell import FlowCell
 from cg.models.demultiplex.run_parameters import RunParameters
@@ -24,7 +25,7 @@ def create_sample_sheet(
 
     run_parameters: RunParameters = flow_cell.run_parameters_object
 
-    if run_parameters.flow_cell_type != "novaseq":
+    if run_parameters.flow_cell_type != FlowCellType.NOVASEQ:
         message = (
             f"Can only demultiplex novaseq with cg. Found type {run_parameters.flow_cell_type}"
         )

--- a/cg/apps/demultiplex/sample_sheet/create.py
+++ b/cg/apps/demultiplex/sample_sheet/create.py
@@ -24,8 +24,10 @@ def create_sample_sheet(
 
     run_parameters: RunParameters = flow_cell.run_parameters_object
 
-    if run_parameters.flowcell_type != "novaseq":
-        message = f"Can only demultiplex novaseq with cg. Found type {run_parameters.flowcell_type}"
+    if run_parameters.flow_cell_type != "novaseq":
+        message = (
+            f"Can only demultiplex novaseq with cg. Found type {run_parameters.flow_cell_type}"
+        )
         LOG.warning(message)
         raise FlowCellError(message=message)
 

--- a/cg/apps/demultiplex/sample_sheet/index.py
+++ b/cg/apps/demultiplex/sample_sheet/index.py
@@ -4,7 +4,7 @@ import logging
 from typing import Dict, List, Set
 
 from cg.apps.lims.samplesheet import LimsFlowcellSample
-from cg.resources import valid_indexes_path
+from cg.resources import VALID_INDEXES_PATH
 from packaging import version
 from pydantic import BaseModel
 
@@ -37,9 +37,9 @@ class Index(BaseModel):
 
 
 def get_valid_indexes(dual_indexes_only: bool = True) -> List[Index]:
-    LOG.info(f"Fetch valid indexes from {valid_indexes_path}")
+    LOG.info(f"Fetch valid indexes from {VALID_INDEXES_PATH}")
     indexes: List[Index] = []
-    with open(valid_indexes_path, "r") as csv_file:
+    with open(VALID_INDEXES_PATH, "r") as csv_file:
         indexes_csv = csv.reader(csv_file)
         for row in indexes_csv:
             index_name = row[0]

--- a/cg/apps/demultiplex/sample_sheet/novaseq_sample_sheet.py
+++ b/cg/apps/demultiplex/sample_sheet/novaseq_sample_sheet.py
@@ -113,7 +113,7 @@ class SampleSheetCreator:
         """Construct the sample sheet"""
         LOG.info(f"Constructing sample sheet for {self.flowcell_id}")
         # Create dummy samples for the indexes that is missing
-        if self.run_parameters.run_type == "wgs":
+        if self.run_parameters.requires_dummy_samples:
             self.add_dummy_samples()
         else:
             LOG.info("Skip adding dummy samples since run is not WGS")

--- a/cg/constants/demultiplexing.py
+++ b/cg/constants/demultiplexing.py
@@ -5,9 +5,20 @@ from cgmodels.cg.constants import StrEnum
 
 
 class BclConverter(StrEnum):
+    """Define the BCL converter."""
+
     DRAGEN: str = "dragen"
     BCL2FASTQ: str = "bcl2fastq"
 
+
+class FlowCellType(StrEnum):
+    """Define the flow cell type."""
+
+    NOVASEQ: str = "novaseq"
+    HISEQ: str = "hiseq"
+
+
+UNKNOWN_REAGENT_KIT_VERSION: str = "unknown"
 
 SAMPLE_SHEET_HEADERS = {
     "bcl2fastq": [

--- a/cg/meta/workflow/rnafusion.py
+++ b/cg/meta/workflow/rnafusion.py
@@ -295,7 +295,7 @@ class RnafusionAnalysisAPI(AnalysisAPI):
     def report_deliver(self, case_id: str) -> None:
         """Get a deliverables file template from resources, parse it and, then write the deliverables file."""
         deliverables_content: dict = NextflowAnalysisAPI.get_template_deliverables_file_content(
-            resources.rnafusion_bundle_filenames_path
+            resources.RNAFUSION_BUNDLE_FILENAMES_PATH
         )
         try:
             for index, deliver_file in enumerate(deliverables_content):

--- a/cg/models/demultiplex/run_parameters.py
+++ b/cg/models/demultiplex/run_parameters.py
@@ -76,7 +76,7 @@ class RunParameters:
 
     @property
     def run_type(self) -> Literal["wgs", "fluffy"]:
-        """Return the run type of the sequencing."""
+        """Return the sequencing run type."""
         if self.index_length == 8:
             return "fluffy"
         return "wgs"

--- a/cg/models/demultiplex/run_parameters.py
+++ b/cg/models/demultiplex/run_parameters.py
@@ -10,7 +10,7 @@ LOG = logging.getLogger(__name__)
 
 
 class RunParameters:
-    """Class to handle the run parameters from a sequencing run"""
+    """Class to handle the run parameters from a sequencing run."""
 
     def __init__(self, run_parameters_path: Path):
         self.path: Path = run_parameters_path
@@ -19,14 +19,16 @@ class RunParameters:
 
     @property
     def index_length(self) -> int:
-        index_one_length: int = self.index_read_one()
-        index_two_length: int = self.index_read_two()
+        """Return the length of the indexes if they are equal, raise an error otherwise."""
+        index_one_length: int = self.get_index1_cycles()
+        index_two_length: int = self.get_index2_cycles()
         if index_one_length != index_two_length:
             raise FlowCellError("Index lengths are not the same!")
         return index_one_length
 
     @property
     def control_software_version(self) -> str:
+        """Return the control software version."""
         node_name = ".ApplicationVersion"
         xml_node: Optional[ElementTree.Element] = self.tree.find(node_name)
         self.node_not_found(node=xml_node, name="control software version")
@@ -34,6 +36,7 @@ class RunParameters:
 
     @property
     def reagent_kit_version(self) -> str:
+        """Return the reagent kit version if existent, return 'unknown' otherwise."""
         node_name = "./RfidsInfo/SbsConsumableVersion"
         xml_node: Optional[ElementTree.Element] = self.tree.find(node_name)
         if xml_node is None:
@@ -44,7 +47,7 @@ class RunParameters:
 
     @property
     def flowcell_type(self) -> Literal["novaseq", "hiseq"]:
-        """Fetch the flowcell type from the run parameters"""
+        """Fetch the flowcell type from the run parameters."""
         # First try with the node name for hiseq
         node_name = "./Setup/ApplicationName"
         xml_node = self.tree.find(node_name)
@@ -61,56 +64,68 @@ class RunParameters:
         raise FlowCellError(message)
 
     @property
+    def flow_cell_mode(self) -> Optional[str]:
+        """Return the flow cell mode."""
+        node_name = "/RfidsInfo/FlowCellMode"
+        xml_node = self.tree.find(node_name)
+        if xml_node is None:
+            LOG.warning("Could not determine flow cell mode")
+            LOG.info("Set flow cell mode to None")
+            return
+        return xml_node.text
+
+    @property
     def run_type(self) -> Literal["wgs", "fluffy"]:
-        """Fetch what type of run the parameters is"""
+        """Return the run type of the sequencing."""
         if self.index_length == 8:
             return "fluffy"
         return "wgs"
 
     @staticmethod
     def node_not_found(node: Optional[ElementTree.Element], name: str) -> None:
-        """Raise exception if node if not found"""
+        """Raise exception if the given node is not found."""
         if node is None:
             message = f"Could not determine {name}"
             LOG.warning(message)
             raise FlowCellError(message)
 
     def get_node_integer_value(self, node_name: str, name: str) -> int:
+        """Return the value of the node as an integer."""
         xml_node = self.tree.find(node_name)
         self.node_not_found(node=xml_node, name=name)
         return int(xml_node.text)
 
-    def index_read_one(self) -> int:
-        """Get the value for index read one"""
+    def get_index1_cycles(self) -> int:
+        """Return the number of cycles in the first index read."""
         node_name = "./IndexRead1NumberOfCycles"
         return self.get_node_integer_value(node_name=node_name, name="length of index one")
 
-    def index_read_two(self) -> int:
-        """Get the value for index read one"""
+    def get_index2_cycles(self) -> int:
+        """Return the number of cycles in the second index read."""
         node_name = "./IndexRead2NumberOfCycles"
         return self.get_node_integer_value(node_name=node_name, name="length of index two")
 
-    def read_one_nr_cycles(self) -> int:
-        """Get the nr of cycles for read one"""
+    def get_read1_cycles(self) -> int:
+        """Return the number of cycles in the first read."""
         node_name = "./Read1NumberOfCycles"
         return self.get_node_integer_value(node_name=node_name, name="length of reads one")
 
-    def read_two_nr_cycles(self) -> int:
-        """Get the nr of cycles for read one"""
+    def get_read2_cycles(self) -> int:
+        """Return the number of cycles in the second read."""
         node_name = "./Read2NumberOfCycles"
         return self.get_node_integer_value(node_name=node_name, name="length of reads two")
 
-    def base_mask(self) -> str:
-        """create the bcl2fastq basemask for novaseq flowcells
+    def get_base_mask(self) -> str:
+        """Create the bcl2fastq basemask for novaseq flow cells.
 
         Basemask is used in this comma format as an argument to bcl2fastq.
-        When creating the unaligned path the commas are stripped
+        When creating the unaligned path the commas are stripped.
         """
         return (
-            f"Y{self.read_one_nr_cycles()},"
-            f"I{self.index_read_one()},"
-            f"I{self.read_two_nr_cycles()},"
-            f"Y{self.index_read_two()}"
+            f"Y{self.get_read1_cycles()},"
+            f"I{self.get_index1_cycles()},"
+            f"I{self.get_index2_cycles()},"
+            f"Y{self.get_read2_cycles()}"
         )
 
     def __str__(self):

--- a/cg/models/demultiplex/run_parameters.py
+++ b/cg/models/demultiplex/run_parameters.py
@@ -46,8 +46,8 @@ class RunParameters:
         return xml_node.text
 
     @property
-    def flowcell_type(self) -> Literal["novaseq", "hiseq"]:
-        """Fetch the flowcell type from the run parameters."""
+    def flow_cell_type(self) -> Literal["novaseq", "hiseq"]:
+        """Fetch the flow cell type from the run parameters."""
         # First try with the node name for hiseq
         node_name = "./Setup/ApplicationName"
         xml_node = self.tree.find(node_name)
@@ -55,11 +55,11 @@ class RunParameters:
             # Then try with node name for novaseq
             node_name = ".Application"
             xml_node = self.tree.find(node_name)
-        self.node_not_found(node=xml_node, name="flowcell type")
+        self.node_not_found(node=xml_node, name="flow cell type")
         for flow_cell_name in ["novaseq", "hiseq"]:
             if flow_cell_name in xml_node.text.lower():
                 return flow_cell_name
-        message = f"Unknown flowcell type {xml_node.text}"
+        message = f"Unknown flow cell type {xml_node.text}"
         LOG.warning(message)
         raise FlowCellError(message)
 
@@ -129,11 +129,11 @@ class RunParameters:
         )
 
     def __str__(self):
-        return f"RunParameters(path={self.path},flowcell_type={self.flowcell_type},run_type={self.run_type}"
+        return f"RunParameters(path={self.path},flow_cell_type={self.flow_cell_type},run_type={self.run_type}"
 
     def __repr__(self):
         return (
-            f"RunParameters(path={self.path},flowcell_type={self.flowcell_type},run_type={self.run_type},"
+            f"RunParameters(path={self.path},flow_cell_type={self.flow_cell_type},run_type={self.run_type},"
             f"reagent_kit_version={self.reagent_kit_version},control_software_version={self.control_software_version},"
             f"index_length={self.index_length})"
         )

--- a/cg/resources/__init__.py
+++ b/cg/resources/__init__.py
@@ -2,12 +2,12 @@ from pathlib import Path
 
 import pkg_resources
 
-valid_indexes_file: str = Path("resources", "20181012_Indices.csv").as_posix()
+VALID_INDEXES_FILE: str = Path("resources", "20181012_Indices.csv").as_posix()
 
-valid_indexes_path: Path = Path(pkg_resources.resource_filename("cg", valid_indexes_file))
+VALID_INDEXES_PATH: Path = Path(pkg_resources.resource_filename("cg", VALID_INDEXES_FILE))
 
-rnafusion_bundle_filenames: str = Path("resources", "rnafusion_bundle_filenames.csv").as_posix()
+RNAFUSION_BUNDLE_FILENAMES: str = Path("resources", "rnafusion_bundle_filenames.csv").as_posix()
 
-rnafusion_bundle_filenames_path: Path = Path(
-    pkg_resources.resource_filename("cg", rnafusion_bundle_filenames)
+RNAFUSION_BUNDLE_FILENAMES_PATH: Path = Path(
+    pkg_resources.resource_filename("cg", RNAFUSION_BUNDLE_FILENAMES)
 )

--- a/tests/apps/demultiplex/conftest.py
+++ b/tests/apps/demultiplex/conftest.py
@@ -38,12 +38,6 @@ def fixture_index_obj() -> Index:
     return Index(name="C07 - UDI0051", sequence="AACAGGTT-ATACCAAG")
 
 
-@pytest.fixture(name="novaseq_dir")
-def fixture_novaseq_dir(demux_run_dir: Path, flow_cell_full_name: str) -> Path:
-    """Return the path to the novaseq demultiplex fixtures"""
-    return Path(demux_run_dir, flow_cell_full_name)
-
-
 @pytest.fixture(name="flow_cell_dir_bcl2fastq")
 def fixture_novaseq_dir_bcl2fastq(demux_run_dir_bcl2fastq: Path, flow_cell_full_name: str) -> Path:
     """Return the path to the novaseq demultiplex fixtures"""
@@ -54,36 +48,6 @@ def fixture_novaseq_dir_bcl2fastq(demux_run_dir_bcl2fastq: Path, flow_cell_full_
 def fixture_novaseq_dir_dragen(demux_run_dir_dragen: Path, flow_cell_full_name: str) -> Path:
     """Return the path to the novaseq demultiplex fixtures"""
     return Path(demux_run_dir_dragen, flow_cell_full_name)
-
-
-@pytest.fixture(name="hiseq_dir")
-def fixture_hiseq_dir(demultiplex_fixtures: Path) -> Path:
-    """Return the path to the novaseq demultiplex fixtures"""
-    return Path(demultiplex_fixtures, "hiseq_run")
-
-
-@pytest.fixture(name="unknown_run_parameters")
-def fixture_unknown_run_parameters(demultiplex_fixtures: Path) -> Path:
-    """Return the path to a file with hiseq run parameters"""
-    return Path(demultiplex_fixtures, "unknown_run_parameters.xml")
-
-
-@pytest.fixture(name="run_parameters_missing_flowcell_type")
-def fixture_run_parameters_missing_flowcell_type(demultiplex_fixtures: Path) -> Path:
-    """Return the path to a file with hiseq run parameters"""
-    return Path(demultiplex_fixtures, "runParameters_missing_flowcell_run_field.xml")
-
-
-@pytest.fixture(name="hiseq_run_parameters")
-def fixture_hiseq_run_parameters(hiseq_dir: Path) -> Path:
-    """Return the path to a file with hiseq run parameters"""
-    return Path(hiseq_dir, "runParameters.xml")
-
-
-@pytest.fixture(name="novaseq_run_parameters")
-def fixture_novaseq_run_parameters(novaseq_dir: Path) -> Path:
-    """Return the path to a file with hiseq run parameters"""
-    return Path(novaseq_dir, "RunParameters.xml")
 
 
 @pytest.fixture(name="raw_lims_sample")

--- a/tests/cli/demultiplex/conftest.py
+++ b/tests/cli/demultiplex/conftest.py
@@ -18,10 +18,8 @@ from tests.apps.demultiplex.conftest import (
     fixture_lims_novaseq_bcl2fastq_samples,
     fixture_lims_novaseq_dragen_samples,
     fixture_lims_novaseq_samples,
-    fixture_novaseq_dir,
     fixture_novaseq_dir_bcl2fastq,
     fixture_novaseq_dir_dragen,
-    fixture_novaseq_run_parameters,
 )
 
 LOG = logging.getLogger(__name__)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -706,6 +706,42 @@ def fixture_demux_run_dir(demultiplex_fixtures: Path) -> Path:
     return Path(demultiplex_fixtures, "flowcell-runs")
 
 
+@pytest.fixture(name="novaseq_dir")
+def fixture_novaseq_dir(demux_run_dir: Path, flow_cell_full_name: str) -> Path:
+    """Return the path to the novaseq demultiplex fixtures"""
+    return Path(demux_run_dir, flow_cell_full_name)
+
+
+@pytest.fixture(name="hiseq_dir")
+def fixture_hiseq_dir(demultiplex_fixtures: Path) -> Path:
+    """Return the path to the novaseq demultiplex fixtures"""
+    return Path(demultiplex_fixtures, "hiseq_run")
+
+
+@pytest.fixture(name="unknown_run_parameters")
+def fixture_unknown_run_parameters(demultiplex_fixtures: Path) -> Path:
+    """Return the path to a file with hiseq run parameters"""
+    return Path(demultiplex_fixtures, "unknown_run_parameters.xml")
+
+
+@pytest.fixture(name="run_parameters_missing_flowcell_type")
+def fixture_run_parameters_missing_flowcell_type(demultiplex_fixtures: Path) -> Path:
+    """Return the path to a file with hiseq run parameters"""
+    return Path(demultiplex_fixtures, "runParameters_missing_flowcell_run_field.xml")
+
+
+@pytest.fixture(name="hiseq_run_parameters")
+def fixture_hiseq_run_parameters(hiseq_dir: Path) -> Path:
+    """Return the path to a file with hiseq run parameters"""
+    return Path(hiseq_dir, "runParameters.xml")
+
+
+@pytest.fixture(name="novaseq_run_parameters")
+def fixture_novaseq_run_parameters(novaseq_dir: Path) -> Path:
+    """Return the path to a file with hiseq run parameters"""
+    return Path(novaseq_dir, "RunParameters.xml")
+
+
 @pytest.fixture(name="flow_cell")
 def fixture_flow_cell(demux_run_dir: Path, flow_cell_full_name: str) -> FlowCell:
     """Create a flow cell object with flow cell that is demultiplexed."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -708,38 +708,44 @@ def fixture_demux_run_dir(demultiplex_fixtures: Path) -> Path:
 
 @pytest.fixture(name="novaseq_dir")
 def fixture_novaseq_dir(demux_run_dir: Path, flow_cell_full_name: str) -> Path:
-    """Return the path to the novaseq demultiplex fixtures"""
+    """Return the path to the novaseq demultiplex fixtures."""
     return Path(demux_run_dir, flow_cell_full_name)
 
 
 @pytest.fixture(name="hiseq_dir")
 def fixture_hiseq_dir(demultiplex_fixtures: Path) -> Path:
-    """Return the path to the novaseq demultiplex fixtures"""
+    """Return the path to the novaseq demultiplex fixtures."""
     return Path(demultiplex_fixtures, "hiseq_run")
 
 
 @pytest.fixture(name="unknown_run_parameters")
 def fixture_unknown_run_parameters(demultiplex_fixtures: Path) -> Path:
-    """Return the path to a file with hiseq run parameters"""
+    """Return the path to a file with hiseq run parameters with unknown flow cell."""
     return Path(demultiplex_fixtures, "unknown_run_parameters.xml")
 
 
 @pytest.fixture(name="run_parameters_missing_flowcell_type")
 def fixture_run_parameters_missing_flowcell_type(demultiplex_fixtures: Path) -> Path:
-    """Return the path to a file with hiseq run parameters"""
+    """Return the path to a file with hiseq run parameters without flow cell."""
     return Path(demultiplex_fixtures, "runParameters_missing_flowcell_run_field.xml")
 
 
 @pytest.fixture(name="hiseq_run_parameters")
 def fixture_hiseq_run_parameters(hiseq_dir: Path) -> Path:
-    """Return the path to a file with hiseq run parameters"""
+    """Return the path to a file with hiseq run parameters."""
     return Path(hiseq_dir, "runParameters.xml")
 
 
 @pytest.fixture(name="novaseq_run_parameters")
 def fixture_novaseq_run_parameters(novaseq_dir: Path) -> Path:
-    """Return the path to a file with hiseq run parameters"""
+    """Return the path to a file with novaseq run parameters."""
     return Path(novaseq_dir, "RunParameters.xml")
+
+
+@pytest.fixture(name="run_parameters_different_index")
+def fixture_run_parameters_different_index(novaseq_dir: Path) -> Path:
+    """Return the path to a file with novaseq run parameters with different index cycles."""
+    return Path(novaseq_dir, "RunParameters_different_index_cycles.xml")
 
 
 @pytest.fixture(name="flow_cell")

--- a/tests/fixtures/apps/demultiplexing/flowcell-runs/201203_A00689_0200_AHVKJCDRXX/RunParameters_different_index_cycles.xml
+++ b/tests/fixtures/apps/demultiplexing/flowcell-runs/201203_A00689_0200_AHVKJCDRXX/RunParameters_different_index_cycles.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0"?>
+<RunParameters xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Surface>Both</Surface>
+  <ReadType>PairedEnd</ReadType>
+  <Side>A</Side>
+  <Read1NumberOfCycles>151</Read1NumberOfCycles>
+  <Read2NumberOfCycles>151</Read2NumberOfCycles>
+  <IndexRead1NumberOfCycles>10</IndexRead1NumberOfCycles>
+  <IndexRead2NumberOfCycles>8</IndexRead2NumberOfCycles>
+  <PlannedRead1Cycles>151</PlannedRead1Cycles>
+  <PlannedRead2Cycles>151</PlannedRead2Cycles>
+  <PlannedIndex1ReadCycles>10</PlannedIndex1ReadCycles>
+  <PlannedIndex2ReadCycles>10</PlannedIndex2ReadCycles>
+  <RunNumber>226</RunNumber>
+  <RtaVersion>v3.4.4</RtaVersion>
+  <RecipeVersion>1.7.0</RecipeVersion>
+  <ExperimentName>HMYJ7DSXY</ExperimentName>
+  <RfidsInfo>
+    <FlowCellSerialBarcode>HMYJ7DSXY</FlowCellSerialBarcode>
+    <FlowCellPartNumber>20015843</FlowCellPartNumber>
+    <FlowCellLotNumber>20482659</FlowCellLotNumber>
+    <FlowCellExpirationdate>09/21/2021 00:00:00</FlowCellExpirationdate>
+    <FlowCellStartDate>02/06/2021 12:40:00</FlowCellStartDate>
+    <FlowCellNumberOfReuseRemaining>1</FlowCellNumberOfReuseRemaining>
+    <FlowCellSupportedModes>HTWashOnly;S4</FlowCellSupportedModes>
+    <FlowCellMode>S4</FlowCellMode>
+    <FlowCellConsumableVersion>1</FlowCellConsumableVersion>
+    <FlowCellRssi>2</FlowCellRssi>
+    <LibraryTubeSerialBarcode>NV0297539-LIB</LibraryTubeSerialBarcode>
+    <LibraryTubeSupportedModes>Universal</LibraryTubeSupportedModes>
+    <LibraryTubePartNumber>20005221</LibraryTubePartNumber>
+    <LibraryTubeLotNumber>1000008040</LibraryTubeLotNumber>
+    <LibraryTubeExpirationdate>12/31/2169 00:00:00</LibraryTubeExpirationdate>
+    <LibraryTubeStartDate>02/06/2021 12:40:00</LibraryTubeStartDate>
+    <LibraryTubeRssi>4</LibraryTubeRssi>
+    <SbsSerialBarcode>NV3040624-RGSBS</SbsSerialBarcode>
+    <SbsSupportedModes>S4</SbsSupportedModes>
+    <SbsPartNumber>20031051</SbsPartNumber>
+    <SbsLotNumber>20485602</SbsLotNumber>
+    <SbsExpirationdate>10/24/2021 00:00:00</SbsExpirationdate>
+    <SbsStartDate>02/06/2021 12:40:00</SbsStartDate>
+    <SbsCycleKit>338</SbsCycleKit>
+    <SbsNumberOfCyclesRemaining>16</SbsNumberOfCyclesRemaining>
+    <SbsNumberOfCyclesSupported>338</SbsNumberOfCyclesSupported>
+    <SbsConsumableVersion>3</SbsConsumableVersion>
+    <SbsRssi>4</SbsRssi>
+    <ClusterSerialBarcode>NV3048388-RGCPE</ClusterSerialBarcode>
+    <ClusterSupportedModes>S4</ClusterSupportedModes>
+    <ClusterPartNumber>20031056</ClusterPartNumber>
+          <ClusterLotNumber>20491402</ClusterLotNumber>
+    <ClusterExpirationdate>10/31/2021 00:00:00</ClusterExpirationdate>
+    <ClusterStartDate>02/06/2021 12:40:00</ClusterStartDate>
+    <ClusterCycleKit>338</ClusterCycleKit>
+    <ClusterNumberOfCyclesRemaining>16</ClusterNumberOfCyclesRemaining>
+    <ClusterRssi>5</ClusterRssi>
+    <BufferSerialBarcode>NV5091519-BUFFR</BufferSerialBarcode>
+    <BufferSupportedModes>S4</BufferSupportedModes>
+    <BufferPartNumber>20003187</BufferPartNumber>
+    <BufferLotNumber>50000132</BufferLotNumber>
+    <BufferExpirationdate>07/15/2021 00:00:00</BufferExpirationdate>
+    <BufferNumberOfCyclesRemaining>8</BufferNumberOfCyclesRemaining>
+    <BufferStartDate>02/06/2021 12:40:00</BufferStartDate>
+    <BufferRssi>3</BufferRssi>
+  </RfidsInfo>
+  <RecipeFilePath>C:\Program Files\Illumina\NovaSeq Control Software\Recipe</RecipeFilePath>
+  <SamplesheetFile />
+  <UsedLimsSetup>false</UsedLimsSetup>
+  <CeLinuxRunFolder>/ilmn/outputfolder/210206_A00689_0226_AHMYJ7DSXY/</CeLinuxRunFolder>
+  <RtaRawRunFolder>/ilmn/outputfolder</RtaRawRunFolder>
+  <CeMountRunFolder>Z:\outputfolder\210206_A00689_0226_AHMYJ7DSXY\</CeMountRunFolder>
+  <OutputRunFolder>\\172.16.1.6\clinicaldata\Runs\210206_A00689_0226_AHMYJ7DSXY\</OutputRunFolder>
+  <OutputRootFolder>\\172.16.1.6\clinicaldata\Runs</OutputRootFolder>
+  <SbcRunFolder>C:\ProgramData\Illumina\NovaSeq\NovaSeqTemp\210206_A00689_0226_AHMYJ7DSXY\</SbcRunFolder>
+  <PreRunFolder>C:\ProgramData\Illumina\NovaSeq\NovaSeqTemp\RunSetupLogs\A00689_2021-02-06__11_58_48_SideA</PreRunFolder>
+  <RunStartDate>210206</RunStartDate>
+  <RunId>210206_A00689_0226_AHMYJ7DSXY</RunId>
+  <UseBaseSpace>true</UseBaseSpace>
+  <UseBaseSpaceMonitoringAndStorage>false</UseBaseSpaceMonitoringAndStorage>
+  <BaseSpaceRunId>6300294</BaseSpaceRunId>
+  <BaseSpaceEnvironment>euc1-prod</BaseSpaceEnvironment>
+  <BaseSpaceDomain />
+  <Autocenter>true</Autocenter>
+  <BiDirectionalScanning>true</BiDirectionalScanning>
+  <UseCustomRecipe>false</UseCustomRecipe>
+  <UseCustomRead1Primer>false</UseCustomRead1Primer>
+  <UseCustomRead2Primer>false</UseCustomRead2Primer>
+  <UseCustomIndexRead1Primer>false</UseCustomIndexRead1Primer>
+  <IsRehyb>false</IsRehyb>
+  <InstrumentName>A00689</InstrumentName>
+  <PlatformType>HighThroughput</PlatformType>
+  <Application>NovaSeq Control Software</Application>
+  <ApplicationVersion>1.7.0</ApplicationVersion>
+  <Build>16</Build>
+  <FirmwareVersions>
+    <FirmwareVersion>
+      <Board>Fluidics Board</Board>
+      <Version>novaseq_flu@NovaSeq_1.26.1</Version>
+    </FirmwareVersion>
+      <FirmwareVersion>
+      <Board>Left Buffer Interface Board</Board>
+      <Version>novaseq_bim@NovaSeq_1.26.1</Version>
+    </FirmwareVersion>
+    <FirmwareVersion>
+      <Board>Right Buffer Interface Board</Board>
+      <Version>novaseq_bim@NovaSeq_1.26.1</Version>
+    </FirmwareVersion>
+    <FirmwareVersion>
+      <Board>Chassis Module Board</Board>
+      <Version>novaseq_chm@NovaSeq_1.26.1</Version>
+    </FirmwareVersion>
+    <FirmwareVersion>
+      <Board>Camera Interface Board</Board>
+      <Version>novaseq_cib_2@NovaSeq_1.26.1</Version>
+    </FirmwareVersion>
+    <FirmwareVersion>
+      <Board>Focus Interface Board</Board>
+      <Version>novaseq_fib_2@NovaSeq_1.26.1</Version>
+    </FirmwareVersion>
+    <FirmwareVersion>
+      <Board>Flow Cell Holder Board</Board>
+      <Version>novaseq_fch_2@NovaSeq_1.26.1</Version>
+    </FirmwareVersion>
+    <FirmwareVersion>
+      <Board>System Thermal Board</Board>
+      <Version>novaseq_syst@NovaSeq_1.26.1</Version>
+    </FirmwareVersion>
+    <FirmwareVersion>
+      <Board>Left Reagent Chiller Board</Board>
+      <Version>novaseq_rca@NovaSeq_1.26.1</Version>
+    </FirmwareVersion>
+    <FirmwareVersion>
+      <Board>Right Reagent Chiller Board</Board>
+      <Version>novaseq_rca@NovaSeq_1.26.1</Version>
+    </FirmwareVersion>
+  </FirmwareVersions>
+  <SendIlluminaHealthData>true</SendIlluminaHealthData>
+  <UcsRunId>17A89287DCD6C742</UcsRunId>
+  <UcsVersion>1.6.3.1575</UcsVersion>
+  <RunSetupMode>Manual</RunSetupMode>
+  <WorkflowType>NovaSeqStandard</WorkflowType>
+</RunParameters>

--- a/tests/meta/clean/conftest.py
+++ b/tests/meta/clean/conftest.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import pytest
 
-from tests.apps.demultiplex.conftest import fixture_novaseq_dir
 from tests.cli.demultiplex.conftest import fixture_demultiplexed_flow_cells_working_directory
 from tests.models.demultiplexing.conftest import (
     fixture_flowcell_path,

--- a/tests/models/demultiplexing/test_run_parameters.py
+++ b/tests/models/demultiplexing/test_run_parameters.py
@@ -2,51 +2,52 @@ import logging
 from pathlib import Path
 
 import pytest
+from cg.constants.demultiplexing import FlowCellType, UNKNOWN_REAGENT_KIT_VERSION
 from cg.exc import FlowCellError
 from cg.models.demultiplex.run_parameters import RunParameters
 
 
 def test_get_flow_cell_type_hiseq_run_parameters(hiseq_run_parameters: Path):
-    """Test that reading a hiseq run_parameters file assigns the correct flowcell type."""
-    # GIVEN a RunParameters object created from a hiseq run parameters file
-    run_parameters = RunParameters(hiseq_run_parameters)
+    """Test that reading a hiseq run_parameters file assigns the correct flow cell type."""
+    # GIVEN a RunParameters object created from a Hiseq run parameters file
+    run_parameters = RunParameters(run_parameters_path=hiseq_run_parameters)
 
-    # WHEN fetching the flowcell type
+    # WHEN fetching the flow cell type
 
-    # THEN the flowcell type is hiseq
-    assert run_parameters.flow_cell_type == "hiseq"
+    # THEN the flow cell type is hiseq
+    assert run_parameters.flow_cell_type == FlowCellType.HISEQ
 
 
 def test_get_flow_cell_type_novaseq_run_parameters(novaseq_run_parameters: Path):
-    """Test that reading a novaseq run_parameters file assigns the correct flowcell type."""
-    # GIVEN a RunParameters object created from a novaseq run parameters file
-    run_parameters = RunParameters(novaseq_run_parameters)
+    """Test that reading a Novaseq run_parameters file assigns the correct flow cell type."""
+    # GIVEN a RunParameters object created from a Novaseq run parameters file
+    run_parameters = RunParameters(run_parameters_path=novaseq_run_parameters)
 
-    # WHEN fetching the flowcell type
+    # WHEN fetching the flow cell type
 
-    # THEN assert that the flowcell type is novaseq
-    assert run_parameters.flow_cell_type == "novaseq"
+    # THEN assert that the flow cell type is novaseq
+    assert run_parameters.flow_cell_type == FlowCellType.NOVASEQ
 
 
 def test_get_unknown_type_run_parameters(unknown_run_parameters: Path, caplog):
-    """Test that reading a run_parameters with unknown flowcell file raises an error."""
+    """Test that reading a run_parameters with unknown flow cell file raises an error."""
     caplog.set_level(logging.INFO)
-    # GIVEN a RunParameters object created from a run parameters file with unknown flowcell
-    run_parameters = RunParameters(unknown_run_parameters)
+    # GIVEN a RunParameters object created from a run parameters file with unknown flow cell
+    run_parameters = RunParameters(run_parameters_path=unknown_run_parameters)
 
-    # WHEN fetching the flowcell type
+    # WHEN fetching the flow cell type
     with pytest.raises(FlowCellError):
-        # THEN assert that an exception was raised since the flowcell type was unknown
+        # THEN assert that an exception was raised since the flow cell type was unknown
         run_parameters.flow_cell_type
 
     assert "Unknown flow cell type" in caplog.text
 
 
 def test_get_flow_cell_type_when_missing(run_parameters_missing_flowcell_type: Path, caplog):
-    """Test that reading a run_parameters with missing flowcell file raises an error."""
+    """Test that reading a run_parameters with missing flow cell file raises an error."""
     caplog.set_level(logging.INFO)
-    # GIVEN a RunParameters object created from a run parameters file with missing flowcell
-    run_parameters = RunParameters(run_parameters_missing_flowcell_type)
+    # GIVEN a RunParameters object created from a run parameters file with missing flow cell
+    run_parameters = RunParameters(run_parameters_path=run_parameters_missing_flowcell_type)
 
     # WHEN parsing the run parameters
     with pytest.raises(FlowCellError):
@@ -59,7 +60,7 @@ def test_get_flow_cell_type_when_missing(run_parameters_missing_flowcell_type: P
 def test_get_base_mask(novaseq_run_parameters: Path):
     """Test that generating the run parameters base mask returns the expected result."""
     # GIVEN a RunParameters object created from a valid run parameters file
-    run_parameters = RunParameters(novaseq_run_parameters)
+    run_parameters = RunParameters(run_parameters_path=novaseq_run_parameters)
 
     # WHEN fetching the base mask
     base_mask: str = run_parameters.get_base_mask()
@@ -73,7 +74,7 @@ def test_get_base_mask_undetermined_cycles(run_parameters_missing_flowcell_type:
     """Test that generating the base mask from a file without cycle info fails."""
     caplog.set_level(logging.INFO)
     # GIVEN a RunParameters object created from a run parameters file with missing cycle info
-    run_parameters = RunParameters(run_parameters_missing_flowcell_type)
+    run_parameters = RunParameters(run_parameters_path=run_parameters_missing_flowcell_type)
 
     # WHEN creating the base mask
     with pytest.raises(FlowCellError):
@@ -86,7 +87,7 @@ def test_get_base_mask_undetermined_cycles(run_parameters_missing_flowcell_type:
 def test_flow_cell_mode(novaseq_run_parameters: Path):
     """Test that the flow cell mode is of a valid file in the list of expected values."""
     # GIVEN a RunParameters object created from a valid run parameters file
-    run_parameters = RunParameters(novaseq_run_parameters)
+    run_parameters = RunParameters(run_parameters_path=novaseq_run_parameters)
 
     # WHEN fetching the flow cell mode
 
@@ -97,7 +98,7 @@ def test_flow_cell_mode(novaseq_run_parameters: Path):
 def test_flow_cell_mode_missing_mode(run_parameters_missing_flowcell_type: Path):
     """Test that getting the flow cell mode from a file lacking flow cell mode returns None."""
     # GIVEN a RunParameters object created from a file without flow cell mode
-    run_parameters = RunParameters(run_parameters_missing_flowcell_type)
+    run_parameters = RunParameters(run_parameters_path=run_parameters_missing_flowcell_type)
 
     # WHEN fetching the flow cell mode
 
@@ -108,33 +109,33 @@ def test_flow_cell_mode_missing_mode(run_parameters_missing_flowcell_type: Path)
 def test_reagent_kit_version(novaseq_run_parameters: Path):
     """Test that getting reagent kit version from a correct file returns an expected value."""
     # GIVEN a RunParameters object created from a valid run parameters file
-    run_parameters = RunParameters(novaseq_run_parameters)
+    run_parameters = RunParameters(run_parameters_path=novaseq_run_parameters)
 
     # WHEN fetching the reagent kit version
     reagent_kit_version: str = run_parameters.reagent_kit_version
 
     # THEN the reagent kit version exists and is not "unknown"
     assert reagent_kit_version
-    assert reagent_kit_version != "unknown"
+    assert reagent_kit_version != UNKNOWN_REAGENT_KIT_VERSION
 
 
 def test_reagent_kit_version_missing_version(run_parameters_missing_flowcell_type: Path, caplog):
     """Test that 'unknown' will be returned if the run parameters file has no reagent kit method."""
     caplog.set_level(logging.INFO)
     # GIVEN a RunParameters object created from a file without reagent kit version
-    run_parameters = RunParameters(run_parameters_missing_flowcell_type)
+    run_parameters = RunParameters(run_parameters_path=run_parameters_missing_flowcell_type)
 
     # WHEN fetching the reagent kit version
 
     # THEN the reagent kit version is unknown
-    assert run_parameters.reagent_kit_version == "unknown"
+    assert run_parameters.reagent_kit_version == UNKNOWN_REAGENT_KIT_VERSION
     assert "Could not determine reagent kit version" in caplog.text
 
 
 def test_control_software_version(novaseq_run_parameters: Path):
     """Test that getting control software version from a correct file returns an expected value."""
     # GIVEN a RunParameters object created from a valid run parameters file
-    run_parameters = RunParameters(novaseq_run_parameters)
+    run_parameters = RunParameters(run_parameters_path=novaseq_run_parameters)
 
     # WHEN fetching the control software version
 
@@ -146,11 +147,11 @@ def test_control_software_version_no_version(run_parameters_missing_flowcell_typ
     """Test that fetching the control software version from a file without that field fails."""
     caplog.set_level(logging.INFO)
     # GIVEN a RunParameters object created from a file without control software version
-    run_parameters = RunParameters(run_parameters_missing_flowcell_type)
+    run_parameters = RunParameters(run_parameters_path=run_parameters_missing_flowcell_type)
 
     # WHEN fetching the control software version
     with pytest.raises(FlowCellError):
-        # THEN assert that an exception was raised since the cycle data was not found
+        # THEN assert that an exception was raised since the control software version was not found
         run_parameters.control_software_version
 
     assert "Could not determine control software version" in caplog.text
@@ -159,7 +160,7 @@ def test_control_software_version_no_version(run_parameters_missing_flowcell_typ
 def test_index_length(novaseq_run_parameters: Path):
     """Test that getting the index length from a valid file returns the expected output."""
     # GIVEN a RunParameters object created from a valid run parameters file
-    run_parameters = RunParameters(novaseq_run_parameters)
+    run_parameters = RunParameters(run_parameters_path=novaseq_run_parameters)
 
     # WHEN getting the index length
 
@@ -170,7 +171,7 @@ def test_index_length(novaseq_run_parameters: Path):
 def test_index_length_different_length(run_parameters_different_index: Path):
     """Test that getting the index length from a file with different index cycles fails."""
     # GIVEN a RunParameters object created from a file with different index cycles
-    run_parameters = RunParameters(run_parameters_different_index)
+    run_parameters = RunParameters(run_parameters_path=run_parameters_different_index)
 
     # WHEN fetching index length
     with pytest.raises(FlowCellError) as exc_info:

--- a/tests/models/demultiplexing/test_run_parameters.py
+++ b/tests/models/demultiplexing/test_run_parameters.py
@@ -6,51 +6,175 @@ from cg.exc import FlowCellError
 from cg.models.demultiplex.run_parameters import RunParameters
 
 
-def test_get_flowcell_type_hiseq_run_parameters(hiseq_run_parameters: Path):
-    # GIVEN the path to a file with hiseq run parameters
-    # GIVEN a RunParameters object
-    run_parameters_object = RunParameters(hiseq_run_parameters)
+def test_get_flow_cell_type_hiseq_run_parameters(hiseq_run_parameters: Path):
+    """Test that reading a hiseq run_parameters file assigns the correct flowcell type."""
+    # GIVEN a RunParameters object created from a hiseq run parameters file
+    run_parameters = RunParameters(hiseq_run_parameters)
 
     # WHEN fetching the flowcell type
 
-    # THEN assert that the flowcell type is correct
-    assert run_parameters_object.flowcell_type == "hiseq"
+    # THEN the flowcell type is hiseq
+    assert run_parameters.flow_cell_type == "hiseq"
 
 
-def test_get_flowcell_type_novaseq_run_parameters(novaseq_run_parameters: Path):
-    # GIVEN the path to a file with novaseq run parameters
-    # GIVEN a RunParameters object
-    run_parameters_object = RunParameters(novaseq_run_parameters)
+def test_get_flow_cell_type_novaseq_run_parameters(novaseq_run_parameters: Path):
+    """Test that reading a novaseq run_parameters file assigns the correct flowcell type."""
+    # GIVEN a RunParameters object created from a novaseq run parameters file
+    run_parameters = RunParameters(novaseq_run_parameters)
 
     # WHEN fetching the flowcell type
 
-    # THEN assert that the flowcell type is correct
-    assert run_parameters_object.flowcell_type == "novaseq"
+    # THEN assert that the flowcell type is novaseq
+    assert run_parameters.flow_cell_type == "novaseq"
 
 
 def test_get_unknown_type_run_parameters(unknown_run_parameters: Path, caplog):
+    """Test that reading a run_parameters with unknown flowcell file raises an error."""
     caplog.set_level(logging.INFO)
-    # GIVEN the path to a file with a unknown flowcell type
-    # GIVEN a run parameters object
-    run_parameters_obj = RunParameters(unknown_run_parameters)
+    # GIVEN a RunParameters object created from a run parameters file with unknown flowcell
+    run_parameters = RunParameters(unknown_run_parameters)
 
     # WHEN fetching the flowcell type
     with pytest.raises(FlowCellError):
         # THEN assert that an exception was raised since the flowcell type was unknown
-        run_parameters_obj.flowcell_type
+        run_parameters.flow_cell_type
 
-    assert "Unknown flowcell type" in caplog.text
+    assert "Unknown flow cell type" in caplog.text
 
 
-def test_get_flowcell_type_when_missing(run_parameters_missing_flowcell_type: Path, caplog):
+def test_get_flow_cell_type_when_missing(run_parameters_missing_flowcell_type: Path, caplog):
+    """Test that reading a run_parameters with missing flowcell file raises an error."""
     caplog.set_level(logging.INFO)
-    # GIVEN the path to a file where the field that indicates flowcell type is missing
-    # GIVEN a run parameters object
-    run_parameters_obj = RunParameters(run_parameters_missing_flowcell_type)
+    # GIVEN a RunParameters object created from a run parameters file with missing flowcell
+    run_parameters = RunParameters(run_parameters_missing_flowcell_type)
 
     # WHEN parsing the run parameters
     with pytest.raises(FlowCellError):
-        # THEN assert that an exception was raised since the flowcell type was unknown
-        run_parameters_obj.flowcell_type
+        # THEN assert that an exception was raised since the flow cell type was unknown
+        run_parameters.flow_cell_type
 
-    assert "Could not determine flowcell type" in caplog.text
+    assert "Could not determine flow cell type" in caplog.text
+
+
+def test_get_base_mask(novaseq_run_parameters: Path):
+    """Test that generating the run parameters base mask returns the expected result."""
+    # GIVEN a RunParameters object created from a valid run parameters file
+    run_parameters = RunParameters(novaseq_run_parameters)
+
+    # WHEN fetching the base mask
+    base_mask: str = run_parameters.get_base_mask()
+
+    # THEN the base mask has the correct structure
+    assert base_mask.startswith("Y")
+    assert ",I" in base_mask
+
+
+def test_get_base_mask_undetermined_cycles(run_parameters_missing_flowcell_type: Path, caplog):
+    """Test that generating the base mask from a file without cycle info fails."""
+    caplog.set_level(logging.INFO)
+    # GIVEN a RunParameters object created from a run parameters file with missing cycle info
+    run_parameters = RunParameters(run_parameters_missing_flowcell_type)
+
+    # WHEN creating the base mask
+    with pytest.raises(FlowCellError):
+        # THEN assert that an exception was raised since the cycle data was not found
+        run_parameters.get_base_mask()
+
+    assert "Could not determine length of reads one" in caplog.text
+
+
+def test_flow_cell_mode(novaseq_run_parameters: Path):
+    """Test that the flow cell mode is of a valid file in the list of expected values."""
+    # GIVEN a RunParameters object created from a valid run parameters file
+    run_parameters = RunParameters(novaseq_run_parameters)
+
+    # WHEN fetching the flow cell mode
+
+    # THEN the flow cell mode is in the list of expected values
+    assert run_parameters.flow_cell_mode in ["S2", "S4"]
+
+
+def test_flow_cell_mode_missing_mode(run_parameters_missing_flowcell_type: Path):
+    """Test that getting the flow cell mode from a file lacking flow cell mode returns None."""
+    # GIVEN a RunParameters object created from a file without flow cell mode
+    run_parameters = RunParameters(run_parameters_missing_flowcell_type)
+
+    # WHEN fetching the flow cell mode
+
+    # THEN the flow cell mode is none
+    assert run_parameters.flow_cell_mode is None
+
+
+def test_reagent_kit_version(novaseq_run_parameters: Path):
+    """Test that getting reagent kit version from a correct file returns an expected value."""
+    # GIVEN a RunParameters object created from a valid run parameters file
+    run_parameters = RunParameters(novaseq_run_parameters)
+
+    # WHEN fetching the reagent kit version
+    reagent_kit_version: str = run_parameters.reagent_kit_version
+
+    # THEN the reagent kit version exists and is not "unknown"
+    assert reagent_kit_version
+    assert reagent_kit_version != "unknown"
+
+
+def test_reagent_kit_version_missing_version(run_parameters_missing_flowcell_type: Path, caplog):
+    """Test that 'unknown' will be returned if the run parameters file has no reagent kit method."""
+    caplog.set_level(logging.INFO)
+    # GIVEN a RunParameters object created from a file without reagent kit version
+    run_parameters = RunParameters(run_parameters_missing_flowcell_type)
+
+    # WHEN fetching the reagent kit version
+
+    # THEN the reagent kit version is unknown
+    assert run_parameters.reagent_kit_version == "unknown"
+    assert "Could not determine reagent kit version" in caplog.text
+
+
+def test_control_software_version(novaseq_run_parameters: Path):
+    """Test that getting control software version from a correct file returns an expected value."""
+    # GIVEN a RunParameters object created from a valid run parameters file
+    run_parameters = RunParameters(novaseq_run_parameters)
+
+    # WHEN fetching the control software version
+
+    # THEN the control software version is a string
+    assert isinstance(run_parameters.control_software_version, str)
+
+
+def test_control_software_version_no_version(run_parameters_missing_flowcell_type: Path, caplog):
+    """Test that fetching the control software version from a file without that field fails."""
+    caplog.set_level(logging.INFO)
+    # GIVEN a RunParameters object created from a file without control software version
+    run_parameters = RunParameters(run_parameters_missing_flowcell_type)
+
+    # WHEN fetching the control software version
+    with pytest.raises(FlowCellError):
+        # THEN assert that an exception was raised since the cycle data was not found
+        run_parameters.control_software_version
+
+    assert "Could not determine control software version" in caplog.text
+
+
+def test_index_length(novaseq_run_parameters: Path):
+    """Test that getting the index length from a valid file returns the expected output."""
+    # GIVEN a RunParameters object created from a valid run parameters file
+    run_parameters = RunParameters(novaseq_run_parameters)
+
+    # WHEN getting the index length
+
+    # THEN the index length is an int
+    assert isinstance(run_parameters.index_length, int)
+
+
+def test_index_length_different_length(run_parameters_different_index: Path):
+    """Test that getting the index length from a file with different index cycles fails."""
+    # GIVEN a RunParameters object created from a file with different index cycles
+    run_parameters = RunParameters(run_parameters_different_index)
+
+    # WHEN fetching index length
+    with pytest.raises(FlowCellError) as exc_info:
+        # THEN assert that an exception was raised since the index cycles are different
+        run_parameters.index_length
+
+    assert str(exc_info.value) == "Index lengths are not the same!"

--- a/tests/models/demultiplexing/test_run_parameters.py
+++ b/tests/models/demultiplexing/test_run_parameters.py
@@ -18,7 +18,7 @@ def test_get_flowcell_type_hiseq_run_parameters(hiseq_run_parameters: Path):
 
 
 def test_get_flowcell_type_novaseq_run_parameters(novaseq_run_parameters: Path):
-    # GIVEN the path to a file with hiseq run parameters
+    # GIVEN the path to a file with novaseq run parameters
     # GIVEN a RunParameters object
     run_parameters_object = RunParameters(novaseq_run_parameters)
 


### PR DESCRIPTION
## Description

This refactoring, test improvement and modification of the class RunParameters is aimed at facilitating the introduction of new RunParameter classes (maybe child classes) for the NovaSeqXPlus and NovaSeq6000Dx run parameter files, which are considerably different from the actual ones.

### Added

- Function `flow_cell_mode` in `cg/models/demultiplex/run_parameters.py` that extracts the flow cell mode (S2/S4) from the run parameters file.
- Test functions for the class RunParameters.
- Fixture for a run parameters file with different index cycles.
- Property `requires_dummy_samples` in RunParameters class that replaces the functionality of `run_type` in a much more clear way.

### Changed

- Capitalized the names of path constants in `cg/resources/__init__.py`.
- Renamed cycle returning functions with the prefix 'get'.
- Renamed `RunParameters.flowcell_type` to `RunParameters.flow_cell_type`
- Moved run parameters file fixtures from `tests/apps/demultiplex/conftest.py` to `test/conftest.py` to make them accessible to the model tests.
- Moved run parameters test functions from `tests/apps/demultiplex/test_parse_run_parameters.py` to `tests/models/demultiplexing` to be consistent with the location of the functions.
- Removed property `run_type` from RunParameters class as it was unclear why it was relating number of index cycles to run type.

### Fixed

- The `base_mask` function (also renamed) which had some interchanged values. The function was not used (so no usage was affected by this bug), but it will be useful when building the sample sheet v2.


### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b extract-run-params-flowcell -a
    ```

### How to test

#### Bcl2fastq converter

- [x] Go to a flow cell folder `cd ../proj/stage/flowcells/novaseq/runs/200207_A00689_0103_BHYG7YDSXX`
- [x] Delete the sample sheet if existing `rm SampleSheet.csv`
- [x] Create the sample sheet again for `bcl2fastq` converter on dry run
     ```
     cg demultiplex samplesheet create 221031_A00187_0862_AHJJJNDRX2 -b bcl2fastq --dry-run
     ```
#### Dragen converter
- [x] Create the sample sheet again for `dragen` converter on dry run
     ```
     cg demultiplex samplesheet create 221031_A00187_0862_AHJJJNDRX2 -b dragen --dry-run
     ```

### Expected test outcome

- [x] Verify from the command output that dummy samples are added
- [x] The sample sheets are created without any errors (Sample sheet printed on stdout omitted in comments)

## Review

- [x] Tests executed by SD
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Deploy this branch on
  - [ ] cg stage
  - [ ] cg production 
