### PR TITLE
Rename trailblazer api to client

### DIFF
--- a/cg/apps/demultiplex/demultiplex_api.py
+++ b/cg/apps/demultiplex/demultiplex_api.py
@@ -8,7 +8,7 @@ from typing_extensions import Literal
 from cgmodels.trailblazer.constants import AnalysisTypes
 from cg.apps.demultiplex.sbatch import DEMULTIPLEX_COMMAND, DEMULTIPLEX_ERROR
 from cg.apps.slurm.slurm_api import SlurmAPI
-from cg.apps.tb import TrailblazerAPI
+from cg.apps.tb import TrailblazerClient
 from cg.constants.constants import FileFormat
 from cg.constants.demultiplexing import DemultiplexingDirsAndFiles, BclConverter
 from cg.constants.priority import SlurmQos
@@ -192,7 +192,7 @@ class DemultiplexingAPI:
         )
 
     def add_to_trailblazer(
-        self, tb_api: TrailblazerAPI, slurm_job_id: int, flow_cell: FlowCellDirectoryData
+        self, tb_api: TrailblazerClient, slurm_job_id: int, flow_cell: FlowCellDirectoryData
     ):
         """Add demultiplexing entry to trailblazer."""
         if self.dry_run:

--- a/cg/apps/tb/__init__.py
+++ b/cg/apps/tb/__init__.py
@@ -1,1 +1,1 @@
-from .api import TrailblazerAPI
+from .api import TrailblazerClient

--- a/cg/apps/tb/api.py
+++ b/cg/apps/tb/api.py
@@ -18,7 +18,7 @@ from cg.io.controller import APIRequest, ReadStream
 LOG = logging.getLogger(__name__)
 
 
-class TrailblazerAPI:
+class TrailblazerClient:
     """Interface to Trailblazer for `cg`."""
 
     __STARTED_STATUSES = [

--- a/cg/cli/clean.py
+++ b/cg/cli/clean.py
@@ -9,7 +9,7 @@ from cg.apps.demultiplex.demultiplex_api import DemultiplexingAPI
 from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.apps.scout.scout_export import ScoutExportCase
 from cg.apps.scout.scoutapi import ScoutAPI
-from cg.apps.tb import TrailblazerAPI
+from cg.apps.tb import TrailblazerClient
 from cg.cli.workflow.commands import (
     balsamic_past_run_dirs,
     balsamic_pon_past_run_dirs,
@@ -267,7 +267,7 @@ def remove_invalid_flow_cell_directories(context: CGConfig, failed_only: bool, d
     status_db: Store = context.status_db
     demux_api: DemultiplexingAPI = context.demultiplex_api
     housekeeper_api: HousekeeperAPI = context.housekeeper_api
-    trailblazer_api: TrailblazerAPI = context.trailblazer_api
+    trailblazer_api: TrailblazerClient = context.trailblazer_api
     sample_sheets_dir: str = context.clean.flow_cells.sample_sheets_dir_name
     checked_flow_cells: List[DemultiplexedRunsFlowCell] = []
     search: str = f"%{demux_api.out_dir}%"
@@ -451,7 +451,7 @@ def remove_old_demutliplexed_run_dirs(context: CGConfig, days_old: int, dry_run:
     status_db: Store = context.status_db
     demux_api: DemultiplexingAPI = context.demultiplex_api
     housekeeper_api: HousekeeperAPI = context.housekeeper_api
-    trailblazer_api: TrailblazerAPI = context.trailblazer_api
+    trailblazer_api: TrailblazerClient = context.trailblazer_api
     for flow_cell_dir in demux_api.get_all_demultiplexed_flow_cell_dirs():
         try:
             flow_cell: DemultiplexFlowCell = DemultiplexFlowCell(flow_cell_path=flow_cell_dir)

--- a/cg/cli/deliver/base.py
+++ b/cg/cli/deliver/base.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 
 import click
 from cg.meta.rsync.rsync_api import RsyncAPI
-from cg.apps.tb import TrailblazerAPI
+from cg.apps.tb import TrailblazerClient
 from cg.constants.delivery import PIPELINE_ANALYSIS_OPTIONS, PIPELINE_ANALYSIS_TAG_MAP
 from cg.meta.deliver import DeliverAPI
 from cg.meta.deliver_ticket import DeliverTicketAPI
@@ -120,7 +120,7 @@ def rsync(context: CGConfig, ticket: str, dry_run: bool):
     """The folder generated using the "cg deliver analysis" command will be
     rsynced with this function to the customers inbox on the delivery server
     """
-    tb_api: TrailblazerAPI = context.trailblazer_api
+    tb_api: TrailblazerClient = context.trailblazer_api
     rsync_api: RsyncAPI = RsyncAPI(config=context)
     slurm_id = rsync_api.run_rsync_on_slurm(ticket=ticket, dry_run=dry_run)
     LOG.info("Rsync to the delivery server running as job %s", slurm_id)

--- a/cg/cli/demultiplex/demux.py
+++ b/cg/cli/demultiplex/demux.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import click
 
 from cg.apps.demultiplex.demultiplex_api import DemultiplexingAPI
-from cg.apps.tb import TrailblazerAPI
+from cg.apps.tb import TrailblazerClient
 from cg.constants.demultiplexing import OPTION_BCL_CONVERTER
 from cg.exc import FlowCellError
 from cg.meta.demultiplex.delete_demultiplex_api import DeleteDemuxAPI
@@ -32,7 +32,7 @@ def demultiplex_all(
         flow_cells_directory: Path = Path(context.demultiplex.run_dir)
     demultiplex_api: DemultiplexingAPI = context.demultiplex_api
     demultiplex_api.set_dry_run(dry_run=dry_run)
-    tb_api: TrailblazerAPI = context.trailblazer_api
+    tb_api: TrailblazerClient = context.trailblazer_api
     LOG.info(f"Search for flow cells ready to demultiplex in {flow_cells_directory}")
     for sub_dir in flow_cells_directory.iterdir():
         if not sub_dir.is_dir():
@@ -100,7 +100,7 @@ def demultiplex_flow_cell(
         raise click.Abort
 
     slurm_job_id: int = demultiplex_api.start_demultiplexing(flow_cell=flow_cell)
-    tb_api: TrailblazerAPI = context.trailblazer_api
+    tb_api: TrailblazerClient = context.trailblazer_api
     demultiplex_api.add_to_trailblazer(
         tb_api=tb_api, slurm_job_id=slurm_job_id, flow_cell=flow_cell
     )

--- a/cg/cli/upload/clinical_delivery.py
+++ b/cg/cli/upload/clinical_delivery.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Set
 
 import click
-from cg.apps.tb import TrailblazerAPI
+from cg.apps.tb import TrailblazerClient
 from cg.constants import Pipeline
 from cg.constants.constants import DRY_RUN
 from cg.constants.delivery import PIPELINE_ANALYSIS_TAG_MAP
@@ -85,7 +85,7 @@ def auto_fastq(context: click.Context, dry_run: bool):
     clinical-delivery."""
 
     status_db: Store = context.obj.status_db
-    trailblazer_api: TrailblazerAPI = context.obj.trailblazer_api
+    trailblazer_api: TrailblazerClient = context.obj.trailblazer_api
     for analysis_obj in status_db.get_analyses_to_upload(pipeline=Pipeline.FASTQ):
         if analysis_obj.family.analyses[0].uploaded_at:
             LOG.warning(

--- a/cg/meta/clean/demultiplexed_flow_cells.py
+++ b/cg/meta/clean/demultiplexed_flow_cells.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Query
 from housekeeper.store.models import Bundle, Version
 
 from cg.apps.housekeeper.hk import HousekeeperAPI
-from cg.apps.tb import TrailblazerAPI
+from cg.apps.tb import TrailblazerClient
 from cg.constants import FlowCellStatus
 from cg.constants.demultiplexing import DemultiplexingDirsAndFiles
 from cg.constants.sequencing import Sequencers, sequencer_types
@@ -39,7 +39,7 @@ class DemultiplexedRunsFlowCell:
         flow_cell_path: Path,
         status_db: Store,
         housekeeper_api: HousekeeperAPI,
-        trailblazer_api: Optional[TrailblazerAPI] = None,
+        trailblazer_api: Optional[TrailblazerClient] = None,
         sample_sheets_dir: Optional[str] = None,
         fastq_files: Optional[Query] = None,
         spring_files: Optional[Query] = None,
@@ -48,7 +48,7 @@ class DemultiplexedRunsFlowCell:
         self.path: Path = flow_cell_path
         self.status_db: Store = status_db
         self.hk: HousekeeperAPI = housekeeper_api
-        self.tb: TrailblazerAPI = trailblazer_api
+        self.tb: TrailblazerClient = trailblazer_api
         self.all_fastq_files: Optional[Query] = fastq_files
         self.all_spring_files: Optional[Query] = spring_files
         self.run_name: str = self.path.name

--- a/cg/meta/meta.py
+++ b/cg/meta/meta.py
@@ -7,7 +7,7 @@ from cg.apps.lims import LimsAPI
 from cg.apps.madeline.api import MadelineAPI
 from cg.apps.mutacc_auto import MutaccAutoAPI
 from cg.apps.scout.scoutapi import ScoutAPI
-from cg.apps.tb import TrailblazerAPI
+from cg.apps.tb import TrailblazerClient
 from cg.meta.backup.backup import SpringBackupAPI
 from cg.meta.compress import CompressAPI
 from cg.meta.encryption.encryption import SpringEncryptionAPI
@@ -48,4 +48,4 @@ class MetaAPI:
         )
         self.status_db: Store = config.status_db
         self.scout_api: ScoutAPI = config.scout_api
-        self.trailblazer_api: TrailblazerAPI = config.trailblazer_api
+        self.trailblazer_api: TrailblazerClient = config.trailblazer_api

--- a/cg/meta/rsync/rsync_api.py
+++ b/cg/meta/rsync/rsync_api.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Dict, Iterable, List, Tuple
 
 from cg.apps.slurm.slurm_api import SlurmAPI
-from cg.apps.tb import TrailblazerAPI
+from cg.apps.tb import TrailblazerClient
 from cg.constants import Pipeline
 from cg.constants.constants import FileFormat
 from cg.constants.delivery import INBOX_NAME
@@ -119,7 +119,7 @@ class RsyncAPI(MetaAPI):
         return source_and_destination_paths
 
     def add_to_trailblazer_api(
-        self, tb_api: TrailblazerAPI, slurm_job_id: int, ticket: str, dry_run: bool
+        self, tb_api: TrailblazerClient, slurm_job_id: int, ticket: str, dry_run: bool
     ) -> None:
         """Add rsync process to trailblazer."""
         if dry_run:

--- a/cg/meta/upload/nipt/nipt.py
+++ b/cg/meta/upload/nipt/nipt.py
@@ -17,7 +17,7 @@ from cg.models.cg_config import CGConfig
 from cg.store import Store
 from cg.store.models import Analysis, Flowcell, Family
 from housekeeper.store.models import File
-from cg.apps.tb import TrailblazerAPI
+from cg.apps.tb import TrailblazerClient
 
 LOG = logging.getLogger(__name__)
 
@@ -42,7 +42,7 @@ class NiptUploadAPI:
         self.stats_api: StatsAPI = config.cg_stats_api
         self.status_db: Store = config.status_db
         self.dry_run: bool = False
-        self.trailblazer_api: TrailblazerAPI = config.trailblazer_api
+        self.trailblazer_api: TrailblazerClient = config.trailblazer_api
 
     def set_dry_run(self, dry_run: bool) -> None:
         """Set dry run"""

--- a/cg/models/cg_config.py
+++ b/cg/models/cg_config.py
@@ -17,7 +17,7 @@ from cg.apps.loqus import LoqusdbAPI
 from cg.apps.madeline.api import MadelineAPI
 from cg.apps.mutacc_auto import MutaccAutoAPI
 from cg.apps.scout.scoutapi import ScoutAPI
-from cg.apps.tb import TrailblazerAPI
+from cg.apps.tb import TrailblazerClient
 from cg.constants.observations import LoqusdbInstance
 from cg.constants.priority import SlurmQos
 from cg.store import Store
@@ -284,7 +284,7 @@ class CGConfig(BaseModel):
     scout_api_: ScoutAPI = None
     tar: Optional[CommonAppConfig] = None
     trailblazer: TrailblazerConfig = None
-    trailblazer_api_: TrailblazerAPI = None
+    trailblazer_api_: TrailblazerClient = None
 
     # Meta APIs that will use the apps from CGConfig
     balsamic: BalsamicConfig = None
@@ -452,10 +452,10 @@ class CGConfig(BaseModel):
         return status_db
 
     @property
-    def trailblazer_api(self) -> TrailblazerAPI:
+    def trailblazer_api(self) -> TrailblazerClient:
         api = self.__dict__.get("trailblazer_api_")
         if api is None:
             LOG.debug("Instantiating trailblazer api")
-            api = TrailblazerAPI(config=self.dict())
+            api = TrailblazerClient(config=self.dict())
             self.trailblazer_api_ = api
         return api

--- a/tests/cli/clean/test_balsamic_clean.py
+++ b/tests/cli/clean/test_balsamic_clean.py
@@ -3,7 +3,7 @@ import datetime as dt
 import logging
 from pathlib import Path
 
-from cg.apps.tb import TrailblazerAPI
+from cg.apps.tb import TrailblazerClient
 from cg.cli.workflow.commands import clean_run_dir, past_run_dirs
 from cg.constants import Pipeline
 from click.testing import CliRunner
@@ -53,8 +53,8 @@ def test_with_yes(
     case_path = analysis_api.get_case_path(balsamic_case_clean)
     Path(case_path).mkdir(exist_ok=True, parents=True)
 
-    mocker.patch.object(TrailblazerAPI, "is_latest_analysis_ongoing")
-    TrailblazerAPI.is_latest_analysis_ongoing.return_value = False
+    mocker.patch.object(TrailblazerClient, "is_latest_analysis_ongoing")
+    TrailblazerClient.is_latest_analysis_ongoing.return_value = False
 
     # WHEN running with yes and remove stuff from before today
     result = cli_runner.invoke(past_run_dirs, ["-y", str(timestamp_now)], obj=clean_context)
@@ -91,8 +91,8 @@ def test_dry_run(
     case_path = clean_context.meta_apis["analysis_api"].get_case_path(balsamic_case_clean)
     Path(case_path).mkdir(exist_ok=True, parents=True)
 
-    mocker.patch.object(TrailblazerAPI, "is_latest_analysis_ongoing")
-    TrailblazerAPI.is_latest_analysis_ongoing.return_value = False
+    mocker.patch.object(TrailblazerClient, "is_latest_analysis_ongoing")
+    TrailblazerClient.is_latest_analysis_ongoing.return_value = False
 
     # WHEN dry running with dry run specified
     result = cli_runner.invoke(clean_run_dir, [balsamic_case_clean, "-d", "-y"], obj=clean_context)
@@ -112,8 +112,8 @@ def test_cleaned_at_valid(
     case_path = clean_context.meta_apis["analysis_api"].get_case_path(balsamic_case_clean)
     Path(case_path).mkdir(exist_ok=True, parents=True)
 
-    mocker.patch.object(TrailblazerAPI, "is_latest_analysis_ongoing")
-    TrailblazerAPI.is_latest_analysis_ongoing.return_value = False
+    mocker.patch.object(TrailblazerClient, "is_latest_analysis_ongoing")
+    TrailblazerClient.is_latest_analysis_ongoing.return_value = False
 
     # WHEN dry running with dry run specified
     result = cli_runner.invoke(clean_run_dir, [balsamic_case_clean, "-y"], obj=clean_context)

--- a/tests/cli/clean/test_microbial_clean.py
+++ b/tests/cli/clean/test_microbial_clean.py
@@ -3,7 +3,7 @@ import logging
 from pathlib import Path
 
 
-from cg.apps.tb import TrailblazerAPI
+from cg.apps.tb import TrailblazerClient
 from cg.cli.workflow.commands import clean_run_dir
 from cg.constants import Pipeline
 from click.testing import CliRunner
@@ -44,8 +44,8 @@ def test_dry_run(
     for path in case_path_list:
         Path(path).mkdir(exist_ok=True, parents=True)
 
-    mocker.patch.object(TrailblazerAPI, "is_latest_analysis_ongoing")
-    TrailblazerAPI.is_latest_analysis_ongoing.return_value = False
+    mocker.patch.object(TrailblazerClient, "is_latest_analysis_ongoing")
+    TrailblazerClient.is_latest_analysis_ongoing.return_value = False
 
     # WHEN dry running with dry run specified
     result = cli_runner.invoke(
@@ -92,8 +92,8 @@ def test_clean_run(
     for path in case_path_list:
         Path(path).mkdir(exist_ok=True, parents=True)
 
-    mocker.patch.object(TrailblazerAPI, "is_latest_analysis_ongoing")
-    TrailblazerAPI.is_latest_analysis_ongoing.return_value = False
+    mocker.patch.object(TrailblazerClient, "is_latest_analysis_ongoing")
+    TrailblazerClient.is_latest_analysis_ongoing.return_value = False
 
     # WHEN dry running with dry run specified
     result = cli_runner.invoke(

--- a/tests/cli/demultiplex/test_demultiplex_flowcell.py
+++ b/tests/cli/demultiplex/test_demultiplex_flowcell.py
@@ -68,7 +68,7 @@ def test_demultiplex_flow_cell(
     assert demux_api.is_demultiplexing_possible(flow_cell=flow_cell)
     assert demux_dir.exists() is False
     assert unaligned_dir.exists() is False
-    mocker.patch("cg.apps.tb.TrailblazerAPI.add_pending_analysis")
+    mocker.patch("cg.apps.tb.TrailblazerClient.add_pending_analysis")
 
     # WHEN starting demultiplexing from the CLI with dry run flag
     result: testing.Result = cli_runner.invoke(
@@ -107,7 +107,7 @@ def test_demultiplex_bcl2fastq_flowcell(
     assert demux_api.is_demultiplexing_possible(flow_cell=flow_cell)
     assert demux_dir.exists() is False
     assert unaligned_dir.exists() is False
-    mocker.patch("cg.apps.tb.TrailblazerAPI.add_pending_analysis")
+    mocker.patch("cg.apps.tb.TrailblazerClient.add_pending_analysis")
 
     # WHEN starting demultiplexing from the CLI with dry run flag
     result: testing.Result = cli_runner.invoke(
@@ -149,7 +149,7 @@ def test_demultiplex_dragen_flowcell(
     assert demux_api.is_demultiplexing_possible(flow_cell=flow_cell)
     assert demux_dir.exists() is False
     assert unaligned_dir.exists() is False
-    mocker.patch("cg.apps.tb.TrailblazerAPI.add_pending_analysis")
+    mocker.patch("cg.apps.tb.TrailblazerClient.add_pending_analysis")
 
     # WHEN starting demultiplexing from the CLI with dry run flag
     result: testing.Result = cli_runner.invoke(

--- a/tests/cli/upload/conftest.py
+++ b/tests/cli/upload/conftest.py
@@ -12,7 +12,7 @@ from cgmodels.cg.constants import Pipeline
 from cg.apps.gens import GensAPI
 from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.apps.scout.scoutapi import ScoutAPI
-from cg.apps.tb import TrailblazerAPI
+from cg.apps.tb import TrailblazerClient
 from cg.constants.constants import FileFormat
 from cg.constants.delivery import PIPELINE_ANALYSIS_TAG_MAP
 from cg.constants.housekeeper_tags import HkMipAnalysisTag, GensAnalysisTag, HK_DELIVERY_REPORT_TAG
@@ -174,7 +174,7 @@ def fixture_base_context(
     analysis_store: Store,
     housekeeper_api: HousekeeperAPI,
     upload_scout_api: UploadScoutAPI,
-    trailblazer_api: TrailblazerAPI,
+    trailblazer_api: TrailblazerClient,
     cg_context: CGConfig,
 ) -> CGConfig:
     """context to use in cli"""
@@ -194,7 +194,7 @@ def fixture_fastq_context(
     analysis_store: Store,
     housekeeper_api: HousekeeperAPI,
     upload_scout_api: UploadScoutAPI,
-    trailblazer_api: TrailblazerAPI,
+    trailblazer_api: TrailblazerClient,
     cg_context: CGConfig,
 ) -> CGConfig:
     """Fastq context to use in cli"""

--- a/tests/cli/upload/test_cli_upload_nipt.py
+++ b/tests/cli/upload/test_cli_upload_nipt.py
@@ -6,7 +6,7 @@ from click.testing import CliRunner
 
 from cg.cli.upload.nipt.base import nipt_upload_all, nipt_upload_case
 from cg.meta.upload.nipt import NiptUploadAPI
-from cg.apps.tb.api import TrailblazerAPI
+from cg.apps.tb.api import TrailblazerClient
 from cg.models.cg_config import CGConfig
 from cgmodels.cg.constants import Pipeline
 from cg.store.models import Analysis
@@ -42,7 +42,7 @@ def test_nipt_statina_upload_case(
     mocker.patch.object(NiptUploadAPI, "get_results_file_path")
     mocker.patch.object(NiptUploadAPI, "upload_to_ftp_server")
     mocker.patch.object(NiptUploadAPI, "flowcell_passed_qc_value", return_value=True)
-    mocker.patch.object(TrailblazerAPI, "set_analysis_uploaded")
+    mocker.patch.object(TrailblazerClient, "set_analysis_uploaded")
     result = cli_runner.invoke(
         cli=nipt_upload_case, args=[case_id], obj=upload_context, catch_exceptions=False
     )
@@ -124,7 +124,7 @@ def test_nipt_statina_upload_auto(
     mocker.patch.object(NiptUploadAPI, "get_results_file_path")
     mocker.patch.object(NiptUploadAPI, "upload_to_ftp_server")
     mocker.patch.object(NiptUploadAPI, "flowcell_passed_qc_value", return_value=True)
-    mocker.patch.object(TrailblazerAPI, "set_analysis_uploaded")
+    mocker.patch.object(TrailblazerClient, "set_analysis_uploaded")
 
     result = cli_runner.invoke(cli=nipt_upload_all, args=[], obj=upload_context)
 
@@ -241,7 +241,7 @@ def test_nipt_statina_upload_force_failed_case(
     mocker.patch.object(NiptUploadAPI, "get_results_file_path")
     mocker.patch.object(NiptUploadAPI, "upload_to_ftp_server")
     mocker.patch.object(NiptUploadAPI, "flowcell_passed_qc_value", return_value=False)
-    mocker.patch.object(TrailblazerAPI, "set_analysis_uploaded")
+    mocker.patch.object(TrailblazerClient, "set_analysis_uploaded")
     result = cli_runner.invoke(
         cli=nipt_upload_case, args=[case_id, "--force"], obj=upload_context, catch_exceptions=False
     )

--- a/tests/cli/workflow/conftest.py
+++ b/tests/cli/workflow/conftest.py
@@ -212,23 +212,23 @@ class MockTB:
         return self._add_pending_was_called
 
     def is_latest_analysis_ongoing(self, case_id: str):
-        """Override TrailblazerAPI is_ongoing method to avoid default behaviour"""
+        """Override TrailblazerClient is_ongoing method to avoid default behaviour"""
         return False
 
     def is_latest_analysis_failed(self, case_id: str):
-        """Override TrailblazerAPI is_failed method to avoid default behaviour"""
+        """Override TrailblazerClient is_failed method to avoid default behaviour"""
         return False
 
     def is_latest_analysis_completed(self, case_id: str):
-        """Override TrailblazerAPI is_completed method to avoid default behaviour"""
+        """Override TrailblazerClient is_completed method to avoid default behaviour"""
         return False
 
     def get_latest_analysis_status(self, case_id: str):
-        """Override TrailblazerAPI get_analysis_status method to avoid default behaviour"""
+        """Override TrailblazerClient get_analysis_status method to avoid default behaviour"""
         return None
 
     def has_latest_analysis_started(self, case_id: str):
-        """Override TrailblazerAPI has_analysis_started method to avoid default behaviour"""
+        """Override TrailblazerClient has_analysis_started method to avoid default behaviour"""
         return False
 
     def set_analysis_uploaded(self, case_id: str, uploaded_at: datetime):

--- a/tests/cli/workflow/mip/conftest.py
+++ b/tests/cli/workflow/mip/conftest.py
@@ -4,7 +4,7 @@ import pytest
 
 from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.apps.housekeeper.models import InputBundle
-from cg.apps.tb import TrailblazerAPI
+from cg.apps.tb import TrailblazerClient
 from cg.constants import Pipeline
 from cg.meta.compress import CompressAPI
 from cg.meta.workflow.mip import MipAnalysisAPI
@@ -171,8 +171,8 @@ def setup_mocks(
     mocker.patch.object(PrepareFastqAPI, "is_spring_decompression_needed")
     PrepareFastqAPI.is_spring_decompression_needed.return_value = is_spring_decompression_needed
 
-    mocker.patch.object(TrailblazerAPI, "has_latest_analysis_started")
-    TrailblazerAPI.has_latest_analysis_started.return_value = has_latest_analysis_started
+    mocker.patch.object(TrailblazerClient, "has_latest_analysis_started")
+    TrailblazerClient.has_latest_analysis_started.return_value = has_latest_analysis_started
 
     mocker.patch.object(PrepareFastqAPI, "can_at_least_one_sample_be_decompressed")
     PrepareFastqAPI.can_at_least_one_sample_be_decompressed.return_value = (

--- a/tests/cli/workflow/mip/test_cli_mip_rna_run.py
+++ b/tests/cli/workflow/mip/test_cli_mip_rna_run.py
@@ -1,7 +1,7 @@
 """ Test the CLI for run mip-rna """
 import logging
 
-from cg.apps.tb import TrailblazerAPI
+from cg.apps.tb import TrailblazerClient
 from cg.cli.workflow.mip_rna.base import run
 
 
@@ -12,8 +12,8 @@ def test_cg_dry_run(cli_runner, caplog, case_id, email_adress, mip_rna_context, 
     # GIVEN a cli function
     # WHEN we run a case in dry run mode
 
-    mocker.patch.object(TrailblazerAPI, "is_latest_analysis_ongoing")
-    TrailblazerAPI.is_latest_analysis_ongoing.return_value = False
+    mocker.patch.object(TrailblazerClient, "is_latest_analysis_ongoing")
+    TrailblazerClient.is_latest_analysis_ongoing.return_value = False
 
     result = cli_runner.invoke(
         run, ["--dry-run", "--email", email_adress, case_id], obj=mip_rna_context

--- a/tests/meta/clean/test_clean_demultiplexed_runs.py
+++ b/tests/meta/clean/test_clean_demultiplexed_runs.py
@@ -7,7 +7,7 @@ from unittest import mock
 import pytest
 
 from cg.apps.housekeeper.hk import HousekeeperAPI
-from cg.apps.tb import TrailblazerAPI
+from cg.apps.tb import TrailblazerClient
 from cg.meta.clean.demultiplexed_flow_cells import DemultiplexedRunsFlowCell
 from cg.store import Store
 from cg.store.models import Flowcell
@@ -21,13 +21,13 @@ from cg.store.models import Flowcell
         ("incorrect_flow_cell_path_extension", False),
     ],
 )
-@mock.patch("cg.apps.tb.api.TrailblazerAPI")
+@mock.patch("cg.apps.tb.api.TrailblazerClient")
 @mock.patch("cg.apps.housekeeper.hk.HousekeeperAPI")
 @mock.patch("cg.store.Store")
 def test_flow_cell_name(
     mock_statusdb: Store,
     mock_hk: HousekeeperAPI,
-    mock_tb: TrailblazerAPI,
+    mock_tb: TrailblazerClient,
     bcl2fastq_flow_cell_dir: Path,
     result: bool,
     request,
@@ -55,13 +55,13 @@ def test_flow_cell_name(
         ("non-existent_flow_cell_path", None, False),
     ],
 )
-@mock.patch("cg.apps.tb.api.TrailblazerAPI")
+@mock.patch("cg.apps.tb.api.TrailblazerClient")
 @mock.patch("cg.apps.housekeeper.hk.HousekeeperAPI")
 @mock.patch("cg.store.Store")
 def test_flow_cell_exists_in_statusdb_(
     mock_statusdb: Store,
     mock_hk: HousekeeperAPI,
-    mock_tb: TrailblazerAPI,
+    mock_tb: TrailblazerClient,
     bcl2fastq_flow_cell_dir: Path,
     statusdb_return_value: Optional[Flowcell],
     result: bool,
@@ -84,11 +84,11 @@ def test_flow_cell_exists_in_statusdb_(
     assert flow_cell_obj.exists_in_statusdb == result
 
 
-@mock.patch("cg.apps.tb.api.TrailblazerAPI")
+@mock.patch("cg.apps.tb.api.TrailblazerClient")
 @mock.patch("cg.apps.housekeeper.hk.HousekeeperAPI")
 @mock.patch("cg.store.Store")
 def test_check_fastq_files_exist_in_hk(
-    mock_statusdb: Store, mock_hk: HousekeeperAPI, mock_tb: TrailblazerAPI, correct_flow_cell_path
+    mock_statusdb: Store, mock_hk: HousekeeperAPI, mock_tb: TrailblazerClient, correct_flow_cell_path
 ):
     # GIVEN a flow cell that has fastq files in housekeeper
     flow_cell_obj = DemultiplexedRunsFlowCell(
@@ -105,11 +105,11 @@ def test_check_fastq_files_exist_in_hk(
     assert flow_cell_obj.fastq_files_exist_in_housekeeper
 
 
-@mock.patch("cg.apps.tb.api.TrailblazerAPI")
+@mock.patch("cg.apps.tb.api.TrailblazerClient")
 @mock.patch("cg.apps.housekeeper.hk.HousekeeperAPI")
 @mock.patch("cg.store.Store")
 def test_check_no_fastq_files_exist_in_hk(
-    mock_statusdb: Store, mock_hk: HousekeeperAPI, mock_tb: TrailblazerAPI, correct_flow_cell_path
+    mock_statusdb: Store, mock_hk: HousekeeperAPI, mock_tb: TrailblazerClient, correct_flow_cell_path
 ):
     # GIVEN a flow cell that has no fastq files in housekeeper
     flow_cell_obj = DemultiplexedRunsFlowCell(

--- a/tests/meta/workflow/test_microsalt.py
+++ b/tests/meta/workflow/test_microsalt.py
@@ -1,7 +1,7 @@
 """Tests for MicroSALT analysis."""
 from typing import List
 
-from cg.apps.tb import TrailblazerAPI
+from cg.apps.tb import TrailblazerClient
 from cg.meta.workflow.microsalt import MicrosaltAnalysisAPI
 from cg.models.cg_config import CGConfig
 from pathlib import Path
@@ -123,8 +123,8 @@ def test_get_cases_to_store_pass(
     store = qc_microsalt_context.status_db
     microsalt_api: MicrosaltAnalysisAPI = qc_microsalt_context.meta_apis["analysis_api"]
     mocker.patch.object(MicrosaltAnalysisAPI, "create_qc_done_file")
-    mocker.patch.object(TrailblazerAPI, "set_analysis_status")
-    mocker.patch.object(TrailblazerAPI, "add_comment")
+    mocker.patch.object(TrailblazerClient, "set_analysis_status")
+    mocker.patch.object(TrailblazerClient, "add_comment")
 
     # GIVEN a store with a QC ready microsalt case that will pass QC
     microsalt_pass_case: Family = store.get_case_by_internal_id(internal_id=microsalt_case_qc_pass)
@@ -165,8 +165,8 @@ def test_get_cases_to_store_fail(
     store = qc_microsalt_context.status_db
     microsalt_api: MicrosaltAnalysisAPI = qc_microsalt_context.meta_apis["analysis_api"]
     mocker.patch.object(MicrosaltAnalysisAPI, "create_qc_done_file")
-    mocker.patch.object(TrailblazerAPI, "set_analysis_status")
-    mocker.patch.object(TrailblazerAPI, "add_comment")
+    mocker.patch.object(TrailblazerClient, "set_analysis_status")
+    mocker.patch.object(TrailblazerClient, "add_comment")
 
     # GIVEN a store with a QC ready microsalt case that will fail QC
     microsalt_fail_case: Family = store.get_case_by_internal_id(internal_id=microsalt_case_qc_fail)


### PR DESCRIPTION
## Description
This PR changes the name of the `TrailblazerAPI` to `TrailblazerClient`. Calling it an API is misleading since it is a client consuming an api.

Changes all instances of `TrailblazerAPI` to `TrailblazerClient`.

### Fixed
- Naming of Trailblazer client

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
