### PR TITLE
Rm deprecated sequncers

### DIFF
--- a/cg/apps/demultiplex/sample_sheet/validate.py
+++ b/cg/apps/demultiplex/sample_sheet/validate.py
@@ -79,7 +79,6 @@ def get_raw_samples(sample_sheet_content: List[List[str]]) -> List[Dict[str, str
 def validate_sample_sheet(
     sample_sheet_content: List[List[str]],
     flow_cell_mode: Literal[
-        FlowCellMode.MISEQ,
         FlowCellMode.HISEQX,
         FlowCellMode.NOVASEQ,
     ],
@@ -100,7 +99,6 @@ def validate_sample_sheet(
 def get_sample_sheet_from_file(
     infile: Path,
     flow_cell_mode: Literal[
-        FlowCellMode.MISEQ,
         FlowCellMode.HISEQX,
         FlowCellMode.NOVASEQ,
     ],

--- a/cg/apps/demultiplex/sample_sheet/validate.py
+++ b/cg/apps/demultiplex/sample_sheet/validate.py
@@ -81,7 +81,6 @@ def validate_sample_sheet(
     flow_cell_mode: Literal[
         FlowCellMode.MISEQ,
         FlowCellMode.HISEQX,
-        FlowCellMode.NEXTSEQ,
         FlowCellMode.NOVASEQ,
     ],
     bcl_converter: Literal[BclConverter.BCL2FASTQ, BclConverter.DRAGEN],
@@ -103,7 +102,6 @@ def get_sample_sheet_from_file(
     flow_cell_mode: Literal[
         FlowCellMode.MISEQ,
         FlowCellMode.HISEQX,
-        FlowCellMode.NEXTSEQ,
         FlowCellMode.NOVASEQ,
     ],
     bcl_converter: Literal[BclConverter.BCL2FASTQ, BclConverter.DRAGEN],

--- a/cg/constants/demultiplexing.py
+++ b/cg/constants/demultiplexing.py
@@ -103,7 +103,6 @@ class FlowCellMode(StrEnum):
     """Define sample sheet flow cell mode."""
 
     HISEQX: str = "SP"
-    NEXTSEQ: str = "S2"
     NOVASEQ: str = "S4"
     MISEQ: str = "2500"
 

--- a/cg/constants/demultiplexing.py
+++ b/cg/constants/demultiplexing.py
@@ -104,7 +104,6 @@ class FlowCellMode(StrEnum):
 
     HISEQX: str = "SP"
     NOVASEQ: str = "S4"
-    MISEQ: str = "2500"
 
 
 SEQUENCER_FLOW_CELL_MODES: Dict[str, str] = {

--- a/cg/constants/sequencing.py
+++ b/cg/constants/sequencing.py
@@ -7,7 +7,6 @@ class Sequencers(StrEnum):
 
     ALL: str = "all"
     MISEQ: str = "miseq"
-    NEXTSEQ: str = "nextseq"
     HISEQX: str = "hiseqx"
     HISEQGA: str = "hiseqga"
     NOVASEQ: str = "novaseq"

--- a/cg/constants/sequencing.py
+++ b/cg/constants/sequencing.py
@@ -6,7 +6,6 @@ class Sequencers(StrEnum):
     """Sequencer instruments."""
 
     ALL: str = "all"
-    MISEQ: str = "miseq"
     HISEQX: str = "hiseqx"
     HISEQGA: str = "hiseqga"
     NOVASEQ: str = "novaseq"

--- a/cg/models/demultiplex/flow_cell.py
+++ b/cg/models/demultiplex/flow_cell.py
@@ -96,9 +96,7 @@ class FlowCell:
     @property
     def mode(
         self,
-    ) -> Literal[
-        FlowCellMode.MISEQ, FlowCellMode.NOVASEQ, FlowCellMode.NEXTSEQ, FlowCellMode.HISEQX
-    ]:
+    ) -> Literal[FlowCellMode.MISEQ, FlowCellMode.NOVASEQ, FlowCellMode.HISEQX]:
         """Return the flow cell mode."""
         return self.run_parameters.flow_cell_mode or SEQUENCER_FLOW_CELL_MODES[self.sequencer_type]
 

--- a/cg/models/demultiplex/flow_cell.py
+++ b/cg/models/demultiplex/flow_cell.py
@@ -96,7 +96,7 @@ class FlowCell:
     @property
     def mode(
         self,
-    ) -> Literal[FlowCellMode.MISEQ, FlowCellMode.NOVASEQ, FlowCellMode.HISEQX]:
+    ) -> Literal[FlowCellMode.NOVASEQ, FlowCellMode.HISEQX]:
         """Return the flow cell mode."""
         return self.run_parameters.flow_cell_mode or SEQUENCER_FLOW_CELL_MODES[self.sequencer_type]
 

--- a/tests/apps/demultiplex/test_validate_sample_sheet.py
+++ b/tests/apps/demultiplex/test_validate_sample_sheet.py
@@ -115,11 +115,11 @@ def test_get_sample_sheet_s2_bcl2fastq(
     # WHEN creating the sample sheet object from a string
     sheet: SampleSheet = validate_sample_sheet(
         sample_sheet_content=valid_sample_sheet_bcl2fastq,
-        flow_cell_mode=FlowCellMode.NEXTSEQ,
+        flow_cell_mode=FlowCellMode.NOVASEQ,
         bcl_converter=BclConverter.BCL2FASTQ,
     )
     # THEN it has the correct type
-    assert sheet.flow_cell_mode == FlowCellMode.NEXTSEQ
+    assert sheet.flow_cell_mode == FlowCellMode.NOVASEQ
 
 
 def test_get_sample_sheet_s2_dragen(
@@ -131,11 +131,11 @@ def test_get_sample_sheet_s2_dragen(
     # WHEN creating the sample sheet object from a string
     sheet: SampleSheet = validate_sample_sheet(
         sample_sheet_content=valid_sample_sheet_dragen,
-        flow_cell_mode=FlowCellMode.NEXTSEQ,
+        flow_cell_mode=FlowCellMode.NOVASEQ,
         bcl_converter=BclConverter.DRAGEN,
     )
     # THEN it has the correct type
-    assert sheet.flow_cell_mode == FlowCellMode.NEXTSEQ
+    assert sheet.flow_cell_mode == FlowCellMode.NOVASEQ
 
 
 def test_get_sample_sheet_s2_bcl2fastq_duplicate_same_lane(
@@ -149,7 +149,7 @@ def test_get_sample_sheet_s2_bcl2fastq_duplicate_same_lane(
         # THEN a sample sheet error is raised
         validate_sample_sheet(
             sample_sheet_content=sample_sheet_bcl2fastq_duplicate_same_lane,
-            flow_cell_mode=FlowCellMode.NEXTSEQ,
+            flow_cell_mode=FlowCellMode.NOVASEQ,
             bcl_converter=BclConverter.BCL2FASTQ,
         )
 
@@ -165,7 +165,7 @@ def test_get_sample_sheet_s2_dragen_duplicate_same_lane(
         # THEN a sample sheet error is raised
         validate_sample_sheet(
             sample_sheet_content=sample_sheet_dragen_duplicate_same_lane,
-            flow_cell_mode=FlowCellMode.NEXTSEQ,
+            flow_cell_mode=FlowCellMode.NOVASEQ,
             bcl_converter=BclConverter.DRAGEN,
         )
 
@@ -179,7 +179,7 @@ def test_get_sample_sheet_s2_bcl2fastq_duplicate_different_lanes(
     # WHEN creating the sample sheet object
     sample_sheet: SampleSheet = validate_sample_sheet(
         sample_sheet_content=sample_sheet_bcl2fastq_duplicate_different_lane,
-        flow_cell_mode=FlowCellMode.NEXTSEQ,
+        flow_cell_mode=FlowCellMode.NOVASEQ,
         bcl_converter=BclConverter.BCL2FASTQ,
     )
 
@@ -196,7 +196,7 @@ def test_get_sample_sheet_s2_dragen_duplicate_different_lanes(
     # WHEN creating the sample sheet object
     sample_sheet: SampleSheet = validate_sample_sheet(
         sample_sheet_content=sample_sheet_dragen_duplicate_different_lane,
-        flow_cell_mode=FlowCellMode.NEXTSEQ,
+        flow_cell_mode=FlowCellMode.NOVASEQ,
         bcl_converter=BclConverter.DRAGEN,
     )
 
@@ -213,12 +213,12 @@ def test_get_sample_sheet_from_file_s2_bcl2fastq(
     # WHEN creating the sample sheet object
     sheet: SampleSheet = get_sample_sheet_from_file(
         infile=valid_sample_sheet_bcl2fastq_path,
-        flow_cell_mode=FlowCellMode.NEXTSEQ,
+        flow_cell_mode=FlowCellMode.NOVASEQ,
         bcl_converter=BclConverter.BCL2FASTQ,
     )
 
     # THEN the sample sheet has the correct type
-    assert sheet.flow_cell_mode == FlowCellMode.NEXTSEQ
+    assert sheet.flow_cell_mode == FlowCellMode.NOVASEQ
 
 
 def test_get_sample_sheet_from_file_s2_dragen(
@@ -230,9 +230,9 @@ def test_get_sample_sheet_from_file_s2_dragen(
     # WHEN creating the sample sheet
     sheet: SampleSheet = get_sample_sheet_from_file(
         infile=valid_sample_sheet_dragen_path,
-        flow_cell_mode=FlowCellMode.NEXTSEQ,
+        flow_cell_mode=FlowCellMode.NOVASEQ,
         bcl_converter=BclConverter.DRAGEN,
     )
 
     # THEN the sample sheet has the correct type
-    assert sheet.flow_cell_mode == FlowCellMode.NEXTSEQ
+    assert sheet.flow_cell_mode == FlowCellMode.NOVASEQ

--- a/tests/cli/demultiplex/test_validate_sample_sheet.py
+++ b/tests/cli/demultiplex/test_validate_sample_sheet.py
@@ -59,7 +59,7 @@ def test_validate_correct_bcl2fastq_sample_sheet(
     # GIVEN that the sample sheet is correct
     get_sample_sheet_from_file(
         infile=sample_sheet,
-        flow_cell_mode=FlowCellMode.NEXTSEQ,
+        flow_cell_mode=FlowCellMode.NOVASEQ,
         bcl_converter=BclConverter.BCL2FASTQ,
     )
 
@@ -83,7 +83,7 @@ def test_validate_correct_dragen_sample_sheet(
 
     # GIVEN that the sample sheet is correct
     get_sample_sheet_from_file(
-        infile=sample_sheet, flow_cell_mode=FlowCellMode.NEXTSEQ, bcl_converter=BclConverter.DRAGEN
+        infile=sample_sheet, flow_cell_mode=FlowCellMode.NOVASEQ, bcl_converter=BclConverter.DRAGEN
     )
 
     # WHEN validating the sample sheet


### PR DESCRIPTION
## Description

The Miseq never made it production and we never had any Nextseqs. This PR removes them.

### Changed

- Rm deprecated sequncers: Miseq and Nextseq

### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
