### PR TITLE
Change read count type on statistics model

### DIFF
--- a/alembic/versions/e6a3f1ad4b50_change_read_count_to_bigint.py
+++ b/alembic/versions/e6a3f1ad4b50_change_read_count_to_bigint.py
@@ -1,0 +1,26 @@
+"""Change read count to BigInt
+
+Revision ID: e6a3f1ad4b50
+Revises: f5e0db62a5a7
+Create Date: 2023-06-01 16:48:37.134267
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+# revision identifiers, used by Alembic.
+revision = 'e6a3f1ad4b50'
+down_revision = 'f5e0db62a5a7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Alter the column to use BigInteger
+    op.alter_column('sample_lane_sequencing_metrics', 'sample_total_reads_in_lane', type_=sa.BigInteger)
+
+
+def downgrade():
+    # Alter the column to use Integer
+    op.alter_column('sample_lane_sequencing_metrics', 'sample_total_reads_in_lane', type_=sa.Integer)

--- a/alembic/versions/e6a3f1ad4b50_change_read_count_to_bigint.py
+++ b/alembic/versions/e6a3f1ad4b50_change_read_count_to_bigint.py
@@ -10,17 +10,21 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import mysql
 
 # revision identifiers, used by Alembic.
-revision = 'e6a3f1ad4b50'
-down_revision = 'f5e0db62a5a7'
+revision = "e6a3f1ad4b50"
+down_revision = "f5e0db62a5a7"
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
     # Alter the column to use BigInteger
-    op.alter_column('sample_lane_sequencing_metrics', 'sample_total_reads_in_lane', type_=sa.BigInteger)
+    op.alter_column(
+        "sample_lane_sequencing_metrics", "sample_total_reads_in_lane", type_=sa.BigInteger
+    )
 
 
 def downgrade():
     # Alter the column to use Integer
-    op.alter_column('sample_lane_sequencing_metrics', 'sample_total_reads_in_lane', type_=sa.Integer)
+    op.alter_column(
+        "sample_lane_sequencing_metrics", "sample_total_reads_in_lane", type_=sa.Integer
+    )

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -770,7 +770,7 @@ class SampleLaneSequencingMetrics(Model):
     flow_cell_lane_number = Column(types.Integer)
 
     sample_internal_id = Column(types.String(128), nullable=False)
-    sample_total_reads_in_lane = Column(types.Integer)
+    sample_total_reads_in_lane = Column(types.BigInteger)
     sample_base_fraction_passing_q30 = Column(types.Numeric(10, 5))
     sample_base_mean_quality_score = Column(types.Numeric(10, 5))
 


### PR DESCRIPTION
## Description
This PR fixes an issue discovered with the statistics table discovered when populating it with old data. Some of the read counts exceed the upper bound of an Integer (`2147483647`) in Python. Does it make sense to have read counts bigger than this? Maybe the issue is not with the model but with invalid data.

### Fixed
- Type of the `sample_total_reads_in_lane` to BigInteger

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
