### PR TITLE
Wire flow cell mode

### DIFF
--- a/cg/apps/demultiplex/sample_sheet/novaseq_sample_sheet.py
+++ b/cg/apps/demultiplex/sample_sheet/novaseq_sample_sheet.py
@@ -135,5 +135,5 @@ class SampleSheetCreator:
             flow_cell_mode=self.flow_cell_mode,
             bcl_converter=self.bcl_converter,
         )
-        LOG.info("Sample sheet looks fine")
+        LOG.info("Sample sheet validated successfully")
         return sample_sheet

--- a/cg/apps/demultiplex/sample_sheet/novaseq_sample_sheet.py
+++ b/cg/apps/demultiplex/sample_sheet/novaseq_sample_sheet.py
@@ -35,6 +35,7 @@ class SampleSheetCreator:
         self.flow_cell_id: str = flow_cell.id
         self.lims_samples: List[LimsFlowcellSample] = lims_samples
         self.run_parameters: RunParameters = flow_cell.run_parameters
+        self.flow_cell_mode: str = flow_cell.mode
         self.force = force
 
     @property
@@ -131,7 +132,7 @@ class SampleSheetCreator:
         LOG.info("Validating sample sheet")
         get_sample_sheet(
             sample_sheet=sample_sheet,
-            flow_cell_mode="S2",
+            flow_cell_mode=self.flow_cell_mode,
             bcl_converter=self.bcl_converter,
         )
         LOG.info("Sample sheet looks fine")

--- a/cg/apps/demultiplex/sample_sheet/novaseq_sample_sheet.py
+++ b/cg/apps/demultiplex/sample_sheet/novaseq_sample_sheet.py
@@ -135,5 +135,5 @@ class SampleSheetCreator:
             flow_cell_mode=self.flow_cell_mode,
             bcl_converter=self.bcl_converter,
         )
-        LOG.info("Sample sheet validated successfully")
+        LOG.info("Sample sheet passed validation")
         return sample_sheet

--- a/cg/apps/demultiplex/sample_sheet/validate.py
+++ b/cg/apps/demultiplex/sample_sheet/validate.py
@@ -80,7 +80,7 @@ def get_sample_sheet(
     sample_sheet: str,
     flow_cell_mode: Literal[
         FlowCellMode.MISEQ,
-        FlowCellMode.HISEQ_X,
+        FlowCellMode.HISEQX,
         FlowCellMode.NEXTSEQ,
         FlowCellMode.NOVASEQ,
     ],
@@ -102,7 +102,7 @@ def get_sample_sheet_from_file(
     infile: Path,
     flow_cell_mode: Literal[
         FlowCellMode.MISEQ,
-        FlowCellMode.HISEQ_X,
+        FlowCellMode.HISEQX,
         FlowCellMode.NEXTSEQ,
         FlowCellMode.NOVASEQ,
     ],

--- a/cg/cli/demultiplex/sample_sheet.py
+++ b/cg/cli/demultiplex/sample_sheet.py
@@ -57,7 +57,7 @@ def validate_sample_sheet(
     except ValidationError as error:
         LOG.warning(error)
         raise click.Abort from error
-    LOG.info("Sample sheet looks fine")
+    LOG.info("Sample sheet validated successfully")
 
 
 @sample_sheet_commands.command(name="create")

--- a/cg/cli/demultiplex/sample_sheet.py
+++ b/cg/cli/demultiplex/sample_sheet.py
@@ -57,7 +57,7 @@ def validate_sample_sheet(
     except ValidationError as error:
         LOG.warning(error)
         raise click.Abort from error
-    LOG.info("Sample sheet validated successfully")
+    LOG.info("Sample sheet passed validation")
 
 
 @sample_sheet_commands.command(name="create")

--- a/cg/constants/demultiplexing.py
+++ b/cg/constants/demultiplexing.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import click
-from typing import List
+from typing import List, Dict
 from cg.constants.sequencing import Sequencers
 from cg.utils.enums import StrEnum
 
@@ -105,4 +105,7 @@ class FlowCellMode(StrEnum):
     MISEQ: str = "2500"
 
 
-FLOW_CELL_MODES: List[str] = [mode.value for mode in FlowCellMode]
+sequencer_flow_cell_modes: Dict[str, str] = {
+    Sequencers.__members__[mode.name].value: mode.value for mode in FlowCellMode
+}
+FLOW_CELL_MODES: List[str] = list(sequencer_flow_cell_modes.values())

--- a/cg/constants/demultiplexing.py
+++ b/cg/constants/demultiplexing.py
@@ -105,7 +105,7 @@ class FlowCellMode(StrEnum):
     MISEQ: str = "2500"
 
 
-sequencer_flow_cell_modes: Dict[str, str] = {
+SEQUENCER_FLOW_CELL_MODES: Dict[str, str] = {
     Sequencers.__members__[mode.name].value: mode.value for mode in FlowCellMode
 }
-FLOW_CELL_MODES: List[str] = list(sequencer_flow_cell_modes.values())
+FLOW_CELL_MODES: List[str] = list(SEQUENCER_FLOW_CELL_MODES.values())

--- a/cg/constants/demultiplexing.py
+++ b/cg/constants/demultiplexing.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import click
 from typing import List
+from cg.constants.sequencing import Sequencers
 from cg.utils.enums import StrEnum
 
 
@@ -98,7 +99,7 @@ class DemultiplexingDirsAndFiles(StrEnum):
 class FlowCellMode(StrEnum):
     """Define sample sheet flow cell mode."""
 
-    HISEQ_X: str = "SP"
+    HISEQX: str = "SP"
     NEXTSEQ: str = "S2"
     NOVASEQ: str = "S4"
     MISEQ: str = "2500"

--- a/cg/constants/sequencing.py
+++ b/cg/constants/sequencing.py
@@ -6,6 +6,8 @@ class Sequencers(StrEnum):
     """Sequencer instruments."""
 
     ALL: str = "all"
+    MISEQ: str = "miseq"
+    NEXTSEQ: str = "nextseq"
     HISEQX: str = "hiseqx"
     HISEQGA: str = "hiseqga"
     NOVASEQ: str = "novaseq"

--- a/cg/models/demultiplex/flow_cell.py
+++ b/cg/models/demultiplex/flow_cell.py
@@ -11,8 +11,8 @@ from cg.apps.demultiplex.sample_sheet.models import SampleSheet
 from cg.apps.demultiplex.sample_sheet.validate import get_sample_sheet_from_file
 from cg.constants.demultiplexing import (
     DemultiplexingDirsAndFiles,
-    sequencer_flow_cell_modes,
     FlowCellMode,
+    sequencer_flow_cell_modes,
 )
 from cg.constants.sequencing import Sequencers, sequencer_types
 from cg.exc import FlowCellError, SampleSheetError

--- a/cg/models/demultiplex/flow_cell.py
+++ b/cg/models/demultiplex/flow_cell.py
@@ -12,7 +12,7 @@ from cg.apps.demultiplex.sample_sheet.validate import get_sample_sheet_from_file
 from cg.constants.demultiplexing import (
     DemultiplexingDirsAndFiles,
     FlowCellMode,
-    sequencer_flow_cell_modes,
+    SEQUENCER_FLOW_CELL_MODES,
 )
 from cg.constants.sequencing import Sequencers, sequencer_types
 from cg.exc import FlowCellError, SampleSheetError
@@ -100,7 +100,7 @@ class FlowCell:
         FlowCellMode.MISEQ, FlowCellMode.NOVASEQ, FlowCellMode.NEXTSEQ, FlowCellMode.HISEQX
     ]:
         """Return the flow cell mode."""
-        return self.run_parameters.flow_cell_mode or sequencer_flow_cell_modes[self.sequencer_type]
+        return self.run_parameters.flow_cell_mode or SEQUENCER_FLOW_CELL_MODES[self.sequencer_type]
 
     @property
     def rta_complete_path(self) -> Path:

--- a/tests/apps/demultiplex/test_convert_to_sample_sheet.py
+++ b/tests/apps/demultiplex/test_convert_to_sample_sheet.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from cg.apps.demultiplex.sample_sheet.novaseq_sample_sheet import SampleSheetCreator
 from cg.apps.demultiplex.sample_sheet.models import SampleSheet
 from cg.apps.demultiplex.sample_sheet.validate import get_sample_sheet
+from cg.constants.demultiplexing import FlowCellMode
 
 
 def test_convert_to_bcl2fastq_sheet(
@@ -17,7 +18,7 @@ def test_convert_to_bcl2fastq_sheet(
     # THEN assert a correctly formatted sample sheet was created
     sample_sheet_object: SampleSheet = get_sample_sheet(
         sample_sheet=sample_sheet,
-        flow_cell_mode="S4",
+        flow_cell_mode=FlowCellMode.NOVASEQ,
         bcl_converter=novaseq_bcl2fastq_sample_sheet_object.bcl_converter,
     )
     assert sample_sheet_object.samples
@@ -35,7 +36,7 @@ def test_convert_to_dragen_sheet(
     # THEN assert a correctly formatted sample sheet was created
     sample_sheet_object: SampleSheet = get_sample_sheet(
         sample_sheet=sample_sheet,
-        flow_cell_mode="S4",
+        flow_cell_mode=FlowCellMode.NOVASEQ,
         bcl_converter=novaseq_dragen_sample_sheet_object.bcl_converter,
     )
     assert sample_sheet_object.samples

--- a/tests/apps/demultiplex/test_convert_to_sample_sheet.py
+++ b/tests/apps/demultiplex/test_convert_to_sample_sheet.py
@@ -9,6 +9,7 @@ from cg.constants.demultiplexing import FlowCellMode
 def test_convert_to_bcl2fastq_sheet(
     novaseq_bcl2fastq_sample_sheet_object: SampleSheetCreator, project_dir: Path
 ):
+    """Test that a created bcl2fastq sample sheet has samples."""
     # GIVEN a sample sheet object populated with samples
     assert novaseq_bcl2fastq_sample_sheet_object.lims_samples
 
@@ -27,6 +28,7 @@ def test_convert_to_bcl2fastq_sheet(
 def test_convert_to_dragen_sheet(
     novaseq_dragen_sample_sheet_object: SampleSheetCreator, project_dir: Path
 ):
+    """Test that a created bcl2fastq sample sheet has samples."""
     # GIVEN a sample sheet object populated with samples
     assert novaseq_dragen_sample_sheet_object.lims_samples
 


### PR DESCRIPTION
## Description
Flow cell mode is an attribute of the flow cell included in the RunParameters file and inherent to the sequencing type. It can take values `["S2", S4", "SP", "2500"]`. It is currently hard-wired to the sample sheet applications. This PR connects the values from the RunParameters and FlowCell objects to the sample sheet creation.

### Added

- `MISEQ` and `NEXTSEQ` constants to the Sequencer types.
- Mapping between FlowCellModes and Sequencers
- Attribute `mode` to the `FlowCell` class

### Changed

- Renamed FlowCellMode `HISEQ_X` to `HISEQX` to be consistent with other constants
- Sample sheet validation message

### Fixed

- Replaced the new variable `flow_cell.mode` where "S2" or "S4" was hard-wired.


### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b wire-flow-cell-mode -a
    ```

### How to test

- [x] Go to a flowcell dir with `cg ../proj/stage/flowcells/novaseq/runs/200207_A00689_0103_BHYG7YDSXX`
- [x] Remove sample sheet if there is one with `rm SampleSheet.csv`
- [x] `cg demultiplex samplesheet create 200207_A00689_0103_BHYG7YDSXX`
- [x] `cg demultiplex samplesheet validate SampleSheet.csv --flow-cell-mode S4`
- [x] Remove again the sample sheet and go on directory above
     ```
     rm SampleSheet.csv
     cd ..
     cg demultiplex samplesheet create-all
     ```
- [x] `cg demultiplex flow-cell 221031_A00187_0862_AHJJJNDRX2 --dry-run`
- [x] `cg demultiplex all --flow-cell-directory . --dry-run`
- [x] `cg demultiplex finish flow-cell 230503_A00621_0843_BH27NHDRX3 --dry-run`
- [x] `cg demultiplex finish all --dry-run`
- [x] `cg demultiplex add 230503_A00621_0843_BH27NHDRX3 -b dragen`

### Expected test outcome

- [x] All the commands finish successfully except `cg demultiplex add` which prints duplicated entry error and `cg demultiplex finish all` which shows `ValueError: time data 'novaseq' does not match format '%y%m%d'` after finishing all flow cells.
- [x] Take a screenshot and attach or copy/paste the output.

## Review

- [x] Tests executed by SD
- [x] "Merge and deploy" approved by CO, HS
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Deploy this branch on 
  - [ ] cg stage
  - [ ] cg production