### PR TITLE
Add data archive location to Customer table

### DIFF
--- a/alembic/versions/c3fdf3a8a5b3_add_data_archive_location.py
+++ b/alembic/versions/c3fdf3a8a5b3_add_data_archive_location.py
@@ -1,0 +1,25 @@
+"""add data archive location
+
+Revision ID: c3fdf3a8a5b3
+Revises: ffb9f8ab8e62
+Create Date: 2023-07-04 15:29:48.507215
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c3fdf3a8a5b3"
+down_revision = "ffb9f8ab8e62"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        table_name="customer", column=sa.column("data_archive_location", sa.String(length=32))
+    )
+
+
+def downgrade():
+    op.drop_column(table_name="customer", column_name="data_archive_location")

--- a/alembic/versions/c3fdf3a8a5b3_add_data_archive_location.py
+++ b/alembic/versions/c3fdf3a8a5b3_add_data_archive_location.py
@@ -8,6 +8,8 @@ Create Date: 2023-07-04 15:29:48.507215
 import sqlalchemy as sa
 from alembic import op
 
+from cg.store.models import Customer
+
 # revision identifiers, used by Alembic.
 revision = "c3fdf3a8a5b3"
 down_revision = "ffb9f8ab8e62"
@@ -18,6 +20,17 @@ depends_on = None
 def upgrade():
     op.add_column(
         table_name="customer", column=sa.column("data_archive_location", sa.String(length=32))
+    )
+    bind = op.get_bind()
+    session = sa.orm.Session(bind=bind)
+    for customer in session.query(Customer):
+        customer.data_archive_location = "PDC"
+    session.commit()
+    op.alter_column(
+        table_name="customer",
+        column_name="data_archive_location",
+        existing_type=sa.String(length=32),
+        nullable=False
     )
 
 

--- a/alembic/versions/c3fdf3a8a5b3_add_data_archive_location.py
+++ b/alembic/versions/c3fdf3a8a5b3_add_data_archive_location.py
@@ -17,9 +17,7 @@ depends_on = None
 
 
 def upgrade():
-    op.add_column(
-        table_name="customer", column=sa.column("data_archive_location", sa.String(32))
-    )
+    op.add_column(table_name="customer", column=sa.column("data_archive_location", sa.String(32)))
     bind = op.get_bind()
     session = sa.orm.Session(bind=bind)
     for customer in session.query(Customer):

--- a/alembic/versions/c3fdf3a8a5b3_add_data_archive_location.py
+++ b/alembic/versions/c3fdf3a8a5b3_add_data_archive_location.py
@@ -7,7 +7,6 @@ Create Date: 2023-07-04 15:29:48.507215
 """
 import sqlalchemy as sa
 from alembic import op
-
 from cg.store.models import Customer
 
 # revision identifiers, used by Alembic.
@@ -30,7 +29,7 @@ def upgrade():
         table_name="customer",
         column_name="data_archive_location",
         existing_type=sa.String(length=32),
-        nullable=False
+        nullable=False,
     )
 
 

--- a/alembic/versions/c3fdf3a8a5b3_add_data_archive_location.py
+++ b/alembic/versions/c3fdf3a8a5b3_add_data_archive_location.py
@@ -18,7 +18,7 @@ depends_on = None
 
 def upgrade():
     op.add_column(
-        table_name="customer", column=sa.column("data_archive_location", sa.String(length=32))
+        table_name="customer", column=sa.column("data_archive_location", sa.String(32))
     )
     bind = op.get_bind()
     session = sa.orm.Session(bind=bind)

--- a/alembic/versions/c3fdf3a8a5b3_add_data_archive_location.py
+++ b/alembic/versions/c3fdf3a8a5b3_add_data_archive_location.py
@@ -17,7 +17,7 @@ depends_on = None
 
 
 def upgrade():
-    op.add_column(table_name="customer", column=sa.column("data_archive_location", sa.String(32)))
+    op.add_column(table_name="customer", column=sa.Column("data_archive_location", sa.String(32)))
     bind = op.get_bind()
     session = sa.orm.Session(bind=bind)
     for customer in session.query(Customer):

--- a/cg/cli/add.py
+++ b/cg/cli/add.py
@@ -1,26 +1,24 @@
 import logging
-from typing import Optional, Tuple, List
+from typing import List, Optional, Tuple
 
 import click
-from cg.constants import STATUS_OPTIONS, DataDelivery, Pipeline
+from cg.constants import STATUS_OPTIONS, DataDelivery, Pipeline, Priority
 from cg.constants.subject import Gender
 from cg.meta.transfer.external_data import ExternalDataAPI
 from cg.models.cg_config import CGConfig
 from cg.store import Store
-from cg.utils.click.EnumChoice import EnumChoice
 from cg.store.models import (
-    Family,
-    FamilySample,
-    Sample,
-    User,
-    Collaboration,
-    Customer,
     Application,
     ApplicationVersion,
+    Collaboration,
+    Customer,
+    Family,
+    FamilySample,
     Panel,
+    Sample,
+    User,
 )
-
-from cg.constants import Priority
+from cg.utils.click.EnumChoice import EnumChoice
 
 LOG = logging.getLogger(__name__)
 
@@ -55,6 +53,15 @@ def add():
     required=True,
     help="Invoice reference (text)",
 )
+@click.option(
+    "-da",
+    "--data-archive-location",
+    "data_archive_location",
+    help="Specifies where to store data for the customer.",
+    default="PDC",
+    show_default=True,
+    required=False,
+)
 @click.pass_obj
 def add_customer(
     context: CGConfig,
@@ -63,6 +70,7 @@ def add_customer(
     collaboration_internal_ids: Optional[List[str]],
     invoice_address: str,
     invoice_reference: str,
+    data_archive_location: str,
 ):
     """Add a new customer with a unique internal id and name."""
     collaboration_internal_ids = collaboration_internal_ids or []
@@ -85,6 +93,7 @@ def add_customer(
         name=name,
         invoice_address=invoice_address,
         invoice_reference=invoice_reference,
+        data_archive_location=data_archive_location,
     )
     for collaboration in collaborations:
         new_customer.collaborations.append(collaboration)

--- a/cg/store/api/add.py
+++ b/cg/store/api/add.py
@@ -3,29 +3,26 @@ import logging
 from typing import List, Optional
 
 import petname
-
-from cg.constants import DataDelivery, Pipeline, FlowCellStatus
+from cg.constants import DataDelivery, FlowCellStatus, Pipeline, Priority
 from cg.store.api.base import BaseHandler
-
-from cg.constants import Priority
 from cg.store.models import (
+    Analysis,
+    Application,
+    ApplicationVersion,
+    Bed,
+    BedVersion,
+    Collaboration,
+    Customer,
+    Delivery,
+    Family,
+    FamilySample,
     Flowcell,
     Invoice,
     Organism,
-    Customer,
-    Sample,
-    Pool,
-    Delivery,
-    ApplicationVersion,
     Panel,
-    Analysis,
-    Family,
-    FamilySample,
-    Bed,
-    BedVersion,
-    Application,
+    Pool,
+    Sample,
     User,
-    Collaboration,
 )
 
 LOG = logging.getLogger(__name__)
@@ -46,6 +43,7 @@ class AddHandler(BaseHandler):
         name: str,
         invoice_address: str,
         invoice_reference: str,
+        data_archive_location: str = "PDC",
         scout_access: bool = False,
         *args,
         **kwargs,
@@ -58,6 +56,7 @@ class AddHandler(BaseHandler):
             scout_access=scout_access,
             invoice_address=invoice_address,
             invoice_reference=invoice_reference,
+            data_archive_location=data_archive_location,
             **kwargs,
         )
 

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -272,6 +272,7 @@ class Customer(Model):
     return_samples = Column(types.Boolean, nullable=False, default=False)
     scout_access = Column(types.Boolean, nullable=False, default=False)
     uppmax_account = Column(types.String(32))
+    data_archive_location = Column(types.String(32))
 
     collaborations = orm.relationship("Collaboration", secondary=customer_collaboration)
     delivery_contact_id = Column(ForeignKey("user.id"))

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -272,7 +272,7 @@ class Customer(Model):
     return_samples = Column(types.Boolean, nullable=False, default=False)
     scout_access = Column(types.Boolean, nullable=False, default=False)
     uppmax_account = Column(types.String(32))
-    data_archive_location = Column(types.String(32))
+    data_archive_location = Column(types.String(32), nullable=False, default="PDC")
 
     collaborations = orm.relationship("Collaboration", secondary=customer_collaboration)
     delivery_contact_id = Column(ForeignKey("user.id"))


### PR DESCRIPTION
## Description

We need to deliver and archive data for different customers at different locations.

For instance K customers should get data to Ks' Ceph storage while KI customers should use PDC.

### Added

- Field to Customer table called "data_archive_location" with type str(32).
- Alembic revision to reflect the change.


### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b add-data-archive-location-to-customer-table -a
    ```

### How to test

- [x] Verify that the table "customer" now has a column called "data_archive_location" with type str(32).
- [x] Redeploy master.
- [x] Verify that the table "customer" no longer has the added column.

### Expected test outcome

- [x] customer table is modified successfully.
- [x] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
