### PR TITLE
Fix SampleLaneSequencingMetrics view

### DIFF
--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -536,11 +536,10 @@ class UserView(BaseView):
     edit_modal = True
 
 
-class SequencingStatisticsView(BaseView):
-    """Admin view for the Model.SequencingStats."""
+class SampleLaneSequencingMetricsView(BaseView):
+    """Admin view for the Model.SampleLaneSequencingMetrics."""
 
     column_filters = ["sample_internal_id", "flow_cell_name"]
     column_searchable_list = ["sample_internal_id", "flow_cell_name"]
-    column_editable_list = ["read_counts"]
     create_modal = True
     edit_modal = True

--- a/cg/server/app.py
+++ b/cg/server/app.py
@@ -109,7 +109,9 @@ def _register_admin_views():
     ext.admin.add_view(admin.OrganismView(Organism, ext.db.session))
     ext.admin.add_view(admin.PanelView(Panel, ext.db.session))
     ext.admin.add_view(admin.UserView(User, ext.db.session))
-    ext.admin.add_view(admin.SequencingStatisticsView(SampleLaneSequencingMetrics, ext.db.session))
+    ext.admin.add_view(
+        admin.SampleLaneSequencingMetricsView(SampleLaneSequencingMetrics, ext.db.session)
+    )
 
     # Business data views
     ext.admin.add_view(admin.FamilyView(Family, ext.db.session))


### PR DESCRIPTION
## Description
This PR fixes an error due to trying to access a non existing field on the SampleLaneSequencingMetrics model.

### Fixed
- Invalid attribute access on the ` SampleLaneSequencingMetrics` model


### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions