### PR TITLE
Update parsing and calculation of metrics from bcl2fastq

### DIFF
--- a/cg/apps/sequencing_metrics_parser/models/bcl2fastq_metrics.py
+++ b/cg/apps/sequencing_metrics_parser/models/bcl2fastq_metrics.py
@@ -69,15 +69,11 @@ class ConversionResult(BaseModel):
 
     Fields:
     - lane_number: The number of the lane this result pertains to.
-    - total_clusters_raw: The total number of raw clusters in this lane.
-    - total_clusters_pf: The total number of pass-filter (PF) clusters in this lane.
     - yield_: The total yield from this lane.
     - demux_results: A list of demultiplexing results for each sample in this lane.
     """
 
     lane_number: int = Field(..., alias="LaneNumber", gt=0)
-    total_clusters_raw: int = Field(..., alias="TotalClustersRaw", ge=0)
-    total_clusters_pf: int = Field(..., alias="TotalClustersPF", ge=0)
     yield_: int = Field(..., alias="Yield", ge=0)
     demux_results: List[DemuxResult] = Field(..., alias="DemuxResults")
 

--- a/cg/apps/sequencing_metrics_parser/parsers/bcl2fastq_to_sequencing_statistics.py
+++ b/cg/apps/sequencing_metrics_parser/parsers/bcl2fastq_to_sequencing_statistics.py
@@ -35,17 +35,19 @@ def get_sequencing_metrics_from_bcl2fastq(stats_json_path: str):
 
     for conversion_result in raw_sequencing_metrics.conversion_results:
         for demux_result in conversion_result.demux_results:
-            metrics_for_sample_in_lane: SampleLaneSequencingMetrics = create_sequencing_metrics(
-                conversion_result=conversion_result,
-                demux_result=demux_result,
-                raw_sequencing_metrics=raw_sequencing_metrics,
+            metrics_for_sample_in_lane: SampleLaneSequencingMetrics = (
+                create_sample_lane_sequencing_metrics(
+                    conversion_result=conversion_result,
+                    demux_result=demux_result,
+                    raw_sequencing_metrics=raw_sequencing_metrics,
+                )
             )
             sample_lane_metrics.append(metrics_for_sample_in_lane)
 
     return sample_lane_metrics
 
 
-def create_sequencing_metrics(
+def create_sample_lane_sequencing_metrics(
     conversion_result: ConversionResult,
     demux_result: DemuxResult,
     raw_sequencing_metrics: Bcl2FastqSequencingMetrics,
@@ -69,8 +71,12 @@ def create_sequencing_metrics(
         in a lane on the flow cell.
     """
 
-    average_quality_score: float = calculate_average_quality_score(demux_result=demux_result)
-    bases_with_q30_percent: float = calculate_q30_ratio(demux_result=demux_result)
+    average_quality_score: float = calculate_average_quality_score_for_sample_in_lane(
+        demux_result=demux_result
+    )
+    bases_with_q30_percent: float = calculate_q30_ratio_for_sample_in_lane(
+        demux_result=demux_result
+    )
 
     return SampleLaneSequencingMetrics(
         flow_cell_name=raw_sequencing_metrics.flowcell,
@@ -83,7 +89,7 @@ def create_sequencing_metrics(
     )
 
 
-def calculate_q30_ratio(demux_result: DemuxResult) -> float:
+def calculate_q30_ratio_for_sample_in_lane(demux_result: DemuxResult) -> float:
     """
     Calculate the proportion of bases that have a Phred quality score of 30 or more (Q30) for a sample
     in a lane from the demux result.
@@ -101,7 +107,7 @@ def calculate_q30_ratio(demux_result: DemuxResult) -> float:
     return q30_ratio(q30_yield=q30_yield, total_yield=total_yield)
 
 
-def calculate_average_quality_score(demux_result: DemuxResult) -> float:
+def calculate_average_quality_score_for_sample_in_lane(demux_result: DemuxResult) -> float:
     """
     Calculate the mean quality score across all bases for a sample in a lane from the demux result.
 

--- a/cg/apps/sequencing_metrics_parser/parsers/bcl2fastq_to_sequencing_statistics.py
+++ b/cg/apps/sequencing_metrics_parser/parsers/bcl2fastq_to_sequencing_statistics.py
@@ -10,10 +10,6 @@ from cg.apps.sequencing_metrics_parser.parsers.bcl2fastq import parse_bcl2fastq_
 from cg.apps.sequencing_metrics_parser.sequencing_metrics_calculator import (
     q30_ratio,
     average_quality_score,
-    yield_in_megabases,
-    pass_filter_ratio,
-    perfect_reads_ratio,
-    average_clusters_per_lane,
 )
 from cg.store.models import SampleLaneSequencingMetrics
 
@@ -35,23 +31,21 @@ def get_sequencing_metrics_from_bcl2fastq(stats_json_path: str):
         stats_json_path=stats_json_path
     )
 
-    sequencing_statistics: List[SampleLaneSequencingMetrics] = []
+    sample_lane_metrics: List[SampleLaneSequencingMetrics] = []
 
     for conversion_result in raw_sequencing_metrics.conversion_results:
         for demux_result in conversion_result.demux_results:
-            statistics_for_sample_in_lane: SampleLaneSequencingMetrics = (
-                create_sequencing_statistics(
-                    conversion_result=conversion_result,
-                    demux_result=demux_result,
-                    raw_sequencing_metrics=raw_sequencing_metrics,
-                )
+            metrics_for_sample_in_lane: SampleLaneSequencingMetrics = create_sequencing_metrics(
+                conversion_result=conversion_result,
+                demux_result=demux_result,
+                raw_sequencing_metrics=raw_sequencing_metrics,
             )
-            sequencing_statistics.append(statistics_for_sample_in_lane)
+            sample_lane_metrics.append(metrics_for_sample_in_lane)
 
-    return sequencing_statistics
+    return sample_lane_metrics
 
 
-def create_sequencing_statistics(
+def create_sequencing_metrics(
     conversion_result: ConversionResult,
     demux_result: DemuxResult,
     raw_sequencing_metrics: Bcl2FastqSequencingMetrics,
@@ -74,55 +68,19 @@ def create_sequencing_statistics(
         SampleLaneSequencingMetrics: A SampleLaneSequencingMetrics object that encapsulates the statistics for a sample
         in a lane on the flow cell.
     """
-    yield_in_megabases: float = calculate_yield_in_megabases(conversion_result=conversion_result)
-
-    passed_filter_percent: float = calculate_pass_filter_ratio(conversion_result=conversion_result)
 
     average_quality_score: float = calculate_average_quality_score(demux_result=demux_result)
-
     bases_with_q30_percent: float = calculate_q30_ratio(demux_result=demux_result)
-
-    perfect_reads_ratio: float = calculate_perfect_reads_ratio(demux_result=demux_result)
-
-    number_of_lanes: int = len(raw_sequencing_metrics.conversion_results)
-    avg_clusters_per_lane = average_clusters_per_lane(
-        total_clusters=conversion_result.total_clusters_raw,
-        lane_count=number_of_lanes,
-    )
 
     return SampleLaneSequencingMetrics(
         flow_cell_name=raw_sequencing_metrics.flowcell,
+        flow_cell_lane_number=conversion_result.lane_number,
         sample_internal_id=demux_result.sample_id,
-        lane=conversion_result.lane_number,
-        yield_in_megabases=yield_in_megabases,
-        read_counts=demux_result.number_reads,
-        passed_filter_percent=passed_filter_percent,
-        raw_clusters_per_lane_percent=avg_clusters_per_lane,
-        perfect_index_reads_percent=perfect_reads_ratio,
-        bases_with_q30_percent=bases_with_q30_percent,
-        lanes_mean_quality_score=average_quality_score,
+        sample_total_reads_in_lane=demux_result.number_reads,
+        sample_base_fraction_passing_q30=bases_with_q30_percent,
+        sample_base_mean_quality_score=average_quality_score,
         started_at=datetime.now(),
     )
-
-
-def calculate_perfect_reads_ratio(demux_result: DemuxResult) -> float:
-    """
-    Calculate the proportion of perfect index reads for a sample in a lane from the demux result,
-    which is the portion of reads with no mismatches in the index.
-
-    Args:
-        demux_result (DemuxResult): A DemuxResult object encapsulating the result of the demultiplexing
-        for a sample in a lane.
-
-    Returns:
-        float: The proportion of perfect index reads for the sample.
-    """
-    perfect_reads: int = sum(
-        [metric.mismatch_counts.get("0", 0) for metric in demux_result.index_metrics]
-    )
-    total_reads: int = demux_result.number_reads
-
-    return perfect_reads_ratio(perfect_reads=perfect_reads, total_reads=total_reads)
 
 
 def calculate_q30_ratio(demux_result: DemuxResult) -> float:
@@ -158,43 +116,3 @@ def calculate_average_quality_score(demux_result: DemuxResult) -> float:
     total_yield: int = sum([read.yield_ for read in demux_result.read_metrics])
 
     return average_quality_score(total_quality_score=total_quality_score, total_yield=total_yield)
-
-
-def calculate_yield_in_megabases(conversion_result: ConversionResult) -> float:
-    """
-    Calculate the total yield in megabases for a lane from the conversion result. The yield is the total
-    number of bases generated in the lane.
-
-    Args:
-        conversion_result (ConversionResult): A ConversionResult object encapsulating the conversion
-        results for a lane.
-
-    Returns:
-        float: The yield in megabases for the lane.
-    """
-    lane_yields_in_bases: List[int] = [demux.yield_ for demux in conversion_result.demux_results]
-    total_lane_yield_in_bases: int = sum(lane_yields_in_bases)
-
-    return yield_in_megabases(total_bases=total_lane_yield_in_bases)
-
-
-def calculate_pass_filter_ratio(conversion_result: ConversionResult) -> float:
-    """
-    Calculate the proportion of clusters that passed the filter in a lane from the conversion result.
-    Clusters passing the filter are those determined to be good quality.
-
-    Args:
-        conversion_result (ConversionResult): A ConversionResult object encapsulating the conversion
-        results for a lane.
-
-    Returns:
-        float: The proportion of clusters that passed the filter for the lane.
-    """
-    total_clusters: int = conversion_result.total_clusters_raw
-    clusters_passed: int = conversion_result.total_clusters_pf
-
-    passed_filter_percent: float = pass_filter_ratio(
-        clusters_passed=clusters_passed, total_clusters=total_clusters
-    )
-
-    return passed_filter_percent

--- a/cg/apps/sequencing_metrics_parser/sequencing_metrics_calculator.py
+++ b/cg/apps/sequencing_metrics_parser/sequencing_metrics_calculator.py
@@ -1,44 +1,3 @@
-SCALE_TO_MEGABASES = 1_000_000
-
-
-def yield_in_megabases(total_bases: int) -> float:
-    """
-    Calculate the yield in megabases.
-    Args:
-        total_bases (int): The total yield in bases.
-    Returns:
-        int: The yield in megabases.
-    """
-    return total_bases / SCALE_TO_MEGABASES
-
-
-def pass_filter_ratio(clusters_passed: int, total_clusters: int) -> float:
-    """
-    Calculate the ratio of clusters that passed the filter.
-    Args:
-        clusters_passed (int): The total clusters in a lane passing the filter.
-        total_clusters (int): The total clusters generated in a lane.
-    Returns:
-        float: The pass filter ratio.
-    """
-    if total_clusters == 0:
-        return 0
-
-    return clusters_passed / total_clusters
-
-
-def average_clusters_per_lane(total_clusters: int, lane_count: int) -> float:
-    """
-    Calculate the average number of clusters per lane.
-    Args:
-        total_clusters (int): Total number of clusters generated.
-        lane_count (int): Total number of lanes.
-    Returns:
-        float: Average clusters per lane.
-    """
-    return total_clusters / lane_count
-
-
 def q30_ratio(q30_yield: int, total_yield: int) -> float:
     """
     Calculate the proportion of bases that have a Phred quality score of 30 or more.
@@ -61,18 +20,3 @@ def average_quality_score(total_quality_score: int, total_yield: int) -> float:
         float: Average quality score of all bases.
     """
     return total_quality_score / total_yield
-
-
-def perfect_reads_ratio(perfect_reads: int, total_reads: int) -> float:
-    """
-    Calculate the proportion of perfect reads.
-    Args:
-        perfect_reads (int): The number of perfect reads for a sample.
-        total_reads (int): The total number of reads for a sample.
-    Returns:
-        float: The perfect reads ratio.
-    """
-    if total_reads == 0:
-        return 0
-
-    return (perfect_reads / total_reads) * 100

--- a/tests/apps/sequencing_metrics_parser/parsers/conftest.py
+++ b/tests/apps/sequencing_metrics_parser/parsers/conftest.py
@@ -24,8 +24,6 @@ def valid_bcl2fastq_metrics_data() -> Dict:
         "ConversionResults": [
             {
                 "LaneNumber": 1,
-                "TotalClustersRaw": 100,
-                "TotalClustersPF": 100,
                 "Yield": 1000,
                 "DemuxResults": [
                     {
@@ -53,8 +51,6 @@ def valid_bcl2fastq_metrics_data() -> Dict:
 def conversion_result() -> ConversionResult:
     return ConversionResult(
         LaneNumber=1,
-        TotalClustersRaw=100,
-        TotalClustersPF=80,
         Yield=1000,
         DemuxResults=[
             DemuxResult(

--- a/tests/apps/sequencing_metrics_parser/parsers/test_bcl2fastq_to_sequencing_statistics.py
+++ b/tests/apps/sequencing_metrics_parser/parsers/test_bcl2fastq_to_sequencing_statistics.py
@@ -1,6 +1,6 @@
 from cg.apps.sequencing_metrics_parser.parsers.bcl2fastq_to_sequencing_statistics import (
-    calculate_average_quality_score,
-    calculate_q30_ratio,
+    calculate_average_quality_score_for_sample_in_lane,
+    calculate_q30_ratio_for_sample_in_lane,
 )
 from cg.apps.sequencing_metrics_parser.models.bcl2fastq_metrics import ConversionResult, DemuxResult
 
@@ -13,7 +13,7 @@ def test_calculate_average_quality_score(conversion_result: ConversionResult):
         read.yield_ = 100
 
     # WHEN calculating the average quality score
-    average_quality_score: float = calculate_average_quality_score(
+    average_quality_score: float = calculate_average_quality_score_for_sample_in_lane(
         demux_result=conversion_result.demux_results[0]
     )
 
@@ -30,7 +30,9 @@ def test_calculate_q30_ratio(conversion_result: ConversionResult):
         read.yield_ = 100
 
     # WHEN calculating the q30 ratio
-    q30_ratio: float = calculate_q30_ratio(demux_result=conversion_result.demux_results[0])
+    q30_ratio: float = calculate_q30_ratio_for_sample_in_lane(
+        demux_result=conversion_result.demux_results[0]
+    )
 
     # THEN the q30 ratio should be the sum of the q30 bases for all reads in the sample
     # divided by the total yield for the sample

--- a/tests/apps/sequencing_metrics_parser/parsers/test_bcl2fastq_to_sequencing_statistics.py
+++ b/tests/apps/sequencing_metrics_parser/parsers/test_bcl2fastq_to_sequencing_statistics.py
@@ -1,42 +1,8 @@
 from cg.apps.sequencing_metrics_parser.parsers.bcl2fastq_to_sequencing_statistics import (
     calculate_average_quality_score,
-    calculate_pass_filter_ratio,
-    calculate_perfect_reads_ratio,
     calculate_q30_ratio,
-    calculate_yield_in_megabases,
 )
 from cg.apps.sequencing_metrics_parser.models.bcl2fastq_metrics import ConversionResult, DemuxResult
-
-
-def test_calculate_pass_ratio_from_conversion_result(
-    conversion_result: ConversionResult,
-):
-    """Test calculating the pass filter ratio from a conversion result."""
-    # GIVEN a conversion result with valid total clusters
-
-    # WHEN calculating the pass filter ratio
-    pass_filter_ratio: float = calculate_pass_filter_ratio(conversion_result=conversion_result)
-
-    # THEN the pass filter ratio should be the the clusters passing the filter divided by the total clusters
-    correct_filter_ratio: float = (
-        conversion_result.total_clusters_pf / conversion_result.total_clusters_raw
-    )
-
-    assert pass_filter_ratio == correct_filter_ratio
-
-
-def test_calculate_yield_in_megabases_from_conversion_result(conversion_result: ConversionResult):
-    """Test calculating the yield in megabases from a conversion result."""
-    # GIVEN a conversion result with a known yield
-    YIELD_IN_BASES = 1_000_000
-    for demux_result in conversion_result.demux_results:
-        demux_result.yield_ = YIELD_IN_BASES
-
-    # WHEN calculating the yield in megabases
-    yield_in_megabases: float = calculate_yield_in_megabases(conversion_result=conversion_result)
-
-    # THEN the yield in megabases should be the sum of the yields for all samples in the lane divided by 1 million
-    assert yield_in_megabases == len(conversion_result.demux_results)
 
 
 def test_calculate_average_quality_score(conversion_result: ConversionResult):
@@ -69,22 +35,3 @@ def test_calculate_q30_ratio(conversion_result: ConversionResult):
     # THEN the q30 ratio should be the sum of the q30 bases for all reads in the sample
     # divided by the total yield for the sample
     assert q30_ratio == 1.0
-
-
-def test_calculate_perfect_reads_ratio(conversion_result: ConversionResult):
-    """Test calculating the perfect reads ratio from a conversion result."""
-    # GIVEN a conversion result with a known perfect reads ratio
-    sample_demux_result: DemuxResult = conversion_result.demux_results[0]
-
-    total_perfect_reads: int = 0
-    for index_metric in sample_demux_result.index_metrics:
-        total_perfect_reads += index_metric.mismatch_counts["0"]
-
-    perfect_reads_ratio: float = total_perfect_reads / sample_demux_result.number_reads * 100
-
-    # WHEN calculating the perfect reads ratio for the sample
-    ratio: float = calculate_perfect_reads_ratio(demux_result=sample_demux_result)
-
-    # THEN the perfect reads ratio should be the number of reads with 0 mismatches divided by the total number of reads
-    # for the sample
-    assert ratio == perfect_reads_ratio

--- a/tests/apps/sequencing_metrics_parser/test_sequencing_metrics_calculator.py
+++ b/tests/apps/sequencing_metrics_parser/test_sequencing_metrics_calculator.py
@@ -1,68 +1,7 @@
 from cg.apps.sequencing_metrics_parser.sequencing_metrics_calculator import (
     q30_ratio,
     average_quality_score,
-    yield_in_megabases,
-    pass_filter_ratio,
-    perfect_reads_ratio,
-    average_clusters_per_lane,
 )
-
-
-def test_calculate_yield_in_megabases():
-    """Test calculating the yield in megabases."""
-    # GIVEN a number of bases
-    total_bases: int = 5_000_000
-
-    # WHEN calculating the yield in megabases
-    yield_metric: int = yield_in_megabases(total_bases=total_bases)
-
-    # THEN the yield in megabases should be the number of bases divided by 1 million
-    assert yield_metric == 5
-
-
-def test_calculate_valid_pass_filter_ratio():
-    """Test calculating the pass filter ratio."""
-    # GIVEN a number of clusters passing the filter and a total number of clusters
-    clusters_passed: int = 100
-    total_clusters: int = 200
-
-    # WHEN calculating the pass filter ratio
-    passed_filter_percent: float = pass_filter_ratio(
-        clusters_passed=clusters_passed, total_clusters=total_clusters
-    )
-
-    # THEN the pass filter ratio should be the the clusters passing the filter divided by the total clusters
-    assert passed_filter_percent == 0.5
-
-
-def test_calculate_pass_filter_ratio_when_total_clusters_zero():
-    """Test calculating the pass filter ratio when the total clusters is zero."""
-    # GIVEN a number of clusters passing the filter and a total number of clusters
-    clusters_passed: int = 100
-    total_clusters: int = 0
-
-    # WHEN calculating the pass filter ratio
-    passed_filter_percent: float = pass_filter_ratio(
-        clusters_passed=clusters_passed, total_clusters=total_clusters
-    )
-
-    # THEN the pass filter ratio should be zero
-    assert passed_filter_percent == 0
-
-
-def test_average_clusters_per_lane():
-    """Test calculating the average clusters per lane."""
-    # GIVEN a total number of clusters and a number of lanes
-    total_clusters: int = 100
-    lane_count: int = 10
-
-    # WHEN calculating the average clusters per lane
-    avg_clusters_per_lane: float = average_clusters_per_lane(
-        total_clusters=total_clusters, lane_count=lane_count
-    )
-
-    # THEN the average clusters per lane should be the total clusters divided by the number of lanes
-    assert avg_clusters_per_lane == total_clusters / lane_count
 
 
 def test_calculate_bases_with_q30_ratio():
@@ -91,16 +30,3 @@ def test_calculate_lane_mean_quality_score():
 
     # THEN the average quality score should be the total quality score divided by the total yield
     assert avg_quality_score == total_quality_score / total_yield
-
-
-def test_calculate_perfect_index_reads_ratio():
-    """Test calculating the perfect index reads ratio."""
-    # GIVEN a number of perfect reads and a total number of reads
-    perfect_reads: int = 100
-    total_reads: int = 200
-
-    # WHEN calculating the perfect index reads ratio
-    perfect_ratio: float = perfect_reads_ratio(perfect_reads=perfect_reads, total_reads=total_reads)
-
-    # THEN the perfect index reads ratio should be the number of perfect reads divided by the total number of reads
-    assert perfect_ratio == perfect_reads / total_reads * 100


### PR DESCRIPTION
## Description
This PR updates the population of the SampleLaneSequencingMetrics model to only include the required fields and removes logic that is now unnecessary for parsing bcl2fastq data and calculating metrics.

### Fixed
- Population of `SampleLaneSequencingMetrics` from bcl2fastq data.
