### PR TITLE
Remove bcl argument

### DIFF
--- a/cg/cli/demultiplex/finish.py
+++ b/cg/cli/demultiplex/finish.py
@@ -35,13 +35,10 @@ def finish_all_cmd(context: CGConfig, bcl_converter: str, dry_run: bool) -> None
 
 @finish_group.command(name="flow-cell")
 @click.argument("flow-cell-name")
-@OPTION_BCL_CONVERTER
 @DRY_RUN
 @click.option("--force", is_flag=True)
 @click.pass_obj
-def finish_flow_cell(
-    context: CGConfig, flow_cell_name: str, bcl_converter: str, dry_run: bool, force: bool
-) -> None:
+def finish_flow_cell(context: CGConfig, flow_cell_name: str, dry_run: bool, force: bool) -> None:
     """Command to finish up a flow cell after demultiplexing.
 
     flow-cell-name is full flow cell name, e.g. '201203_A00689_0200_AHVKJCDRXX'.
@@ -51,9 +48,7 @@ def finish_flow_cell(
         config=context
     )
     demux_post_processing_api.set_dry_run(dry_run)
-    demux_post_processing_api.finish_flow_cell(
-        flow_cell_name=flow_cell_name, force=force, bcl_converter=bcl_converter
-    )
+    demux_post_processing_api.finish_flow_cell(flow_cell_name=flow_cell_name, force=force)
 
 
 @finish_group.command(name="temporary")

--- a/cg/cli/demultiplex/finish.py
+++ b/cg/cli/demultiplex/finish.py
@@ -4,7 +4,6 @@ import logging
 import click
 
 from cg.constants.constants import DRY_RUN
-from cg.constants.demultiplexing import OPTION_BCL_CONVERTER, BclConverter
 from cg.meta.demultiplex.demux_post_processing import (
     DemuxPostProcessingAPI,
     DemuxPostProcessingNovaseqAPI,
@@ -21,16 +20,15 @@ def finish_group():
 
 
 @finish_group.command(name="all")
-@OPTION_BCL_CONVERTER
 @DRY_RUN
 @click.pass_obj
-def finish_all_cmd(context: CGConfig, bcl_converter: str, dry_run: bool) -> None:
+def finish_all_cmd(context: CGConfig, dry_run: bool) -> None:
     """Command to post-process all demultiplexed flow cells."""
     demux_post_processing_api: DemuxPostProcessingNovaseqAPI = DemuxPostProcessingNovaseqAPI(
         config=context
     )
     demux_post_processing_api.set_dry_run(dry_run=dry_run)
-    demux_post_processing_api.finish_all_flow_cells(bcl_converter=bcl_converter)
+    demux_post_processing_api.finish_all_flow_cells()
 
 
 @finish_group.command(name="flow-cell")
@@ -69,4 +67,4 @@ def finish_all_hiseq_x(context: CGConfig, dry_run: bool) -> None:
         config=context
     )
     demux_post_processing_api.set_dry_run(dry_run=dry_run)
-    demux_post_processing_api.finish_all_flow_cells(bcl_converter=BclConverter.BCL2FASTQ.value)
+    demux_post_processing_api.finish_all_flow_cells()

--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -188,9 +188,11 @@ class DemuxPostProcessingHiseqXAPI(DemuxPostProcessingAPI):
         )
 
     def finish_flow_cell(
-        self, bcl_converter: str, flow_cell_name: str, flow_cell_path: Path
+        self, flow_cell_name: str, flow_cell_path: Path
     ) -> None:
         """Post-processing flow cell."""
+        bcl_converter: str = self.get_bcl_converter(flow_cell_name=flow_cell_name)
+
         LOG.info(f"Check demultiplexed flow cell {flow_cell_name}")
         try:
             flow_cell: FlowCell = FlowCell(
@@ -219,7 +221,6 @@ class DemuxPostProcessingHiseqXAPI(DemuxPostProcessingAPI):
         """Loop over all flow cells and post process those that need it."""
         for flow_cell_dir in self.demux_api.get_all_demultiplexed_flow_cell_dirs():
             self.finish_flow_cell(
-                bcl_converter=bcl_converter,
                 flow_cell_name=flow_cell_dir.name,
                 flow_cell_path=flow_cell_dir,
             )
@@ -356,12 +357,14 @@ class DemuxPostProcessingNovaseqAPI(DemuxPostProcessingAPI):
         )
 
     def finish_flow_cell(
-        self, flow_cell_name: str, bcl_converter: str, force: bool = False
+        self, flow_cell_name: str, force: bool = False
     ) -> None:
         """Go through the post-processing steps for a flow cell.
 
         Force is used to finish a flow cell even if the files are renamed already.
         """
+        bcl_converter: str = self.get_bcl_converter(flow_cell_name=flow_cell_name)
+
         LOG.info(
             f"Check demuxed flow cell {flow_cell_name}",
         )
@@ -395,4 +398,4 @@ class DemuxPostProcessingNovaseqAPI(DemuxPostProcessingAPI):
     def finish_all_flow_cells(self, bcl_converter: str) -> None:
         """Loop over all flow cells and post-process those that need it."""
         for flow_cell_dir in self.demux_api.get_all_demultiplexed_flow_cell_dirs():
-            self.finish_flow_cell(flow_cell_name=flow_cell_dir.name, bcl_converter=bcl_converter)
+            self.finish_flow_cell(flow_cell_name=flow_cell_dir.name)

--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -1,6 +1,5 @@
 """Post-processing Demultiiplex API."""
 import logging
-import os
 import shutil
 import re
 from contextlib import redirect_stdout

--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -187,9 +187,7 @@ class DemuxPostProcessingHiseqXAPI(DemuxPostProcessingAPI):
             flow_cell_dir=demux_results.flow_cell.path, flow_cell_id=demux_results.flow_cell.id
         )
 
-    def finish_flow_cell(
-        self, flow_cell_name: str, flow_cell_path: Path
-    ) -> None:
+    def finish_flow_cell(self, flow_cell_name: str, flow_cell_path: Path) -> None:
         """Post-processing flow cell."""
         bcl_converter: str = self.get_bcl_converter(flow_cell_name=flow_cell_name)
 
@@ -356,9 +354,7 @@ class DemuxPostProcessingNovaseqAPI(DemuxPostProcessingAPI):
             flow_cell_dir=demux_results.flow_cell.path, flow_cell_id=demux_results.flow_cell.id
         )
 
-    def finish_flow_cell(
-        self, flow_cell_name: str, force: bool = False
-    ) -> None:
+    def finish_flow_cell(self, flow_cell_name: str, force: bool = False) -> None:
         """Go through the post-processing steps for a flow cell.
 
         Force is used to finish a flow cell even if the files are renamed already.

--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -217,7 +217,7 @@ class DemuxPostProcessingHiseqXAPI(DemuxPostProcessingAPI):
         LOG.info(f"{flow_cell_name} copy is complete and delivery will start")
         self.post_process_flow_cell(demux_results=demux_results)
 
-    def finish_all_flow_cells(self, bcl_converter: str) -> None:
+    def finish_all_flow_cells(self) -> None:
         """Loop over all flow cells and post process those that need it."""
         for flow_cell_dir in self.demux_api.get_all_demultiplexed_flow_cell_dirs():
             self.finish_flow_cell(
@@ -395,7 +395,7 @@ class DemuxPostProcessingNovaseqAPI(DemuxPostProcessingAPI):
             LOG.info("Post processing flow cell anyway")
         self.post_process_flow_cell(demux_results=demux_results)
 
-    def finish_all_flow_cells(self, bcl_converter: str) -> None:
+    def finish_all_flow_cells(self) -> None:
         """Loop over all flow cells and post-process those that need it."""
         for flow_cell_dir in self.demux_api.get_all_demultiplexed_flow_cell_dirs():
             self.finish_flow_cell(flow_cell_name=flow_cell_dir.name)

--- a/tests/meta/demultiplex/test_demux_post_processing.py
+++ b/tests/meta/demultiplex/test_demux_post_processing.py
@@ -468,9 +468,7 @@ def test_finish_all_flowcells(
     hiseq_x_copy_complete_file.unlink()
 
     # When post-processing flow cell
-    post_demux_api.finish_all_flow_cells(
-        bcl_converter=BclConverter.BCL2FASTQ,
-    )
+    post_demux_api.finish_all_flow_cells()
 
     # Reinstate
     hiseq_x_copy_complete_file.touch()

--- a/tests/meta/demultiplex/test_demux_post_processing.py
+++ b/tests/meta/demultiplex/test_demux_post_processing.py
@@ -212,7 +212,6 @@ def test_finish_flow_cell_copy_not_completed(
 
     # WHEN finishing flow cell
     post_demux_api.finish_flow_cell(
-        bcl_converter=BclConverter.BCL2FASTQ,
         flow_cell_name=bcl2fastq_flow_cell.full_name,
         flow_cell_path=bcl2fastq_flow_cell.path,
     )
@@ -244,7 +243,6 @@ def test_finish_flow_cell_delivery_started(
 
     # WHEN finishing flow cell
     post_demux_api.finish_flow_cell(
-        bcl_converter=BclConverter.BCL2FASTQ,
         flow_cell_name=bcl2fastq_flow_cell.full_name,
         flow_cell_path=bcl2fastq_flow_cell.path,
     )
@@ -280,7 +278,6 @@ def test_finish_flow_cell_delivery_not_hiseq_x(
 
     # WHEN finishing flow cell
     post_demux_api.finish_flow_cell(
-        bcl_converter=BclConverter.BCL2FASTQ,
         flow_cell_name=bcl2fastq_flow_cell.full_name,
         flow_cell_path=bcl2fastq_flow_cell.path,
     )
@@ -322,7 +319,6 @@ def test_finish_flow_cell_ready(
 
     # WHEN finishing flow cell
     post_demux_api.finish_flow_cell(
-        bcl_converter=BclConverter.BCL2FASTQ,
         flow_cell_name=bcl2fastq_flow_cell.full_name,
         flow_cell_path=bcl2fastq_flow_cell.path,
     )
@@ -441,7 +437,6 @@ def test_finish_flow_cell(
 
     # When post-processing flow cell
     post_demux_api.finish_flow_cell(
-        bcl_converter=BclConverter.BCL2FASTQ,
         flow_cell_name=bcl2fastq_flow_cell.full_name,
         flow_cell_path=bcl2fastq_flow_cell.path,
     )


### PR DESCRIPTION
## Description
This PR removes the `BCL_CONVERT` option from the `cg demultiplex finish` commands and from different functions. The type of demultiplexing software used is determined by the directory structure using the `get_bcl_conversion_type` function.

### Changed
- Removed `--bcl-converter` argument from `cg demultiplex finish` commands
- Determine conversion software used by directory structure

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
