### PR TITLE
1889 - Allow for other pipelines in /families

### DIFF
--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -219,8 +219,9 @@ def get_families():
     status: str = request.args.get("status")
     enquiry: str = request.args.get("enquiry")
     action: str = request.args.get("action")
+    pipeline_str = request.args.get("pipeline")
 
-    if pipeline_str := request.args.get("pipeline"):
+    if pipeline_str:
         try:
             pipeline: Pipeline = Pipeline(pipeline_str)
         except:

--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -225,6 +225,7 @@ def get_families():
         try:
             pipeline: Pipeline = Pipeline(pipeline_str)
         except ValueError:
+            LOG.error("Invalid Pipeline specified.")
             raise
     else:
         pipeline = Pipeline.MIP_DNA

--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -219,7 +219,7 @@ def get_families():
     status: str = request.args.get("status")
     enquiry: str = request.args.get("enquiry")
     action: str = request.args.get("action")
-    pipeline_str = request.args.get("pipeline")
+    pipeline: Pipeline = Pipeline(request.args.get("pipeline", Pipeline.MIP_DNA))
 
     if pipeline_str:
         try:

--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -224,8 +224,8 @@ def get_families():
     if pipeline_str:
         try:
             pipeline: Pipeline = Pipeline(pipeline_str)
-        except:
-            raise ValueError
+        except ValueError as e:
+            raise e
     else:
         pipeline = Pipeline.MIP_DNA
 

--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -224,8 +224,8 @@ def get_families():
     if pipeline_str:
         try:
             pipeline: Pipeline = Pipeline(pipeline_str)
-        except ValueError as e:
-            raise e
+        except ValueError:
+            raise
     else:
         pipeline = Pipeline.MIP_DNA
 


### PR DESCRIPTION
## Description

Addresses issue cg-1889 wherein it was spotted that the MIP pipeline was hard coded to be used when setting "analysis" as parameter for the /families endpoint. Whilst that might work as default, it seems reasonable to allow for other pipelines as well.

### Changed

- Allow user to set Pipeline as parameters in the /families endpoint

### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
