### PR TITLE
Fix housekeeper transfer of data

### DIFF
--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -204,7 +204,7 @@ class DemuxPostProcessingAPI:
     ) -> None:
         LOG.info(f"Add flow cell data to Housekeeper for {flow_cell_name}")
 
-        self.add_bundle_and_version_if_non_existent(flow_cell_name=flow_cell_name)
+        self.add_bundle_and_version_if_non_existent(bundle_name=flow_cell_name)
 
         tags: List[str] = [SequencingFileTag.FASTQ, SequencingFileTag.SAMPLE_SHEET, flow_cell_name]
         self.add_tags_if_non_existent(tag_names=tags)
@@ -228,17 +228,19 @@ class DemuxPostProcessingAPI:
             )
 
             if sample_id:
-                self.add_file_if_non_existent(
+                self.add_bundle_and_version_if_non_existent(bundle_name=sample_id)
+
+                self.add_file_to_bundle_if_non_existent(
                     file_path=fastq_file_path,
-                    flow_cell_name=flow_cell_name,
-                    tag_names=[SequencingFileTag.FASTQ, sample_id],
+                    bundle_name=sample_id,
+                    tag_names=[SequencingFileTag.FASTQ, flow_cell_name],
                 )
 
     def add_sample_sheet(self, flow_cell_directory: Path, flow_cell_name: str) -> None:
         """Add sample sheet to Housekeeper."""
-        self.add_file_if_non_existent(
+        self.add_file_to_bundle_if_non_existent(
             file_path=Path(flow_cell_directory, DemultiplexingDirsAndFiles.SAMPLE_SHEET_FILE_NAME),
-            flow_cell_name=flow_cell_name,
+            bundle_name=flow_cell_name,
             tag_names=[SequencingFileTag.SAMPLE_SHEET, flow_cell_name],
         )
 
@@ -263,10 +265,10 @@ class DemuxPostProcessingAPI:
 
         return directory_parts[0]
 
-    def add_bundle_and_version_if_non_existent(self, flow_cell_name: str) -> None:
+    def add_bundle_and_version_if_non_existent(self, bundle_name: str) -> None:
         """Add bundle if it does not exist."""
-        if not self.hk_api.bundle(name=flow_cell_name):
-            self.hk_api.create_new_bundle_and_version(name=flow_cell_name)
+        if not self.hk_api.bundle(name=bundle_name):
+            self.hk_api.create_new_bundle_and_version(name=bundle_name)
 
     def add_tags_if_non_existent(self, tag_names: List[str]) -> None:
         """Ensure that tags exist in Housekeeper."""
@@ -274,8 +276,8 @@ class DemuxPostProcessingAPI:
             if self.hk_api.get_tag(name=tag_name) is None:
                 self.hk_api.add_tag(name=tag_name)
 
-    def add_file_if_non_existent(
-        self, file_path: Path, flow_cell_name: str, tag_names: List[str]
+    def add_file_to_bundle_if_non_existent(
+        self, file_path: Path, bundle_name: str, tag_names: List[str]
     ) -> None:
         """Add file to Housekeeper if it has not already been added."""
         if not file_path.exists():
@@ -283,19 +285,17 @@ class DemuxPostProcessingAPI:
             return
 
         if not self.file_exists_in_latest_version_for_bundle(
-            file_path=file_path, flow_cell_name=flow_cell_name
+            file_path=file_path, bundle_name=bundle_name
         ):
             self.hk_api.add_and_include_file_to_latest_version(
-                bundle_name=flow_cell_name,
+                bundle_name=bundle_name,
                 file=file_path,
                 tags=tag_names,
             )
 
-    def file_exists_in_latest_version_for_bundle(
-        self, file_path: Path, flow_cell_name: str
-    ) -> bool:
+    def file_exists_in_latest_version_for_bundle(self, file_path: Path, bundle_name: str) -> bool:
         """Check if file exists in latest version for bundle."""
-        latest_version: Version = self.hk_api.get_latest_bundle_version(bundle_name=flow_cell_name)
+        latest_version: Version = self.hk_api.get_latest_bundle_version(bundle_name=bundle_name)
         return any(
             file_path.name == Path(bundle_file.path).name for bundle_file in latest_version.files
         )

--- a/tests/meta/demultiplex/test_demux_post_processing.py
+++ b/tests/meta/demultiplex/test_demux_post_processing.py
@@ -543,7 +543,7 @@ def test_add_flow_cell_data_to_housekeeper(demultiplex_context: CGConfig):
 
     # THEN the bundle and version is added
     demux_post_processing_api.add_bundle_and_version_if_non_existent.assert_called_once_with(
-        flow_cell_name=flow_cell_name
+        bundle_name=flow_cell_name
     )
 
     # THEN the correct tags are added
@@ -571,7 +571,7 @@ def test_add_bundle_and_version_if_non_existent(demultiplex_context: CGConfig):
 
     # WHEN adding a bundle and version which does not exist
     flow_cell_name: str = "flow_cell_name"
-    demux_post_processing_api.add_bundle_and_version_if_non_existent(flow_cell_name=flow_cell_name)
+    demux_post_processing_api.add_bundle_and_version_if_non_existent(bundle_name=flow_cell_name)
 
     # THEN that the expected methods were called with the expected arguments
     demux_post_processing_api.hk_api.bundle.assert_called_once_with(name=flow_cell_name)
@@ -590,7 +590,7 @@ def test_add_bundle_and_version_if_already_exists(demultiplex_context: CGConfig)
 
     # WHEN adding a bundle and version which already exists
     flow_cell_name: str = "flow_cell_name"
-    demux_post_processing_api.add_bundle_and_version_if_non_existent(flow_cell_name=flow_cell_name)
+    demux_post_processing_api.add_bundle_and_version_if_non_existent(bundle_name=flow_cell_name)
 
     # THEN the bundle was retrieved
     demux_post_processing_api.hk_api.bundle.assert_called_once_with(name=flow_cell_name)
@@ -642,7 +642,7 @@ def test_add_tags_if_all_exist(demultiplex_context: CGConfig):
 def test_add_sample_sheet(demultiplex_context: CGConfig, tmpdir_factory):
     # GIVEN a DemuxPostProcessing API
     demux_post_processing_api = DemuxPostProcessingAPI(demultiplex_context)
-    demux_post_processing_api.add_file_if_non_existent = MagicMock()
+    demux_post_processing_api.add_file_to_bundle_if_non_existent = MagicMock()
 
     # GIVEN a flow cell directory and name
     flow_cell_directory: Path = Path(tmpdir_factory.mktemp("flow_cell_directory"))
@@ -659,9 +659,9 @@ def test_add_sample_sheet(demultiplex_context: CGConfig, tmpdir_factory):
     )
     expected_tag_names = [SequencingFileTag.SAMPLE_SHEET, flow_cell_name]
 
-    demux_post_processing_api.add_file_if_non_existent.assert_called_once_with(
+    demux_post_processing_api.add_file_to_bundle_if_non_existent.assert_called_once_with(
         file_path=expected_file_path,
-        flow_cell_name=flow_cell_name,
+        bundle_name=flow_cell_name,
         tag_names=expected_tag_names,
     )
 
@@ -672,7 +672,7 @@ def test_add_fastq_files_with_sample_id(demultiplex_context: CGConfig, tmpdir_fa
 
     demux_post_processing_api.get_sample_fastq_paths_from_flow_cell = MagicMock()
     demux_post_processing_api.get_sample_id_from_sample_fastq_file_path = MagicMock()
-    demux_post_processing_api.add_file_if_non_existent = MagicMock()
+    demux_post_processing_api.add_file_to_bundle_if_non_existent = MagicMock()
 
     mock_fastq_paths = [
         Path(tmpdir_factory.mktemp("first_file.fastq.gz")),
@@ -696,13 +696,13 @@ def test_add_fastq_files_with_sample_id(demultiplex_context: CGConfig, tmpdir_fa
     expected_calls = [
         call(
             file_path=file_path,
-            flow_cell_name=flow_cell_name,
-            tag_names=[SequencingFileTag.FASTQ, sample_id],
+            bundle_name=sample_id,
+            tag_names=[SequencingFileTag.FASTQ, flow_cell_name],
         )
         for file_path in mock_fastq_paths
     ]
 
-    demux_post_processing_api.add_file_if_non_existent.assert_has_calls(expected_calls)
+    demux_post_processing_api.add_file_to_bundle_if_non_existent.assert_has_calls(expected_calls)
 
 
 def test_add_fastq_files_without_sample_id(demultiplex_context: CGConfig, tmpdir_factory):
@@ -712,7 +712,7 @@ def test_add_fastq_files_without_sample_id(demultiplex_context: CGConfig, tmpdir
     demux_post_processing_api.get_sample_id_from_sample_fastq_file_path = MagicMock()
     demux_post_processing_api.get_sample_id_from_sample_fastq_file_path.return_value = None
 
-    demux_post_processing_api.add_file_if_non_existent = MagicMock()
+    demux_post_processing_api.add_file_to_bundle_if_non_existent = MagicMock()
 
     flow_cell_directory: Path = Path(tmpdir_factory.mktemp("flow_cell_directory"))
     flow_cell_name = "flow_cell_name"
@@ -723,7 +723,7 @@ def test_add_fastq_files_without_sample_id(demultiplex_context: CGConfig, tmpdir
     )
 
     # THEN add_file_if_non_existent was not called
-    demux_post_processing_api.add_file_if_non_existent.assert_not_called()
+    demux_post_processing_api.add_file_to_bundle_if_non_existent.assert_not_called()
 
 
 def test_is_valid_sample_fastq_filename(demultiplex_context: CGConfig):


### PR DESCRIPTION
## Description
This PR fixes some issues in the new demultiplex finish command pointed out by @karlnyr:
- A bundle is now created for each sample in the flow cell
- Each sample fastq file is now added to the sample bundle
- Each sample fastq file is now tagged with the flow cell name

### Fixed
- Transfer of sequencing data to housekeeper


### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
