### PR TITLE
add(flow cell and sample links to sample lane seq  metrics)

### DIFF
--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -294,6 +294,15 @@ class FlowcellView(BaseView):
     column_filters = ["sequencer_type", "sequencer_name", "status"]
     column_searchable_list = ["name"]
 
+    @staticmethod
+    def view_flow_cell_link(unused1, unused2, model, unused3):
+        """column formatter to open this view"""
+        del unused1, unused2, unused3
+        return Markup(
+            "<a href='%s'>%s</a>"
+            % (url_for("flowcell.index_view", search=model.flowcell.name), model.flowcell.name)
+        )
+
 
 class InvoiceView(BaseView):
     """Admin view for Model.Invoice"""
@@ -543,3 +552,8 @@ class SampleLaneSequencingMetricsView(BaseView):
     column_searchable_list = ["sample_internal_id", "flow_cell_name"]
     create_modal = True
     edit_modal = True
+
+    column_formatters = {
+        "flowcell": FlowcellView.view_flow_cell_link,
+        "sample": SampleView.view_sample_link,
+    }


### PR DESCRIPTION
## Description

Add clickable links that refer to the flow cell and samples to the sample sequencing metrics table in statusDB.

### Added

-

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
