### PR TITLE
feat(read csv into dict in io controller)

### DIFF
--- a/cg/io/controller.py
+++ b/cg/io/controller.py
@@ -19,9 +19,9 @@ class ReadFile:
     }
 
     @classmethod
-    def get_content_from_file(cls, file_format: str, file_path: Path) -> Any:
+    def get_content_from_file(cls, file_format: str, file_path: Path, **kwargs) -> Any:
         """Read file using file format dispatch table."""
-        return cls.read_file[file_format](file_path=file_path)
+        return cls.read_file[file_format](file_path=file_path, **kwargs)
 
 
 class ReadStream:

--- a/cg/io/csv.py
+++ b/cg/io/csv.py
@@ -11,12 +11,8 @@ from cg.io.validate_path import validate_file_suffix
 def read_csv(file_path: Path, read_to_dict: bool = False) -> Union[List[List[str]], List[dict]]:
     """Read content in a CSV file to a list of list or list of dict."""
     validate_file_suffix(path_to_validate=file_path, target_suffix=FileExtensions.CSV)
-    if read_to_dict:
-        with open(file_path, "r") as file:
-            csv_reader = csv.DictReader(file)
-            return list(csv_reader)
     with open(file_path, "r") as file:
-        csv_reader = csv.reader(file)
+        csv_reader = csv.DictReader(file) if read_to_dict else csv.reader(file)
         return list(csv_reader)
 
 

--- a/cg/io/csv.py
+++ b/cg/io/csv.py
@@ -1,16 +1,20 @@
 """Module for reading and writing comma separated values (CSV) formatted files."""
 import csv
 import io
-from typing import Any, List
+from typing import Any, List, Union
 from pathlib import Path
 
 from cg.constants import FileExtensions
 from cg.io.validate_path import validate_file_suffix
 
 
-def read_csv(file_path: Path) -> List[List[str]]:
-    """Read content in a CSV file."""
+def read_csv(file_path: Path, read_to_dict: bool = False) -> Union[List[List[str]], List[dict]]:
+    """Read content in a CSV file to a list of list or list of dict."""
     validate_file_suffix(path_to_validate=file_path, target_suffix=FileExtensions.CSV)
+    if read_to_dict:
+        with open(file_path, "r") as file:
+            csv_reader = csv.DictReader(file)
+            return list(csv_reader)
     with open(file_path, "r") as file:
         csv_reader = csv.reader(file)
         return list(csv_reader)

--- a/tests/io/test_io_controller.py
+++ b/tests/io/test_io_controller.py
@@ -56,6 +56,22 @@ def test_get_content_from_file_when_csv(csv_file_path: Path):
     assert isinstance(raw_csv_content, list)
 
 
+def test_get_content_from_file_to_dict_when_csv(csv_file_path: Path):
+    """
+    Tests getting content from file when in CSV format.
+    """
+    # GIVEN a csv file
+
+    # WHEN reading the csv file
+    raw_csv_content: list = ReadFile.get_content_from_file(
+        file_format=FileFormat.CSV, file_path=csv_file_path, read_to_dict=True
+    )
+
+    # Then assert a list is returned
+    assert isinstance(raw_csv_content, list)
+    assert isinstance(raw_csv_content[0], dict)
+
+
 def test_get_content_from_stream(yaml_stream: str):
     """
     Tests read_yaml_stream

--- a/tests/io/test_io_controller.py
+++ b/tests/io/test_io_controller.py
@@ -67,7 +67,7 @@ def test_get_content_from_file_to_dict_when_csv(csv_file_path: Path):
         file_format=FileFormat.CSV, file_path=csv_file_path, read_to_dict=True
     )
 
-    # Then assert a list is returned
+    # Then assert a list is returned and that the first element is a dict
     assert isinstance(raw_csv_content, list)
     assert isinstance(raw_csv_content[0], dict)
 

--- a/tests/io/test_io_controller.py
+++ b/tests/io/test_io_controller.py
@@ -58,12 +58,12 @@ def test_get_content_from_file_when_csv(csv_file_path: Path):
 
 def test_get_content_from_file_to_dict_when_csv(csv_file_path: Path):
     """
-    Tests getting content from file when in CSV format.
+    Tests getting content from file using DictReader when in CSV format.
     """
     # GIVEN a csv file
 
     # WHEN reading the csv file
-    raw_csv_content: list = ReadFile.get_content_from_file(
+    raw_csv_content: List[dict] = ReadFile.get_content_from_file(
         file_format=FileFormat.CSV, file_path=csv_file_path, read_to_dict=True
     )
 

--- a/tests/io/test_io_csv.py
+++ b/tests/io/test_io_csv.py
@@ -16,6 +16,20 @@ def test_get_content_from_file(csv_file_path: Path):
     assert isinstance(raw_csv_content, List)
 
 
+def test_get_content_from_file_to_dict(csv_file_path: Path):
+    """
+    Tests read CSV into a list of dictionaries.
+    """
+    # GIVEN a csv file
+
+    # WHEN reading the csv file
+    raw_csv_content: List[List[str]] = read_csv(file_path=csv_file_path, read_to_dict=True)
+
+    # Then assert a list is returned
+    assert isinstance(raw_csv_content, List)
+    assert isinstance(raw_csv_content[0], dict)
+
+
 def test_get_content_from_stream(csv_stream: str):
     """
     Tests read CSV stream.

--- a/tests/io/test_io_csv.py
+++ b/tests/io/test_io_csv.py
@@ -25,7 +25,7 @@ def test_get_content_from_file_to_dict(csv_file_path: Path):
     # WHEN reading the csv file
     raw_csv_content: List[List[str]] = read_csv(file_path=csv_file_path, read_to_dict=True)
 
-    # Then assert a list is returned
+    # Then assert a list is returned and that the first element is a dict
     assert isinstance(raw_csv_content, List)
     assert isinstance(raw_csv_content[0], dict)
 


### PR DESCRIPTION
## Description

Adds functionality to read a csv into a list of dict for efficient data parsing.

### Added

-

### Changed

- read_csv function and the Reader controller

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
