### PR TITLE
#2272: Add check whether flow cell should be finished

### DIFF
--- a/cg/meta/demultiplex/utils.py
+++ b/cg/meta/demultiplex/utils.py
@@ -8,10 +8,8 @@ from typing import List, Optional
 from cg.constants.constants import FileExtensions
 from cg.constants.demultiplexing import BclConverter, DemultiplexingDirsAndFiles
 from cg.constants.sequencing import FLOWCELL_Q30_THRESHOLD, Sequencers
-from cg.exc import FlowCellError
 from cg.meta.demultiplex.validation import (
     is_bcl2fastq_demux_folder_structure,
-    is_flow_cell_directory_valid,
     is_valid_sample_fastq_file,
 )
 from cg.models.demultiplex.flow_cell import FlowCellDirectoryData
@@ -91,7 +89,6 @@ def parse_flow_cell_directory_data(
     flow_cell_directory: Path, bcl_converter: str
 ) -> FlowCellDirectoryData:
     """Return flow cell data from the flow cell directory."""
-    is_flow_cell_directory_valid(flow_cell_directory)
     return FlowCellDirectoryData(flow_cell_path=flow_cell_directory, bcl_converter=bcl_converter)
 
 

--- a/cg/meta/demultiplex/validation.py
+++ b/cg/meta/demultiplex/validation.py
@@ -56,7 +56,7 @@ def is_bcl2fastq_demux_folder_structure(flow_cell_directory: Path) -> bool:
     return False
 
 
-def is_flow_cell_directory_valid(flow_cell_directory: Path) -> None:
+def is_flow_cell_ready_for_postprocessing(flow_cell_directory: Path) -> None:
     """Validate that the flow cell directory exists and that the demultiplexing is complete."""
 
     if not flow_cell_directory.is_dir():
@@ -67,6 +67,15 @@ def is_flow_cell_directory_valid(flow_cell_directory: Path) -> None:
             f"Demultiplexing not completed for flow cell directory {flow_cell_directory}."
         )
 
+    if is_flow_cell_ready_for_delivery(flow_cell_directory):
+        raise FlowCellError(
+            f"Flow cell directory {flow_cell_directory} is already ready for delivery."
+        )
+
 
 def is_demultiplexing_complete(flow_cell_directory: Path) -> bool:
     return Path(flow_cell_directory, DemultiplexingDirsAndFiles.DEMUX_COMPLETE).exists()
+
+
+def is_flow_cell_ready_for_delivery(flow_cell_directory: Path) -> bool:
+    return Path(flow_cell_directory, DemultiplexingDirsAndFiles.DELIVERY).exists()

--- a/tests/meta/demultiplex/test_validation.py
+++ b/tests/meta/demultiplex/test_validation.py
@@ -7,7 +7,7 @@ from cg.exc import FlowCellError
 from cg.meta.demultiplex.utils import create_delivery_file_in_flow_cell_directory
 from cg.meta.demultiplex.validation import (
     is_file_path_compressed_fastq,
-    is_flow_cell_directory_valid,
+    is_flow_cell_ready_for_postprocessing,
     is_lane_in_fastq_file_name,
     is_sample_id_in_directory_name,
     is_valid_sample_fastq_file,
@@ -134,7 +134,7 @@ def test_is_flow_cell_directory_valid_when_directory_exists_and_demultiplexing_c
     Path(flow_cell_directory, DemultiplexingDirsAndFiles.DEMUX_COMPLETE).touch()
 
     # WHEN validating the flow cell directory
-    is_flow_cell_directory_valid(flow_cell_directory)
+    is_flow_cell_ready_for_postprocessing(flow_cell_directory)
 
     # THEN no exception is raised
 
@@ -147,7 +147,7 @@ def test_is_flow_cell_directory_valid_when_directory_exists_but_demultiplexing_n
 
     # WHEN validating the flow cell directory
     with pytest.raises(FlowCellError):
-        is_flow_cell_directory_valid(flow_cell_directory)
+        is_flow_cell_ready_for_postprocessing(flow_cell_directory)
 
 
 def test_is_flow_cell_directory_valid_when_directory_does_not_exist():
@@ -156,4 +156,4 @@ def test_is_flow_cell_directory_valid_when_directory_does_not_exist():
 
     # WHEN validating the flow cell directory
     with pytest.raises(FlowCellError):
-        is_flow_cell_directory_valid(flow_cell_directory)
+        is_flow_cell_ready_for_postprocessing(flow_cell_directory)


### PR DESCRIPTION
## Description
This PR refactors the existing validation of the flow cell directory before post processing and adds a check whether the flow cell already has been processed. In the future, we might want to add a bool flag to a database model instead of relying on the existence of a `delivery.txt` file.

Since some of our automation scripts seem to check for the `delivery.txt` file, lets keep to that pattern.

### Added
- Check whether `delivery.txt` exists before finishinga flow cell

### Fixed
- Refactored val

### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
