### PR TITLE
Fix(RNA scout config) Change dict key to be enum value

### DIFF
--- a/cg/meta/workflow/mip_rna.py
+++ b/cg/meta/workflow/mip_rna.py
@@ -53,9 +53,9 @@ class MipRNAAnalysisAPI(MipAnalysisAPI):
     ) -> Dict[str, Union[str, int]]:
         sample_data: Dict[str, Union[str, int]] = self.get_sample_data(link_obj)
         if link_obj.mother:
-            sample_data[Pedigree.MOTHER]: str = link_obj.mother.internal_id
+            sample_data[Pedigree.MOTHER.value]: str = link_obj.mother.internal_id
         if link_obj.father:
-            sample_data[Pedigree.FATHER]: str = link_obj.father.internal_id
+            sample_data[Pedigree.FATHER.value]: str = link_obj.father.internal_id
         return sample_data
 
     def panel(self, case_id: str, genome_build: str = GENOME_BUILD_38) -> List[str]:


### PR DESCRIPTION
## Description
@jemten Reported a bug where trios in RNA have erroneous scout upload configs generated.

### Fixed

- Dict key is now the enum value


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
