### PR TITLE
adding mobile element files to scout load

### DIFF
--- a/cg/constants/scout_upload.py
+++ b/cg/constants/scout_upload.py
@@ -1,6 +1,6 @@
-from cg.utils.enums import StrEnum
-
 from typing import Dict, Set
+
+from cg.utils.enums import StrEnum
 
 
 class GenomeBuild(StrEnum):
@@ -19,18 +19,20 @@ class ScoutCustomCaseReportTags(StrEnum):
 
 
 MIP_CASE_TAGS = dict(
-    snv_vcf={"vcf-snv-clinical"},
-    snv_research_vcf={"vcf-snv-research"},
-    sv_vcf={"vcf-sv-clinical"},
-    sv_research_vcf={"vcf-sv-research"},
-    vcf_str={"vcf-str"},
-    smn_tsv={"smn-calling"},
+    delivery_report={"delivery-report"},
+    multiqc_report={"multiqc-html"},
+    peddy_check={"ped-check", "peddy"},
     peddy_ped={"ped", "peddy"},
     peddy_sex={"sex-check", "peddy"},
-    peddy_check={"ped-check", "peddy"},
-    multiqc_report={"multiqc-html"},
-    delivery_report={"delivery-report"},
+    smn_tsv={"smn-calling"},
+    snv_research_vcf={"vcf-snv-research"},
+    snv_vcf={"vcf-snv-clinical"},
     str_catalog={"expansionhunter", "variant-catalog"},
+    sv_research_vcf={"vcf-sv-research"},
+    sv_vcf={"vcf-sv-clinical"},
+    vcf_mei={"mobile-elements", "clinical", "vcf"},
+    vcf_mei_research={"mobile-elements", "research", "vcf"},
+    vcf_str={"vcf-str"},
 )
 
 BALSAMIC_CASE_TAGS = dict(

--- a/cg/meta/upload/scout/hk_tags.py
+++ b/cg/meta/upload/scout/hk_tags.py
@@ -59,7 +59,7 @@ class CaseTags(BaseModel):
     vcf_mei: Optional[Set[str]] = Field(
         None, description="VCF with mobile element insertions, clinical"
     )
-    vcf_mei_research: Optional[set[str]] = Field(
+    vcf_mei_research: Optional[Set[str]] = Field(
         None, description="VCF with mobile element insertions, research"
     )
 

--- a/cg/meta/upload/scout/hk_tags.py
+++ b/cg/meta/upload/scout/hk_tags.py
@@ -56,6 +56,12 @@ class CaseTags(BaseModel):
         None, description="RNAfusion inspector report containing all fusions"
     )
     multiqc_rna: Optional[Set[str]] = Field(None, description="MultiQC report for RNA samples")
+    vcf_mei: Optional[Set[str]] = Field(
+        None, description="VCF with mobile element insertions, clinical"
+    )
+    vcf_mei_research: Optional[set[str]] = Field(
+        None, description="VCF with mobile element insertions, research"
+    )
 
 
 class SampleTags(BaseModel):

--- a/cg/meta/upload/scout/mip_config_builder.py
+++ b/cg/meta/upload/scout/mip_config_builder.py
@@ -100,15 +100,17 @@ class MipConfigBuilder(ScoutConfigBuilder):
     def include_case_files(self):
         """Include case level files for mip case"""
         LOG.info("Including MIP specific case level files")
-        self.load_config.vcf_snv = self.get_file_from_hk(self.case_tags.snv_vcf)
-        self.load_config.vcf_sv = self.get_file_from_hk(self.case_tags.sv_vcf)
-        self.load_config.vcf_snv_research = self.get_file_from_hk(self.case_tags.snv_research_vcf)
-        self.load_config.vcf_sv_research = self.get_file_from_hk(self.case_tags.sv_research_vcf)
-        self.load_config.vcf_str = self.get_file_from_hk(self.case_tags.vcf_str)
+        self.load_config.peddy_check = self.get_file_from_hk(self.case_tags.peddy_check)
         self.load_config.peddy_ped = self.get_file_from_hk(self.case_tags.peddy_ped)
         self.load_config.peddy_sex = self.get_file_from_hk(self.case_tags.peddy_sex)
-        self.load_config.peddy_check = self.get_file_from_hk(self.case_tags.peddy_check)
         self.load_config.smn_tsv = self.get_file_from_hk(self.case_tags.smn_tsv)
+        self.load_config.vcf_mei = self.get_file_from_hk(self.case_tags.vcf_mei)
+        self.load_config.vcf_mei_research = self.get_file_from_hk(self.case_tags.vcf_mei_research)
+        self.load_config.vcf_snv = self.get_file_from_hk(self.case_tags.snv_vcf)
+        self.load_config.vcf_snv_research = self.get_file_from_hk(self.case_tags.snv_research_vcf)
+        self.load_config.vcf_str = self.get_file_from_hk(self.case_tags.vcf_str)
+        self.load_config.vcf_sv = self.get_file_from_hk(self.case_tags.sv_vcf)
+        self.load_config.vcf_sv_research = self.get_file_from_hk(self.case_tags.sv_research_vcf)
         self.include_multiqc_report()
         self.include_delivery_report()
 

--- a/cg/models/scout/scout_load_config.py
+++ b/cg/models/scout/scout_load_config.py
@@ -130,20 +130,22 @@ class BalsamicUmiLoadConfig(BalsamicLoadConfig):
 
 
 class MipLoadConfig(ScoutLoadConfig):
-    smn_tsv: Optional[str] = None
     chromograph_image_files: Optional[List[str]]
     chromograph_prefixes: Optional[List[str]]
-    vcf_snv: str = None
-    vcf_sv: Optional[str] = None
-    vcf_str: Optional[str] = None
-    vcf_snv_research: Optional[str] = None
-    vcf_sv_research: Optional[str] = None
+    madeline: Optional[str] = None
+    peddy_check: Optional[str] = None
     peddy_ped: Optional[str] = None
     peddy_sex: Optional[str] = None
-    peddy_check: Optional[str] = None
-    madeline: Optional[str] = None
     samples: List[ScoutMipIndividual] = []
+    smn_tsv: Optional[str] = None
     variant_catalog: Optional[str] = None
+    vcf_mei: Optional[str] = None
+    vcf_mei_research: Optional[str] = None
+    vcf_snv: str = None
+    vcf_snv_research: Optional[str] = None
+    vcf_str: Optional[str] = None
+    vcf_sv: Optional[str] = None
+    vcf_sv_research: Optional[str] = None
 
     @validator("vcf_snv", "vcf_sv", "vcf_snv_research", "vcf_sv_research")
     def check_mandatory_files(cls, vcf):


### PR DESCRIPTION
## Description

### Added

- mobile element files to scout load config


### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [x] Do `cg upload create-scout-load-config --print justhusky`

### Expected test outcome

- [x] Check that `vcf_mei` and `vcf_mei_research` is included
- [x] Take a screenshot and attach or copy/paste the output.

## Review

- [x] Tests executed by AJ
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
