### PR TITLE
Fix - allow forced restart and check related DNA case completion in MIP-RNA upload

### DIFF
--- a/cg/cli/upload/scout.py
+++ b/cg/cli/upload/scout.py
@@ -4,17 +4,15 @@ from pathlib import Path
 from typing import Dict, Optional
 
 import click
-from housekeeper.store.models import File, Version
-
 from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.apps.scout.scoutapi import ScoutAPI
-from cg.constants.scout_upload import ScoutCustomCaseReportTags
 from cg.cli.upload.utils import suggest_cases_to_upload
 from cg.constants import Pipeline
 from cg.constants.constants import FileFormat
+from cg.constants.scout_upload import ScoutCustomCaseReportTags
 from cg.io.controller import WriteStream
-from cg.meta.upload.upload_api import UploadAPI
 from cg.meta.upload.scout.uploadscoutapi import UploadScoutAPI
+from cg.meta.upload.upload_api import UploadAPI
 from cg.meta.workflow.balsamic import BalsamicAnalysisAPI
 from cg.meta.workflow.balsamic_umi import BalsamicUmiAnalysisAPI
 from cg.meta.workflow.mip_dna import MipDNAAnalysisAPI
@@ -24,7 +22,7 @@ from cg.models.cg_config import CGConfig
 from cg.models.scout.scout_load_config import ScoutLoadConfig
 from cg.store import Store
 from cg.store.models import Family
-
+from housekeeper.store.models import File, Version
 
 LOG = logging.getLogger(__name__)
 

--- a/cg/meta/upload/upload_api.py
+++ b/cg/meta/upload/upload_api.py
@@ -1,16 +1,15 @@
 """Upload API"""
 
-import click
 import logging
 from datetime import datetime, timedelta
 
-from cg.exc import AnalysisUploadError, AnalysisAlreadyUploadedError
-from cg.meta.workflow.analysis import AnalysisAPI
-from cg.meta.upload.scout.uploadscoutapi import UploadScoutAPI
-from cg.models.cg_config import CGConfig
+import click
+from cg.exc import AnalysisAlreadyUploadedError, AnalysisUploadError
 from cg.meta.meta import MetaAPI
+from cg.meta.upload.scout.uploadscoutapi import UploadScoutAPI
+from cg.meta.workflow.analysis import AnalysisAPI
+from cg.models.cg_config import CGConfig
 from cg.store.models import Analysis, Family
-
 
 LOG = logging.getLogger(__name__)
 
@@ -63,18 +62,23 @@ class UploadAPI(MetaAPI):
             LOG.error(f"There is no analysis for case: {case_obj.internal_id}")
             raise AnalysisUploadError
 
-        analysis_obj: Analysis = case_obj.analyses[0]
-        if analysis_obj.uploaded_at is not None:
-            LOG.error(f"The analysis has been already uploaded: {analysis_obj.uploaded_at.date()}")
-            raise AnalysisAlreadyUploadedError
+        if not restart:
+            analysis_obj: Analysis = case_obj.analyses[0]
 
-        if not restart and analysis_obj.upload_started_at is not None:
-            if datetime.now() - analysis_obj.upload_started_at > timedelta(hours=24):
+            if analysis_obj.uploaded_at is not None:
                 LOG.error(
-                    f"This upload has already started at {analysis_obj.upload_started_at}, but something went wrong. "
-                    f"Restart it with the --restart flag."
+                    f"The analysis has been already uploaded: {analysis_obj.uploaded_at.date()}"
                 )
-                raise AnalysisUploadError
+                raise AnalysisAlreadyUploadedError
+            elif analysis_obj.upload_started_at is not None:
+                if datetime.now() - analysis_obj.upload_started_at > timedelta(hours=24):
+                    LOG.error(
+                        f"This upload has already started at {analysis_obj.upload_started_at}, but something went wrong. "
+                        f"Restart it with the --restart flag."
+                    )
+                    raise AnalysisUploadError
 
-            LOG.warning(f"The upload has already started: {analysis_obj.upload_started_at.time()}")
-            raise AnalysisAlreadyUploadedError
+                LOG.warning(
+                    f"The upload has already started: {analysis_obj.upload_started_at.time()}"
+                )
+                raise AnalysisAlreadyUploadedError

--- a/cg/store/filters/status_sample_filters.py
+++ b/cg/store/filters/status_sample_filters.py
@@ -1,10 +1,10 @@
-from typing import Optional, List, Callable, Any
 from enum import Enum
-from sqlalchemy.orm import Query
-from sqlalchemy import or_
+from typing import Any, Callable, List, Optional
 
 from cg.constants.constants import SampleType
-from cg.store.models import Sample, Customer
+from cg.store.models import Customer, Sample
+from sqlalchemy import or_
+from sqlalchemy.orm import Query
 
 
 def filter_samples_by_internal_id(internal_id: str, samples: Query, **kwargs) -> Query:
@@ -200,30 +200,26 @@ def apply_sample_filter(
 class SampleFilter(Enum):
     """Define Sample filter functions."""
 
-    FILTER_BY_INTERNAL_ID: Callable = filter_samples_by_internal_id
-    FILTER_WITH_TYPE: Callable = filter_samples_with_type
-    FILTER_WITH_LOQUSDB_ID: Callable = filter_samples_with_loqusdb_id
-    FILTER_WITHOUT_LOQUSDB_ID: Callable = filter_samples_without_loqusdb_id
+    FILTER_BY_CUSTOMER: Callable = filter_samples_by_customer
+    FILTER_BY_CUSTOMER_ENTRY_IDS: Callable = filter_samples_by_entry_customer_ids
     FILTER_BY_ENTRY_ID: Callable = filter_samples_by_entry_id
+    FILTER_BY_IDENTIFIER_NAME_AND_VALUE: Callable = filter_samples_by_identifier_name_and_value
+    FILTER_BY_INTERNAL_ID: Callable = filter_samples_by_internal_id
+    FILTER_BY_INTERNAL_ID_OR_NAME_SEARCH: Callable = filter_samples_by_internal_id_or_name_search
+    FILTER_BY_INTERNAL_ID_PATTERN: Callable = filter_samples_by_internal_id_pattern
+    FILTER_BY_INVOICE_ID: Callable = filter_samples_by_invoice_id
+    FILTER_BY_SAMPLE_NAME: Callable = filter_samples_by_name
+    FILTER_BY_SUBJECT_ID: Callable = filter_samples_by_subject_id
+    FILTER_DO_INVOICE: Callable = filter_samples_do_invoice
+    FILTER_HAS_NO_INVOICE_ID: Callable = filter_samples_without_invoice_id
     FILTER_IS_DELIVERED: Callable = filter_samples_is_delivered
     FILTER_IS_NOT_DELIVERED: Callable = filter_samples_is_not_delivered
-    FILTER_BY_INVOICE_ID: Callable = filter_samples_by_invoice_id
-    FILTER_HAS_NO_INVOICE_ID: Callable = filter_samples_without_invoice_id
     FILTER_IS_NOT_DOWN_SAMPLED: Callable = filter_samples_is_not_down_sampled
     FILTER_IS_SEQUENCED: Callable = filter_samples_is_sequenced
     FILTER_IS_NOT_SEQUENCED: Callable = filter_samples_is_not_sequenced
-    FILTER_DO_INVOICE: Callable = filter_samples_do_invoice
-    FILTER_BY_CUSTOMER_ENTRY_IDS: Callable = filter_samples_by_entry_customer_ids
-    FILTER_IS_RECEIVED: Callable = filter_samples_is_received
-    FILTER_IS_NOT_RECEIVED: Callable = filter_samples_is_not_received
-    FILTER_IS_PREPARED: Callable = filter_samples_is_prepared
-    FILTER_IS_NOT_PREPARED: Callable = filter_samples_is_not_prepared
-    FILTER_BY_SAMPLE_NAME: Callable = filter_samples_by_name
-    FILTER_BY_SUBJECT_ID: Callable = filter_samples_by_subject_id
     FILTER_IS_TUMOUR: Callable = filter_samples_is_tumour
     FILTER_IS_NOT_TUMOUR: Callable = filter_samples_is_not_tumour
-    FILTER_BY_INTERNAL_ID_PATTERN: Callable = filter_samples_by_internal_id_pattern
-    FILTER_BY_CUSTOMER: Callable = filter_samples_by_customer
-    FILTER_BY_INTERNAL_ID_OR_NAME_SEARCH: Callable = filter_samples_by_internal_id_or_name_search
-    FILTER_BY_IDENTIFIER_NAME_AND_VALUE: Callable = filter_samples_by_identifier_name_and_value
+    FILTER_WITH_LOQUSDB_ID: Callable = filter_samples_with_loqusdb_id
+    FILTER_WITHOUT_LOQUSDB_ID: Callable = filter_samples_without_loqusdb_id
+    FILTER_WITH_TYPE: Callable = filter_samples_with_type
     ORDER_BY_CREATED_AT_DESC: Callable = order_samples_by_created_at_desc

--- a/tests/meta/upload/scout/conftest.py
+++ b/tests/meta/upload/scout/conftest.py
@@ -6,8 +6,6 @@ from pathlib import Path
 from typing import Dict, Generator, List
 
 import pytest
-from housekeeper.store.models import Version
-
 from cg.constants import DataDelivery, Pipeline
 from cg.constants.constants import FileFormat, PrepCategory
 from cg.constants.sequencing import SequencingMethod
@@ -18,6 +16,7 @@ from cg.meta.upload.scout.uploadscoutapi import UploadScoutAPI
 from cg.models.scout.scout_load_config import MipLoadConfig
 from cg.store import Store
 from cg.store.models import Analysis, Family, Sample
+from housekeeper.store.models import Version
 
 # Mocks
 from tests.mocks.hk_mock import MockHousekeeperAPI
@@ -218,6 +217,8 @@ def fixture_rna_store(
 
     for link in dna_case.links:
         link.sample.internal_id = link.sample.name
+
+    helpers.add_analysis(store=store, case=dna_case, uploaded_at=datetime.now())
 
     store.session.commit()
     return store


### PR DESCRIPTION
## Description

Related to issue 2116. When a MIP-RNA report is uploaded to Scout, a bug can occur wherein the related DNA case has not finished uploading, prompting the RNA report to be uploaded, but incomplete. When running the upload command again with --restart active, the response is given that thte RNA report is already uploaded, despite the uploaded report being erroneous. This PR adds an additional check on the DNA case and allows for a forced restart even for uploaded mip-rna cases.

### Changed

- Restart flag now works for RNA cases with uploaded_at set.
- When uploading an RNA report to a DNA case, a check for uploaded_at being set, is performed.

### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
