### PR TITLE
Bump pydantic to 2.0.3

### DIFF
--- a/cg/apps/cgstats/db/models/demux_sample.py
+++ b/cg/apps/cgstats/db/models/demux_sample.py
@@ -32,6 +32,8 @@ class DemuxSample(BaseModel):
     perfect_barcodes: int = 0
     one_mismatch_barcodes: int = 0
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("raw_clusters_pc", always=True)
     def set_raw_clusters_pc(cls, value: float, values: dict) -> float:
         """Calculate the percentage of raw clusters"""
@@ -40,6 +42,8 @@ class DemuxSample(BaseModel):
             return value
         return round(conversion_stats.raw_cluster_count / values["nr_raw_clusters_"] * 100, 2)
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("pass_filter_yield_pc", always=True)
     def set_pass_filter_yield_pc(cls, value: float, values: dict) -> float:
         """Calculate the pass filter yield percentage"""
@@ -51,18 +55,24 @@ class DemuxSample(BaseModel):
             2,
         )
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("pass_filter_clusters", always=True)
     def set_pass_filter_clusters(cls, _, values) -> int:
         """Set the number of pass filter clusters"""
         conversion_stats: SampleConversionResults = values["conversion_stats_"]
         return conversion_stats.pass_filter_cluster_count
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("pass_filter_yield", always=True)
     def set_pass_filter_yield(cls, _, values) -> int:
         """Set the number of pass filter yield (reads)"""
         conversion_stats: SampleConversionResults = values["conversion_stats_"]
         return conversion_stats.pass_filter_yield
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("pass_filter_Q30", always=True)
     def set_pass_filter_Q30(cls, value, values) -> float:
         """Set the percentage of pass filter high quality reads"""
@@ -71,6 +81,8 @@ class DemuxSample(BaseModel):
             return value
         return round(conversion_stats.pass_filter_q30 / conversion_stats.pass_filter_yield * 100, 2)
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("pass_filter_read1_q30", always=True)
     def set_percentage_high_quality_read_one(cls, value, values) -> float:
         """Calculate the percentage of high quality read one reads of all reads"""
@@ -82,6 +94,8 @@ class DemuxSample(BaseModel):
             2,
         )
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("pass_filter_read2_q30", always=True)
     def set_percentage_high_quality_read_two(cls, value, values) -> float:
         """Calculate the percentage of high quality read two reads of all reads"""
@@ -93,6 +107,8 @@ class DemuxSample(BaseModel):
             2,
         )
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("pass_filter_qscore", always=True)
     def set_pass_filter_qscore(cls, value, values) -> float:
         """Calculate the average quality score per read"""
@@ -104,6 +120,8 @@ class DemuxSample(BaseModel):
             2,
         )
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("undetermined_pc", always=True)
     def set_undetermined_pc(cls, value, values) -> float:
         """Calculate the average quality score per read"""
@@ -118,18 +136,24 @@ class DemuxSample(BaseModel):
             2,
         )
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("barcodes", always=True)
     def set_nr_barcodes(cls, _, values) -> int:
         """Set the total number of barcodes"""
         barcode_stats: SampleBarcodeStats = values["barcode_stats_"]
         return barcode_stats.barcode_count or 0
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("perfect_barcodes", always=True)
     def set_nr_perfect_barcodes(cls, _, values) -> int:
         """Set the total number of perfect barcodes"""
         barcode_stats: SampleBarcodeStats = values["barcode_stats_"]
         return barcode_stats.perfect_barcode_count or 0
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("one_mismatch_barcodes", always=True)
     def set_nr_one_mismatch_barcodes(cls, _, values) -> int:
         """Set the total number of mismatch barcodes"""

--- a/cg/apps/cgstats/parsers/demux_stats.py
+++ b/cg/apps/cgstats/parsers/demux_stats.py
@@ -12,7 +12,7 @@ LOG = logging.getLogger(__name__)
 class SampleBarcodeStats(BaseModel):
     barcode_count: int
     perfect_barcode_count: int
-    one_mismatch_barcode_count: Optional[int]
+    one_mismatch_barcode_count: Optional[int] = None
 
 
 class DemuxStats:

--- a/cg/apps/crunchy/crunchy.py
+++ b/cg/apps/crunchy/crunchy.py
@@ -10,9 +10,8 @@ import logging
 from pathlib import Path
 from typing import Dict, Optional
 
-from cgmodels.crunchy.metadata import CrunchyFile, CrunchyMetadata
-
 from cg.apps.crunchy import files
+from cg.apps.crunchy.models import CrunchyFile, CrunchyMetadata
 from cg.apps.slurm.slurm_api import SlurmAPI
 from cg.constants import FASTQ_DELTA
 from cg.models import CompressionData

--- a/cg/apps/crunchy/files.py
+++ b/cg/apps/crunchy/files.py
@@ -5,10 +5,10 @@ from json.decoder import JSONDecodeError
 from pathlib import Path
 from typing import Dict, List, Optional
 
+from cg.apps.crunchy.models import CrunchyFile, CrunchyMetadata
 from cg.constants.constants import FileFormat
 from cg.io.controller import ReadFile, ReadStream, WriteFile
 from cg.utils.date import get_date
-from cgmodels.crunchy.metadata import CrunchyFile, CrunchyMetadata
 
 LOG = logging.getLogger(__name__)
 

--- a/cg/apps/crunchy/models.py
+++ b/cg/apps/crunchy/models.py
@@ -1,0 +1,17 @@
+from datetime import date
+from typing import List, Optional
+
+from pydantic import Field, BaseModel
+from typing_extensions import Annotated, Literal
+
+
+class CrunchyFile(BaseModel):
+    path: str
+    file: Literal["first_read", "second_read", "spring"]
+    checksum: Optional[str] = None
+    algorithm: Literal["sha1", "md5", "sha256"] = None
+    updated: date = None
+
+
+class CrunchyMetadata(BaseModel):
+    files: Annotated[List[CrunchyFile], Field(max_length=3, min_length=3)]

--- a/cg/apps/demultiplex/sample_sheet/models.py
+++ b/cg/apps/demultiplex/sample_sheet/models.py
@@ -1,5 +1,5 @@
 import logging
-from pydantic import BaseModel, Extra, Field
+from pydantic import ConfigDict, BaseModel, Field
 from typing import List
 
 from cg.constants.constants import GenomeVersion
@@ -15,10 +15,7 @@ class FlowCellSample(BaseModel):
     sample_id: str
     index: str
     index2: str = ""
-
-    class Config:
-        allow_population_by_field_name = True
-        extra = Extra.ignore
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
 
 
 class FlowCellSampleNovaSeq6000(FlowCellSample):

--- a/cg/apps/hermes/models.py
+++ b/cg/apps/hermes/models.py
@@ -3,7 +3,7 @@ import logging
 from pathlib import Path
 from typing import List, Optional
 
-from pydantic import BaseModel, validator
+from pydantic import field_validator, BaseModel, validator
 
 LOG = logging.getLogger(__name__)
 
@@ -23,6 +23,8 @@ class CGDeliverables(BaseModel):
     bundle_id: str
     files: List[CGTag]
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("files", each_item=True)
     def check_mandatory_exists(cls, file):
         if file.mandatory:
@@ -33,6 +35,7 @@ class CGDeliverables(BaseModel):
             return
         return file
 
-    @validator("files")
+    @field_validator("files")
+    @classmethod
     def remove_invalid(cls, value):
         return [item for item in value if item]

--- a/cg/apps/housekeeper/models.py
+++ b/cg/apps/housekeeper/models.py
@@ -14,5 +14,5 @@ class InputFile(BaseModel):
 class InputBundle(BaseModel):
     name: str
     created: datetime = datetime.now()
-    expires: Optional[datetime]
+    expires: Optional[datetime] = None
     files: List[InputFile]

--- a/cg/apps/scout/scout_export.py
+++ b/cg/apps/scout/scout_export.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import List, Optional, Dict
 
-from pydantic import BaseModel, Field, validator
+from pydantic import field_validator, BaseModel, Field
 from typing_extensions import Literal
 
 from cg.constants.gene_panel import GENOME_BUILD_37
@@ -20,18 +20,20 @@ class Individual(BaseModel):
     bam_file: Optional[str] = None
     individual_id: str
     sex: Literal[PlinkGender.UNKNOWN, PlinkGender.MALE, PlinkGender.FEMALE, Gender.OTHER]
-    father: Optional[str]
-    mother: Optional[str]
+    father: Optional[str] = None
+    mother: Optional[str] = None
     phenotype: PlinkPhenotypeStatus
     analysis_type: str = "wgs"
 
-    @validator(Pedigree.FATHER, Pedigree.MOTHER)
+    @field_validator(Pedigree.FATHER, Pedigree.MOTHER)
+    @classmethod
     def convert_to_zero(cls, value):
         if value is None:
             return RelationshipStatus.HAS_NO_PARENT
         return value
 
-    @validator(Pedigree.SEX)
+    @field_validator(Pedigree.SEX)
+    @classmethod
     def convert_sex_to_zero(cls, value):
         if value == Gender.OTHER:
             return PlinkGender.UNKNOWN
@@ -49,18 +51,18 @@ class Phenotype(BaseModel):
 
 class Gene(BaseModel):
     hgnc_id: int
-    hgnc_symbol: Optional[str]
-    region_annotation: Optional[str]
-    functional_annotation: Optional[str]
-    sift_prediction: Optional[str]
-    polyphen_prediction: Optional[str]
+    hgnc_symbol: Optional[str] = None
+    region_annotation: Optional[str] = None
+    functional_annotation: Optional[str] = None
+    sift_prediction: Optional[str] = None
+    polyphen_prediction: Optional[str] = None
 
 
 class DiagnosisPhenotypes(BaseModel):
     disease_nr: int
     disease_id: str
     description: str
-    individuals: Optional[List[Dict[str, str]]]
+    individuals: Optional[List[Dict[str, str]]] = None
 
 
 class ScoutExportCase(BaseModel):
@@ -70,17 +72,18 @@ class ScoutExportCase(BaseModel):
     causatives: Optional[List[str]] = None
     collaborators: List[str] = []
     individuals: List[Individual]
-    genome_build: Optional[str]
-    panels: Optional[List[Panel]]
-    rank_model_version: Optional[str]
-    sv_rank_model_version: Optional[str]
+    genome_build: Optional[str] = None
+    panels: Optional[List[Panel]] = None
+    rank_model_version: Optional[str] = None
+    sv_rank_model_version: Optional[str] = None
     rank_score_threshold: int = 5
-    phenotype_terms: Optional[List[Phenotype]]
-    phenotype_groups: Optional[List[Phenotype]]
-    diagnosis_phenotypes: Optional[List[DiagnosisPhenotypes]]
-    diagnosis_genes: Optional[List[int]]
+    phenotype_terms: Optional[List[Phenotype]] = None
+    phenotype_groups: Optional[List[Phenotype]] = None
+    diagnosis_phenotypes: Optional[List[DiagnosisPhenotypes]] = None
+    diagnosis_genes: Optional[List[int]] = None
 
-    @validator("genome_build")
+    @field_validator("genome_build")
+    @classmethod
     def convert_genome_build(cls, value):
         if value is None:
             return GENOME_BUILD_37
@@ -109,5 +112,5 @@ class Variant(BaseModel):
     rank_score: int
     category: str
     sub_category: str
-    genes: Optional[List[Gene]]
+    genes: Optional[List[Gene]] = None
     samples: List[Genotype]

--- a/cg/apps/sequencing_metrics_parser/models/bcl2fastq_metrics.py
+++ b/cg/apps/sequencing_metrics_parser/models/bcl2fastq_metrics.py
@@ -15,6 +15,8 @@ class IndexMetric(BaseModel):
 
     mismatch_counts: Dict[str, int] = Field(..., alias="MismatchCounts")
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("mismatch_counts", each_item=True)
     def check_non_negative(cls, value):
         if value < 0:

--- a/cg/apps/tb/models.py
+++ b/cg/apps/tb/models.py
@@ -3,47 +3,48 @@ from pathlib import Path
 from typing import Optional
 
 from dateutil.parser import parse as parse_datestr
-from pydantic import BaseModel, validator
+from pydantic import field_validator, ConfigDict, BaseModel, validator
 
 
 class TrailblazerAnalysis(BaseModel):
     id: int
     family: str
-    case_id = Optional[str]
+    case_id: Optional[str] = None
 
-    version: Optional[str]
-    logged_at: Optional[str]
-    started_at: Optional[str]
-    completed_at: Optional[str]
-    status: Optional[str]
-    priority: Optional[str]
-    out_dir: Optional[str]
-    config_path: Optional[str]
-    comment: Optional[str]
-    is_deleted: Optional[bool]
-    is_visible: Optional[bool]
-    type: Optional[str]
-    user_id: Optional[int]
+    version: Optional[str] = None
+    logged_at: Optional[str] = None
+    started_at: Optional[str] = None
+    completed_at: Optional[str] = None
+    status: Optional[str] = None
+    priority: Optional[str] = None
+    out_dir: Optional[str] = None
+    config_path: Optional[str] = None
+    comment: Optional[str] = None
+    is_deleted: Optional[bool] = None
+    is_visible: Optional[bool] = None
+    type: Optional[str] = None
+    user_id: Optional[int] = None
     progress: Optional[float] = 0.0
-    data_analysis: Optional[str]
-    ticket: Optional[str]
-    uploaded_at: Optional[str]
+    data_analysis: Optional[str] = None
+    ticket: Optional[str] = None
+    uploaded_at: Optional[str] = None
 
-    @validator("case_id")
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
+    @field_validator("case_id")
     def inherit_family_value(cls, value: str, values: dict) -> str:
         return values.get("family")
 
-    @validator("logged_at", "started_at", "completed_at")
+    @field_validator("logged_at", "started_at", "completed_at")
+    @classmethod
     def parse_str_to_datetime(cls, value: str) -> Optional[dt.datetime]:
         if value:
             return parse_datestr(value)
 
-    @validator("out_dir", "config_path")
+    @field_validator("out_dir", "config_path")
+    @classmethod
     def parse_str_to_path(cls, value: str) -> Optional[Path]:
         if value:
             return Path(value)
 
-    class Config:
-        extra = "allow"
-        validate_all = True
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(extra="allow", validate_default=True, arbitrary_types_allowed=True)

--- a/cg/meta/archive/ddn_dataflow.py
+++ b/cg/meta/archive/ddn_dataflow.py
@@ -117,7 +117,7 @@ class AuthResponse(BaseModel):
 
     access: str
     expire: int
-    refresh: Optional[str]
+    refresh: Optional[str] = None
 
 
 class DDNDataFlowApi:

--- a/cg/meta/upload/gisaid/models.py
+++ b/cg/meta/upload/gisaid/models.py
@@ -13,13 +13,17 @@ class FastaFile(BaseModel):
 
 class GisaidAccession(BaseModel):
     log_message: str
-    accession_nr: Optional[str]
-    sample_id: Optional[str]
+    accession_nr: Optional[str] = None
+    sample_id: Optional[str] = None
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("accession_nr", always=True)
     def parse_accession(cls, v, values):
         return values["log_message"].split(";")[-1]
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("sample_id", always=True)
     def parse_sample_id(cls, v, values):
         return values["log_message"].split("/")[2].split("_")[2]
@@ -40,31 +44,37 @@ class GisaidSample(BaseModel):
     fn: str
     covv_collection_date: str
     covv_subm_sample_id: str
-    covv_virus_name: Optional[str]
-    covv_orig_lab: Optional[str]
+    covv_virus_name: Optional[str] = None
+    covv_orig_lab: Optional[str] = None
     covv_type: Optional[str] = "betacoronavirus"
     covv_passage: Optional[str] = "Original"
-    covv_location: Optional[str]
+    covv_location: Optional[str] = None
     covv_host: Optional[str] = "Human"
     covv_gender: Optional[str] = "unknown"
     covv_patient_age: Optional[str] = "unknown"
     covv_patient_status: Optional[str] = "unknown"
     covv_seq_technology: Optional[str] = "Illumina NovaSeq"
-    covv_orig_lab_addr: Optional[str]
+    covv_orig_lab_addr: Optional[str] = None
     covv_subm_lab: Optional[str] = "Karolinska University Hospital"
     covv_subm_lab_addr: Optional[str] = "171 76 Stockholm, Sweden"
     covv_authors: Optional[str] = " ,".join(AUTHORS)
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("covv_location", always=True)
     def parse_location(cls, v, values):
         region: str = values.get("region")
         return f"Europe/Sweden/{region}"
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("covv_subm_sample_id", always=True)
     def parse_subm_sample_id(cls, v, values):
         region_code = values.get("region_code")
         return f"{region_code}_SE100_{v}"
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("covv_virus_name", always=True)
     def parse_virus_name(cls, v, values):
         sample_name = values.get("covv_subm_sample_id")

--- a/cg/meta/upload/nipt/models.py
+++ b/cg/meta/upload/nipt/models.py
@@ -4,5 +4,5 @@ from pydantic import BaseModel
 
 class StatinaUploadFiles(BaseModel):
     result_file: str
-    multiqc_report: Optional[str]
-    segmental_calls: Optional[str]
+    multiqc_report: Optional[str] = None
+    segmental_calls: Optional[str] = None

--- a/cg/models/balsamic/config.py
+++ b/cg/models/balsamic/config.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Union, Optional
 
-from pydantic import BaseModel, validator
+from pydantic import field_validator, BaseModel, validator
 
 
 class BalsamicConfigAnalysis(BaseModel):
@@ -48,8 +48,10 @@ class BalsamicConfigReference(BaseModel):
     """
 
     reference_genome: Path
-    reference_genome_version: Optional[str]
+    reference_genome_version: Optional[str] = None
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("reference_genome_version", always=True)
     def extract_genome_version_from_path(cls, value: Optional[str], values: dict) -> str:
         """
@@ -70,14 +72,17 @@ class BalsamicConfigPanel(BaseModel):
     """
 
     capture_kit: str
-    capture_kit_version: Optional[str]
+    capture_kit_version: Optional[str] = None
     chrom: List[str]
 
-    @validator("capture_kit", pre=True)
+    @field_validator("capture_kit", mode="before")
+    @classmethod
     def extract_capture_kit_name_from_path(cls, capture_kit: str) -> str:
         """Return the base name of the provided capture kit path."""
         return Path(capture_kit).name
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("capture_kit_version", always=True)
     def extract_capture_kit_name_from_name(
         cls, capture_kit_version: Optional[str], values: dict
@@ -100,12 +105,12 @@ class BalsamicConfigQC(BaseModel):
     """
 
     picard_rmdup: bool
-    adapter: Optional[str]
+    adapter: Optional[str] = None
     quality_trim: bool
     adapter_trim: bool
     umi_trim: bool
-    min_seq_length: Optional[str]
-    umi_trim_length: Optional[str]
+    min_seq_length: Optional[str] = None
+    umi_trim_length: Optional[str] = None
 
 
 class BalsamicVarCaller(BaseModel):
@@ -139,7 +144,7 @@ class BalsamicConfigJSON(BaseModel):
     analysis: BalsamicConfigAnalysis
     samples: Dict[str, BalsamicConfigSample]
     reference: BalsamicConfigReference
-    panel: Optional[BalsamicConfigPanel]
+    panel: Optional[BalsamicConfigPanel] = None
     QC: BalsamicConfigQC
     vcf: Dict[str, BalsamicVarCaller]
     bioinfo_tools_version: Dict[str, List[str]]

--- a/cg/models/balsamic/metrics.py
+++ b/cg/models/balsamic/metrics.py
@@ -18,28 +18,28 @@ class BalsamicMetricsBase(MetricsBase):
         condition: balsamic metric validation condition
     """
 
-    condition: Optional[MetricCondition]
+    condition: Optional[MetricCondition] = None
 
 
 class BalsamicQCMetrics(BaseModel):
     """BALSAMIC common QC metrics"""
 
-    mean_insert_size: Optional[float]
-    fold_80_base_penalty: Optional[float]
+    mean_insert_size: Optional[float] = None
+    fold_80_base_penalty: Optional[float] = None
 
 
 class BalsamicTargetedQCMetrics(BalsamicQCMetrics):
     """BALSAMIC targeted QC metrics"""
 
-    mean_target_coverage: Optional[float]
-    median_target_coverage: Optional[float]
-    percent_duplication: Optional[float]
-    pct_target_bases_50x: Optional[float]
-    pct_target_bases_100x: Optional[float]
-    pct_target_bases_250x: Optional[float]
-    pct_target_bases_500x: Optional[float]
-    pct_target_bases_1000x: Optional[float]
-    pct_off_bait: Optional[float]
+    mean_target_coverage: Optional[float] = None
+    median_target_coverage: Optional[float] = None
+    percent_duplication: Optional[float] = None
+    pct_target_bases_50x: Optional[float] = None
+    pct_target_bases_100x: Optional[float] = None
+    pct_target_bases_250x: Optional[float] = None
+    pct_target_bases_500x: Optional[float] = None
+    pct_target_bases_1000x: Optional[float] = None
+    pct_off_bait: Optional[float] = None
 
     _pct_values = validator(
         "percent_duplication",
@@ -56,13 +56,13 @@ class BalsamicTargetedQCMetrics(BalsamicQCMetrics):
 class BalsamicWGSQCMetrics(BalsamicQCMetrics):
     """BALSAMIC WGS QC metrics"""
 
-    median_coverage: Optional[float]
-    percent_duplication_r1: Optional[float]
-    percent_duplication_r2: Optional[float]
-    pct_15x: Optional[float]
-    pct_30x: Optional[float]
-    pct_60x: Optional[float]
-    pct_100x: Optional[float]
+    median_coverage: Optional[float] = None
+    percent_duplication_r1: Optional[float] = None
+    percent_duplication_r2: Optional[float] = None
+    pct_15x: Optional[float] = None
+    pct_30x: Optional[float] = None
+    pct_60x: Optional[float] = None
+    pct_100x: Optional[float] = None
 
     _pct_values = validator(
         "pct_15x",

--- a/cg/models/cg_config.py
+++ b/cg/models/cg_config.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Optional
 
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import ConfigDict, BaseModel, EmailStr, Field
 from typing_extensions import Literal
 
 from cg.apps.cgstats.stats import StatsAPI
@@ -56,11 +56,11 @@ class CleanConfig(BaseModel):
 
 class SlurmConfig(BaseModel):
     account: str
-    hours: Optional[int]
+    hours: Optional[int] = None
     mail_user: EmailStr
-    memory: Optional[int]
-    number_tasks: Optional[int]
-    conda_env: Optional[str]
+    memory: Optional[int] = None
+    number_tasks: Optional[int] = None
+    conda_env: Optional[str] = None
     qos: SlurmQos = SlurmQos.LOW
 
 
@@ -82,7 +82,7 @@ class TrailblazerConfig(BaseModel):
 
 
 class StatinaConfig(BaseModel):
-    host: Optional[str]
+    host: Optional[str] = None
     user: str
     key: str
     api_url: str
@@ -92,7 +92,7 @@ class StatinaConfig(BaseModel):
 
 class CommonAppConfig(BaseModel):
     binary_path: str
-    config_path: Optional[str]
+    config_path: Optional[str] = None
 
 
 class FluffyUploadConfig(BaseModel):
@@ -198,7 +198,7 @@ class GisaidConfig(CommonAppConfig):
 class DataDeliveryConfig(BaseModel):
     destination_path: str
     covid_destination_path: str
-    covid_source_path = str
+    covid_source_path: Optional[str] = None
     covid_report_path: str
     account: str
     base_path: str
@@ -240,87 +240,70 @@ class CGConfig(BaseModel):
     environment: Literal["production", "stage"] = "stage"
     madeline_exe: str
     delivery_path: str
-    max_flowcells: Optional[int]
+    max_flowcells: Optional[int] = None
     email_base_settings: EmailBaseSettings
 
     # Base APIs that always should exist
-    status_db_: Store = None
+    status_db_: Store = Field(None, alias="status_db")
     housekeeper: HousekeeperConfig
-    housekeeper_api_: HousekeeperAPI = None
+    housekeeper_api_: HousekeeperAPI = Field(None, alias="housekeeper_api")
 
     # App APIs that can be instantiated in CGConfig
-    backup: BackupConfig = None
-    cgstats: CGStatsConfig = None
-    cg_stats_api_: StatsAPI = None
-    chanjo: CommonAppConfig = None
-    chanjo_api_: ChanjoAPI = None
+    backup: Optional[BackupConfig] = None
+    cgstats: Optional[CGStatsConfig] = None
+    cg_stats_api_: Optional[StatsAPI] = Field(None, alias="cg_stats_api")
+    chanjo: Optional[CommonAppConfig] = None
+    chanjo_api_: Optional[ChanjoAPI] = Field(None, alias="chanjo_api")
     clean: Optional[CleanConfig] = None
-    crunchy: CrunchyConfig = None
-    crunchy_api_: CrunchyAPI = None
-    data_delivery: DataDeliveryConfig = Field(None, alias="data-delivery")
+    crunchy: Optional[CrunchyConfig] = None
+    crunchy_api_: Optional[CrunchyAPI] = Field(None, alias="crunchy_api")
+    data_delivery: Optional[DataDeliveryConfig] = Field(None, alias="data-delivery")
     ddn: Optional[DDNDataFlowConfig] = None
-    demultiplex: DemultiplexConfig = None
-    demultiplex_api_: DemultiplexingAPI = None
+    demultiplex: Optional[DemultiplexConfig] = None
+    demultiplex_api_: Optional[DemultiplexingAPI] = Field(None, alias="demultiplex_api")
     encryption: Optional[CommonAppConfig] = None
-    external: ExternalConfig = None
-    genotype: CommonAppConfig = None
-    genotype_api_: GenotypeAPI = None
-    gens: CommonAppConfig = None
-    gens_api_: GensAPI = None
-    hermes: CommonAppConfig = None
-    hermes_api_: HermesApi = None
-    lims: LimsConfig = None
-    lims_api_: LimsAPI = None
-    loqusdb: CommonAppConfig = Field(None, alias=LoqusdbInstance.WGS.value)
-    loqusdb_api_: LoqusdbAPI = None
-    loqusdb_wes: CommonAppConfig = Field(None, alias=LoqusdbInstance.WES.value)
-    loqusdb_somatic: CommonAppConfig = Field(None, alias=LoqusdbInstance.SOMATIC.value)
-    loqusdb_tumor: CommonAppConfig = Field(None, alias=LoqusdbInstance.TUMOR.value)
-    madeline_api_: MadelineAPI = None
-    mutacc_auto: MutaccAutoConfig = Field(None, alias="mutacc-auto")
-    mutacc_auto_api_: MutaccAutoAPI = None
+    external: Optional[ExternalConfig] = None
+    genotype: Optional[CommonAppConfig] = None
+    genotype_api_: Optional[GenotypeAPI] = Field(None, alias="genotype_api")
+    gens: Optional[CommonAppConfig] = None
+    gens_api_: Optional[GensAPI] = Field(None, alias="gens_api")
+    hermes: Optional[CommonAppConfig] = None
+    hermes_api_: Optional[HermesApi] = Field(None, alias="hermes_api")
+    lims: Optional[LimsConfig] = None
+    lims_api_: Optional[LimsAPI] = Field(None, alias="lims_api")
+    loqusdb: Optional[CommonAppConfig] = Field(None, alias=LoqusdbInstance.WGS.value)
+    loqusdb_api_: Optional[LoqusdbAPI] = Field(None, alias="loqusdb_api")
+    loqusdb_wes: Optional[CommonAppConfig] = Field(None, alias=LoqusdbInstance.WES.value)
+    loqusdb_somatic: Optional[CommonAppConfig] = Field(None, alias=LoqusdbInstance.SOMATIC.value)
+    loqusdb_tumor: Optional[CommonAppConfig] = Field(None, alias=LoqusdbInstance.TUMOR.value)
+    madeline_api_: Optional[MadelineAPI] = Field(None, alias="madeline_api")
+    mutacc_auto: Optional[MutaccAutoConfig] = Field(None, alias="mutacc-auto")
+    mutacc_auto_api_: Optional[MutaccAutoAPI] = Field(None, alias="mutacc_auto_api")
     pdc: Optional[CommonAppConfig] = None
-    scout: CommonAppConfig = None
-    scout_api_: ScoutAPI = None
+    scout: Optional[CommonAppConfig] = None
+    scout_api_: Optional[ScoutAPI] = Field(None, alias="scout_api")
     tar: Optional[CommonAppConfig] = None
-    trailblazer: TrailblazerConfig = None
-    trailblazer_api_: TrailblazerAPI = None
+    trailblazer: Optional[TrailblazerConfig] = None
+    trailblazer_api_: Optional[TrailblazerAPI] = Field(None, alias="trailblazer_api")
 
     # Meta APIs that will use the apps from CGConfig
-    balsamic: BalsamicConfig = None
-    statina: StatinaConfig = None
+    balsamic: Optional[BalsamicConfig] = None
+    statina: Optional[StatinaConfig] = None
     fohm: Optional[FOHMConfig] = None
-    fluffy: FluffyConfig = None
-    microsalt: MicrosaltConfig = None
-    gisaid: GisaidConfig = None
-    mip_rd_dna: MipConfig = Field(None, alias="mip-rd-dna")
-    mip_rd_rna: MipConfig = Field(None, alias="mip-rd-rna")
-    mutant: MutantConfig = None
-    rnafusion: RnafusionConfig = Field(None, alias="rnafusion")
-    taxprofiler: TaxprofilerConfig = Field(None, alias="taxprofiler")
+    fluffy: Optional[FluffyConfig] = None
+    microsalt: Optional[MicrosaltConfig] = None
+    gisaid: Optional[GisaidConfig] = None
+    mip_rd_dna: Optional[MipConfig] = Field(None, alias="mip-rd-dna")
+    mip_rd_rna: Optional[MipConfig] = Field(None, alias="mip-rd-rna")
+    mutant: Optional[MutantConfig] = None
+    rnafusion: Optional[RnafusionConfig] = Field(None, alias="rnafusion")
+    taxprofiler: Optional[TaxprofilerConfig] = Field(None, alias="taxprofiler")
 
     # These are meta APIs that gets instantiated in the code
     meta_apis: dict = {}
-
-    class Config:
-        arbitrary_types_allowed = True
-        fields = {
-            "cg_stats_api_": "cg_stats_api",
-            "chanjo_api_": "chanjo_api",
-            "crunchy_api_": "crunchy_api",
-            "demultiplex_api_": "demultiplex_api",
-            "genotype_api_": "genotype_api",
-            "gens_api_": "gens_api",
-            "hermes_api_": "hermes_api",
-            "housekeeper_api_": "housekeeper_api",
-            "lims_api_": "lims_api",
-            "loqusdb_api_": "loqusdb_api",
-            "madeline_api_": "madeline_api",
-            "mutacc_auto_api_": "mutacc_auto_api",
-            "scout_api_": "scout_api",
-            "status_db_": "status_db",
-            "trailblazer_api_": "trailblazer_api",
-        }
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+    )
 
     @property
     def chanjo_api(self) -> ChanjoAPI:

--- a/cg/models/cgstats/flowcell.py
+++ b/cg/models/cgstats/flowcell.py
@@ -12,7 +12,7 @@ class StatsSample(BaseModel):
 
 class StatsFlowcell(BaseModel):
     name: str
-    sequencer: Optional[str]
+    sequencer: Optional[str] = None
     sequencer_type: str
     date: datetime
     samples: List[StatsSample]

--- a/cg/models/cgstats/stats_sample.py
+++ b/cg/models/cgstats/stats_sample.py
@@ -1,6 +1,6 @@
 from typing import List, Set
 
-from pydantic import BaseModel, Field, validator
+from pydantic import field_validator, ConfigDict, BaseModel, Field, validator
 
 
 class Unaligned(BaseModel):
@@ -11,9 +11,7 @@ class Unaligned(BaseModel):
 
     q30_bases_pct: float
     mean_quality_score: float
-
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class StatsSample(BaseModel):
@@ -23,6 +21,8 @@ class StatsSample(BaseModel):
     read_count_sum: int = 0
     sum_yield: int = 0
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("lanes", always=True)
     def set_lanes(cls, _, values: dict) -> List[int]:
         """Set the number of pass filter clusters"""
@@ -32,6 +32,8 @@ class StatsSample(BaseModel):
             lanes_found.add(read.lane)
         return list(lanes_found)
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("read_count_sum", always=True)
     def set_read_count(cls, _, values: dict):
         unaligned_reads: List[Unaligned] = values["unaligned"]
@@ -40,6 +42,8 @@ class StatsSample(BaseModel):
             count += read.read_count
         return count
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("sum_yield", always=True)
     def set_sum_yield(cls, _, values: dict):
         unaligned_reads: List[Unaligned] = values["unaligned"]
@@ -48,9 +52,9 @@ class StatsSample(BaseModel):
             count += read.yield_mb
         return count
 
-    @validator("unaligned")
+    @field_validator("unaligned")
+    @classmethod
     def sort_unaligned(cls, values):
         return sorted(values, key=lambda x: x.lane)
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)

--- a/cg/models/deliverables/metric_deliverables.py
+++ b/cg/models/deliverables/metric_deliverables.py
@@ -1,7 +1,7 @@
 import operator
 from typing import Any, Callable, Dict, List, Optional
 
-from pydantic import BaseModel, Field, validator
+from pydantic import field_validator, BaseModel, Field, validator
 
 from cg.exc import CgError, MetricsQCError
 
@@ -59,7 +59,8 @@ class MetricCondition(BaseModel):
     norm: str
     threshold: float
 
-    @validator("norm")
+    @field_validator("norm")
+    @classmethod
     def validate_operator(cls, norm: str) -> str:
         """Validate that an operator is accepted."""
         try:
@@ -74,13 +75,13 @@ class MetricCondition(BaseModel):
 class MetricsBase(BaseModel):
     """Definition for elements in deliverables metrics file."""
 
-    header: Optional[str]
+    header: Optional[str] = None
     id: str
     input: str
     name: str
     step: str
-    value: Any
-    condition: Optional[MetricCondition]
+    value: Any = None
+    condition: Optional[MetricCondition] = None
 
 
 class SampleMetric(BaseModel):
@@ -95,6 +96,8 @@ class MeanInsertSize(SampleMetric):
 
     value: float
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("value", always=True)
     def convert_mean_insert_size(cls, value) -> int:
         """Convert raw value from float to int"""
@@ -121,8 +124,10 @@ class MetricsDeliverables(BaseModel):
     """Specification for a metric general deliverables file"""
 
     metrics_: List[MetricsBase] = Field(..., alias="metrics")
-    sample_ids: Optional[set]
+    sample_ids: Optional[set] = None
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("sample_ids", always=True)
     def set_sample_ids(cls, _, values: dict) -> set:
         """Set sample_ids gathered from all metrics"""
@@ -138,7 +143,8 @@ class MetricsDeliverablesCondition(BaseModel):
 
     metrics: List[MetricsBase]
 
-    @validator("metrics")
+    @field_validator("metrics")
+    @classmethod
     def validate_metrics(cls, metrics: List[MetricsBase]) -> List[MetricsBase]:
         """Verify that metrics met QC conditions."""
         failed_metrics: List = []
@@ -155,5 +161,5 @@ class MetricsDeliverablesCondition(BaseModel):
 class MultiqcDataJson(BaseModel):
     """Multiqc data json model."""
 
-    report_general_stats_data: Optional[List[Dict]]
-    report_data_sources: Optional[Dict]
+    report_general_stats_data: Optional[List[Dict]] = None
+    report_data_sources: Optional[Dict] = None

--- a/cg/models/email.py
+++ b/cg/models/email.py
@@ -10,4 +10,4 @@ class EmailInfo(EmailBaseSettings):
     sender_email: str = "hiseq.clinical@hasta.scilifelab.se"
     subject: str
     message: str
-    file: Optional[Path]
+    file: Optional[Path] = None

--- a/cg/models/invoice/invoice.py
+++ b/cg/models/invoice/invoice.py
@@ -29,26 +29,26 @@ class InvoiceInfo(BaseModel):
 
     name: str
     id: str
-    lims_id: Optional[str]
+    lims_id: Optional[str] = None
     application_tag: str
     project: str
-    date: Optional[Any]
+    date: Optional[Any] = None
     price: int
     priority: PriorityTerms
-    price_kth: Optional[int]
-    total_price: Optional[int]
+    price_kth: Optional[int] = None
+    total_price: Optional[int] = None
 
 
 class InvoiceReport(BaseModel):
     """Class that collects information used to create the invoice Excel sheet."""
 
     cost_center: str
-    project_number: Optional[str]
+    project_number: Optional[str] = None
     customer_id: str
     customer_name: str
-    agreement: Optional[str]
+    agreement: Optional[str] = None
     invoice_id: int
     contact: dict
     records: List
-    pooled_samples: Optional[Any]
+    pooled_samples: Optional[Any] = None
     record_type: RecordType

--- a/cg/models/lims/sample.py
+++ b/cg/models/lims/sample.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import BaseModel, validator
+from pydantic import field_validator, BaseModel
 from typing_extensions import Literal
 
 from cg.constants import Priority
@@ -10,49 +10,50 @@ SEX_MAP = {"male": "M", "female": "F"}
 
 class Udf(BaseModel):
     application: str
-    capture_kit: Optional[str]
-    collection_date: Optional[str]
-    comment: Optional[str]
-    concentration: Optional[str]
-    concentration_sample: Optional[str]
+    capture_kit: Optional[str] = None
+    collection_date: Optional[str] = None
+    comment: Optional[str] = None
+    concentration: Optional[str] = None
+    concentration_sample: Optional[str] = None
     customer: str
-    control: Optional[str]
-    data_analysis: Optional[str]
-    data_delivery: Optional[str]
-    elution_buffer: Optional[str]
-    extraction_method: Optional[str]
+    control: Optional[str] = None
+    data_analysis: Optional[str] = None
+    data_delivery: Optional[str] = None
+    elution_buffer: Optional[str] = None
+    extraction_method: Optional[str] = None
     family_name: str = "NA"
-    formalin_fixation_time: Optional[str]
-    index: Optional[str]
-    index_number: Optional[str]
-    lab_code: Optional[str]
-    organism: Optional[str]
-    organism_other: Optional[str]
-    original_lab: Optional[str]
-    original_lab_address: Optional[str]
-    pool: Optional[str]
-    post_formalin_fixation_time: Optional[str]
-    pre_processing_method: Optional[str]
-    primer: Optional[str]
+    formalin_fixation_time: Optional[str] = None
+    index: Optional[str] = None
+    index_number: Optional[str] = None
+    lab_code: Optional[str] = None
+    organism: Optional[str] = None
+    organism_other: Optional[str] = None
+    original_lab: Optional[str] = None
+    original_lab_address: Optional[str] = None
+    pool: Optional[str] = None
+    post_formalin_fixation_time: Optional[str] = None
+    pre_processing_method: Optional[str] = None
+    primer: Optional[str] = None
     priority: str = Priority.standard.name
-    quantity: Optional[str]
-    reference_genome: Optional[str]
-    region: Optional[str]
-    region_code: Optional[str]
+    quantity: Optional[str] = None
+    reference_genome: Optional[str] = None
+    region: Optional[str] = None
+    region_code: Optional[str] = None
     require_qc_ok: bool = False
-    rml_plate_name: Optional[str]
-    selection_criteria: Optional[str]
+    rml_plate_name: Optional[str] = None
+    selection_criteria: Optional[str] = None
     sex: Literal["M", "F", "unknown"] = "unknown"
     skip_reception_control: Optional[bool] = None
     source: str = "NA"
-    tissue_block_size: Optional[str]
+    tissue_block_size: Optional[str] = None
     tumour: Optional[bool] = False
-    tumour_purity: Optional[str]
-    volume: Optional[str]
-    well_position_rml: Optional[str]
-    verified_organism: Optional[bool]
+    tumour_purity: Optional[str] = None
+    volume: Optional[str] = None
+    well_position_rml: Optional[str] = None
+    verified_organism: Optional[bool] = None
 
-    @validator("sex", pre=True)
+    @field_validator("sex", mode="before")
+    @classmethod
     def validate_sex(cls, value: str):
         return SEX_MAP.get(value, "unknown")
 
@@ -60,10 +61,10 @@ class Udf(BaseModel):
 class LimsSample(BaseModel):
     name: str
     container: str = "Tube"
-    container_name: Optional[str]
-    well_position: Optional[str]
-    index_sequence: Optional[str]
-    udfs: Optional[Udf]
+    container_name: Optional[str] = None
+    well_position: Optional[str] = None
+    index_sequence: Optional[str] = None
+    udfs: Optional[Udf] = None
 
     @classmethod
     def parse_obj(cls, obj: dict):

--- a/cg/models/mip/mip_config.py
+++ b/cg/models/mip/mip_config.py
@@ -28,11 +28,15 @@ class MipBaseConfig(BaseModel):
     sample_info_path: str = Field(..., alias="sample_info_file")
     sample_ids: List[str]
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("case_id", always=True, pre=True)
     def set_case_id(cls, value, values: dict) -> str:
         """Set case_id. Family_id is used for older versions of MIP analysis"""
         return value or values.get("family_id_")
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("samples", always=True, pre=True)
     def set_samples(cls, _, values: dict) -> List[AnalysisType]:
         """Set samples analysis type"""

--- a/cg/models/mip/mip_metrics_deliverables.py
+++ b/cg/models/mip/mip_metrics_deliverables.py
@@ -27,6 +27,8 @@ class DuplicateReads(SampleMetric):
 
     value: float
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("value", always=True)
     def convert_duplicate_read(cls, value) -> float:
         """Convert raw value from fraction to percent"""
@@ -44,6 +46,8 @@ class MIPMappedReads(SampleMetric):
 
     value: float
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("value", always=True)
     def convert_mapped_read(cls, value) -> float:
         """Convert raw value from fraction to percent"""
@@ -70,19 +74,23 @@ class MIPMetricsDeliverables(MetricsDeliverables):
         "MEDIAN_TARGET_COVERAGE": MedianTargetCoverage,
         "gender": GenderCheck,
     }
-    duplicate_reads: Optional[List[DuplicateReads]]
-    mapped_reads: Optional[List[MIPMappedReads]]
-    mean_insert_size: Optional[List[MeanInsertSize]]
-    median_target_coverage: Optional[List[MedianTargetCoverage]]
-    predicted_sex: Optional[List[GenderCheck]]
+    duplicate_reads: Optional[List[DuplicateReads]] = None
+    mapped_reads: Optional[List[MIPMappedReads]] = None
+    mean_insert_size: Optional[List[MeanInsertSize]] = None
+    median_target_coverage: Optional[List[MedianTargetCoverage]] = None
+    predicted_sex: Optional[List[GenderCheck]] = None
     sample_metric_to_parse: List[str] = SAMPLE_METRICS_TO_PARSE
-    sample_id_metrics: Optional[List[MIPParsedMetrics]]
+    sample_id_metrics: Optional[List[MIPParsedMetrics]] = None
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("duplicate_reads", always=True)
     def set_duplicate_reads(cls, _, values: dict) -> List[DuplicateReads]:
         """Set duplicate_reads"""
         return add_metric(name="fraction_duplicates", values=values)
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("mapped_reads", always=True)
     def set_mapped_reads(cls, _, values: dict) -> List[MIPMappedReads]:
         """Set mapped reads"""
@@ -107,21 +115,29 @@ class MIPMetricsDeliverables(MetricsDeliverables):
             )
         return mapped_reads
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("mean_insert_size", always=True)
     def set_mean_insert_size(cls, _, values: dict) -> List[MeanInsertSize]:
         """Set mean insert size"""
         return add_metric(name="MEAN_INSERT_SIZE", values=values)
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("median_target_coverage", always=True)
     def set_median_target_coverage(cls, _, values: dict) -> List[MedianTargetCoverage]:
         """Set median target coverage"""
         return add_metric(name="MEDIAN_TARGET_COVERAGE", values=values)
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("predicted_sex", always=True)
     def set_predicted_sex(cls, _, values: dict) -> List[GenderCheck]:
         """Set predicted sex"""
         return add_metric(name="gender", values=values)
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("sample_id_metrics", always=True)
     def set_sample_id_metrics(cls, _, values: dict) -> List[MIPParsedMetrics]:
         """Set parsed sample_id metrics gathered from all metrics"""

--- a/cg/models/mip/mip_sample_info.py
+++ b/cg/models/mip/mip_sample_info.py
@@ -10,7 +10,7 @@ class MipBaseSampleInfo(BaseModel):
     """This model is used when validating the mip sample info file"""
 
     family_id_: Optional[str] = Field(None, alias="family_id")
-    case_id: Optional[str]
+    case_id: Optional[str] = None
     human_genome_build_: dict = Field(..., alias="human_genome_build")
     genome_build: str = None
     program_: dict = Field(None, alias="program")
@@ -22,11 +22,15 @@ class MipBaseSampleInfo(BaseModel):
     is_finished: bool = False
     mip_version: str = None
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("case_id", always=True, pre=True)
     def set_case_id(cls, value, values: dict) -> str:
         """Set case_id. Family_id is used for older versions of MIP analysis"""
         return value or values.get("family_id_")
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("genome_build", always=True, pre=True)
     def set_genome_build(cls, _, values: dict) -> str:
         """Set genome_build by combining source i.e. "hg"|"grch" and version"""
@@ -35,11 +39,15 @@ class MipBaseSampleInfo(BaseModel):
         version = raw_genome_build.get("version")
         return f"{source}{version}"
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("is_finished", always=True)
     def set_is_finished(cls, _, values: dict) -> bool:
         """Set is_finished from analysisrunstatus_"""
         return values.get("analysis_run_status_") == "finished"
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("rank_model_version", always=True)
     def set_rank_model_version(cls, _, values: dict) -> str:
         """Set rank_model_version from genmod snv/indel analysis"""
@@ -50,6 +58,8 @@ class MipBaseSampleInfo(BaseModel):
             if "genmod" in values["program_"]:
                 return values["program_"]["genmod"]["rank_model"]["version"]
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("sv_rank_model_version", always=True)
     def set_sv_rank_model_version(cls, _, values: dict) -> str:
         """Set rank_model_version from genmod SV analysis"""

--- a/cg/models/nextflow/deliverables.py
+++ b/cg/models/nextflow/deliverables.py
@@ -1,6 +1,6 @@
 import collections
 
-from pydantic import BaseModel, validator
+from pydantic import field_validator, BaseModel
 
 from cg.constants.nextflow import DELIVER_FILE_HEADERS
 
@@ -23,7 +23,8 @@ class NextflowDeliverables(BaseModel):
 
     deliverables: dict
 
-    @validator("deliverables")
+    @field_validator("deliverables")
+    @classmethod
     def headers(cls, v: dict) -> None:
         """Validate header format."""
         if collections.Counter(list(v.keys())) != collections.Counter(DELIVER_FILE_HEADERS):

--- a/cg/models/nextflow/sample.py
+++ b/cg/models/nextflow/sample.py
@@ -16,6 +16,8 @@ class NextflowSample(BaseModel):
     fastq_r1: List[str]
     fastq_r2: List[str]
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("fastq_r2")
     def fastq1_fastq2_len_match(cls, value: List[str], values: dict) -> str:
         """Verify that the number of fastq files is the same for R1 and R2."""

--- a/cg/models/orders/excel_sample.py
+++ b/cg/models/orders/excel_sample.py
@@ -1,5 +1,5 @@
 from typing import List, Optional
-from pydantic import Field, validator
+from pydantic import field_validator, Field
 
 from cg.constants.orderforms import REV_SEX_MAP, SOURCE_TYPES
 from cg.models.orders.sample_base import OrderSample
@@ -61,7 +61,8 @@ class ExcelSample(OrderSample):
     well_position: str = Field(None, alias="Sample/Well Location")
     well_position_rml: str = Field(None, alias="UDF/RML well position")
 
-    @validator("data_analysis")
+    @field_validator("data_analysis")
+    @classmethod
     def validate_data_analysis(cls, value):
         data_analysis_alternatives = [
             "Balsamic",  # OF 1508
@@ -80,7 +81,8 @@ class ExcelSample(OrderSample):
             raise AttributeError(f"'{value}' is not a valid data analysis")
         return value
 
-    @validator("index_number", "volume", "quantity", "concentration", "concentration_sample")
+    @field_validator("index_number", "volume", "quantity", "concentration", "concentration_sample")
+    @classmethod
     def numeric_value(cls, value: Optional[str]):
         if not value:
             return None
@@ -89,26 +91,30 @@ class ExcelSample(OrderSample):
             return str_value
         raise AttributeError(f"Order contains non-numeric value '{value}'")
 
-    @validator("mother", "father")
+    @field_validator("mother", "father")
+    @classmethod
     def validate_parent(cls, value: str):
         if value == "0.0":
             return None
         return value
 
-    @validator("source")
+    @field_validator("source")
+    @classmethod
     def validate_source(cls, value: Optional[str]):
         if value not in SOURCE_TYPES:
             raise ValueError(f"'{value}' is not a valid source")
         return value
 
-    @validator("sex")
+    @field_validator("sex")
+    @classmethod
     def convert_sex(cls, value: Optional[str]):
         if not value:
             return None
         value = value.strip()
         return REV_SEX_MAP.get(value, "unknown")
 
-    @validator("panels", pre=True)
+    @field_validator("panels", mode="before")
+    @classmethod
     def parse_panels(cls, value):
         if not value:
             return None
@@ -117,22 +123,26 @@ class ExcelSample(OrderSample):
             separator = ":"
         return value.split(separator)
 
-    @validator("data_delivery")
+    @field_validator("data_delivery")
+    @classmethod
     def convert_data_delivery(cls, value: Optional[str]):
         return value.lower()
 
-    @validator("status", "priority")
+    @field_validator("status", "priority")
+    @classmethod
     def convert_to_lower(cls, value: Optional[str]):
         value = value.lower()
         return value
 
-    @validator("priority")
+    @field_validator("priority")
+    @classmethod
     def convert_to_priority(cls, value: Optional[str]):
         if value.lower() == "förtur":
             return "priority"
         return value
 
-    @validator("collection_date")
+    @field_validator("collection_date")
+    @classmethod
     def convert_to_date(cls, value: Optional[str]) -> Optional[str]:
         if not value:
             return None

--- a/cg/models/orders/json_sample.py
+++ b/cg/models/orders/json_sample.py
@@ -2,29 +2,31 @@ from typing import Optional, Any, List
 
 from cg.constants import DataDelivery, Pipeline
 from cg.models.orders.sample_base import OrderSample
-from pydantic import constr, validator
+from pydantic import field_validator, constr
 
 
 class JsonSample(OrderSample):
-    cohorts: Optional[List[str]]
-    concentration: Optional[str]
-    concentration_sample: Optional[str]
-    control: Optional[str]
+    cohorts: Optional[List[str]] = None
+    concentration: Optional[str] = None
+    concentration_sample: Optional[str] = None
+    control: Optional[str] = None
     data_analysis: Pipeline = Pipeline.MIP_DNA
     data_delivery: DataDelivery = DataDelivery.SCOUT
-    index: Optional[str]
-    panels: Optional[List[str]]
-    quantity: Optional[str]
-    synopsis: Optional[str]
-    well_position: Optional[constr(regex=r"[A-H]:[0-9]+")]
+    index: Optional[str] = None
+    panels: Optional[List[str]] = None
+    quantity: Optional[str] = None
+    synopsis: Optional[str] = None
+    well_position: Optional[constr(pattern=r"[A-H]:[0-9]+")] = None
 
-    @validator("synopsis", pre=True)
+    @field_validator("synopsis", mode="before")
+    @classmethod
     def join_list(cls, value: Any):
         if isinstance(value, list):
             return "".join(value)
         return value
 
-    @validator("well_position", pre=True)
+    @field_validator("well_position", mode="before")
+    @classmethod
     def convert_well(cls, value: str):
         if not value:
             return None

--- a/cg/models/orders/order.py
+++ b/cg/models/orders/order.py
@@ -1,21 +1,22 @@
-from typing import Optional, Any
+from typing import List, Optional, Any
 
-from pydantic import BaseModel, constr, conlist
+from pydantic import Field, BaseModel, constr
 
 from cg.models.orders.constants import OrderType
 from cg.models.orders.samples import (
     sample_class_for,
 )
 from cg.store.models import Customer, Sample
+from typing_extensions import Annotated
 
 
 class OrderIn(BaseModel):
     name: constr(min_length=2, max_length=Sample.order.property.columns[0].type.length)
-    comment: Optional[str]
+    comment: Optional[str] = None
     customer: constr(min_length=1, max_length=Customer.internal_id.property.columns[0].type.length)
-    samples: conlist(Any, min_items=1)
+    samples: Annotated[List[Any], Field(min_length=1)]
     skip_reception_control: Optional[bool] = None
-    ticket: Optional[str]
+    ticket: Optional[str] = None
 
     @classmethod
     def parse_obj(cls, obj: dict, project: OrderType) -> "OrderIn":

--- a/cg/models/orders/orderform_schema.py
+++ b/cg/models/orders/orderform_schema.py
@@ -7,31 +7,31 @@ from cg.models.orders.sample_base import OrderSample
 
 # Class for holding information about cases in order
 class OrderCase(BaseModel):
-    cohorts: Optional[List[str]]
+    cohorts: Optional[List[str]] = None
     name: str
-    panels: Optional[List[str]]
+    panels: Optional[List[str]] = None
     priority: str
     samples: List[OrderSample]
-    synopsis: Optional[str]
+    synopsis: Optional[str] = None
 
 
 class OrderPool(BaseModel):
     name: str
     data_analysis: str
-    data_delivery: Optional[str]
+    data_delivery: Optional[str] = None
     application: str
     samples: List[OrderSample]
 
 
 # This is for validating in data
 class Orderform(BaseModel):
-    comment: Optional[str]
+    comment: Optional[str] = None
     delivery_type: str
     project_type: str
     customer: str
     name: str
-    data_analysis: Optional[str]
-    data_delivery: Optional[str]
-    ticket: Optional[int]
+    data_analysis: Optional[str] = None
+    data_delivery: Optional[str] = None
+    ticket: Optional[int] = None
     samples: List[OrderSample]
-    cases: Optional[List[OrderCase]]
+    cases: Optional[List[OrderCase]] = None

--- a/cg/models/orders/sample_base.py
+++ b/cg/models/orders/sample_base.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import List, Optional
 
 from cg.constants import DataDelivery, Pipeline
-from pydantic import BaseModel, constr, validator
+from pydantic import field_validator, BaseModel, constr
 
 from cg.store.models import Application, Family, Customer, Pool, Sample
 
@@ -43,80 +43,85 @@ NAME_PATTERN = r"^[A-Za-z0-9-]*$"
 
 
 class OrderSample(BaseModel):
-    age_at_sampling: Optional[str]
+    age_at_sampling: Optional[str] = None
     application: constr(max_length=Application.tag.property.columns[0].type.length)
-    capture_kit: Optional[str]
-    collection_date: Optional[str]
-    comment: Optional[constr(max_length=Sample.comment.property.columns[0].type.length)]
-    concentration: Optional[float]
-    concentration_sample: Optional[float]
-    container: Optional[ContainerEnum]
-    container_name: Optional[str]
-    control: Optional[str]
-    customer: Optional[constr(max_length=Customer.internal_id.property.columns[0].type.length)]
-    custom_index: Optional[str]
+    capture_kit: Optional[str] = None
+    collection_date: Optional[str] = None
+    comment: Optional[constr(max_length=Sample.comment.property.columns[0].type.length)] = None
+    concentration: Optional[float] = None
+    concentration_sample: Optional[float] = None
+    container: Optional[ContainerEnum] = None
+    container_name: Optional[str] = None
+    control: Optional[str] = None
+    customer: Optional[
+        constr(max_length=Customer.internal_id.property.columns[0].type.length)
+    ] = None
+    custom_index: Optional[str] = None
     data_analysis: Pipeline
     data_delivery: DataDelivery
-    elution_buffer: Optional[str]
-    extraction_method: Optional[str]
+    elution_buffer: Optional[str] = None
+    extraction_method: Optional[str] = None
     family_name: Optional[
         constr(
-            regex=NAME_PATTERN,
+            pattern=NAME_PATTERN,
             min_length=2,
             max_length=Family.name.property.columns[0].type.length,
         )
-    ]
+    ] = None
     father: Optional[
-        constr(regex=NAME_PATTERN, max_length=Sample.name.property.columns[0].type.length)
-    ]
-    formalin_fixation_time: Optional[int]
-    index: Optional[str]
-    index_number: Optional[str]
-    index_sequence: Optional[str]
-    internal_id: Optional[constr(max_length=Sample.internal_id.property.columns[0].type.length)]
-    lab_code: Optional[str]
+        constr(pattern=NAME_PATTERN, max_length=Sample.name.property.columns[0].type.length)
+    ] = None
+    formalin_fixation_time: Optional[int] = None
+    index: Optional[str] = None
+    index_number: Optional[str] = None
+    index_sequence: Optional[str] = None
+    internal_id: Optional[
+        constr(max_length=Sample.internal_id.property.columns[0].type.length)
+    ] = None
+    lab_code: Optional[str] = None
     mother: Optional[
-        constr(regex=NAME_PATTERN, max_length=Sample.name.property.columns[0].type.length)
-    ]
+        constr(pattern=NAME_PATTERN, max_length=Sample.name.property.columns[0].type.length)
+    ] = None
     name: constr(
-        regex=NAME_PATTERN,
+        pattern=NAME_PATTERN,
         min_length=2,
         max_length=Sample.name.property.columns[0].type.length,
     )
-    organism: Optional[str]
-    organism_other: Optional[str]
-    original_lab: Optional[str]
-    original_lab_address: Optional[str]
-    phenotype_groups: Optional[List[str]]
-    phenotype_terms: Optional[List[str]]
-    pool: Optional[constr(max_length=Pool.name.property.columns[0].type.length)]
-    post_formalin_fixation_time: Optional[int]
-    pre_processing_method: Optional[str]
+    organism: Optional[str] = None
+    organism_other: Optional[str] = None
+    original_lab: Optional[str] = None
+    original_lab_address: Optional[str] = None
+    phenotype_groups: Optional[List[str]] = None
+    phenotype_terms: Optional[List[str]] = None
+    pool: Optional[constr(max_length=Pool.name.property.columns[0].type.length)] = None
+    post_formalin_fixation_time: Optional[int] = None
+    pre_processing_method: Optional[str] = None
     priority: PriorityEnum = PriorityEnum.standard
-    quantity: Optional[int]
-    reagent_label: Optional[str]
+    quantity: Optional[int] = None
+    reagent_label: Optional[str] = None
     reference_genome: Optional[
         constr(max_length=Sample.reference_genome.property.columns[0].type.length)
-    ]
-    region: Optional[str]
-    region_code: Optional[str]
+    ] = None
+    region: Optional[str] = None
+    region_code: Optional[str] = None
     require_qc_ok: bool = False
-    rml_plate_name: Optional[str]
-    selection_criteria: Optional[str]
+    rml_plate_name: Optional[str] = None
+    selection_criteria: Optional[str] = None
     sex: SexEnum = SexEnum.unknown
-    source: Optional[str]
+    source: Optional[str] = None
     status: StatusEnum = StatusEnum.unknown
     subject_id: Optional[
-        constr(regex=NAME_PATTERN, max_length=Sample.subject_id.property.columns[0].type.length)
-    ]
-    tissue_block_size: Optional[str]
+        constr(pattern=NAME_PATTERN, max_length=Sample.subject_id.property.columns[0].type.length)
+    ] = None
+    tissue_block_size: Optional[str] = None
     tumour: bool = False
-    tumour_purity: Optional[int]
-    verified_organism: Optional[bool]
-    volume: Optional[str]
-    well_position: Optional[str]
-    well_position_rml: Optional[str]
+    tumour_purity: Optional[int] = None
+    verified_organism: Optional[bool] = None
+    volume: Optional[str] = None
+    well_position: Optional[str] = None
+    well_position_rml: Optional[str] = None
 
-    @validator("priority", pre=True)
+    @field_validator("priority", mode="before")
+    @classmethod
     def snake_case(cls, value: str):
         return value.lower().replace(" ", "_")

--- a/cg/models/report/metadata.py
+++ b/cg/models/report/metadata.py
@@ -19,8 +19,8 @@ class SampleMetadataModel(BaseModel):
 
     """
 
-    million_read_pairs: Union[None, float, str]
-    duplicates: Union[None, float, str]
+    million_read_pairs: Union[None, float, str] = None
+    duplicates: Union[None, float, str] = None
 
     _float_values = validator("million_read_pairs", "duplicates", always=True, allow_reuse=True)(
         validate_float
@@ -38,11 +38,11 @@ class MipDNASampleMetadataModel(SampleMetadataModel):
         pct_10x: percent of targeted bases that are covered to 10X coverage or more; source: pipeline workflow
     """
 
-    bait_set: Optional[str]
-    gender: Optional[str]
-    mapped_reads: Union[None, float, str]
-    mean_target_coverage: Union[None, float, str]
-    pct_10x: Union[None, float, str]
+    bait_set: Optional[str] = None
+    gender: Optional[str] = None
+    mapped_reads: Union[None, float, str] = None
+    mean_target_coverage: Union[None, float, str] = None
+    pct_10x: Union[None, float, str] = None
 
     _bait_set = validator("bait_set", always=True, allow_reuse=True)(validate_empty_field)
     _gender = validator("gender", always=True, allow_reuse=True)(validate_gender)
@@ -60,8 +60,8 @@ class BalsamicSampleMetadataModel(SampleMetadataModel):
             fold_80: fold 80 base penalty; source: pipeline workflow
     """
 
-    mean_insert_size: Union[None, float, str]
-    fold_80: Union[None, float, str]
+    mean_insert_size: Union[None, float, str] = None
+    fold_80: Union[None, float, str] = None
 
     _float_values_balsamic = validator(
         "mean_insert_size", "fold_80", always=True, allow_reuse=True
@@ -79,11 +79,11 @@ class BalsamicTargetedSampleMetadataModel(BalsamicSampleMetadataModel):
             pct_500x: percent of targeted bases that are covered to 500X coverage or more; source: pipeline workflow
     """
 
-    bait_set: Optional[str]
-    bait_set_version: Union[None, int, str]
-    median_target_coverage: Union[None, float, str]
-    pct_250x: Union[None, float, str]
-    pct_500x: Union[None, float, str]
+    bait_set: Optional[str] = None
+    bait_set_version: Union[None, int, str] = None
+    median_target_coverage: Union[None, float, str] = None
+    pct_250x: Union[None, float, str] = None
+    pct_500x: Union[None, float, str] = None
 
     _str_values = validator("bait_set", "bait_set_version", always=True, allow_reuse=True)(
         validate_empty_field
@@ -103,9 +103,9 @@ class BalsamicWGSSampleMetadataModel(BalsamicSampleMetadataModel):
             pct_60x: fraction of bases that attained at least 15X sequence coverage; source: pipeline workflow
     """
 
-    median_coverage: Union[None, float, str]
-    pct_15x: Union[None, float, str]
-    pct_60x: Union[None, float, str]
+    median_coverage: Union[None, float, str] = None
+    pct_15x: Union[None, float, str] = None
+    pct_60x: Union[None, float, str] = None
 
     _float_values_balsamic_wgs = validator(
         "median_coverage", "pct_15x", "pct_60x", always=True, allow_reuse=True
@@ -133,21 +133,21 @@ class RnafusionSampleMetadataModel(SampleMetadataModel):
         uniquely_mapped_reads: percentage of mapped reads; source: pipeline workflow
     """
 
-    bias_5_3: Union[None, float, str]
-    gc_content: Union[None, float, str]
-    input_amount: Union[None, float, str]
-    insert_size: Union[None, float, str]
-    insert_size_peak: Union[None, float, str]
-    mapped_reads: Union[None, float, str]
-    mean_length_r1: Union[None, float, str]
-    mrna_bases: Union[None, float, str]
-    pct_adapter: Union[None, float, str]
-    pct_surviving: Union[None, float, str]
-    q20_rate: Union[None, float, str]
-    q30_rate: Union[None, float, str]
-    ribosomal_bases: Union[None, float, str]
-    rin: Union[None, float, str]
-    uniquely_mapped_reads: Union[None, float, str]
+    bias_5_3: Union[None, float, str] = None
+    gc_content: Union[None, float, str] = None
+    input_amount: Union[None, float, str] = None
+    insert_size: Union[None, float, str] = None
+    insert_size_peak: Union[None, float, str] = None
+    mapped_reads: Union[None, float, str] = None
+    mean_length_r1: Union[None, float, str] = None
+    mrna_bases: Union[None, float, str] = None
+    pct_adapter: Union[None, float, str] = None
+    pct_surviving: Union[None, float, str] = None
+    q20_rate: Union[None, float, str] = None
+    q30_rate: Union[None, float, str] = None
+    ribosomal_bases: Union[None, float, str] = None
+    rin: Union[None, float, str] = None
+    uniquely_mapped_reads: Union[None, float, str] = None
 
     _float_values = validator(
         "bias_5_3",

--- a/cg/models/report/report.py
+++ b/cg/models/report/report.py
@@ -24,10 +24,10 @@ class CustomerModel(BaseModel):
         scout_access: whether the customer has access to scout or not; source: statusDB/family/customer/scout_access
     """
 
-    name: Optional[str]
-    id: Optional[str]
-    invoice_address: Optional[str]
-    scout_access: Optional[bool]
+    name: Optional[str] = None
+    id: Optional[str] = None
+    invoice_address: Optional[str] = None
+    scout_access: Optional[bool] = None
 
     _values = validator("name", "id", "invoice_address", always=True, allow_reuse=True)(
         validate_empty_field
@@ -47,12 +47,12 @@ class ScoutReportFiles(BaseModel):
         smn_tsv: SMN gene variants file (MIP-DNA specific); source: HK
     """
 
-    snv_vcf: Optional[str]
-    snv_research_vcf: Optional[str]
-    sv_vcf: Optional[str]
-    sv_research_vcf: Optional[str]
-    vcf_str: Optional[str]
-    smn_tsv: Optional[str]
+    snv_vcf: Optional[str] = None
+    snv_research_vcf: Optional[str] = None
+    sv_vcf: Optional[str] = None
+    sv_research_vcf: Optional[str] = None
+    vcf_str: Optional[str] = None
+    smn_tsv: Optional[str] = None
 
     _str_values = validator(
         "snv_vcf",
@@ -82,14 +82,14 @@ class DataAnalysisModel(BaseModel):
         scout_files: list of file names uploaded to Scout
     """
 
-    customer_pipeline: Optional[Pipeline]
-    data_delivery: Optional[DataDelivery]
-    pipeline: Optional[Pipeline]
-    pipeline_version: Optional[str]
-    type: Optional[str]
-    genome_build: Optional[str]
-    variant_callers: Union[None, List[str], str]
-    panels: Union[None, List[str], str]
+    customer_pipeline: Optional[Pipeline] = None
+    data_delivery: Optional[DataDelivery] = None
+    pipeline: Optional[Pipeline] = None
+    pipeline_version: Optional[str] = None
+    type: Optional[str] = None
+    genome_build: Optional[str] = None
+    variant_callers: Union[None, List[str], str] = None
+    panels: Union[None, List[str], str] = None
     scout_files: ScoutReportFiles
 
     _values = root_validator(pre=True, allow_reuse=True)(validate_supported_pipeline)
@@ -120,8 +120,8 @@ class CaseModel(BaseModel):
         applications: case associated unique applications
     """
 
-    name: Optional[str]
-    id: Optional[str]
+    name: Optional[str] = None
+    id: Optional[str] = None
     samples: List[SampleModel]
     data_analysis: DataAnalysisModel
     applications: List[ApplicationModel]
@@ -142,10 +142,10 @@ class ReportModel(BaseModel):
     """
 
     customer: CustomerModel
-    version: Union[None, int, str]
-    date: Union[None, datetime, str]
+    version: Union[None, int, str] = None
+    date: Union[None, datetime, str] = None
     case: CaseModel
-    accredited: Optional[bool]
+    accredited: Optional[bool] = None
 
     _version = validator("version", always=True, allow_reuse=True)(validate_empty_field)
     _date = validator("date", always=True, allow_reuse=True)(validate_date)

--- a/cg/models/report/sample.py
+++ b/cg/models/report/sample.py
@@ -27,13 +27,13 @@ class ApplicationModel(BaseModel):
         external: whether the app tag is external or not; source: StatusDB/application/is_external
     """
 
-    tag: Optional[str]
-    version: Union[None, int, str]
-    prep_category: Optional[str]
-    description: Optional[str]
-    limitations: Optional[str]
-    accredited: Optional[bool]
-    external: Optional[bool]
+    tag: Optional[str] = None
+    version: Union[None, int, str] = None
+    prep_category: Optional[str] = None
+    description: Optional[str] = None
+    limitations: Optional[str] = None
+    accredited: Optional[bool] = None
+    external: Optional[bool] = None
 
     _prep_category = validator("prep_category", always=True, allow_reuse=True)(validate_rml_sample)
     _values = validator(
@@ -56,8 +56,8 @@ class MethodsModel(BaseModel):
         sequencing: sequencing procedure; source: LIMS/sample/sequencing_method
     """
 
-    library_prep: Optional[str]
-    sequencing: Optional[str]
+    library_prep: Optional[str] = None
+    sequencing: Optional[str] = None
 
     _values = validator("library_prep", "sequencing", always=True, allow_reuse=True)(
         validate_empty_field
@@ -75,10 +75,10 @@ class TimestampModel(BaseModel):
         sequenced_at: sequencing date; source: StatusDB/sample/sequenced_at
     """
 
-    ordered_at: Union[None, datetime, str]
-    received_at: Union[None, datetime, str]
-    prepared_at: Union[None, datetime, str]
-    sequenced_at: Union[None, datetime, str]
+    ordered_at: Union[None, datetime, str] = None
+    received_at: Union[None, datetime, str] = None
+    prepared_at: Union[None, datetime, str] = None
+    sequenced_at: Union[None, datetime, str] = None
 
     _values = validator(
         "ordered_at",
@@ -108,13 +108,13 @@ class SampleModel(BaseModel):
         timestamps: processing timestamp attributes
     """
 
-    name: Optional[str]
-    id: Optional[str]
-    ticket: Union[None, int, str]
-    status: Optional[str]
+    name: Optional[str] = None
+    id: Optional[str] = None
+    ticket: Union[None, int, str] = None
+    status: Optional[str] = None
     gender: Optional[str] = Gender.UNKNOWN
-    source: Optional[str]
-    tumour: Union[None, bool, str]
+    source: Optional[str] = None
+    tumour: Union[None, bool, str] = None
     application: ApplicationModel
     methods: MethodsModel
     metadata: SampleMetadataModel

--- a/cg/models/rnafusion/command_args.py
+++ b/cg/models/rnafusion/command_args.py
@@ -7,17 +7,17 @@ from pydantic import BaseModel
 class CommandArgs(BaseModel):
     """Model for arguments and options supported."""
 
-    log: Optional[Union[str, Path]]
-    resume: Optional[bool]
-    profile: Optional[str]
-    stub: Optional[bool]
-    config: Optional[Union[str, Path]]
-    name: Optional[str]
-    revision: Optional[str]
-    wait: Optional[str]
-    id: Optional[str]
-    with_tower: Optional[bool]
-    use_nextflow: Optional[bool]
-    compute_env: Optional[str]
-    work_dir: Optional[Union[str, Path]]
-    params_file: Optional[Union[str, Path]]
+    log: Optional[Union[str, Path]] = None
+    resume: Optional[bool] = None
+    profile: Optional[str] = None
+    stub: Optional[bool] = None
+    config: Optional[Union[str, Path]] = None
+    name: Optional[str] = None
+    revision: Optional[str] = None
+    wait: Optional[str] = None
+    id: Optional[str] = None
+    with_tower: Optional[bool] = None
+    use_nextflow: Optional[bool] = None
+    compute_env: Optional[str] = None
+    work_dir: Optional[Union[str, Path]] = None
+    params_file: Optional[Union[str, Path]] = None

--- a/cg/models/rnafusion/metrics.py
+++ b/cg/models/rnafusion/metrics.py
@@ -7,16 +7,16 @@ from pydantic import BaseModel
 class RnafusionQCMetrics(BaseModel):
     """RNAfusion QC metrics."""
 
-    after_filtering_gc_content: Optional[float]
-    after_filtering_q20_rate: Optional[float]
-    after_filtering_q30_rate: Optional[float]
-    after_filtering_read1_mean_length: Optional[float]
-    before_filtering_total_reads: Optional[float]
-    bias_5_3: Optional[float]
-    pct_adapter: Optional[float]
-    pct_mrna_bases: Optional[float]
-    pct_ribosomal_bases: Optional[float]
-    pct_surviving: Optional[float]
-    pct_duplication: Optional[float]
-    reads_aligned: Optional[float]
-    uniquely_mapped_percent: Optional[float]
+    after_filtering_gc_content: Optional[float] = None
+    after_filtering_q20_rate: Optional[float] = None
+    after_filtering_q30_rate: Optional[float] = None
+    after_filtering_read1_mean_length: Optional[float] = None
+    before_filtering_total_reads: Optional[float] = None
+    bias_5_3: Optional[float] = None
+    pct_adapter: Optional[float] = None
+    pct_mrna_bases: Optional[float] = None
+    pct_ribosomal_bases: Optional[float] = None
+    pct_surviving: Optional[float] = None
+    pct_duplication: Optional[float] = None
+    reads_aligned: Optional[float] = None
+    uniquely_mapped_percent: Optional[float] = None

--- a/cg/models/rnafusion/rnafusion_sample.py
+++ b/cg/models/rnafusion/rnafusion_sample.py
@@ -11,6 +11,8 @@ class RnafusionSample(NextflowSample):
 
     strandedness: str
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("strandedness", always=True)
     def valid_value_strandedness(cls, value) -> str:
         """Verify that the strandedness value is accepted."""

--- a/cg/models/scout/scout_load_config.py
+++ b/cg/models/scout/scout_load_config.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import List, Optional
 
-from pydantic import BaseModel, validator
+from pydantic import field_validator, ConfigDict, BaseModel
 from typing_extensions import Literal
 
 
@@ -45,14 +45,14 @@ class ScoutIndividual(BaseModel):
     subject_id: Optional[str] = None
     tissue_type: Optional[str] = None
 
-    @validator("sample_id", "sex", "analysis_type")
+    @field_validator("sample_id", "sex", "analysis_type")
+    @classmethod
     def field_not_none(cls, value):
         if value is None:
             raise ValueError("sample_id, sex and analysis_type can not be None")
         return value
 
-    class Config:
-        validate_assignment = True
+    model_config = ConfigDict(validate_assignment=True)
 
 
 class ScoutMipIndividual(ScoutIndividual):
@@ -100,25 +100,26 @@ class ScoutLoadConfig(BaseModel):
     multiqc: Optional[str] = None
     track: Literal["rare", "cancer"] = "rare"
 
-    @validator("owner", "family")
+    @field_validator("owner", "family")
+    @classmethod
     def field_not_none(cls, value):
         if value is None:
             raise ValueError("Owner and family can not be None")
         return value
 
-    class Config:
-        validate_assignment = True
+    model_config = ConfigDict(validate_assignment=True)
 
 
 class BalsamicLoadConfig(ScoutLoadConfig):
-    madeline: Optional[str]
+    madeline: Optional[str] = None
     vcf_cancer: str = None
     vcf_cancer_sv: Optional[str] = None
     vcf_cancer_research: Optional[str] = None
     vcf_cancer_sv_research: Optional[str] = None
     samples: List[ScoutCancerIndividual] = []
 
-    @validator("vcf_cancer")
+    @field_validator("vcf_cancer")
+    @classmethod
     def check_mandatory_files(cls, vcf):
         if vcf is None:
             raise ValueError("Vcf can not be none")
@@ -130,8 +131,8 @@ class BalsamicUmiLoadConfig(BalsamicLoadConfig):
 
 
 class MipLoadConfig(ScoutLoadConfig):
-    chromograph_image_files: Optional[List[str]]
-    chromograph_prefixes: Optional[List[str]]
+    chromograph_image_files: Optional[List[str]] = None
+    chromograph_prefixes: Optional[List[str]] = None
     madeline: Optional[str] = None
     peddy_check: Optional[str] = None
     peddy_ped: Optional[str] = None
@@ -147,7 +148,8 @@ class MipLoadConfig(ScoutLoadConfig):
     vcf_sv: Optional[str] = None
     vcf_sv_research: Optional[str] = None
 
-    @validator("vcf_snv", "vcf_sv", "vcf_snv_research", "vcf_sv_research")
+    @field_validator("vcf_snv", "vcf_sv", "vcf_snv_research", "vcf_sv_research")
+    @classmethod
     def check_mandatory_files(cls, vcf):
         if vcf is None:
             raise ValueError("Mandatory vcf can not be None")

--- a/cg/models/slurm/sbatch.py
+++ b/cg/models/slurm/sbatch.py
@@ -16,10 +16,10 @@ class Sbatch(BaseModel):
     minutes: str = "00"
     quality_of_service: SlurmQos = SlurmQos.LOW
     commands: str
-    error: Optional[str]
+    error: Optional[str] = None
     exclude: Optional[str] = ""
-    number_tasks: Optional[int]
-    memory: Optional[int]
+    number_tasks: Optional[int] = None
+    memory: Optional[int] = None
 
 
 class SbatchDragen(Sbatch):

--- a/cg/models/workflow/mutant.py
+++ b/cg/models/workflow/mutant.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, validator
+from pydantic import field_validator, BaseModel
 
 
 class MutantSampleConfig(BaseModel):
@@ -21,6 +21,7 @@ class MutantSampleConfig(BaseModel):
     selection_criteria: str
     primer: str
 
-    @validator("region_code", "lab_code")
+    @field_validator("region_code", "lab_code")
+    @classmethod
     def sanitize_values(cls, value):
         return value.split(" ")[0]

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ packaging
 pandas
 paramiko
 petname
-pydantic<2.0
+pydantic>=2.0
 python-dateutil
 pyyaml
 setuptools>=39.2.0      # due to WeasyPrint 45, tinycss2 1.0.1 and cairocffi file-.cairocffi-VERSION

--- a/tests/apps/crunchy/conftest.py
+++ b/tests/apps/crunchy/conftest.py
@@ -5,10 +5,10 @@ from typing import List
 
 import pytest
 
+from cg.apps.crunchy.models import CrunchyMetadata
 from cg.constants.constants import FileFormat
 from cg.io.controller import WriteFile
 from cg.models import CompressionData
-from cgmodels.crunchy.metadata import CrunchyMetadata
 
 LOG = logging.getLogger(__name__)
 

--- a/tests/apps/crunchy/test_compress_fastq.py
+++ b/tests/apps/crunchy/test_compress_fastq.py
@@ -11,12 +11,12 @@ from cg.apps.crunchy.files import (
     get_log_dir,
     get_spring_archive_files,
 )
+from cg.apps.crunchy.models import CrunchyFile, CrunchyMetadata
 from cg.apps.slurm.slurm_api import SlurmAPI
 from cg.constants.constants import FileFormat
 from cg.io.controller import WriteFile
 from cg.models import CompressionData
 from cg.utils import Process
-from cgmodels.crunchy.metadata import CrunchyFile, CrunchyMetadata
 from pydantic import ValidationError
 
 

--- a/tests/apps/crunchy/test_config.py
+++ b/tests/apps/crunchy/test_config.py
@@ -3,9 +3,9 @@ from pathlib import Path
 from typing import Dict, Any
 
 from cg.apps.crunchy.files import get_crunchy_metadata, update_metadata_date, update_metadata_paths
+from cg.apps.crunchy.models import CrunchyMetadata
 from cg.constants.constants import FileFormat
 from cg.io.controller import ReadFile
-from cgmodels.crunchy.metadata import CrunchyMetadata
 
 
 def test_get_spring_metadata_real_file(

--- a/tests/mocks/scout.py
+++ b/tests/mocks/scout.py
@@ -2,7 +2,7 @@
 
 import logging
 from pathlib import Path
-from pydantic import BaseModel, validator
+from pydantic import field_validator, ConfigDict, BaseModel
 from typing import List
 from typing_extensions import Literal
 
@@ -27,7 +27,8 @@ class MockScoutIndividual(BaseModel):
         "wts",
     ] = "wgs"
 
-    @validator("sample_id", "sex", "analysis_type")
+    @field_validator("sample_id", "sex", "analysis_type")
+    @classmethod
     def field_not_none(cls, value):
         if value is None:
             raise ValueError("sample_id, sex and analysis_type can not be None")
@@ -38,14 +39,14 @@ class MockScoutLoadConfig(BaseModel):
     owner: str = "cust000"
     family: str = "family_id"
 
-    @validator("owner", "family")
+    @field_validator("owner", "family")
+    @classmethod
     def field_not_none(cls, value):
         if value is None:
             raise ValueError("Owner and family can not be None")
         return value
 
-    class Config:
-        validate_assignment = True
+    model_config = ConfigDict(validate_assignment=True)
 
 
 class MockScoutAPI(ScoutAPI):


### PR DESCRIPTION
## Description
As mentioned in #2249 we need to update pydantic to 2.x. 

I have run a [code transformation tool](https://docs.pydantic.dev/latest/migration/#code-transformation-tool) developed by pydantic over cg/cg and cg/tests. This helps modify part of the code but still needs some human eyes for a final check.

I also copied some pydantic models from `cgmodels` so that the bumping is done only on `cg`.

### Added

- Crunchy pydantic models previously imported from `cgmodels` to `cg/apps/crunchy/models.py`

### Changed

- Hopefully all pydantic models have been updated to be compatible with pydantic v2 
- The version of pydantic in requirements

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
