### PR TITLE
change(rnafusion) exclude files from delivery

### DIFF
--- a/cg/constants/delivery.py
+++ b/cg/constants/delivery.py
@@ -148,15 +148,12 @@ RNAFUSION_ANALYSIS_CASE_TAGS = [
     {"fusion", "star-fusion"},
     {"fusion", "fusioncatcher"},
     {"cram"},
-    {"fusioncatcher-summary"},
     {"fusioninspector"},
     {"fusionreport", "research"},
     {"fusioninspector-html", "research"},
     {"arriba-visualisation", "research"},
     {"multiqc-html", "rna"},
     {"software-versions"},
-    {"qc-metrics"},
-    {"multiqc-json"},
 ]
 
 RNAFUSION_ANALYSIS_SAMPLE_TAGS = []


### PR DESCRIPTION
## Description

### Changed

- Exclude files from caesar delivery in rnafusion. Excluded files: multqc-json, metricsqc, fusioncatcher summary

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
