### PR TITLE
fix(force-all will deliver even if not needed)

### DIFF
--- a/cg/cli/deliver/base.py
+++ b/cg/cli/deliver/base.py
@@ -167,7 +167,7 @@ def deliver_ticket(
     cg_context: CGConfig = context.obj
     deliver_ticket_api = DeliverTicketAPI(config=cg_context)
     is_upload_needed = deliver_ticket_api.check_if_upload_is_needed(ticket=ticket)
-    if is_upload_needed:
+    if is_upload_needed or force_all:
         LOG.info("Delivering files to customer inbox on the HPC")
         context.invoke(
             deliver_analysis,

--- a/tests/cli/deliver/test_deliver_base.py
+++ b/tests/cli/deliver/test_deliver_base.py
@@ -75,6 +75,31 @@ def test_run_deliver_delivered_ticket(
     assert "Files already delivered to customer inbox on the HPC" in caplog.text
 
 
+def test_deliver_ticket_with_force_all_flag(
+    cli_runner: CliRunner, cg_context: CGConfig, mocker, caplog, ticket_id
+):
+    """Test that when the --force-all flag is used,
+    the files are delivered to the customer inbox on the HPC"""
+    caplog.set_level(logging.INFO)
+
+    # GIVEN a cli runner
+
+    # GIVEN uploading data to the delivery server is not needed
+    mocker.patch.object(DeliverTicketAPI, "check_if_upload_is_needed")
+    DeliverTicketAPI.check_if_upload_is_needed.return_value = False
+
+    # WHEN running cg deliver ticket with --force-all flag
+    result = cli_runner.invoke(
+        deliver_cmd,
+        ["ticket", "--dry-run", "--ticket", ticket_id, "--delivery-type", "fastq", "--force-all"],
+        obj=cg_context,
+    )
+
+    # THEN assert that the text is not present in the log
+    assert "Files already delivered to customer inbox on the HPC" not in caplog.text
+    assert "Delivering files to customer inbox on the HPC" in caplog.text
+
+
 def test_run_deliver_ticket(cli_runner: CliRunner, cg_context: CGConfig, mocker, caplog, ticket_id):
     """Test for delivering tu customer inbox"""
     caplog.set_level(logging.INFO)


### PR DESCRIPTION
## Description

In the last couple of weeks I have delayed the delivery of fastq data due to the fact that the directory is already existing on hasta. To avoid this I would like to add the feature so that when we force the delivery of all samples we also force it so that we deliver despite the directorys existance. 

### Fixed

- When force-all flag is used we also deliver even if its not needed


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
