### PR TITLE
Fix update date in uploading MIPRNA

### DIFF
--- a/cg/meta/upload/mip/mip_rna.py
+++ b/cg/meta/upload/mip/mip_rna.py
@@ -37,9 +37,4 @@ class MipRNAUploadAPI(UploadAPI):
             except CalledProcessError as error:
                 LOG.error(error)
                 return
-        else:
-            LOG.warning(
-                f"There is nothing to upload to Scout for case {case.internal_id} and "
-                f"the specified data delivery ({case.data_delivery})"
-            )
         self.update_uploaded_at(analysis)

--- a/cg/meta/upload/mip/mip_rna.py
+++ b/cg/meta/upload/mip/mip_rna.py
@@ -34,11 +34,12 @@ class MipRNAUploadAPI(UploadAPI):
         if DataDelivery.SCOUT in case.data_delivery:
             try:
                 ctx.invoke(upload_rna_to_scout, case_id=case.internal_id)
-                self.update_uploaded_at(analysis)
             except CalledProcessError as error:
                 LOG.error(error)
+                return
         else:
             LOG.warning(
                 f"There is nothing to upload to Scout for case {case.internal_id} and "
                 f"the specified data delivery ({case.data_delivery})"
             )
+        self.update_uploaded_at(analysis)


### PR DESCRIPTION
## Description
Fix that some MipRNA analyses have no `uploaded_at` if they had no SCOUT on data delivery

### Added

- A return that avoids ùploaded_at` be updated for not uploaded samples

### Changed

-

### Fixed

- Moved the `self.update_uploaded_at(analysis)` outside the if statement for scout delivery


### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b fix-rna-upload2 -a
    ```

### How to test

- [x] Change the `Delivery Data` field of a sample to `NO_DELIVERY`
- [x] `cg upload -c activealpaca`
- [x] Change the `delivery data` back to the original value

### Expected test outcome
- [x] Check that the ùploaded_at`field in statusdb is updated to the current date and time
- [x] Take a screenshot and attach or copy/paste the output.

## Review

- [x] Tests executed by SD
- [x] "Merge and deploy" approved by VJ
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Deploy this branch on
  - [ ] cg stage
  - [ ] cg production 
