### PR TITLE
add(track demux logs in housekeeper)

### DIFF
--- a/cg/constants/housekeeper_tags.py
+++ b/cg/constants/housekeeper_tags.py
@@ -40,6 +40,7 @@ class SequencingFileTag(StrEnum):
     SAMPLE_SHEET: str = "samplesheet"
     SPRING: str = "spring"
     SPRING_METADATA: str = "spring-metadata"
+    DEMUX_LOG: str = "log"
 
 
 HK_MULTIQC_HTML_TAG = ["multiqc-html"]

--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -41,7 +41,7 @@ from cg.models.demultiplex.flow_cell import FlowCellDirectoryData
 from cg.store import Store
 from cg.store.models import Flowcell, SampleLaneSequencingMetrics
 from cg.utils import Process
-from cg.utils.files import get_file_in_directory
+from cg.utils.files import get_file_in_directory, get_files_matching_pattern
 from cg.constants.demultiplexing import DemultiplexingDirsAndFiles
 
 LOG = logging.getLogger(__name__)
@@ -227,10 +227,11 @@ class DemuxPostProcessingAPI:
 
     def add_demux_logs_to_housekeeper(self, flow_cell: FlowCellDirectoryData) -> None:
         """Add demux logs to Housekeeper."""
-        demux_log_file_paths: List[Path] = [
-            self.demux_api.get_stderr_logfile(flow_cell=flow_cell),
-            self.demux_api.get_stdout_logfile(flow_cell=flow_cell),
-        ]
+        log_pattern: str = "*_demultiplex.std*"
+        demux_log_file_paths: List[Path] = get_files_matching_pattern(
+            directory=self.demux_api.run_dir, pattern=log_pattern
+        )
+
         tag_names: List[str] = [SequencingFileTag.DEMUX_LOG, flow_cell.id]
         for file_path in demux_log_file_paths:
             try:

--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -233,9 +233,12 @@ class DemuxPostProcessingAPI:
         ]
         tag_names: List[str] = [SequencingFileTag.DEMUX_LOG, flow_cell.id]
         for file_path in demux_log_file_paths:
-            self.add_file_to_bundle_if_non_existent(
-                file_path=file_path, bundle_name=flow_cell.id, tag_names=tag_names
-            )
+            try:
+                self.add_file_to_bundle_if_non_existent(
+                    file_path=file_path, bundle_name=flow_cell.id, tag_names=tag_names
+                )
+            except FileNotFoundError as e:
+                LOG.error(f"Cannot find demux log file {file_path}. Error: {e}.")
 
     def add_sample_fastq_files_to_housekeeper(self, flow_cell: FlowCellDirectoryData) -> None:
         """Add sample fastq files from flow cell to Housekeeper."""

--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -175,6 +175,9 @@ class DemuxPostProcessingAPI:
             )
         return bool(existing_metrics_entry)
 
+    def add_demux_logs_to_housekeeper(self):
+        pass
+
     def add_metric_to_status_db(self, metric: SampleLaneSequencingMetrics) -> None:
         LOG.debug(
             f"Adding sample lane sequencing metrics for {metric.flow_cell_name}, {metric.sample_internal_id}, and {metric.flow_cell_lane_number}."

--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -229,7 +229,7 @@ class DemuxPostProcessingAPI:
         """Add demux logs to Housekeeper."""
         log_pattern: str = r"*_demultiplex.std*"
         demux_log_file_paths: List[Path] = get_files_matching_pattern(
-            directory=self.demux_api.run_dir, pattern=log_pattern
+            directory=Path(self.demux_api.run_dir, flow_cell.full_name), pattern=log_pattern
         )
 
         tag_names: List[str] = [SequencingFileTag.DEMUX_LOG, flow_cell.id]

--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -19,6 +19,7 @@ from cg.apps.sequencing_metrics_parser.api import (
 from cg.constants.cgstats import STATS_HEADER
 from cg.constants.housekeeper_tags import SequencingFileTag
 from cg.constants.sequencing import Sequencers
+from cg.constants.demultiplexing import DemultiplexingDirsAndFiles
 from cg.exc import FlowCellError
 from cg.meta.demultiplex import files
 from cg.meta.demultiplex.utils import (
@@ -42,7 +43,7 @@ from cg.store import Store
 from cg.store.models import Flowcell, SampleLaneSequencingMetrics
 from cg.utils import Process
 from cg.utils.files import get_file_in_directory, get_files_matching_pattern
-from cg.constants.demultiplexing import DemultiplexingDirsAndFiles
+
 
 LOG = logging.getLogger(__name__)
 

--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -238,6 +238,7 @@ class DemuxPostProcessingAPI:
                 self.add_file_to_bundle_if_non_existent(
                     file_path=file_path, bundle_name=flow_cell.id, tag_names=tag_names
                 )
+                LOG.info(f"Added demux log file {file_path} to Housekeeper.")
             except FileNotFoundError as e:
                 LOG.error(f"Cannot find demux log file {file_path}. Error: {e}.")
 

--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -227,7 +227,7 @@ class DemuxPostProcessingAPI:
 
     def add_demux_logs_to_housekeeper(self, flow_cell: FlowCellDirectoryData) -> None:
         """Add demux logs to Housekeeper."""
-        log_pattern: str = "*_demultiplex.std*"
+        log_pattern: str = r"*_demultiplex.std*"
         demux_log_file_paths: List[Path] = get_files_matching_pattern(
             directory=self.demux_api.run_dir, pattern=log_pattern
         )

--- a/cg/meta/demultiplex/utils.py
+++ b/cg/meta/demultiplex/utils.py
@@ -1,10 +1,10 @@
 import logging
-import os
 import re
+
 from pathlib import Path
 from typing import List, Optional
 
-from cg.apps.demultiplex.sample_sheet.models import FlowCellSample
+from cg.apps.demultiplex.demultiplex_api import DemultiplexingAPI
 from cg.constants.constants import FileExtensions
 from cg.constants.demultiplexing import BclConverter, DemultiplexingDirsAndFiles
 from cg.constants.sequencing import FLOWCELL_Q30_THRESHOLD, Sequencers

--- a/cg/utils/files.py
+++ b/cg/utils/files.py
@@ -21,4 +21,7 @@ def get_file_in_directory(directory: Path, file_name: str) -> Path:
 
 def get_files_matching_pattern(directory: Path, pattern: str) -> List[Path]:
     """Search for all files in a directory that match a pattern."""
-    return list(directory.glob(pattern))
+    file_paths = list(directory.glob(pattern))
+    if not file_paths:
+        raise FileNotFoundError(f"No files matching pattern {pattern} in {directory}")
+    return file_paths

--- a/cg/utils/files.py
+++ b/cg/utils/files.py
@@ -21,7 +21,4 @@ def get_file_in_directory(directory: Path, file_name: str) -> Path:
 
 def get_files_matching_pattern(directory: Path, pattern: str) -> List[Path]:
     """Search for all files in a directory that match a pattern."""
-    file_paths = list(directory.glob(pattern))
-    if not file_paths:
-        raise FileNotFoundError(f"No files matching pattern {pattern} in {directory}")
-    return file_paths
+    return list(directory.glob(pattern))

--- a/tests/meta/demultiplex/test_demux_post_processing.py
+++ b/tests/meta/demultiplex/test_demux_post_processing.py
@@ -882,14 +882,17 @@ def test_add_demux_logs_to_housekeeper(
     demux_log_file_paths: List[Path] = [
         Path(
             demux_post_processing_api.demux_api.run_dir,
-            f"({dragen_flow_cell.id}_demultiplex.stdout)",
+            f"{dragen_flow_cell.full_name}",
+            f"{dragen_flow_cell.id}_demultiplex.stdout",
         ),
         Path(
             demux_post_processing_api.demux_api.run_dir,
-            f"({dragen_flow_cell.id}_demultiplex.stderr)",
+            f"{dragen_flow_cell.full_name}",
+            f"{dragen_flow_cell.id}_demultiplex.stderr",
         ),
     ]
     for file_path in demux_log_file_paths:
+        file_path.parent.mkdir(parents=True, exist_ok=True)
         file_path.touch()
 
     # WHEN adding the demux logs to housekeeper

--- a/tests/meta/demultiplex/test_demux_post_processing.py
+++ b/tests/meta/demultiplex/test_demux_post_processing.py
@@ -1,9 +1,8 @@
 import logging
 from pathlib import Path
 from typing import Generator, List
-from mock import MagicMock, call, patch
+from mock import MagicMock, call
 
-import cg.apps.demultiplex.sample_sheet.models
 from cg.constants.demultiplexing import BclConverter, DemultiplexingDirsAndFiles
 from cg.constants.housekeeper_tags import SequencingFileTag
 from cg.meta.demultiplex.demux_post_processing import (
@@ -15,10 +14,6 @@ from cg.models.cg_config import CGConfig
 from cg.models.demultiplex.demux_results import DemuxResults
 from cg.models.demultiplex.flow_cell import FlowCellDirectoryData
 from cg.store import Store
-from cg.store.models import SampleLaneSequencingMetrics
-from cg.apps.demultiplex.sample_sheet.read_sample_sheet import (
-    get_sample_internal_ids_from_sample_sheet,
-)
 
 
 def test_set_dry_run(
@@ -877,6 +872,11 @@ def test_add_demux_logs_to_housekeeper(
 ):
     # GIVEN a DemuxPostProcessing API
     demux_post_processing_api = DemuxPostProcessingAPI(demultiplex_context)
+
+    # GIVEN a bundle and flow cell version exists in housekeeper
+    demux_post_processing_api.add_bundle_and_version_if_non_existent(
+        bundle_name=dragen_flow_cell.id
+    )
 
     # GIVEN a demux log in the run directory
     demux_log_file_paths: List[Path] = [

--- a/tests/meta/demultiplex/test_demux_post_processing.py
+++ b/tests/meta/demultiplex/test_demux_post_processing.py
@@ -896,8 +896,9 @@ def test_add_demux_logs_to_housekeeper(
     demux_post_processing_api.add_demux_logs_to_housekeeper(flow_cell=dragen_flow_cell)
 
     # THEN the demux log was added to housekeeper
-    for file in demux_post_processing_api.hk_api.get_files(
+    files = demux_post_processing_api.hk_api.get_files(
         tags=[SequencingFileTag.DEMUX_LOG],
-        bundle=demux_post_processing_api.demux_api.run_dir.name,
-    ):
-        assert file.path in demux_log_file_paths
+        bundle=dragen_flow_cell.id,
+    ).all()
+
+    assert len(files) == 2

--- a/tests/meta/demultiplex/test_demux_post_processing.py
+++ b/tests/meta/demultiplex/test_demux_post_processing.py
@@ -901,4 +901,11 @@ def test_add_demux_logs_to_housekeeper(
         bundle=dragen_flow_cell.id,
     ).all()
 
+    expected_file_names: List[str] = []
+    for file_path in demux_log_file_paths:
+        expected_file_names.append(file_path.name.split("/")[-1])
+
+    # THEN the demux logs were added to housekeeper with the correct names
     assert len(files) == 2
+    for file in files:
+        assert file.path.split("/")[-1] in expected_file_names


### PR DESCRIPTION
## Description

Demux logs are no longer tracked when cgstats is deprecated. This PR adds logic to track them in housekeeper as propred here: #2217

### Added

-

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
