### PR TITLE
temporary bump of pydantic to 2.0.3

### DIFF
--- a/cg/apps/cgstats/db/models/demux_sample.py
+++ b/cg/apps/cgstats/db/models/demux_sample.py
@@ -1,5 +1,5 @@
 import logging
-from pydantic import BaseModel, validator
+from pydantic.v1 import BaseModel, validator
 
 from cg.apps.cgstats.parsers.conversion_stats import SampleConversionResults
 from cg.apps.cgstats.parsers.demux_stats import SampleBarcodeStats

--- a/cg/apps/cgstats/db/models/dragen_demux_sample.py
+++ b/cg/apps/cgstats/db/models/dragen_demux_sample.py
@@ -3,7 +3,7 @@
 
 import logging
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 LOG = logging.getLogger(__name__)
 

--- a/cg/apps/cgstats/parsers/conversion_stats.py
+++ b/cg/apps/cgstats/parsers/conversion_stats.py
@@ -27,7 +27,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Set
 from xml.etree.ElementTree import Element, iterparse
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 LOG = logging.getLogger(__name__)
 

--- a/cg/apps/cgstats/parsers/demux_stats.py
+++ b/cg/apps/cgstats/parsers/demux_stats.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Dict, Optional, Set
 from xml.etree.ElementTree import Element, iterparse
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 LOG = logging.getLogger(__name__)
 

--- a/cg/apps/cgstats/parsers/dragen_demultiplexing_stats.py
+++ b/cg/apps/cgstats/parsers/dragen_demultiplexing_stats.py
@@ -4,7 +4,7 @@ import logging
 from pathlib import Path
 from typing import Dict
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 LOG = logging.getLogger(__name__)
 

--- a/cg/apps/crunchy/crunchy.py
+++ b/cg/apps/crunchy/crunchy.py
@@ -10,9 +10,8 @@ import logging
 from pathlib import Path
 from typing import Dict, Optional
 
-from cgmodels.crunchy.metadata import CrunchyFile, CrunchyMetadata
-
 from cg.apps.crunchy import files
+from cg.apps.crunchy.models import CrunchyFile, CrunchyMetadata
 from cg.apps.slurm.slurm_api import SlurmAPI
 from cg.constants import FASTQ_DELTA
 from cg.models import CompressionData

--- a/cg/apps/crunchy/files.py
+++ b/cg/apps/crunchy/files.py
@@ -5,10 +5,10 @@ from json.decoder import JSONDecodeError
 from pathlib import Path
 from typing import Dict, List, Optional
 
+from cg.apps.crunchy.models import CrunchyFile, CrunchyMetadata
 from cg.constants.constants import FileFormat
 from cg.io.controller import ReadFile, ReadStream, WriteFile
 from cg.utils.date import get_date
-from cgmodels.crunchy.metadata import CrunchyFile, CrunchyMetadata
 
 LOG = logging.getLogger(__name__)
 

--- a/cg/apps/crunchy/models.py
+++ b/cg/apps/crunchy/models.py
@@ -1,0 +1,17 @@
+from datetime import date
+from typing import Optional
+
+from pydantic.v1 import BaseModel, conlist
+from typing_extensions import Literal
+
+
+class CrunchyFile(BaseModel):
+    path: str
+    file: Literal["first_read", "second_read", "spring"]
+    checksum: Optional[str]
+    algorithm: Literal["sha1", "md5", "sha256"] = None
+    updated: date = None
+
+
+class CrunchyMetadata(BaseModel):
+    files: conlist(CrunchyFile, max_items=3, min_items=3)

--- a/cg/apps/demultiplex/demux_report.py
+++ b/cg/apps/demultiplex/demux_report.py
@@ -6,7 +6,7 @@ from cg.apps.cgstats.parsers.conversion_stats import (
     SampleConversionResults,
     UnknownBarcode,
 )
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from typing_extensions import Literal
 
 LOG = logging.getLogger(__name__)

--- a/cg/apps/demultiplex/sample_sheet/index.py
+++ b/cg/apps/demultiplex/sample_sheet/index.py
@@ -10,7 +10,7 @@ from cg.models.demultiplex.run_parameters import RunParameters
 from cg.resources import VALID_INDEXES_PATH
 from cg.utils.utils import get_hamming_distance
 from packaging import version
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 LOG = logging.getLogger(__name__)
 DNA_COMPLEMENTS: Dict[str, str] = {"A": "T", "C": "G", "G": "C", "T": "A"}

--- a/cg/apps/demultiplex/sample_sheet/models.py
+++ b/cg/apps/demultiplex/sample_sheet/models.py
@@ -1,5 +1,5 @@
 import logging
-from pydantic import BaseModel, Extra, Field
+from pydantic.v1 import BaseModel, Extra, Field
 from typing import List
 
 from cg.constants.constants import GenomeVersion

--- a/cg/apps/demultiplex/sample_sheet/read_sample_sheet.py
+++ b/cg/apps/demultiplex/sample_sheet/read_sample_sheet.py
@@ -1,7 +1,7 @@
 import logging
 from pathlib import Path
 from typing import Dict, List, Type
-from pydantic import parse_obj_as
+from pydantic.v1 import parse_obj_as
 
 from cg.apps.demultiplex.sample_sheet.models import FlowCellSample, SampleSheet
 from cg.constants.constants import FileFormat

--- a/cg/apps/hermes/models.py
+++ b/cg/apps/hermes/models.py
@@ -3,7 +3,7 @@ import logging
 from pathlib import Path
 from typing import List, Optional
 
-from pydantic import BaseModel, validator
+from pydantic.v1 import BaseModel, validator
 
 LOG = logging.getLogger(__name__)
 

--- a/cg/apps/housekeeper/models.py
+++ b/cg/apps/housekeeper/models.py
@@ -2,7 +2,7 @@
 from datetime import datetime
 from typing import List, Optional
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 
 class InputFile(BaseModel):

--- a/cg/apps/orderform/excel_orderform_parser.py
+++ b/cg/apps/orderform/excel_orderform_parser.py
@@ -6,7 +6,7 @@ import openpyxl
 from openpyxl.cell.cell import Cell
 from openpyxl.workbook import Workbook
 from openpyxl.worksheet.worksheet import Worksheet
-from pydantic import parse_obj_as
+from pydantic.v1 import parse_obj_as
 
 from cg.apps.orderform.orderform_parser import OrderformParser
 from cg.constants import DataDelivery

--- a/cg/apps/orderform/orderform_parser.py
+++ b/cg/apps/orderform/orderform_parser.py
@@ -2,7 +2,7 @@ import logging
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Hashable, Iterable
 
-from pydantic import constr, BaseModel
+from pydantic.v1 import constr, BaseModel
 
 from cg.constants import DataDelivery
 from cg.exc import OrderFormError

--- a/cg/apps/scout/scout_export.py
+++ b/cg/apps/scout/scout_export.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import List, Optional, Dict
 
-from pydantic import BaseModel, Field, validator
+from pydantic.v1 import BaseModel, Field, validator
 from typing_extensions import Literal
 
 from cg.constants.gene_panel import GENOME_BUILD_37

--- a/cg/apps/sequencing_metrics_parser/models/bcl2fastq_metrics.py
+++ b/cg/apps/sequencing_metrics_parser/models/bcl2fastq_metrics.py
@@ -1,5 +1,5 @@
 from typing import List, Dict
-from pydantic import BaseModel, Field, validator
+from pydantic.v1 import BaseModel, Field, validator
 
 
 class IndexMetric(BaseModel):

--- a/cg/apps/sequencing_metrics_parser/models/bcl_convert.py
+++ b/cg/apps/sequencing_metrics_parser/models/bcl_convert.py
@@ -1,5 +1,4 @@
-from pydantic import BaseModel, BaseConfig, Field
-import xml.etree.ElementTree as ET
+from pydantic.v1 import BaseModel, BaseConfig, Field
 from cg.constants.bcl_convert_metrics import (
     BclConvertQualityMetricsColumnNames,
     BclConvertDemuxMetricsColumnNames,

--- a/cg/apps/tb/models.py
+++ b/cg/apps/tb/models.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Optional
 
 from dateutil.parser import parse as parse_datestr
-from pydantic import BaseModel, validator
+from pydantic.v1 import BaseModel, validator
 
 
 class TrailblazerAnalysis(BaseModel):

--- a/cg/cli/demultiplex/sample_sheet.py
+++ b/cg/cli/demultiplex/sample_sheet.py
@@ -14,7 +14,7 @@ from cg.exc import FlowCellError
 from cg.io.controller import WriteFile, WriteStream
 from cg.models.cg_config import CGConfig
 from cg.models.demultiplex.flow_cell import FlowCellDirectoryData
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 LOG = logging.getLogger(__name__)
 

--- a/cg/cli/upload/observations/observations.py
+++ b/cg/cli/upload/observations/observations.py
@@ -8,7 +8,7 @@ from typing import Optional, Union
 import click
 from sqlalchemy.orm import Query
 from cgmodels.cg.constants import Pipeline
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 from cg.cli.upload.observations.utils import get_observations_case_to_upload, get_observations_api
 from cg.exc import LoqusdbError, CaseNotFoundError

--- a/cg/cli/workflow/balsamic/base.py
+++ b/cg/cli/workflow/balsamic/base.py
@@ -22,7 +22,7 @@ from cg.meta.workflow.analysis import AnalysisAPI
 from cg.meta.workflow.balsamic import BalsamicAnalysisAPI
 from cg.models.cg_config import CGConfig
 from cg.store import Store
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 
 LOG = logging.getLogger(__name__)

--- a/cg/cli/workflow/rnafusion/base.py
+++ b/cg/cli/workflow/rnafusion/base.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Optional
 
 import click
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.cli.workflow.commands import ARGUMENT_CASE_ID, resolve_compression

--- a/cg/meta/archive/ddn_dataflow.py
+++ b/cg/meta/archive/ddn_dataflow.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Dict, List, Optional
 from urllib.parse import urljoin
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from requests.models import Response
 
 from datetime import datetime

--- a/cg/meta/invoice.py
+++ b/cg/meta/invoice.py
@@ -11,7 +11,7 @@ from cg.constants.invoice import (
     CustomerNames,
 )
 from cg.models.invoice.invoice import InvoiceContact, InvoiceApplication, InvoiceReport, InvoiceInfo
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 
 class InvoiceAPI:

--- a/cg/meta/upload/gisaid/models.py
+++ b/cg/meta/upload/gisaid/models.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from typing import Optional
-from pydantic import BaseModel, validator
+from pydantic.v1 import BaseModel, validator
 from datetime import datetime
 
 from cg.meta.upload.gisaid.constants import AUTHORS

--- a/cg/meta/upload/nipt/models.py
+++ b/cg/meta/upload/nipt/models.py
@@ -1,5 +1,5 @@
 from typing import Optional
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 
 class StatinaUploadFiles(BaseModel):

--- a/cg/meta/upload/scout/hk_tags.py
+++ b/cg/meta/upload/scout/hk_tags.py
@@ -2,7 +2,7 @@
 
 from typing import Optional, Set
 
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 
 class CaseTags(BaseModel):

--- a/cg/meta/upload/scout/uploadscoutapi.py
+++ b/cg/meta/upload/scout/uploadscoutapi.py
@@ -23,7 +23,7 @@ from cg.models.scout.scout_load_config import ScoutLoadConfig
 from cg.store import Store
 from cg.store.models import Analysis, Customer, Family, Sample
 from housekeeper.store.models import File, Version
-from pydantic.dataclasses import dataclass
+from pydantic.v1.dataclasses import dataclass
 
 LOG = logging.getLogger(__name__)
 

--- a/cg/meta/workflow/balsamic.py
+++ b/cg/meta/workflow/balsamic.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Union
 
 from housekeeper.store.models import Version, File
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 from cg.constants import Pipeline
 from cg.constants.constants import FileFormat, SampleType, AnalysisType

--- a/cg/meta/workflow/mip.py
+++ b/cg/meta/workflow/mip.py
@@ -3,7 +3,7 @@ import logging
 from pathlib import Path
 from typing import Any, List, Optional, Dict, Union
 
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 from cg.apps.mip.confighandler import ConfigHandler
 from cg.constants import COLLABORATORS, COMBOS, GenePanelMasterList, Pipeline, FileExtensions

--- a/cg/meta/workflow/rnafusion.py
+++ b/cg/meta/workflow/rnafusion.py
@@ -4,7 +4,7 @@ import logging
 from pathlib import Path
 from typing import Dict, List, Optional
 
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 from cg import resources
 from cg.constants import Pipeline

--- a/cg/meta/workflow/taxprofiler.py
+++ b/cg/meta/workflow/taxprofiler.py
@@ -1,10 +1,9 @@
 """Module for Taxprofiler Analysis API."""
 
 import logging
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional
 
-from pydantic import ValidationError
-from cg.constants import Pipeline
+from pydantic.v1 import ValidationError
 from cg.meta.workflow.analysis import AnalysisAPI
 from cg.models.cg_config import CGConfig
 from cg.constants import Pipeline

--- a/cg/models/analysis.py
+++ b/cg/models/analysis.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 
 class AnalysisModel(BaseModel):

--- a/cg/models/balsamic/config.py
+++ b/cg/models/balsamic/config.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Union, Optional
 
-from pydantic import BaseModel, validator
+from pydantic.v1 import BaseModel, validator
 
 
 class BalsamicConfigAnalysis(BaseModel):

--- a/cg/models/balsamic/metrics.py
+++ b/cg/models/balsamic/metrics.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import BaseModel, validator
+from pydantic.v1 import BaseModel, validator
 
 from cg.models.deliverables.metric_deliverables import MetricCondition, MetricsBase
 

--- a/cg/models/cg_config.py
+++ b/cg/models/cg_config.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Optional
 
-from pydantic import BaseModel, EmailStr, Field
+from pydantic.v1 import BaseModel, EmailStr, Field
 from typing_extensions import Literal
 
 from cg.apps.cgstats.stats import StatsAPI

--- a/cg/models/cgstats/flowcell.py
+++ b/cg/models/cgstats/flowcell.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import List, Optional
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 
 class StatsSample(BaseModel):

--- a/cg/models/cgstats/stats_sample.py
+++ b/cg/models/cgstats/stats_sample.py
@@ -1,6 +1,6 @@
 from typing import List, Set
 
-from pydantic import BaseModel, Field, validator
+from pydantic.v1 import BaseModel, Field, validator
 
 
 class Unaligned(BaseModel):

--- a/cg/models/deliverables/metric_deliverables.py
+++ b/cg/models/deliverables/metric_deliverables.py
@@ -1,7 +1,7 @@
 import operator
 from typing import Any, Callable, Dict, List, Optional
 
-from pydantic import BaseModel, Field, validator
+from pydantic.v1 import BaseModel, Field, validator
 
 from cg.exc import CgError, MetricsQCError
 

--- a/cg/models/demultiplex/demux_results.py
+++ b/cg/models/demultiplex/demux_results.py
@@ -4,7 +4,7 @@ import socket
 from pathlib import Path
 from typing import Iterable, Optional, Union
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from typing_extensions import Literal
 
 from cg.apps.cgstats.parsers.adapter_metrics import AdapterMetrics

--- a/cg/models/demultiplex/flow_cell.py
+++ b/cg/models/demultiplex/flow_cell.py
@@ -4,7 +4,7 @@ import logging
 from pathlib import Path
 from typing import List, Optional, Type, Union
 
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 from typing_extensions import Literal
 
 from cg.apps.demultiplex.sample_sheet.models import (

--- a/cg/models/demultiplex/sbatch.py
+++ b/cg/models/demultiplex/sbatch.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from typing_extensions import Literal
 
 

--- a/cg/models/invoice/invoice.py
+++ b/cg/models/invoice/invoice.py
@@ -1,5 +1,5 @@
 """Module for defining invoice models."""
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from typing import List, Optional, Any
 from cg.constants.priority import PriorityTerms
 from cg.constants.sequencing import RecordType

--- a/cg/models/lims/sample.py
+++ b/cg/models/lims/sample.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import BaseModel, validator
+from pydantic.v1 import BaseModel, validator
 from typing_extensions import Literal
 
 from cg.constants import Priority

--- a/cg/models/mip/mip_config.py
+++ b/cg/models/mip/mip_config.py
@@ -1,6 +1,6 @@
 """Model MIP config"""
 
-from pydantic import BaseModel, EmailStr, Field, validator
+from pydantic.v1 import BaseModel, EmailStr, Field, validator
 from typing import List
 
 from cg.constants.priority import SlurmQos

--- a/cg/models/mip/mip_metrics_deliverables.py
+++ b/cg/models/mip/mip_metrics_deliverables.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional
 
-from pydantic import validator
+from pydantic.v1 import validator
 
 from cg.constants.subject import Gender
 from cg.models.deliverables.metric_deliverables import (

--- a/cg/models/mip/mip_sample_info.py
+++ b/cg/models/mip/mip_sample_info.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 import datetime
 
-from pydantic import BaseModel, Field, validator
+from pydantic.v1 import BaseModel, Field, validator
 
 
 class MipBaseSampleInfo(BaseModel):

--- a/cg/models/nextflow/deliverables.py
+++ b/cg/models/nextflow/deliverables.py
@@ -1,6 +1,6 @@
 import collections
 
-from pydantic import BaseModel, validator
+from pydantic.v1 import BaseModel, validator
 
 from cg.constants.nextflow import DELIVER_FILE_HEADERS
 

--- a/cg/models/nextflow/sample.py
+++ b/cg/models/nextflow/sample.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from pydantic import BaseModel, validator
+from pydantic.v1 import BaseModel, validator
 
 
 class NextflowSample(BaseModel):

--- a/cg/models/observations/input_files.py
+++ b/cg/models/observations/input_files.py
@@ -4,7 +4,7 @@ import logging
 from pathlib import Path
 from typing import Optional
 
-from pydantic import BaseModel, validator
+from pydantic.v1 import BaseModel, validator
 
 
 LOG = logging.getLogger(__name__)

--- a/cg/models/orders/excel_sample.py
+++ b/cg/models/orders/excel_sample.py
@@ -1,5 +1,5 @@
 from typing import List, Optional
-from pydantic import Field, validator
+from pydantic.v1 import Field, validator
 
 from cg.constants.orderforms import REV_SEX_MAP, SOURCE_TYPES
 from cg.models.orders.sample_base import OrderSample

--- a/cg/models/orders/json_sample.py
+++ b/cg/models/orders/json_sample.py
@@ -2,7 +2,7 @@ from typing import Optional, Any, List
 
 from cg.constants import DataDelivery, Pipeline
 from cg.models.orders.sample_base import OrderSample
-from pydantic import constr, validator
+from pydantic.v1 import constr, validator
 
 
 class JsonSample(OrderSample):

--- a/cg/models/orders/order.py
+++ b/cg/models/orders/order.py
@@ -1,6 +1,6 @@
 from typing import Optional, Any
 
-from pydantic import BaseModel, constr, conlist
+from pydantic.v1 import BaseModel, constr, conlist
 
 from cg.models.orders.constants import OrderType
 from cg.models.orders.samples import (

--- a/cg/models/orders/orderform_schema.py
+++ b/cg/models/orders/orderform_schema.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 from cg.models.orders.sample_base import OrderSample
 

--- a/cg/models/orders/sample_base.py
+++ b/cg/models/orders/sample_base.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import List, Optional
 
 from cg.constants import DataDelivery, Pipeline
-from pydantic import BaseModel, constr, validator
+from pydantic.v1 import BaseModel, constr, validator
 
 from cg.store.models import Application, Family, Customer, Pool, Sample
 

--- a/cg/models/orders/samples.py
+++ b/cg/models/orders/samples.py
@@ -13,7 +13,7 @@ from cg.models.orders.sample_base import (
 )
 from cg.store.models import Application, Family, Organism, Panel, Pool, Sample
 from cgmodels.cg.constants import Pipeline
-from pydantic import BaseModel, constr, validator
+from pydantic.v1 import BaseModel, constr, validator
 
 
 class OptionalIntValidator:

--- a/cg/models/report/metadata.py
+++ b/cg/models/report/metadata.py
@@ -1,6 +1,6 @@
 from typing import Optional, Union
 
-from pydantic import BaseModel, validator
+from pydantic.v1 import BaseModel, validator
 from cg.models.report.validators import (
     validate_empty_field,
     validate_float,

--- a/cg/models/report/report.py
+++ b/cg/models/report/report.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import List, Optional, Union
 
-from pydantic import BaseModel, validator, root_validator
+from pydantic.v1 import BaseModel, validator, root_validator
 from cg.constants import Pipeline, DataDelivery
 from cg.models.report.sample import SampleModel, ApplicationModel
 from cg.models.report.validators import (

--- a/cg/models/report/sample.py
+++ b/cg/models/report/sample.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Optional, Union
 
 from cg.constants.subject import Gender
-from pydantic import BaseModel, validator
+from pydantic.v1 import BaseModel, validator
 from cg.models.report.metadata import SampleMetadataModel
 from cg.models.report.validators import (
     validate_empty_field,

--- a/cg/models/rnafusion/command_args.py
+++ b/cg/models/rnafusion/command_args.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Optional, Union
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 
 class CommandArgs(BaseModel):

--- a/cg/models/rnafusion/metrics.py
+++ b/cg/models/rnafusion/metrics.py
@@ -1,7 +1,7 @@
 """Rnafusion quality control metrics model."""
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 
 class RnafusionQCMetrics(BaseModel):

--- a/cg/models/scout/scout_load_config.py
+++ b/cg/models/scout/scout_load_config.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import List, Optional
 
-from pydantic import BaseModel, validator
+from pydantic.v1 import BaseModel, validator
 from typing_extensions import Literal
 
 

--- a/cg/models/slurm/sbatch.py
+++ b/cg/models/slurm/sbatch.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 from cg.constants.constants import HastaSlurmPartitions
 from cg.constants.priority import SlurmQos

--- a/cg/models/workflow/mutant.py
+++ b/cg/models/workflow/mutant.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, validator
+from pydantic.v1 import BaseModel, validator
 
 
 class MutantSampleConfig(BaseModel):

--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -22,7 +22,7 @@ from cg.server.ext import db, lims, osticket
 from cg.store.models import Analysis, Application, Customer, Family, Flowcell, Pool, Sample, User
 from flask import Blueprint, abort, current_app, g, jsonify, make_response, request
 from google.auth import jwt
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 from requests.exceptions import HTTPError
 from sqlalchemy.exc import IntegrityError
 from urllib3.exceptions import MaxRetryError, NewConnectionError

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ packaging
 pandas
 paramiko
 petname
-pydantic<2.0
+pydantic>2.0
 python-dateutil
 pyyaml
 setuptools>=39.2.0      # due to WeasyPrint 45, tinycss2 1.0.1 and cairocffi file-.cairocffi-VERSION

--- a/tests/apps/cgstats/conftest.py
+++ b/tests/apps/cgstats/conftest.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Dict
 
 import pytest
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 from cg.apps.cgstats.crud import create
 from cg.apps.cgstats.db.models import Supportparams, Sample, Project, Datasource, Demux

--- a/tests/apps/crunchy/conftest.py
+++ b/tests/apps/crunchy/conftest.py
@@ -5,10 +5,10 @@ from typing import List
 
 import pytest
 
+from cg.apps.crunchy.models import CrunchyMetadata
 from cg.constants.constants import FileFormat
 from cg.io.controller import WriteFile
 from cg.models import CompressionData
-from cgmodels.crunchy.metadata import CrunchyMetadata
 
 LOG = logging.getLogger(__name__)
 

--- a/tests/apps/crunchy/test_compress_fastq.py
+++ b/tests/apps/crunchy/test_compress_fastq.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from typing import Dict, List
 
 import pytest
+from pydantic.v1 import ValidationError
+
 from cg.apps.crunchy import CrunchyAPI
 from cg.apps.crunchy.files import (
     get_crunchy_metadata,
@@ -11,13 +13,12 @@ from cg.apps.crunchy.files import (
     get_log_dir,
     get_spring_archive_files,
 )
+from cg.apps.crunchy.models import CrunchyFile, CrunchyMetadata
 from cg.apps.slurm.slurm_api import SlurmAPI
 from cg.constants.constants import FileFormat
 from cg.io.controller import WriteFile
 from cg.models import CompressionData
 from cg.utils import Process
-from cgmodels.crunchy.metadata import CrunchyFile, CrunchyMetadata
-from pydantic import ValidationError
 
 
 def test_get_spring_metadata(spring_metadata_file: Path):

--- a/tests/apps/crunchy/test_config.py
+++ b/tests/apps/crunchy/test_config.py
@@ -3,9 +3,9 @@ from pathlib import Path
 from typing import Dict, Any
 
 from cg.apps.crunchy.files import get_crunchy_metadata, update_metadata_date, update_metadata_paths
+from cg.apps.crunchy.models import CrunchyMetadata
 from cg.constants.constants import FileFormat
 from cg.io.controller import ReadFile
-from cgmodels.crunchy.metadata import CrunchyMetadata
 
 
 def test_get_spring_metadata_real_file(

--- a/tests/apps/orderform/test_excel_sample_schema.py
+++ b/tests/apps/orderform/test_excel_sample_schema.py
@@ -1,5 +1,5 @@
 import pytest
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 from cg.constants import DataDelivery
 from cg.models.orders.excel_sample import ExcelSample

--- a/tests/apps/scout/test_scout_load_config.py
+++ b/tests/apps/scout/test_scout_load_config.py
@@ -2,7 +2,7 @@
 from typing import Any
 
 import pytest
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 from cg.models.scout import scout_load_config
 from cg.models.scout.scout_load_config import MipLoadConfig, ScoutMipIndividual

--- a/tests/cli/workflow/balsamic/test_store_housekeeper.py
+++ b/tests/cli/workflow/balsamic/test_store_housekeeper.py
@@ -13,7 +13,7 @@ from cg.meta.workflow.balsamic import BalsamicAnalysisAPI
 from cg.models.cg_config import CGConfig
 from cg.utils import Process
 from click.testing import CliRunner
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 
 def test_without_options(cli_runner: CliRunner, balsamic_context: CGConfig):

--- a/tests/cli/workflow/rnafusion/test_cli_rnafusion_store_housekeeper.py
+++ b/tests/cli/workflow/rnafusion/test_cli_rnafusion_store_housekeeper.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 from _pytest.logging import LogCaptureFixture
 from click.testing import CliRunner
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 from pytest_mock import MockFixture
 
 from cg.apps.hermes.hermes_api import HermesApi

--- a/tests/mocks/limsmock.py
+++ b/tests/mocks/limsmock.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 
 from cg.apps.lims import LimsAPI
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from typing_extensions import Literal
 
 

--- a/tests/mocks/scout.py
+++ b/tests/mocks/scout.py
@@ -2,7 +2,7 @@
 
 import logging
 from pathlib import Path
-from pydantic import BaseModel, validator
+from pydantic.v1 import BaseModel, validator
 from typing import List
 from typing_extensions import Literal
 

--- a/tests/models/nextflow/test_nextflow_deliver.py
+++ b/tests/models/nextflow/test_nextflow_deliver.py
@@ -1,6 +1,6 @@
 from typing import Dict, Optional
 
-import pydantic
+from pydantic.v1 import ValidationError as PydanticValidationError
 import pytest
 
 from cg.models.nextflow.deliverables import NextflowDeliverables
@@ -30,7 +30,7 @@ def test_instantiate_nextflow_deliverables_with_empty_entry(
     Tests nextflow delivery object with empty entry.
     """
     # WHEN instantiating a deliverables object with an empty entry THEN assert that it was successfully created
-    with pytest.raises(pydantic.ValidationError):
+    with pytest.raises(PydanticValidationError):
         NextflowDeliverables(deliverables=nextflow_deliverables_with_empty_entry)
 
 
@@ -41,5 +41,5 @@ def test_instantiate_nextflow_deliverables_with_faulty_entry(
     Tests nextflow delivery object with empty entry.
     """
     # WHEN instantiating a deliverables object with an empty entry THEN assert that it was successfully created
-    with pytest.raises(pydantic.ValidationError):
+    with pytest.raises(PydanticValidationError):
         NextflowDeliverables(deliverables=nextflow_deliverables_with_faulty_entry)

--- a/tests/models/rnafusion/test_rnafusion_sample.py
+++ b/tests/models/rnafusion/test_rnafusion_sample.py
@@ -1,6 +1,6 @@
 from typing import List
 
-import pydantic
+from pydantic.v1 import ValidationError as PydanticValidationError
 import pytest
 
 from cg.models.rnafusion.rnafusion_sample import RnafusionSample
@@ -43,7 +43,7 @@ def test_instantiate_rnafusion_sample_fastq_r1_r2_different_length(
 
     # WHEN instantiating a sample object THEN throws a ValidationError
 
-    with pytest.raises(pydantic.ValidationError):
+    with pytest.raises(PydanticValidationError):
         RnafusionSample(
             sample=rnafusion_sample,
             fastq_r1=rnafusion_fastq_r1,
@@ -87,7 +87,7 @@ def test_instantiate_rnafusion_strandedness_not_acceptable(
     """
     # WHEN instantiating a sample object THEN throws a ValidationError
 
-    with pytest.raises(pydantic.ValidationError):
+    with pytest.raises(PydanticValidationError):
         RnafusionSample(
             sample=rnafusion_sample,
             fastq_r1=rnafusion_fastq_r1,


### PR DESCRIPTION
## Description

The task of bumping pydantic to the newest version turned out to be a complex task, as tried in #2265. This new approach proposes a temporary solution to the issues stated in #2249, which is bumping the version but importing the v1 of pydantic by changing all imports to:
```python
from pydantic.v1 import <submodules>
```

### Added

- Crunchy pydantic models previously imported from `cgmodels` to `cg/apps/crunchy/models.py`

### Changed

- The version of pydantic in the requirements
- All the imports of pydantic so that it uses v1 instead of v2

### Fixed

-


### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b temp-pydantic-bumping -a
    ```

### How to test

- [x] cg compress fastq -c keytiger --dry-run

### Expected test outcome

- [x] Check that the crunchy API was created successfully

## Review

- [x] Tests executed by SD
- [x] "Merge and deploy" approved by VI
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
