### PR TITLE
Fix precision for sequencing metrics

### DIFF
--- a/alembic/versions/367ed257e4ee_change_data_type_of_metrics.py
+++ b/alembic/versions/367ed257e4ee_change_data_type_of_metrics.py
@@ -7,7 +7,6 @@ Create Date: 2023-06-02 16:10:19.975435
 """
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.dialects import mysql
 
 # revision identifiers, used by Alembic.
 revision = "367ed257e4ee"
@@ -20,13 +19,13 @@ def upgrade():
     op.alter_column(
         "sample_lane_sequencing_metrics",
         "sample_base_fraction_passing_q30",
-        type_=sa.Numeric(precision=5, scale=2),
+        type_=sa.Numeric(precision=6, scale=2),
         existing_type=sa.Numeric(precision=10, scale=5),
     )
     op.alter_column(
         "sample_lane_sequencing_metrics",
         "sample_base_mean_quality_score",
-        type_=sa.Numeric(precision=5, scale=2),
+        type_=sa.Numeric(precision=6, scale=2),
         existing_type=sa.Numeric(precision=10, scale=5),
     )
 

--- a/alembic/versions/367ed257e4ee_change_data_type_of_metrics.py
+++ b/alembic/versions/367ed257e4ee_change_data_type_of_metrics.py
@@ -1,4 +1,4 @@
-"""Change data type of metrics
+"""Change precision for sequencing metrics
 
 Revision ID: 367ed257e4ee
 Revises: 869d352cc614

--- a/alembic/versions/367ed257e4ee_change_data_type_of_metrics.py
+++ b/alembic/versions/367ed257e4ee_change_data_type_of_metrics.py
@@ -1,0 +1,46 @@
+"""Change data type of metrics
+
+Revision ID: 367ed257e4ee
+Revises: 869d352cc614
+Create Date: 2023-06-02 16:10:19.975435
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+# revision identifiers, used by Alembic.
+revision = "367ed257e4ee"
+down_revision = "869d352cc614"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        "sample_lane_sequencing_metrics",
+        "sample_base_fraction_passing_q30",
+        type_=sa.Numeric(precision=5, scale=2),
+        existing_type=sa.Numeric(precision=10, scale=5),
+    )
+    op.alter_column(
+        "sample_lane_sequencing_metrics",
+        "sample_base_mean_quality_score",
+        type_=sa.Numeric(precision=5, scale=2),
+        existing_type=sa.Numeric(precision=10, scale=5),
+    )
+
+
+def downgrade():
+    op.alter_column(
+        "sample_lane_sequencing_metrics",
+        "sample_base_mean_quality_score",
+        type_=sa.Numeric(precision=10, scale=5),
+        existing_type=sa.Numeric(precision=5, scale=2),
+    )
+    op.alter_column(
+        "sample_lane_sequencing_metrics",
+        "sample_base_fraction_passing_q30",
+        type_=sa.Numeric(precision=10, scale=5),
+        existing_type=sa.Numeric(precision=5, scale=2),
+    )

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -774,8 +774,8 @@ class SampleLaneSequencingMetrics(Model):
 
     sample_internal_id = Column(types.String(32), ForeignKey("sample.internal_id"), nullable=False)
     sample_total_reads_in_lane = Column(types.BigInteger)
-    sample_base_fraction_passing_q30 = Column(types.Numeric(10, 5))
-    sample_base_mean_quality_score = Column(types.Numeric(10, 5))
+    sample_base_fraction_passing_q30 = Column(types.Numeric(5, 2))
+    sample_base_mean_quality_score = Column(types.Numeric(5, 2))
 
     created_at = Column(types.DateTime)
 

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -774,8 +774,8 @@ class SampleLaneSequencingMetrics(Model):
 
     sample_internal_id = Column(types.String(32), ForeignKey("sample.internal_id"), nullable=False)
     sample_total_reads_in_lane = Column(types.BigInteger)
-    sample_base_fraction_passing_q30 = Column(types.Numeric(5, 2))
-    sample_base_mean_quality_score = Column(types.Numeric(5, 2))
+    sample_base_fraction_passing_q30 = Column(types.Numeric(6, 2))
+    sample_base_mean_quality_score = Column(types.Numeric(6, 2))
 
     created_at = Column(types.DateTime)
 


### PR DESCRIPTION
## Description
This PR changes the precision used for the calculated metrics stored in the sequencing metrics table.

### Fixed
- Adjust precision for calculated metrics in the `SampleLaneSequencingMetrics` table.


### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
