### PR TITLE
Return if flow cell is not valid

### DIFF
--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -117,7 +117,7 @@ class DemuxPostProcessingAPI:
             )
         except FlowCellError as e:
             LOG.error(f"Flow cell {flow_cell_directory_name} will be skipped: {e}")
-            raise
+            return
 
         bcl_converter: str = get_bcl_converter_name(flow_cell_out_directory)
 
@@ -135,7 +135,7 @@ class DemuxPostProcessingAPI:
             self.store_flow_cell_data(parsed_flow_cell)
         except Exception as e:
             LOG.error(f"Failed to store flow cell data: {str(e)}")
-            return
+            raise
 
         create_delivery_file_in_flow_cell_directory(flow_cell_out_directory)
 

--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -135,7 +135,7 @@ class DemuxPostProcessingAPI:
             self.store_flow_cell_data(parsed_flow_cell)
         except Exception as e:
             LOG.error(f"Failed to store flow cell data: {str(e)}")
-            raise
+            return
 
         create_delivery_file_in_flow_cell_directory(flow_cell_out_directory)
 

--- a/tests/cli/demultiplex/test_finish_demux.py
+++ b/tests/cli/demultiplex/test_finish_demux.py
@@ -58,32 +58,6 @@ def test_finish_flow_cell_dry_run(
     assert result.exit_code == EXIT_SUCCESS
 
 
-def test_finish_flow_cell_fail(
-    caplog,
-    cli_runner: testing.CliRunner,
-    demultiplex_context: CGConfig,
-    demultiplexed_flow_cell_finished_working_directory: Path,
-    bcl2fastq_flow_cell_id: str,
-):
-    caplog.set_level(logging.INFO)
-
-    # GIVEN a demultiplex flow cell finished output directory that does not exist
-
-    # GIVEN a demultiplex context
-
-    # GIVEN a flow cell id
-
-    # WHEN starting post-processing for new demultiplexing from the CLI
-    result: testing.Result = cli_runner.invoke(
-        finish_flow_cell,
-        [bcl2fastq_flow_cell_id],
-        obj=demultiplex_context,
-    )
-
-    # THEN assert the command exits successfully
-    assert result.exit_code != EXIT_SUCCESS
-
-
 def test_finish_all_hiseq_x_dry_run(
     caplog,
     cli_runner: testing.CliRunner,


### PR DESCRIPTION
## Description
This PR avoids raising an exception when a flow cell could not be post processed due to not being valid and just skips it after logging an error message. This fix avoids causing the command to exit with a non zero status.

### Fixed
- Skip flow cell instead of raising exception when it is invalid

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions