### PR TITLE
Add creation of delivery.txt

### DIFF
--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -121,7 +121,7 @@ class DemuxPostProcessingAPI:
         self.update_sample_read_counts(sample_internal_ids=flow_cell_sample_ids)
 
         self.create_delivery_file_in_flow_cell_directory(
-            flow_cell_directory=flow_cell_directory_name
+            flow_cell_directory=flow_cell_directory_path
         )
 
     def create_delivery_file_in_flow_cell_directory(self, flow_cell_directory: Path) -> None:

--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -138,7 +138,7 @@ class DemuxPostProcessingAPI:
         self.update_sample_read_counts(sample_internal_ids=sample_ids)
         self.create_delivery_file_in_flow_cell_directory(flow_cell_directory=flow_cell_dir)
 
-    def create_delivery_file_in_flow_cell_directory(flow_cell_directory: Path) -> None:
+    def create_delivery_file_in_flow_cell_directory(self, flow_cell_directory: Path) -> None:
         Path(flow_cell_directory, DemultiplexingDirsAndFiles.DELIVERY).touch()
 
     def get_sample_ids_from_sample_sheet(

--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -136,6 +136,10 @@ class DemuxPostProcessingAPI:
         )
 
         self.update_sample_read_counts(sample_internal_ids=sample_ids)
+        self.create_delivery_file_in_flow_cell_directory(flow_cell_directory=flow_cell_dir)
+
+    def create_delivery_file_in_flow_cell_directory(flow_cell_directory: Path) -> None:
+        Path(flow_cell_directory, DemultiplexingDirsAndFiles.DELIVERY).touch()
 
     def get_sample_ids_from_sample_sheet(
         self, parsed_flow_cell_directory: FlowCellDirectoryData


### PR DESCRIPTION
## Description
This PR adds the creation of the `delivery.txt` file in the demultiplexed flow cell directory in the new `demultiplex finish` command. It seems like this file is necessary for the system d tasks to start delivering the data (?)


### Added
- Creation of `delivery.txt` file in the new `cg demultiplex finish` command

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
