### PR TITLE
Try alternate sample sheet path

### DIFF
--- a/cg/models/demultiplex/flow_cell.py
+++ b/cg/models/demultiplex/flow_cell.py
@@ -197,10 +197,21 @@ class FlowCellDirectoryData:
 
     def get_sample_sheet(self) -> SampleSheet:
         """Return sample sheet object."""
-        return get_sample_sheet_from_file(
-            infile=self.sample_sheet_path,
-            flow_cell_sample_type=self.sample_type,
-        )
+        try:
+            return get_sample_sheet_from_file(
+                infile=self.sample_sheet_path,
+                flow_cell_sample_type=self.sample_type,
+            )
+        except:
+            alternative_sample_sheet_path: Path = Path(
+                self.path,
+                DemultiplexingDirsAndFiles.UNALIGNED_DIR_NAME,
+                DemultiplexingDirsAndFiles.SAMPLE_SHEET_FILE_NAME,
+            )
+            return get_sample_sheet_from_file(
+                infile=alternative_sample_sheet_path,
+                flow_cell_sample_type=self.sample_type,
+            )
 
     def is_sequencing_done(self) -> bool:
         """Check if sequencing is done.

--- a/cg/models/demultiplex/flow_cell.py
+++ b/cg/models/demultiplex/flow_cell.py
@@ -110,7 +110,10 @@ class FlowCellDirectoryData:
         """Return the sample class used in the flow cell."""
         if self.sequencer_type == Sequencers.NOVASEQX:
             return FlowCellSampleNovaSeqX
-        if self.bcl_converter == BclConverter.DRAGEN:
+        if (
+            self.bcl_converter == BclConverter.DRAGEN
+            or self.bcl_converter == BclConverter.BCLCONVERT
+        ):
             return FlowCellSampleNovaSeq6000Dragen
         return FlowCellSampleNovaSeq6000Bcl2Fastq
 

--- a/cg/models/demultiplex/flow_cell.py
+++ b/cg/models/demultiplex/flow_cell.py
@@ -202,7 +202,7 @@ class FlowCellDirectoryData:
                 infile=self.sample_sheet_path,
                 flow_cell_sample_type=self.sample_type,
             )
-        except:
+        except Exception as error:
             alternative_sample_sheet_path: Path = Path(
                 self.path,
                 DemultiplexingDirsAndFiles.UNALIGNED_DIR_NAME,


### PR DESCRIPTION
## Description
This PR adresess https://github.com/Clinical-Genomics/cg/issues/2175 which causes the new `cg demultiplex finish` command to fail. If the sample sheet is not found in the root flow cell run directory by `get_sample_sheet`, it looks for the sample sheet in the `Unaligned` directory instead.

### Fixed
- Retry retrieving the sample sheet from the `Unaligned` directory in the `get_sample_sheet` method

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
