### PR TITLE
Remove flow cell name and directory as attributes

### DIFF
--- a/cg/cli/demultiplex/finish.py
+++ b/cg/cli/demultiplex/finish.py
@@ -60,10 +60,8 @@ def finish_flow_cell(
 @click.argument("flow-cell-name")
 @click.pass_obj
 def store_sequencing_metrics(context: CGConfig, flow_cell_name: str):
-    demux_post_processing_api: DemuxPostProcessingAPI = DemuxPostProcessingAPI(
-        config=context, flow_cell_name=flow_cell_name
-    )
-    demux_post_processing_api.finish_flow_cell_temp()
+    demux_post_processing_api: DemuxPostProcessingAPI = DemuxPostProcessingAPI(config=context)
+    demux_post_processing_api.finish_flow_cell_temp(flow_cell_name=flow_cell_name)
 
 
 @finish_group.command(name="all-hiseq-x")

--- a/tests/meta/demultiplex/test_demux_post_processing.py
+++ b/tests/meta/demultiplex/test_demux_post_processing.py
@@ -490,10 +490,12 @@ def test_is_bcl2fastq_folder_structure(
     """Test is_bcl2fastq_demux_folder_structure with a folder structure that follows the bcl2fastq folder structure."""
     # GIVEN a bcl2fastq folder structure
     demux_post_processing_api = DemuxPostProcessingAPI(demultiplex_context)
-    demux_post_processing_api.flow_cell_dir = bcl2fastq_folder_structure
+    demux_post_processing_api.demux_api.out_dir = bcl2fastq_folder_structure
 
     # WHEN checking if it is a bcl2fastq folder structure
-    is_bcl2fastq_folder_structure = demux_post_processing_api.is_bcl2fastq_demux_folder_structure()
+    is_bcl2fastq_folder_structure = demux_post_processing_api.is_bcl2fastq_demux_folder_structure(
+        flow_cell_name=""
+    )
 
     # THEN it should be a bcl2fastq folder structure
     assert is_bcl2fastq_folder_structure is True
@@ -509,7 +511,9 @@ def test_is_not_bcl2fastq_folder_structure(
     demux_post_processing_api.flow_cell_dir = not_bcl2fastq_folder_structure
 
     # WHEN checking if it is a bcl2fastq folder structure
-    is_bcl2fastq_folder_structure = demux_post_processing_api.is_bcl2fastq_demux_folder_structure()
+    is_bcl2fastq_folder_structure = demux_post_processing_api.is_bcl2fastq_demux_folder_structure(
+        flow_cell_name=""
+    )
 
     # THEN it should not be a bcl2fastq folder structure
     assert is_bcl2fastq_folder_structure is False


### PR DESCRIPTION
## Description
Since the DemuxPostProcessingApi contains methods like `finish_all_flow_cells`, it does not really make sense to store the flow cell name and directory as attributes. The class does not only process a single flow cell directory, it also contains logic for finishing all flow cells.

### Fixed
- Remove flow cell name and directory as attributes from the DemuxPostProcessingApi 

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
