### PR TITLE
Fix csv printing in sample sheet create-all command

### DIFF
--- a/cg/cli/demultiplex/sample_sheet.py
+++ b/cg/cli/demultiplex/sample_sheet.py
@@ -148,8 +148,10 @@ def create_all_sheets(context: CGConfig, bcl_converter: str, dry_run: bool):
             continue
 
         if dry_run:
-            WriteStream.write_stream_from_content(
-                file_format=FileFormat.CSV, content=sample_sheet_content
+            click.echo(
+                WriteStream.write_stream_from_content(
+                    file_format=FileFormat.CSV, content=sample_sheet_content
+                )
             )
             return
         LOG.info(f"Writing sample sheet to {flow_cell.sample_sheet_path.resolve()}")

--- a/cg/cli/demultiplex/sample_sheet.py
+++ b/cg/cli/demultiplex/sample_sheet.py
@@ -148,7 +148,9 @@ def create_all_sheets(context: CGConfig, bcl_converter: str, dry_run: bool):
             continue
 
         if dry_run:
-            click.echo(sample_sheet_content)
+            WriteStream.write_stream_from_content(
+                file_format=FileFormat.CSV, content=sample_sheet_content
+            )
             return
         LOG.info(f"Writing sample sheet to {flow_cell.sample_sheet_path.resolve()}")
         WriteFile.write_file_from_content(

--- a/cg/cli/demultiplex/sample_sheet.py
+++ b/cg/cli/demultiplex/sample_sheet.py
@@ -153,7 +153,7 @@ def create_all_sheets(context: CGConfig, bcl_converter: str, dry_run: bool):
                     file_format=FileFormat.CSV, content=sample_sheet_content
                 )
             )
-            return
+            continue
         LOG.info(f"Writing sample sheet to {flow_cell.sample_sheet_path.resolve()}")
         WriteFile.write_file_from_content(
             content=sample_sheet_content,


### PR DESCRIPTION
## Description

When using samplesheet create-all with dry run active, the csv files are printed incorrectly. They are printed as nested lists instead of as csv files. This pr converts the nested list to a csv stream when printing, correcting the issue.

### Fixed

- Nested list "sample_sheet_content" is now converted to a csv stream before issuing Click.echo in the samplesheet create-all CLI command.


### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b fix-csv-print-samplesheet-create-all -a
    ```

### How to test

- [x] Run a samplesheet create-all command with dry run active.

### Expected test outcome

- [x] Check that the printed sample sheet looks as expected.
- [x] Take a screenshot and attach or copy/paste the output.

## Review

- [x] Tests executed by SD
- [x] "Merge and deploy" approved by SD
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
