### PR TITLE
Revert "Revert "add(temporary column sample table)""

### DIFF
--- a/alembic/versions/ffb9f8ab8e62_add_temp_read_col.py
+++ b/alembic/versions/ffb9f8ab8e62_add_temp_read_col.py
@@ -1,0 +1,26 @@
+"""add_temp_read_col
+
+Revision ID: ffb9f8ab8e62
+Revises: 97ffd22d7ebc
+Create Date: 2023-06-29 08:39:28.254889
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "ffb9f8ab8e62"
+down_revision = "97ffd22d7ebc"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        table_name="sample", column=sa.Column("calculated_read_count", sa.BigInteger(), default=0)
+    )
+
+
+def downgrade():
+    op.drop_column(table_name="sample", column_name="calculated_read_count")

--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -198,7 +198,7 @@ class DemuxPostProcessingAPI:
                 sample_internal_id=sample_id
             )
             LOG.info(f"Updating sample {sample_id} with read count {sample_read_count}")
-            sample.reads = sample_read_count
+            sample.calculated_read_count = sample_read_count
 
     def add_flow_cell_data_to_housekeeper(
         self, flow_cell_name: str, flow_cell_directory: Path

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -646,6 +646,7 @@ class Sample(Model, PriorityMixin):
     sequenced_at = Column(types.DateTime)
     sex = Column(types.Enum(*SEX_OPTIONS), nullable=False)
     subject_id = Column(types.String(128))
+    calculated_read_count = Column(types.BigInteger, default=0)
 
     sequencing_metrics = orm.relationship("SampleLaneSequencingMetrics", back_populates="sample")
 

--- a/tests/meta/demultiplex/test_demux_post_processing.py
+++ b/tests/meta/demultiplex/test_demux_post_processing.py
@@ -836,7 +836,7 @@ def test_update_samples_with_read_counts_and_sequencing_date(demultiplex_context
     demux_post_processing_api.update_sample_read_counts(sample_ids)
 
     # THEN the read count was set on the mock sample
-    assert mock_sample.reads == mock_read_count
+    assert mock_sample.calculated_read_count == mock_read_count
 
 
 def test_add_single_sequencing_metrics_entry_to_statusdb(


### PR DESCRIPTION
# Description

Revert the revert, since the issue with alembic was not caused by the original merge.

Reverts Clinical-Genomics/cg#2194 