### PR TITLE
Fix fastq files transfer to housekeeper in new demultiplexing finish

### DIFF
--- a/cg/cli/demultiplex/finish.py
+++ b/cg/cli/demultiplex/finish.py
@@ -57,7 +57,7 @@ def finish_flow_cell(
 
 
 @finish_group.command(name="temporary")
-@click.argument("flow-cell-name", "flow_cell_directory_name")
+@click.argument("flow-cell-directory-name")
 @click.pass_obj
 def finish_flow_cell_temporary(context: CGConfig, flow_cell_directory_name: str):
     demux_post_processing_api: DemuxPostProcessingAPI = DemuxPostProcessingAPI(config=context)

--- a/cg/cli/demultiplex/finish.py
+++ b/cg/cli/demultiplex/finish.py
@@ -57,7 +57,7 @@ def finish_flow_cell(
 
 
 @finish_group.command(name="temporary")
-@click.argument("flow-cell-name")
+@click.argument("flow-cell-name", "flow_cell_directory_name")
 @click.pass_obj
 def finish_flow_cell_temporary(context: CGConfig, flow_cell_directory_name: str):
     demux_post_processing_api: DemuxPostProcessingAPI = DemuxPostProcessingAPI(config=context)

--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -224,7 +224,9 @@ class DemuxPostProcessingAPI:
     def get_flowcell_sample_fastq_file_paths(self, flow_cell_directory: Path) -> List[Path]:
         """Get fastq file paths for a flow cell."""
         base_pattern = f"Unaligned*/Project_*/Sample_*/*{FileExtensions.FASTQ}{FileExtensions.GZIP}"
-        alt_pattern = f"Unaligned*/Project_*/Sample_*_*/*{FileExtensions.FASTQ}{FileExtensions.GZIP}"
+        alt_pattern = (
+            f"Unaligned*/Project_*/Sample_*_*/*{FileExtensions.FASTQ}{FileExtensions.GZIP}"
+        )
 
         valid_flowcell_sample_fastq_paths: List[Path] = []
 

--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -200,7 +200,7 @@ class DemuxPostProcessingAPI:
 
     def add_sample_fastq_files(self, flow_cell_directory: Path, flow_cell_name: str) -> None:
         """Add sample fastq files from flow cell to Housekeeper."""
-        fastq_file_paths: List[Path] = self.get_sample_fastq_file_paths(
+        fastq_file_paths: List[Path] = self.get_flowcell_sample_fastq_file_paths(
             flow_cell_directory=flow_cell_directory
         )
 
@@ -228,16 +228,17 @@ class DemuxPostProcessingAPI:
         """Validate the file name and discard any undetermined fastq files."""
         return "Undetermined" not in fastq_file_name
 
-    def get_sample_fastq_file_paths(self, flow_cell_directory: Path) -> List[Path]:
-        """Get fastq file paths for flow cell."""
-        valid_sample_fastq_file_paths = [
-            file_path
-            for file_path in flow_cell_directory.glob(
-                f"**/*{FileExtensions.FASTQ}{FileExtensions.GZIP}"
-            )
-            if self.is_valid_sample_fastq_filename(file_path.name)
-        ]
-        return valid_sample_fastq_file_paths
+    def get_flowcell_sample_fastq_file_paths(self, flow_cell_directory: Path) -> List[Path]:
+        """Get fastq file paths for a flow cell."""
+        base_pattern = f"Unaligned*/Project_*/Sample_*/*{FileExtensions.FASTQ}{FileExtensions.GZIP}"
+        alt_pattern = f"Unaligned*/Project_*/Sample_*_*/*{FileExtensions.FASTQ}{FileExtensions.GZIP}"
+
+        valid_flowcell_sample_fastq_paths: List[Path] = []
+
+        for pattern in [base_pattern, alt_pattern]:
+            valid_flowcell_sample_fastq_paths.extend(flow_cell_directory.glob(pattern))
+
+        return valid_flowcell_sample_fastq_paths
 
     def get_sample_id_from_sample_fastq_file_path(self, fastq_file_path: Path) -> str:
         """Extract sample id from fastq file path."""

--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -193,7 +193,7 @@ class DemuxPostProcessingAPI:
 
     def add_sample_fastq_files(self, flow_cell_directory: Path, flow_cell_name: str) -> None:
         """Add sample fastq files from flow cell to Housekeeper."""
-        fastq_file_paths: List[Path] = self.get_flowcell_sample_fastq_file_paths(
+        fastq_file_paths: List[Path] = self.get_sample_fastq_paths_from_flow_cell(
             flow_cell_directory=flow_cell_directory
         )
 
@@ -221,19 +221,11 @@ class DemuxPostProcessingAPI:
         """Validate the file name and discard any undetermined fastq files."""
         return "Undetermined" not in fastq_file_name
 
-    def get_flowcell_sample_fastq_file_paths(self, flow_cell_directory: Path) -> List[Path]:
-        """Get fastq file paths for a flow cell."""
-        base_pattern = f"Unaligned*/Project_*/Sample_*/*{FileExtensions.FASTQ}{FileExtensions.GZIP}"
-        alt_pattern = (
-            f"Unaligned*/Project_*/Sample_*_*/*{FileExtensions.FASTQ}{FileExtensions.GZIP}"
+    def get_sample_fastq_paths_from_flow_cell(self, flow_cell_directory: Path) -> List[Path]:
+        fastq_sample_pattern: str = (
+            f"Unaligned*/Project_*/Sample_*/*{FileExtensions.FASTQ}{FileExtensions.GZIP}"
         )
-
-        valid_flowcell_sample_fastq_paths: List[Path] = []
-
-        for pattern in [base_pattern, alt_pattern]:
-            valid_flowcell_sample_fastq_paths.extend(flow_cell_directory.glob(pattern))
-
-        return valid_flowcell_sample_fastq_paths
+        return list(flow_cell_directory.glob(fastq_sample_pattern))
 
     def get_sample_id_from_sample_fastq_file_path(self, fastq_file_path: Path) -> str:
         """Extract sample id from fastq file path."""

--- a/tests/meta/demultiplex/test_demux_post_processing.py
+++ b/tests/meta/demultiplex/test_demux_post_processing.py
@@ -738,6 +738,7 @@ def test_is_valid_sample_fastq_filename(demultiplex_context: CGConfig):
     file_name = "valid_file.fastq"
     assert demux_post_processing_api.is_valid_sample_fastq_filename(file_name)
 
+
 def test_get_valid_flowcell_sample_fastq_file_path(demultiplex_context, tmpdir_factory):
     # GIVEN a DemuxPostProcessing API
     demux_post_processing_api = DemuxPostProcessingAPI(demultiplex_context)
@@ -757,6 +758,7 @@ def test_get_valid_flowcell_sample_fastq_file_path(demultiplex_context, tmpdir_f
     # THEN we should only get the valid files
     assert len(result) == 1
     assert valid_fastq_file in result
+
 
 def test_get_invalid_flowcell_sample_fastq_file_path(demultiplex_context, tmpdir_factory):
     # GIVEN a DemuxPostProcessing API


### PR DESCRIPTION
## Description
This PR fixes the issue where unnecessary fastq files are being transferred in the new `demultiplex finish` command. A stricter pattern on directory structure for the fastq files ensures only the correct ones are transferred.

### Fixed
- Only transfer sample specific fastq-files in the new `cg demultiplexing finish` command

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
