### PR TITLE
Changed Black version to be compatible with Python 3.7

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -18,3 +18,4 @@ jobs:
         uses: psf/black@stable
         with:
           options: ". --check --line-length 100"
+          version: "~=23.3.0"


### PR DESCRIPTION
## Description

The latest Black version (23.7.0) does not support Python 3.7, and so our linting fails. This PR specifies an earlier release of Black, which should be compatible with Python 3.7. See documentation here: https://black.readthedocs.io/en/stable/integrations/github_actions.html.

### Fixed

- Specified which version to use in the black.yaml to 23.3.0 (or closest one covered by their stability policy).

### How to test

- [x] Create this PR.

### Expected test outcome

- [x] Black is installed successfully and linting passes.
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [x] Tests executed by IO
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
