### PR TITLE
Fix(clean demux) Make sure demux is complete when cleaning and catch missing bundle error

### DIFF
--- a/cg/models/demultiplex/flow_cell.py
+++ b/cg/models/demultiplex/flow_cell.py
@@ -156,6 +156,10 @@ class FlowCellDirectoryData:
         """Return path to Hiseq X flow cell directory."""
         return Path(self.path, DemultiplexingDirsAndFiles.Hiseq_X_TILE_DIR)
 
+    @property
+    def is_demultiplexing_complete(self) -> bool:
+        return Path(self.path, DemultiplexingDirsAndFiles.DEMUX_COMPLETE).exists()
+
     def _parse_date(self):
         """Return the parsed date in the correct format."""
         if len(self.split_flow_cell_name[0]) == LENGTH_LONG_DATE:

--- a/tests/cli/demultiplex/test_demultiplex_flowcell.py
+++ b/tests/cli/demultiplex/test_demultiplex_flowcell.py
@@ -6,6 +6,7 @@ from click import testing
 
 from cg.apps.demultiplex.demultiplex_api import DemultiplexingAPI
 from cg.cli.demultiplex.demux import demultiplex_all, demultiplex_flow_cell, delete_flow_cell
+from cg.constants.demultiplexing import DemultiplexingDirsAndFiles
 from cg.models.cg_config import CGConfig
 from cg.models.demultiplex.flow_cell import FlowCellDirectoryData
 
@@ -195,6 +196,21 @@ def test_demultiplex_all_novaseq(
 
     # THEN assert it found a flow cell that is ready for demultiplexing
     assert f"Flow cell {flow_cell.id} is ready for demultiplexing" in caplog.text
+
+
+def test_is_demultiplexing_complete(demultiplex_ready_flow_cell: Path):
+    """Tests the is_demultiplexing_complete property of FlowCellDirectoryData"""
+    # GIVEN a demultiplexing directory with no demuxcomplete.txt file
+    flow_cell: FlowCellDirectoryData = FlowCellDirectoryData(
+        flow_cell_path=demultiplex_ready_flow_cell
+    )
+    assert not flow_cell.is_demultiplexing_complete
+
+    # WHEN creating the demuxcomplete.txt file
+    Path(flow_cell.path, DemultiplexingDirsAndFiles.DEMUX_COMPLETE).touch()
+
+    # THEN the property should return true
+    assert flow_cell.is_demultiplexing_complete
 
 
 def test_delete_flow_cell_dry_run_cgstats(


### PR DESCRIPTION
## Description
Currently the cg clean is crashing when encountering a flow directory where the samples are in statusdb but not in housekeeper

### Added

- Check for the demuxcomplete.txt file
- Try/except clause when fetching bundes from housekeeper


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
