### PR TITLE
Removed housekeeper version lock

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -44,4 +44,4 @@ urllib3
 
 # apps
 genologics
-housekeeper==4.1.0
+housekeeper==4.*


### PR DESCRIPTION
## Description
During the work to refactor housekeeper the version was at one point locked to prevent any breaking changes to affect the cg repo.

### Changed

- Only the major version of housekeeper is now locked


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b unlock_hk_dependencies -a
    ```

### How to test
Test the major commands using housekeeper
- [x] `cg deliver analysis -c justhusky -d mip-dna`
- [x] `cg workflow mip-dna store justhusky`
- [x] `cg upload scout justhusky -p`

### Expected test outcome

- [x] Check that the commands behave as expected

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
