### PR TITLE
change(rnafusion): make tower names unique when resuming

### DIFF
--- a/cg/meta/workflow/tower_common.py
+++ b/cg/meta/workflow/tower_common.py
@@ -1,6 +1,7 @@
 """Module for Tower Analysis API."""
 
 import logging
+from datetime import datetime
 from pathlib import Path
 from typing import Iterable, List
 
@@ -58,7 +59,7 @@ class TowerAnalysisAPI:
             "--id",
             str(from_tower_id),
             "--name",
-            f"{command_args.get('name')}_from{str(from_tower_id)}",
+            f"{command_args.get('name')}_from{str(from_tower_id)}_{datetime.now().strftime('%Y%m%d%H%M%S')}",
         ] + tower_options
 
     @staticmethod


### PR DESCRIPTION
## Description

Closes https://github.com/Clinical-Genomics/MTP-RNAFUSION/issues/24


### Changed

- Added unique suffix for tower names for re-runs 



### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
