### PR TITLE
enhance(set rsync api production QOS to high)

### DIFF
--- a/cg/constants/priority.py
+++ b/cg/constants/priority.py
@@ -21,7 +21,7 @@ class PriorityTerms(StrEnum):
 
 
 SLURM_ACCOUNT_TO_QOS = {
-    "production": SlurmQos.NORMAL,
+    "production": SlurmQos.HIGH,
     "development": SlurmQos.LOW,
 }
 

--- a/cg/constants/priority.py
+++ b/cg/constants/priority.py
@@ -35,3 +35,9 @@ PRIORITY_TO_SLURM_QOS = {
     Priority.express: SlurmQos.EXPRESS,
     Priority.clinical_trials: SlurmQos.NORMAL,
 }
+
+
+class SlurmAccount(StrEnum):
+    PRODUCTION: str = "production"
+    DEVELOPMENT: str = "development"
+    STAGE: str = "stage"

--- a/cg/constants/priority.py
+++ b/cg/constants/priority.py
@@ -20,12 +20,6 @@ class PriorityTerms(StrEnum):
     CLINICAL_TRIALS: str = "clinical_trials"
 
 
-SLURM_ACCOUNT_TO_QOS = {
-    "production": SlurmQos.HIGH,
-    "development": SlurmQos.LOW,
-}
-
-
 class Priority(IntEnum):
     research: int = 0
     standard: int = 1

--- a/cg/meta/rsync/rsync_api.py
+++ b/cg/meta/rsync/rsync_api.py
@@ -38,7 +38,7 @@ class RsyncAPI(MetaAPI):
 
     @property
     def slurm_quality_of_service(self) -> str:
-        """Return the slurm quality of service."""
+        """Return the slurm quality of service depending on the slurm account."""
         return SlurmQos.HIGH if self.account == SlurmAccount.PRODUCTION.value else SlurmQos.LOW
 
     @property

--- a/cg/meta/rsync/rsync_api.py
+++ b/cg/meta/rsync/rsync_api.py
@@ -10,7 +10,7 @@ from cg.apps.tb import TrailblazerAPI
 from cg.constants import Pipeline
 from cg.constants.constants import FileFormat
 from cg.constants.delivery import INBOX_NAME
-from cg.constants.priority import SLURM_ACCOUNT_TO_QOS, SlurmQos
+from cg.constants.priority import SlurmQos
 from cg.exc import CgError
 from cg.io.controller import WriteFile
 from cg.meta.meta import MetaAPI

--- a/cg/meta/rsync/rsync_api.py
+++ b/cg/meta/rsync/rsync_api.py
@@ -10,7 +10,7 @@ from cg.apps.tb import TrailblazerAPI
 from cg.constants import Pipeline
 from cg.constants.constants import FileFormat
 from cg.constants.delivery import INBOX_NAME
-from cg.constants.priority import SlurmQos
+from cg.constants.priority import SlurmQos, SlurmAccount
 from cg.exc import CgError
 from cg.io.controller import WriteFile
 from cg.meta.meta import MetaAPI
@@ -39,7 +39,7 @@ class RsyncAPI(MetaAPI):
     @property
     def slurm_quality_of_service(self) -> str:
         """Return the slurm quality of service."""
-        return SlurmQos.HIGH if self.account == "production" else SlurmQos.LOW
+        return SlurmQos.HIGH if self.account == SlurmAccount.PRODUCTION.value else SlurmQos.LOW
 
     @property
     def trailblazer_config_path(self) -> Path:

--- a/cg/meta/rsync/rsync_api.py
+++ b/cg/meta/rsync/rsync_api.py
@@ -34,8 +34,12 @@ class RsyncAPI(MetaAPI):
         self.account: str = config.data_delivery.account
         self.log_dir: Path = Path(config.data_delivery.base_path)
         self.mail_user: str = config.data_delivery.mail_user
-        self.slurm_quality_of_service: str = SLURM_ACCOUNT_TO_QOS[self.account] or SlurmQos.LOW
         self.pipeline: str = Pipeline.RSYNC
+
+    @property
+    def slurm_quality_of_service(self) -> str:
+        """Return the slurm quality of service."""
+        return SlurmQos.HIGH if self.account == "production" else SlurmQos.LOW
 
     @property
     def trailblazer_config_path(self) -> Path:

--- a/tests/meta/rsync/test_rsync.py
+++ b/tests/meta/rsync/test_rsync.py
@@ -260,7 +260,7 @@ def test_slurm_rsync_single_case_missing_file(
 def test_slurm_quality_of_service_production(rsync_api: RsyncAPI):
     # GIVEN an RsyncAPI instance
 
-    # WHEN the account of the api is set to "production
+    # WHEN the account of the api is set to production
     rsync_api.account = SlurmAccount.PRODUCTION
 
     # THEN the quality of service should be set to HIGH
@@ -270,8 +270,8 @@ def test_slurm_quality_of_service_production(rsync_api: RsyncAPI):
 def test_slurm_quality_of_service_other(rsync_api: RsyncAPI):
     # GIVEN an RsyncAPI instance
 
-    # WHEN the account of the api is set to "production
+    # WHEN the account of the api is set to development
     rsync_api.account = SlurmAccount.DEVELOPMENT
 
-    # THEN the quality of service should be set to HIGH
+    # THEN the quality of service should be set to LOW
     assert rsync_api.slurm_quality_of_service == SlurmQos.LOW

--- a/tests/meta/rsync/test_rsync.py
+++ b/tests/meta/rsync/test_rsync.py
@@ -9,6 +9,7 @@ from cg.exc import CgError
 from cg.meta.rsync import RsyncAPI
 from cg.store import Store
 from cg.store.models import Family
+from cg.constants.priority import SlurmQos, SlurmAccount
 from tests.meta.deliver.conftest import fixture_all_samples_in_inbox, fixture_dummy_file_name
 from tests.store.conftest import fixture_case_obj
 
@@ -254,3 +255,23 @@ def test_slurm_rsync_single_case_missing_file(
     # THEN check that an integer was returned as sbatch number
     assert isinstance(sbatch_number, int)
     assert not is_complete_delivery
+
+
+def test_slurm_quality_of_service_production(rsync_api: RsyncAPI):
+    # GIVEN an RsyncAPI instance
+
+    # WHEN the account of the api is set to "production
+    rsync_api.account = SlurmAccount.PRODUCTION
+
+    # THEN the quality of service should be set to HIGH
+    assert rsync_api.slurm_quality_of_service == SlurmQos.HIGH
+
+
+def test_slurm_quality_of_service_other(rsync_api: RsyncAPI):
+    # GIVEN an RsyncAPI instance
+
+    # WHEN the account of the api is set to "production
+    rsync_api.account = SlurmAccount.DEVELOPMENT
+
+    # THEN the quality of service should be set to HIGH
+    assert rsync_api.slurm_quality_of_service == SlurmQos.LOW


### PR DESCRIPTION
## Description

According to issue #2251 
Setting the production QOS to high for rsync jobs.

### Added

-

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
