### PR TITLE
patch(demultiplexing) Catch all error in new finish flow-cell

### DIFF
--- a/cg/cli/demultiplex/finish.py
+++ b/cg/cli/demultiplex/finish.py
@@ -35,7 +35,9 @@ def finish_all_cmd(context: CGConfig, bcl_converter: str, dry_run: bool) -> None
     # Temporary finish flow cell logic will replace logic above when validated
     demux_post_processing_api_temp: DemuxPostProcessingAPI = DemuxPostProcessingAPI(config=context)
     demux_post_processing_api_temp.set_dry_run(dry_run=dry_run)
-    demux_post_processing_api_temp.finish_all_flow_cells_temp()
+    is_error_raised: bool = demux_post_processing_api_temp.finish_all_flow_cells_temp()
+    if is_error_raised:
+        raise click.Abort
 
 
 @finish_group.command(name="flow-cell")

--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -137,8 +137,8 @@ class DemuxPostProcessingAPI:
         for flow_cell_dir in flow_cell_dirs:
             try:
                 self.finish_flow_cell_temp(flow_cell_dir.name)
-            except Exception as e:
-                LOG.error(f"Failed to finish flow cell {flow_cell_dir.name}: {str(e)}")
+            except Exception as error:
+                LOG.error(f"Failed to finish flow cell {flow_cell_dir.name}: {str(error)}")
                 is_error_raised = True
                 continue
         return is_error_raised

--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -130,15 +130,18 @@ class DemuxPostProcessingAPI:
 
         create_delivery_file_in_flow_cell_directory(flow_cell_directory)
 
-    def finish_all_flow_cells_temp(self) -> None:
+    def finish_all_flow_cells_temp(self) -> bool:
         """Finish all flow cells that need it."""
         flow_cell_dirs = self.demux_api.get_all_demultiplexed_flow_cell_dirs()
+        is_error_raised: bool = False
         for flow_cell_dir in flow_cell_dirs:
             try:
                 self.finish_flow_cell_temp(flow_cell_dir.name)
-            except FlowCellError as e:
+            except Exception as e:
                 LOG.error(f"Failed to finish flow cell {flow_cell_dir.name}: {str(e)}")
+                is_error_raised = True
                 continue
+        return is_error_raised
 
     def store_flow_cell_data(self, parsed_flow_cell: FlowCellDirectoryData) -> None:
         """Store data from the flow cell directory in status db and housekeeper."""

--- a/tests/cli/demultiplex/test_finish_demux.py
+++ b/tests/cli/demultiplex/test_finish_demux.py
@@ -32,28 +32,6 @@ def test_finish_all_cmd_dry_run(
     assert result.exit_code == EXIT_SUCCESS
 
 
-def test_finish_all_cmd(
-    caplog,
-    cli_runner: testing.CliRunner,
-    demultiplex_context: CGConfig,
-    demultiplexed_flow_cell_finished_working_directory: Path,
-):
-    caplog.set_level(logging.INFO)
-
-    # GIVEN a demultiplex flow cell finished output directory that does not exist
-
-    # GIVEN a demultiplex context
-
-    # WHEN starting post-processing for new demultiplexing from the CLI
-    result: testing.Result = cli_runner.invoke(
-        finish_all_cmd,
-        obj=demultiplex_context,
-    )
-
-    # THEN assert the command exits successfully
-    assert result.exit_code == EXIT_SUCCESS
-
-
 def test_finish_flow_cell_dry_run(
     caplog,
     cli_runner: testing.CliRunner,


### PR DESCRIPTION
## Description
When iterating through the flow cells we don't want one failing flow cell to block all others. This PR excepts all errors, logs them and aborts at the end of the for loop
### Added

- Except all errors in finish_all_flow_cells_temp



### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
