### PR TITLE
Fix adding sample sheet to housekeeper

### DIFF
--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -254,12 +254,6 @@ class DemuxPostProcessingAPI:
         """
         Recursively searches for the given sample sheet file in the provided flow cell directory.
 
-        Args:
-            flow_cell_directory (Path): The path to the flow cell directory.
-
-        Returns:
-            Path: The path to the found sample sheet file.
-
         Raises:
             FileNotFoundError: If the sample sheet file is not found in the flow cell directory.
         """

--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -259,6 +259,7 @@ class DemuxPostProcessingAPI:
         """
         for directory_path, _, files in os.walk(flow_cell_directory):
             if DemultiplexingDirsAndFiles.SAMPLE_SHEET_FILE_NAME in files:
+                LOG.info(f"Found sample sheet in {directory_path}")
                 return Path(directory_path, DemultiplexingDirsAndFiles.SAMPLE_SHEET_FILE_NAME)
 
         raise FileNotFoundError(

--- a/tests/meta/demultiplex/test_demux_post_processing.py
+++ b/tests/meta/demultiplex/test_demux_post_processing.py
@@ -698,13 +698,8 @@ def test_add_fastq_files_with_sample_id(demultiplex_context: CGConfig, tmpdir_fa
     expected_calls = [
         call(
             file_path=file_path,
-<<<<<<< HEAD
-            bundle_name=flow_cell_name,
-            tag_names=[SequencingFileTag.FASTQ, sample_id],
-=======
             bundle_name=sample_id,
             tag_names=[SequencingFileTag.FASTQ, flow_cell_name],
->>>>>>> master
         )
         for file_path in mock_fastq_paths
     ]

--- a/tests/meta/demultiplex/test_demux_post_processing.py
+++ b/tests/meta/demultiplex/test_demux_post_processing.py
@@ -646,6 +646,8 @@ def test_add_sample_sheet(demultiplex_context: CGConfig, tmpdir_factory):
 
     # GIVEN a flow cell directory and name
     flow_cell_directory: Path = Path(tmpdir_factory.mktemp("flow_cell_directory"))
+    sample_sheet_file = Path(flow_cell_directory, DemultiplexingDirsAndFiles.SAMPLE_SHEET_FILE_NAME)
+    sample_sheet_file.touch()
     flow_cell_name = "flow_cell_name"
 
     # WHEN a sample sheet is added
@@ -661,7 +663,7 @@ def test_add_sample_sheet(demultiplex_context: CGConfig, tmpdir_factory):
 
     demux_post_processing_api.add_file_if_non_existent.assert_called_once_with(
         file_path=expected_file_path,
-        flow_cell_name=flow_cell_name,
+        bundle_name=flow_cell_name,
         tag_names=expected_tag_names,
     )
 
@@ -696,7 +698,7 @@ def test_add_fastq_files_with_sample_id(demultiplex_context: CGConfig, tmpdir_fa
     expected_calls = [
         call(
             file_path=file_path,
-            flow_cell_name=flow_cell_name,
+            bundle_name=flow_cell_name,
             tag_names=[SequencingFileTag.FASTQ, sample_id],
         )
         for file_path in mock_fastq_paths


### PR DESCRIPTION
## Description
This PR fixes the issue where the path to the sample sheet in the flow cell run directory was assumed to be in the root when its actual location seems to vary. Instead of hard coding the path, a function has been added which recursively searches the flow cell run directory for it.

### Fixed
- Find sample sheet path in flow cell run directory when transferring housekeeper files in new demultiplex finish

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
