### PR TITLE
Cascade delete metrics associated with flow cell

### DIFF
--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -522,7 +522,11 @@ class Flowcell(Model):
     updated_at = Column(types.DateTime, onupdate=dt.datetime.now)
 
     samples = orm.relationship("Sample", secondary=flowcell_sample, backref="flowcells")
-    sequencing_metrics = orm.relationship("SampleLaneSequencingMetrics", back_populates="flowcell")
+    sequencing_metrics = orm.relationship(
+        "SampleLaneSequencingMetrics",
+        back_populates="flowcell",
+        cascade="all, delete, delete-orphan",
+    )
 
     def __str__(self):
         return self.name
@@ -782,9 +786,7 @@ class SampleLaneSequencingMetrics(Model):
 
     created_at = Column(types.DateTime)
 
-    flowcell = orm.relationship(
-        Flowcell, back_populates="sequencing_metrics", cascade="all, delete-orphan"
-    )
+    flowcell = orm.relationship(Flowcell, back_populates="sequencing_metrics")
     sample = orm.relationship(Sample, back_populates="sequencing_metrics")
 
     __table_args__ = (

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -782,7 +782,9 @@ class SampleLaneSequencingMetrics(Model):
 
     created_at = Column(types.DateTime)
 
-    flowcell = orm.relationship(Flowcell, back_populates="sequencing_metrics")
+    flowcell = orm.relationship(
+        Flowcell, back_populates="sequencing_metrics", cascade="all, delete-orphan"
+    )
     sample = orm.relationship(Sample, back_populates="sequencing_metrics")
 
     __table_args__ = (


### PR DESCRIPTION
## Description
This PR updates the relationship between the sequencing metrics and flow cell tables to cascade deletes on flow cells to all associated sequencing metrics.

### Fixed
- Cascade delete sequencing metrics when flow cell is deleted

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
