### PR TITLE
Fix invalid flow cell name when transferring sequencing data to housekeeper

### DIFF
--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -124,7 +124,7 @@ class DemuxPostProcessingAPI:
 
         # 4. Store flow cell data in housekeeper.
         self.add_flow_cell_data_to_housekeeper(
-            flow_cell_name=flow_cell_name, flow_cell_directory=flow_cell_dir
+            flow_cell_name=parsed_flow_cell.id, flow_cell_directory=flow_cell_dir
         )
 
         # 5. Create sequencing metrics.


### PR DESCRIPTION
## Description
This PR passes the correct flow cell name to the function which transfers the flow cell data to housekeeper.
The current value passed is the entire flow cell run directory name instead of just the flow cell name.

### Fixed
- Pass correct flow cell name when transferring sequencing data to housekeeper


### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
