### PR TITLE
1886 - add /cases/<case_id> endpoint

### DIFF
--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -219,6 +219,17 @@ def _get_cases(
     )
 
 
+@BLUEPRINT.route("/cases/<case_id>")
+def parse_family(case_id):
+    """Return a case with links."""
+    case: Family = db.get_case_by_internal_id(internal_id=case_id)
+    if case is None:
+        return abort(http.HTTPStatus.NOT_FOUND)
+    if not g.current_user.is_admin and (case.customer not in g.current_user.customers):
+        return abort(http.HTTPStatus.FORBIDDEN)
+    return jsonify(**case.to_dict(links=True, analyses=True))
+
+
 @BLUEPRINT.route("/families")
 def get_families():
     """Return cases."""


### PR DESCRIPTION
## Description

As part of replacing /families with /cases, we add a /cases/<case_id> to match /families/<family_id>.

### Added

- Endpoint /cases/<case_id> with same logic as /families/<family_id>.

### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
