### PR TITLE
Filter on q30 threshold for update of read count

### DIFF
--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -200,9 +200,11 @@ class DemuxPostProcessingAPI:
         sample = self.status_db.get_sample_by_internal_id(internal_id=sample_id)
 
         if sample:
-            sample_read_count: int = self.status_db.get_number_of_reads_for_sample_passing_q30_threshold(
-                sample_internal_id=sample_id,
-                q30_threshold=q30_threshold,
+            sample_read_count: int = (
+                self.status_db.get_number_of_reads_for_sample_passing_q30_threshold(
+                    sample_internal_id=sample_id,
+                    q30_threshold=q30_threshold,
+                )
             )
             LOG.debug(f"Updating sample {sample_id} with read count {sample_read_count}")
             sample.calculated_read_count = sample_read_count

--- a/cg/store/api/find_business_data.py
+++ b/cg/store/api/find_business_data.py
@@ -314,12 +314,18 @@ class FindBusinessDataHandler(BaseHandler):
             name=sample_name,
         ).first()
 
-    def get_number_of_reads_for_sample_from_metrics(self, sample_internal_id: str) -> int:
+    def get_number_of_reads_for_sample_from_metrics(
+        self, sample_internal_id: str, q30_threshold: int
+    ) -> int:
         """Get number of reads for sample from sample lane sequencing metrics."""
         total_reads_query: Query = apply_metrics_filter(
             metrics=self._get_query(table=SampleLaneSequencingMetrics),
-            filter_functions=[SequencingMetricsFilter.FILTER_TOTAL_READ_COUNT_FOR_SAMPLE],
+            filter_functions=[
+                SequencingMetricsFilter.FILTER_TOTAL_READ_COUNT_FOR_SAMPLE,
+                SequencingMetricsFilter.FILTER_ABOVE_Q30_THRESHOLD,
+            ],
             sample_internal_id=sample_internal_id,
+            q30_threshold=q30_threshold,
         )
         reads_count: Optional[int] = total_reads_query.scalar()
         return reads_count if reads_count else 0

--- a/cg/store/api/find_business_data.py
+++ b/cg/store/api/find_business_data.py
@@ -317,7 +317,7 @@ class FindBusinessDataHandler(BaseHandler):
     def get_number_of_reads_for_sample_passing_q30_threshold(
         self, sample_internal_id: str, q30_threshold: int
     ) -> int:
-        """Get number of reads for sample from sample lane sequencing metrics."""
+        """Get number of reads above q30 threshold for sample from sample lane sequencing metrics."""
         total_reads_query: Query = apply_metrics_filter(
             metrics=self._get_query(table=SampleLaneSequencingMetrics),
             filter_functions=[

--- a/cg/store/api/find_business_data.py
+++ b/cg/store/api/find_business_data.py
@@ -314,7 +314,7 @@ class FindBusinessDataHandler(BaseHandler):
             name=sample_name,
         ).first()
 
-    def get_number_of_reads_for_sample_from_metrics(
+    def get_number_of_reads_for_sample_passing_q30_threshold(
         self, sample_internal_id: str, q30_threshold: int
     ) -> int:
         """Get number of reads for sample from sample lane sequencing metrics."""

--- a/cg/store/filters/status_metrics_filters.py
+++ b/cg/store/filters/status_metrics_filters.py
@@ -18,6 +18,7 @@ def filter_above_q30_threshold(metrics: Query, q30_threshold: int, **kwargs) -> 
         SampleLaneSequencingMetrics.sample_base_fraction_passing_q30 > q30_threshold / 100,
     )
 
+
 def filter_metrics_for_flow_cell_sample_internal_id_and_lane(
     metrics: Query, flow_cell_name: str, sample_internal_id: str, lane: int, **kwargs
 ) -> Query:

--- a/cg/store/filters/status_metrics_filters.py
+++ b/cg/store/filters/status_metrics_filters.py
@@ -13,6 +13,11 @@ def filter_total_read_count_for_sample(metrics: Query, sample_internal_id: str, 
     return total_reads_query
 
 
+def filter_above_q30_threshold(metrics: Query, q30_threshold: int, **kwargs) -> Query:
+    return metrics.filter(
+        SampleLaneSequencingMetrics.sample_base_fraction_passing_q30 > q30_threshold / 100,
+    )
+
 def filter_metrics_for_flow_cell_sample_internal_id_and_lane(
     metrics: Query, flow_cell_name: str, sample_internal_id: str, lane: int, **kwargs
 ) -> Query:
@@ -28,6 +33,7 @@ class SequencingMetricsFilter(Enum):
     FILTER_METRICS_FOR_FLOW_CELL_SAMPLE_INTERNAL_ID_AND_LANE: Callable = (
         filter_metrics_for_flow_cell_sample_internal_id_and_lane
     )
+    FILTER_ABOVE_Q30_THRESHOLD: Callable = filter_above_q30_threshold
 
 
 def apply_metrics_filter(
@@ -36,6 +42,7 @@ def apply_metrics_filter(
     sample_internal_id: Optional[str] = None,
     flow_cell_name: Optional[str] = None,
     lane: Optional[int] = None,
+    q30_threshold: Optional[int] = None,
 ) -> Query:
     for filter_function in filter_functions:
         metrics: Query = filter_function(
@@ -43,5 +50,6 @@ def apply_metrics_filter(
             sample_internal_id=sample_internal_id,
             flow_cell_name=flow_cell_name,
             lane=lane,
+            q30_threshold=q30_threshold,
         )
     return metrics

--- a/tests/meta/demultiplex/test_demux_post_processing.py
+++ b/tests/meta/demultiplex/test_demux_post_processing.py
@@ -7,6 +7,7 @@ from cg.constants.constants import FileExtensions
 
 from cg.constants.demultiplexing import DemultiplexingDirsAndFiles, BclConverter
 from cg.constants.housekeeper_tags import SequencingFileTag
+from cg.constants.sequencing import Sequencers
 
 from cg.meta.demultiplex.demux_post_processing import (
     DemuxPostProcessingAPI,
@@ -823,17 +824,18 @@ def test_update_samples_with_read_counts_and_sequencing_date(demultiplex_context
 
     mock_sample = MagicMock()
     mock_read_count = 1_000
+    mock_flow_cell_data = MagicMock()
+    mock_flow_cell_data.sequencer_type = Sequencers.HISEQGA.value
 
     demux_post_processing_api.status_db.get_sample_by_internal_id.return_value = mock_sample
     demux_post_processing_api.status_db.get_number_of_reads_for_sample_from_metrics.return_value = (
         mock_read_count
     )
+    demux_post_processing_api.get_sample_ids_from_sample_sheet = MagicMock()
+    demux_post_processing_api.get_sample_ids_from_sample_sheet.return_value = [1]
 
-    # GIVEN a list of internal sample IDs
-    sample_ids = ["sample1", "sample2"]
-
-    # WHEN calling the method with the sample IDs
-    demux_post_processing_api.update_sample_read_counts(sample_ids)
+    # WHEN calling the method with the flow cell directory
+    demux_post_processing_api.update_sample_read_counts(mock_flow_cell_data)
 
     # THEN the read count was set on the mock sample
     assert mock_sample.calculated_read_count == mock_read_count

--- a/tests/meta/demultiplex/test_demux_post_processing.py
+++ b/tests/meta/demultiplex/test_demux_post_processing.py
@@ -820,7 +820,7 @@ def test_update_samples_with_read_counts_and_sequencing_date(demultiplex_context
     demux_post_processing_api = DemuxPostProcessingAPI(demultiplex_context)
 
     demux_post_processing_api.status_db.get_sample_by_internal_id = MagicMock()
-    demux_post_processing_api.status_db.get_number_of_reads_for_sample_from_metrics = MagicMock()
+    demux_post_processing_api.status_db.get_number_of_reads_for_sample_passing_q30_threshold = MagicMock()
 
     mock_sample = MagicMock()
     mock_read_count = 1_000
@@ -828,7 +828,7 @@ def test_update_samples_with_read_counts_and_sequencing_date(demultiplex_context
     mock_flow_cell_data.sequencer_type = Sequencers.HISEQGA.value
 
     demux_post_processing_api.status_db.get_sample_by_internal_id.return_value = mock_sample
-    demux_post_processing_api.status_db.get_number_of_reads_for_sample_from_metrics.return_value = (
+    demux_post_processing_api.status_db.get_number_of_reads_for_sample_passing_q30_threshold.return_value = (
         mock_read_count
     )
     demux_post_processing_api.get_sample_ids_from_sample_sheet = MagicMock()

--- a/tests/meta/demultiplex/test_demux_post_processing.py
+++ b/tests/meta/demultiplex/test_demux_post_processing.py
@@ -820,7 +820,9 @@ def test_update_samples_with_read_counts_and_sequencing_date(demultiplex_context
     demux_post_processing_api = DemuxPostProcessingAPI(demultiplex_context)
 
     demux_post_processing_api.status_db.get_sample_by_internal_id = MagicMock()
-    demux_post_processing_api.status_db.get_number_of_reads_for_sample_passing_q30_threshold = MagicMock()
+    demux_post_processing_api.status_db.get_number_of_reads_for_sample_passing_q30_threshold = (
+        MagicMock()
+    )
 
     mock_sample = MagicMock()
     mock_read_count = 1_000

--- a/tests/store/api/find/test_find_business_data.py
+++ b/tests/store/api/find/test_find_business_data.py
@@ -779,8 +779,7 @@ def test_get_total_read_counts(
     # WHEN getting total read counts for a sample
     total_reads_count: int = (
         store_with_sequencing_metrics.get_number_of_reads_for_sample_from_metrics(
-            sample_internal_id=sample_id,
-            q30_threshold=0
+            sample_internal_id=sample_id, q30_threshold=0
         )
     )
 

--- a/tests/store/api/find/test_find_business_data.py
+++ b/tests/store/api/find/test_find_business_data.py
@@ -831,3 +831,32 @@ def test_get_number_of_reads_for_sample_passing_q30_threshold(
 
     # THEN assert that the number of reads is at least the number of reads in the lane for the sample passing the q30
     assert number_of_reads >= sample_metric.sample_total_reads_in_lane
+
+
+def test_get_number_of_reads_for_sample_with_some_not_passing_q30_threshold(
+    store_with_sequencing_metrics: Store, sample_id: str
+):
+    # GIVEN a store with sequencing metrics
+    metrics: Query = store_with_sequencing_metrics._get_query(table=SampleLaneSequencingMetrics)
+
+    # GIVEN a metric for a specific sample
+    sample_metrics: List[SampleLaneSequencingMetrics] = metrics.filter(
+        SampleLaneSequencingMetrics.sample_internal_id == sample_id
+    ).all()
+
+    assert sample_metrics
+
+    # GIVEN a Q30 threshold that some of the sample's metrics will not pass
+    q30_values = [int(metric.sample_base_fraction_passing_q30 * 100) for metric in sample_metrics]
+    q30_threshold = sorted(q30_values)[len(q30_values) // 2]  # This is the median
+
+    # WHEN getting the number of reads for the sample that pass the Q30 threshold
+    number_of_reads: int = (
+        store_with_sequencing_metrics.get_number_of_reads_for_sample_passing_q30_threshold(
+            sample_internal_id=sample_id, q30_threshold=q30_threshold
+        )
+    )
+
+    # THEN assert that the number of reads is less than the total number of reads for the sample
+    total_sample_reads = sum([metric.sample_total_reads_in_lane for metric in sample_metrics])
+    assert number_of_reads < total_sample_reads

--- a/tests/store/api/find/test_find_business_data.py
+++ b/tests/store/api/find/test_find_business_data.py
@@ -779,7 +779,8 @@ def test_get_total_read_counts(
     # WHEN getting total read counts for a sample
     total_reads_count: int = (
         store_with_sequencing_metrics.get_number_of_reads_for_sample_from_metrics(
-            sample_internal_id=sample_id
+            sample_internal_id=sample_id,
+            q30_threshold=0
         )
     )
 

--- a/tests/store/api/find/test_find_business_data.py
+++ b/tests/store/api/find/test_find_business_data.py
@@ -778,7 +778,7 @@ def test_get_total_read_counts(
 
     # WHEN getting total read counts for a sample
     total_reads_count: int = (
-        store_with_sequencing_metrics.get_number_of_reads_for_sample_from_metrics(
+        store_with_sequencing_metrics.get_number_of_reads_for_sample_passing_q30_threshold(
             sample_internal_id=sample_id, q30_threshold=0
         )
     )

--- a/tests/store/api/find/test_find_business_data_sample.py
+++ b/tests/store/api/find/test_find_business_data_sample.py
@@ -328,8 +328,7 @@ def test_get_number_of_reads_for_sample_from_metrics(
 
     # WHEN getting number of reads for a specific sample
     actual_total_reads = store_with_sequencing_metrics.get_number_of_reads_for_sample_from_metrics(
-        sample_internal_id=sample_id,
-        q30_threshold=0
+        sample_internal_id=sample_id, q30_threshold=0
     )
 
     # THEN it should return correct total reads for the sample

--- a/tests/store/api/find/test_find_business_data_sample.py
+++ b/tests/store/api/find/test_find_business_data_sample.py
@@ -327,8 +327,10 @@ def test_get_number_of_reads_for_sample_from_metrics(
     # GIVEN a store with multiple samples with sequencing metrics
 
     # WHEN getting number of reads for a specific sample
-    actual_total_reads = store_with_sequencing_metrics.get_number_of_reads_for_sample_passing_q30_threshold(
-        sample_internal_id=sample_id, q30_threshold=0
+    actual_total_reads = (
+        store_with_sequencing_metrics.get_number_of_reads_for_sample_passing_q30_threshold(
+            sample_internal_id=sample_id, q30_threshold=0
+        )
     )
 
     # THEN it should return correct total reads for the sample

--- a/tests/store/api/find/test_find_business_data_sample.py
+++ b/tests/store/api/find/test_find_business_data_sample.py
@@ -327,7 +327,7 @@ def test_get_number_of_reads_for_sample_from_metrics(
     # GIVEN a store with multiple samples with sequencing metrics
 
     # WHEN getting number of reads for a specific sample
-    actual_total_reads = store_with_sequencing_metrics.get_number_of_reads_for_sample_from_metrics(
+    actual_total_reads = store_with_sequencing_metrics.get_number_of_reads_for_sample_passing_q30_threshold(
         sample_internal_id=sample_id, q30_threshold=0
     )
 

--- a/tests/store/api/find/test_find_business_data_sample.py
+++ b/tests/store/api/find/test_find_business_data_sample.py
@@ -328,7 +328,8 @@ def test_get_number_of_reads_for_sample_from_metrics(
 
     # WHEN getting number of reads for a specific sample
     actual_total_reads = store_with_sequencing_metrics.get_number_of_reads_for_sample_from_metrics(
-        sample_internal_id=sample_id
+        sample_internal_id=sample_id,
+        q30_threshold=0
     )
 
     # THEN it should return correct total reads for the sample

--- a/tests/store/filters/test_status_metrics_filters.py
+++ b/tests/store/filters/test_status_metrics_filters.py
@@ -1,6 +1,7 @@
 from typing import Optional
 from cg.store import Store
 from cg.store.filters.status_metrics_filters import (
+    filter_above_q30_threshold,
     filter_total_read_count_for_sample,
     filter_metrics_for_flow_cell_sample_internal_id_and_lane,
 )
@@ -57,3 +58,29 @@ def test_filter_metrics_for_flow_cell_sample_internal_id_and_lane(
     assert metrics_query[0].flow_cell_name == flow_cell_name
     assert metrics_query[0].sample_internal_id == sample_id
     assert metrics_query[0].flow_cell_lane_number == 1
+
+
+def test_filter_above_q30_threshold(store_with_sequencing_metrics: Store):
+    # GIVEN a Store with sequencing metrics
+    metrics: Query = store_with_sequencing_metrics._get_query(table=SampleLaneSequencingMetrics)
+    metric: Optional[SampleLaneSequencingMetrics] = metrics.first()
+    assert metric
+
+    # GIVEN a Q30 threshold that at least one metric will pass
+    q30_threshold = int(metric.sample_base_fraction_passing_q30 / 2 * 100)
+
+    # WHEN filtering metrics above the Q30 threshold
+    filtered_metrics: Query = filter_above_q30_threshold(
+        metrics=metrics,
+        q30_threshold=q30_threshold,
+    )
+
+    # THEN assert that the returned object is a Query
+    assert isinstance(filtered_metrics, Query)
+
+    # THEN assert that the query returns a list of filtered metrics
+    assert filtered_metrics.all()
+
+    # THEN assert that all returned metrics have a sample_base_fraction_passing_q30 greater than the threshold
+    for metric in filtered_metrics.all():
+        assert metric.sample_base_fraction_passing_q30 > q30_threshold / 100


### PR DESCRIPTION
## Description
This PR adds a filter on the q30 value of the sequencing metrics when updating the sample read count in the post processing step of demultiplexing. So any read counts from a lane with a q30 score below the threshold for the sequencer type are discarded.

### Fixed
- Use q30 threshold when updating the sample read count

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
