### PR TITLE
Change log messages to debug

### DIFF
--- a/cg/apps/demultiplex/sample_sheet/validate.py
+++ b/cg/apps/demultiplex/sample_sheet/validate.py
@@ -31,7 +31,7 @@ def get_samples_by_lane(
     samples: List[FlowCellSample],
 ) -> Dict[int, List[FlowCellSample]]:
     """Group and return samples by lane."""
-    LOG.info("Order samples by lane")
+    LOG.debug("Order samples by lane")
     sample_by_lane: Dict[int, List[FlowCellSample]] = {}
     for sample in samples:
         if sample.lane not in sample_by_lane:

--- a/cg/apps/housekeeper/hk.py
+++ b/cg/apps/housekeeper/hk.py
@@ -234,7 +234,7 @@ class HousekeeperAPI:
 
     def last_version(self, bundle: str) -> Version:
         """Gets the latest version of a bundle."""
-        LOG.info(f"Fetch latest version from bundle {bundle}")
+        LOG.debug(f"Fetch latest version from bundle {bundle}")
         return (
             self._store._get_query(table=Version)
             .join(Version.bundle)

--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -156,7 +156,7 @@ class DemuxPostProcessingAPI:
                     f"Sample lane sequencing metrics already exists for {sample_lane_sequencing_metric.flow_cell_name}, {sample_lane_sequencing_metric.sample_internal_id} and {sample_lane_sequencing_metric.flow_cell_lane_number}. Skipping."
                 )
             else:
-                LOG.info(
+                LOG.debug(
                     f"Adding Sample lane sequencing metrics for {sample_lane_sequencing_metric.flow_cell_name}, {sample_lane_sequencing_metric.sample_internal_id} and {sample_lane_sequencing_metric.flow_cell_lane_number}."
                 )
                 self.status_db.session.add(sample_lane_sequencing_metric)

--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -197,7 +197,7 @@ class DemuxPostProcessingAPI:
             sample_read_count = self.status_db.get_number_of_reads_for_sample_from_metrics(
                 sample_internal_id=sample_id
             )
-            LOG.info(f"Updating sample {sample_id} with read count {sample_read_count}")
+            LOG.debug(f"Updating sample {sample_id} with read count {sample_read_count}")
             sample.calculated_read_count = sample_read_count
 
     def add_flow_cell_data_to_housekeeper(


### PR DESCRIPTION
## Description
This PR changes some log messages to debug as to not spam the CLI users when running the `demultiplex finish flowcell` command.

### Fixed
- Change some logging to debug mode

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
