### PR TITLE
Fix fastq file pattern bug

### DIFF
--- a/cg/meta/demultiplex/utils.py
+++ b/cg/meta/demultiplex/utils.py
@@ -40,9 +40,10 @@ def get_sample_fastqs_from_flow_cell(
 ) -> Optional[List[Path]]:
     """Retrieve sample FastQs from a flow cell directory."""
     root_pattern = f"{sample_internal_id}_S*_L*_R*_*{FileExtensions.FASTQ}{FileExtensions.GZIP}"
-    unaligned_pattern = f"Unaligned*/Project_*/Sample_{sample_internal_id}*/*{FileExtensions.FASTQ}{FileExtensions.GZIP}"
+    unaligned_pattern = f"Unaligned*/Project_*/Sample_{sample_internal_id}/*{FileExtensions.FASTQ}{FileExtensions.GZIP}"
+    unaligned_alt_pattern = f"Unaligned*/Project_*/Sample_{sample_internal_id}_*/*{FileExtensions.FASTQ}{FileExtensions.GZIP}"
 
-    for pattern in [root_pattern, unaligned_pattern]:
+    for pattern in [root_pattern, unaligned_pattern, unaligned_alt_pattern]:
         sample_fastqs: List[Path] = get_files_matching_pattern(
             directory=flow_cell_directory, pattern=pattern
         )


### PR DESCRIPTION
## Description
This PR fixes a bug where we match too many sample fastq files and store them erroneously in the same sample bundle in housekeeper in the new post processing flow for flow cells.


### Fixed
- Bug adding too many fastq files to a sample bundle in housekeeper

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
