### PR TITLE
fix( check if sample is present in statusDB before adding a metrics entry)

### DIFF
--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -186,7 +186,7 @@ class DemuxPostProcessingAPI:
         )
         if existing_metrics_entry:
             LOG.warning(
-                f"Sample lane sequencing metrics already exist for {metric.flow_cell_name}, {metric.sample_internal_id}, and {metric.flow_cell_lane_number}. Skipping."
+                f"Sample lane sequencing metrics already exist for {metric.flow_cell_name}, {metric.sample_internal_id}, and lane {metric.flow_cell_lane_number}. Skipping."
             )
         return bool(existing_metrics_entry)
 

--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -162,9 +162,19 @@ class DemuxPostProcessingAPI:
         self, sample_lane_sequencing_metrics: List[SampleLaneSequencingMetrics]
     ) -> None:
         for metric in sample_lane_sequencing_metrics:
-            if not self.metric_exists_in_status_db(metric):
+            if not self.metric_exists_in_status_db(metric) and self.metric_has_sample_in_statusdb(
+                metric
+            ):
                 self.add_metric_to_status_db(metric)
         self.status_db.session.commit()
+
+    def metric_has_sample_in_statusdb(self, metric: SampleLaneSequencingMetrics) -> bool:
+        """Check if a sample exists in status db for the sample lane sequencing metrics."""
+        sample: Sample = self.status_db.get_sample_by_internal_id(metric.sample_internal_id)
+        if sample:
+            return True
+        LOG.warning(f"Sample {metric.sample_internal_id} does not exist in status db. Skipping.")
+        return False
 
     def metric_exists_in_status_db(self, metric: SampleLaneSequencingMetrics) -> bool:
         existing_metrics_entry: Optional[

--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -162,18 +162,18 @@ class DemuxPostProcessingAPI:
         self, sample_lane_sequencing_metrics: List[SampleLaneSequencingMetrics]
     ) -> None:
         for metric in sample_lane_sequencing_metrics:
-            if not self.metric_exists_in_status_db(metric) and self.metric_has_sample_in_statusdb(
-                metric
-            ):
+            metric_exists: bool = self.metric_exists_in_status_db(metric)
+            metric_has_sample: bool = self.metric_has_sample_in_statusdb(metric.sample_internal_id)
+            if not metric_exists and metric_has_sample:
                 self.add_metric_to_status_db(metric)
         self.status_db.session.commit()
 
-    def metric_has_sample_in_statusdb(self, metric: SampleLaneSequencingMetrics) -> bool:
+    def metric_has_sample_in_statusdb(self, sample_internal_id: str) -> bool:
         """Check if a sample exists in status db for the sample lane sequencing metrics."""
-        sample: Sample = self.status_db.get_sample_by_internal_id(metric.sample_internal_id)
+        sample: Sample = self.status_db.get_sample_by_internal_id(sample_internal_id)
         if sample:
             return True
-        LOG.warning(f"Sample {metric.sample_internal_id} does not exist in status db. Skipping.")
+        LOG.warning(f"Sample {sample_internal_id} does not exist in status db. Skipping.")
         return False
 
     def metric_exists_in_status_db(self, metric: SampleLaneSequencingMetrics) -> bool:

--- a/tests/meta/demultiplex/test_demux_post_processing.py
+++ b/tests/meta/demultiplex/test_demux_post_processing.py
@@ -14,6 +14,7 @@ from cg.models.cg_config import CGConfig
 from cg.models.demultiplex.demux_results import DemuxResults
 from cg.models.demultiplex.flow_cell import FlowCellDirectoryData
 from cg.store import Store
+from cg.store.models import SampleLaneSequencingMetrics
 
 
 def test_set_dry_run(
@@ -883,3 +884,23 @@ def test_add_demux_logs_to_housekeeper(
     assert len(files) == 2
     for file in files:
         assert file.path.split("/")[-1] in expected_file_names
+
+
+def test_metric_has_sample_in_statusdb(
+    store_with_sequencing_metrics: Store, demultiplex_context: CGConfig
+):
+    # GIVEN a store with a sample and a sequencing metric
+
+    # GIVEN a DemuxPostProcessing API
+    demux_post_processing_api = DemuxPostProcessingAPI(demultiplex_context)
+
+    # GIVEN a sample internal id that does not exist in statusdb
+    sample_internal_id = "does_not_exist"
+
+    # GIVEN a metric with the sample internal id
+    sequencing_metric = store_with_sequencing_metrics._get_query(
+        table=SampleLaneSequencingMetrics
+    ).first()
+    sequencing_metric.sample_id = sample_internal_id
+    # WHEN checking if the sample exists in statusdb
+    assert not demux_post_processing_api.metric_has_sample_in_statusdb(sequencing_metric)

--- a/tests/meta/demultiplex/test_demux_post_processing.py
+++ b/tests/meta/demultiplex/test_demux_post_processing.py
@@ -14,7 +14,6 @@ from cg.models.cg_config import CGConfig
 from cg.models.demultiplex.demux_results import DemuxResults
 from cg.models.demultiplex.flow_cell import FlowCellDirectoryData
 from cg.store import Store
-from cg.store.models import SampleLaneSequencingMetrics
 
 
 def test_set_dry_run(
@@ -886,9 +885,7 @@ def test_add_demux_logs_to_housekeeper(
         assert file.path.split("/")[-1] in expected_file_names
 
 
-def test_metric_has_sample_in_statusdb(
-    store_with_sequencing_metrics: Store, demultiplex_context: CGConfig
-):
+def test_metric_has_sample_in_statusdb(demultiplex_context: CGConfig):
     # GIVEN a store with a sample and a sequencing metric
 
     # GIVEN a DemuxPostProcessing API
@@ -897,10 +894,5 @@ def test_metric_has_sample_in_statusdb(
     # GIVEN a sample internal id that does not exist in statusdb
     sample_internal_id = "does_not_exist"
 
-    # GIVEN a metric with the sample internal id
-    sequencing_metric = store_with_sequencing_metrics._get_query(
-        table=SampleLaneSequencingMetrics
-    ).first()
-    sequencing_metric.sample_id = sample_internal_id
     # WHEN checking if the sample exists in statusdb
-    assert not demux_post_processing_api.metric_has_sample_in_statusdb(sequencing_metric)
+    assert not demux_post_processing_api.metric_has_sample_in_statusdb(sample_internal_id)


### PR DESCRIPTION
## Description

Adds functionality to check if a metrics entry has a sample present in statusDB to avoid foreign key constraint errors

### Added

-

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
