### PR TITLE
Add unique constraint to sequencing metrics

### DIFF
--- a/alembic/versions/97ffd22d7ebc_add_metrics_unique_constraint.py
+++ b/alembic/versions/97ffd22d7ebc_add_metrics_unique_constraint.py
@@ -1,0 +1,28 @@
+"""Add metrics unique constraint
+
+Revision ID: 97ffd22d7ebc
+Revises: 367ed257e4ee
+Create Date: 2023-06-27 09:41:01.028587
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "97ffd22d7ebc"
+down_revision = "367ed257e4ee"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Add a unique constraint
+    op.create_unique_constraint(
+        "uix_flowcell_sample_lane",
+        "sample_lane_sequencing_metrics",
+        ["flow_cell_name", "sample_internal_id", "flow_cell_lane_number"],
+    )
+
+
+def downgrade():
+    # Drop the unique constraint
+    op.drop_constraint("uix_flowcell_sample_lane", "sample_lane_sequencing_metrics", type_="unique")

--- a/cg/apps/sequencing_metrics_parser/api.py
+++ b/cg/apps/sequencing_metrics_parser/api.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from typing import List
 from cg.constants.demultiplexing import BclConverter
-from cg.store.api.core import Store
 from cg.store.models import SampleLaneSequencingMetrics
 from cg.apps.sequencing_metrics_parser.parsers.bcl2fastq_to_sequencing_statistics import (
     create_sample_lane_sequencing_metrics_from_bcl2fastq_for_flow_cell,

--- a/cg/apps/sequencing_metrics_parser/parsers/bcl_convert_to_sequencing_statistics.py
+++ b/cg/apps/sequencing_metrics_parser/parsers/bcl_convert_to_sequencing_statistics.py
@@ -5,7 +5,6 @@ from typing import List
 from cg.store.models import SampleLaneSequencingMetrics
 from cg.apps.sequencing_metrics_parser.parsers.bcl_convert import BclConvertMetricsParser
 from datetime import datetime
-from cg.constants.demultiplexing import DRAGEN_PASSED_FILTER_PCT
 
 
 def create_sample_lane_sequencing_metrics_from_bcl_convert_metrics_for_flow_cell(

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -784,3 +784,12 @@ class SampleLaneSequencingMetrics(Model):
 
     flowcell = orm.relationship(Flowcell, back_populates="sequencing_metrics")
     sample = orm.relationship(Sample, back_populates="sequencing_metrics")
+
+    __table_args__ = (
+        UniqueConstraint(
+            "flow_cell_name",
+            "sample_internal_id",
+            "flow_cell_lane_number",
+            name="uix_flowcell_sample_lane",
+        ),
+    )


### PR DESCRIPTION
## Description
This PR adds a unique constraint to the sequencing metrics table to disallow duplicate entries to exist for the same flow cell, lane and sample.

### Fixed
- Add constraint for implicit uniqueness rule on sequencing metrics table

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
