### PR TITLE
Check if sample exists before creating bundle

### DIFF
--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -278,6 +278,10 @@ class DemuxPostProcessingAPI:
         )
 
         for sample_internal_id in sample_internal_ids:
+            if not self.status_db.get_sample_by_internal_id(sample_internal_id):
+                LOG.warning(f"Sample {sample_internal_id} does not exist in status db. Skipping.")
+                continue
+
             self.add_bundle_and_version_if_non_existent(sample_internal_id)
 
             sample_fastq_paths: Optional[List[Path]] = get_sample_fastqs_from_flow_cell(


### PR DESCRIPTION
## Description
This PR fixes the issue where empty bundles are created for samples in housekeeper in the new post processing flow.

### Fixed
- Creation of empty samples bundles in housekeeper

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
