### PR TITLE
Add endpoint for retrieving sequencing metrics

### DIFF
--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -373,17 +373,17 @@ def get_sequencing_metrics(flow_cell_name: str):
     if not flow_cell_name:
         return jsonify({"error": "Invalid or missing flow cell id"}), http.HTTPStatus.BAD_REQUEST
 
-    metrics: List[
+    sequencing_metrics: List[
         SampleLaneSequencingMetrics
     ] = db.get_sample_lane_sequencing_metrics_by_flow_cell_name(flow_cell_name)
 
-    if not metrics:
+    if not sequencing_metrics:
         return (
             jsonify({"error": f"Sequencing metrics not found for flow cell {flow_cell_name}."}),
             http.HTTPStatus.NOT_FOUND,
         )
 
-    return jsonify([metric.to_dict() for metric in metrics])
+    return jsonify([metric.to_dict() for metric in sequencing_metrics])
 
 
 @BLUEPRINT.route("/analyses")

--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -368,7 +368,7 @@ def parse_flow_cell(flowcell_id):
 
 @BLUEPRINT.route("/flowcells/<flow_cell_id>/sequencing_metrics", methods=["GET"])
 def get_sequencing_metrics(flow_cell_id: str):
-    """Return sequencing metrics for a flow cell."""
+    """Return sample lane sequencing metrics for a flow cell."""
 
     if not flow_cell_id:
         return jsonify({"error": "Invalid or missing flow cell id"}), http.HTTPStatus.BAD_REQUEST

--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -19,7 +19,17 @@ from cg.meta.orders import OrdersAPI
 from cg.models.orders.order import OrderIn, OrderType
 from cg.models.orders.orderform_schema import Orderform
 from cg.server.ext import db, lims, osticket
-from cg.store.models import Analysis, Application, Customer, Family, Flowcell, Pool, Sample, User
+from cg.store.models import (
+    Analysis,
+    Application,
+    Customer,
+    Family,
+    Flowcell,
+    Pool,
+    Sample,
+    SampleLaneSequencingMetrics,
+    User,
+)
 from flask import Blueprint, abort, current_app, g, jsonify, make_response, request
 from google.auth import jwt
 from pydantic.v1 import ValidationError
@@ -354,6 +364,15 @@ def parse_flow_cell(flowcell_id):
     if flow_cell is None:
         return abort(http.HTTPStatus.NOT_FOUND)
     return jsonify(**flow_cell.to_dict(samples=True))
+
+
+@BLUEPRINT.route("/flowcells/<flow_cell_id>/sequencing_metrics", methods=["GET"])
+def get_sequencing_metrics(flow_cell_id: str):
+    """Return sequencing metrics for a flow cell."""
+    metrics: List[
+        SampleLaneSequencingMetrics
+    ] = db.get_sample_lane_sequencing_metrics_by_flow_cell_name(flow_cell_id)
+    return jsonify(metrics)
 
 
 @BLUEPRINT.route("/analyses")

--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -372,7 +372,7 @@ def get_sequencing_metrics(flow_cell_id: str):
     metrics: List[
         SampleLaneSequencingMetrics
     ] = db.get_sample_lane_sequencing_metrics_by_flow_cell_name(flow_cell_id)
-    return jsonify(metrics)
+    return jsonify([metric.to_dict() for metric in metrics])
 
 
 @BLUEPRINT.route("/analyses")

--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -368,7 +368,7 @@ def parse_flow_cell(flowcell_id):
 
 @BLUEPRINT.route("/flowcells/<flow_cell_id>/sequencing_metrics", methods=["GET"])
 def get_sequencing_metrics(flow_cell_id: str):
-    """Return sequencing metrics for a flow cell."""
+    """Return sequencing metrics for a flow cell"""
     metrics: List[
         SampleLaneSequencingMetrics
     ] = db.get_sample_lane_sequencing_metrics_by_flow_cell_name(flow_cell_id)

--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -366,16 +366,16 @@ def parse_flow_cell(flowcell_id):
     return jsonify(**flow_cell.to_dict(samples=True))
 
 
-@BLUEPRINT.route("/flowcells/<flow_cell_id>/sequencing_metrics", methods=["GET"])
-def get_sequencing_metrics(flow_cell_id: str):
+@BLUEPRINT.route("/flowcells/<flow_cell_name>/sequencing_metrics", methods=["GET"])
+def get_sequencing_metrics(flow_cell_name: str):
     """Return sample lane sequencing metrics for a flow cell."""
 
-    if not flow_cell_id:
+    if not flow_cell_name:
         return jsonify({"error": "Invalid or missing flow cell id"}), http.HTTPStatus.BAD_REQUEST
 
     metrics: List[
         SampleLaneSequencingMetrics
-    ] = db.get_sample_lane_sequencing_metrics_by_flow_cell_name(flow_cell_id)
+    ] = db.get_sample_lane_sequencing_metrics_by_flow_cell_name(flow_cell_name)
 
     if not metrics:
         return jsonify({"error": "Sequencing metrics not found"}), http.HTTPStatus.NOT_FOUND

--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -378,7 +378,10 @@ def get_sequencing_metrics(flow_cell_name: str):
     ] = db.get_sample_lane_sequencing_metrics_by_flow_cell_name(flow_cell_name)
 
     if not metrics:
-        return jsonify({"error": "Sequencing metrics not found"}), http.HTTPStatus.NOT_FOUND
+        return (
+            jsonify({"error": f"Sequencing metrics not found for flow cell {flow_cell_name}."}),
+            http.HTTPStatus.NOT_FOUND,
+        )
 
     return jsonify([metric.to_dict() for metric in metrics])
 

--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -368,10 +368,18 @@ def parse_flow_cell(flowcell_id):
 
 @BLUEPRINT.route("/flowcells/<flow_cell_id>/sequencing_metrics", methods=["GET"])
 def get_sequencing_metrics(flow_cell_id: str):
-    """Return sequencing metrics for a flow cell"""
+    """Return sequencing metrics for a flow cell."""
+
+    if not flow_cell_id:
+        return jsonify({"error": "Invalid or missing flow cell id"}), http.HTTPStatus.BAD_REQUEST
+
     metrics: List[
         SampleLaneSequencingMetrics
     ] = db.get_sample_lane_sequencing_metrics_by_flow_cell_name(flow_cell_id)
+
+    if not metrics:
+        return jsonify({"error": "Sequencing metrics not found"}), http.HTTPStatus.NOT_FOUND
+
     return jsonify([metric.to_dict() for metric in metrics])
 
 

--- a/cg/server/app.py
+++ b/cg/server/app.py
@@ -56,6 +56,7 @@ def _configure_extensions(app: Flask):
     if app.config["OSTICKET_API_KEY"]:
         ext.osticket.init_app(app)
     ext.admin.init_app(app, index_view=AdminIndexView(endpoint="admin"))
+    app.json_encoder = ext.CustomJSONEncoder
 
 
 def _initialize_logging(app):

--- a/cg/server/ext.py
+++ b/cg/server/ext.py
@@ -1,6 +1,10 @@
+from decimal import Decimal
+
+from flask.json import JSONEncoder
 from flask_admin import Admin
 from flask_cors import CORS
 from flask_wtf.csrf import CSRFProtect
+
 from cg.apps.lims import LimsAPI
 from cg.apps.osticket import OsTicket
 from cg.store.api.core import Store
@@ -30,6 +34,13 @@ class FlaskStore(Store):
     def init_app(self, app):
         uri = app.config["SQLALCHEMY_DATABASE_URI"]
         super(FlaskStore, self).__init__(uri)
+
+
+class CustomJSONEncoder(JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, Decimal):
+            return float(obj)
+        return super().default(obj)
 
 
 cors = CORS(resources={r"/api/*": {"origins": "*"}}, supports_credentials=True)

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -800,3 +800,6 @@ class SampleLaneSequencingMetrics(Model):
             name="uix_flowcell_sample_lane",
         ),
     )
+
+    def to_dict(self):
+        return to_dict(model_instance=self)


### PR DESCRIPTION
## Description
This PR adds an endpoint to the web api for retrieving sequencing metrics for a flow cell. Part of project https://github.com/Clinical-Genomics/project-planning/issues/482. 

This endpoint will be used in other repos such as `cg_lims`/`clinical_EPPs`, enabling us to remove their dependency on cgstats.
 


### Added
- Endpoint for retrieving sequencing metrics for a flow cell


### How to test
- [x] Send a request with Postman against `https://cg-statusdb-stage.scilifelab.se/api/v1/flowcells/<flow_cell_id>/sequencing_metrics`
### Expected test outcome
- [x] Check that a 200 response is given and the response contains the metrics


### This [version](https://semver.org/) is a
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
