### PR TITLE
Create parent models for archiving

### DIFF
--- a/cg/meta/archive/ddn_dataflow.py
+++ b/cg/meta/archive/ddn_dataflow.py
@@ -129,7 +129,7 @@ class AuthResponse(BaseModel):
     refresh: Optional[str]
 
 
-class DDNDataFlowApi(ArchiveHandler):
+class DDNDataFlowClient(ArchiveHandler):
     """Class for archiving and retrieving folders via DDN Dataflow."""
 
     def __init__(self, config: DDNDataFlowConfig):

--- a/cg/meta/archive/ddn_dataflow.py
+++ b/cg/meta/archive/ddn_dataflow.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from cg.constants.constants import APIMethods, FileFormat
 from cg.exc import DdnDataflowAuthenticationError
 from cg.io.controller import APIRequest, ReadStream
-from cg.meta.archive.models import ArchiveHandler, FileTransferData
+from cg.meta.archive.models import ArchiveInterface, ArchiveFile
 from cg.models.cg_config import DDNDataFlowConfig
 from pydantic.v1 import BaseModel
 from requests.models import Response
@@ -42,7 +42,7 @@ class ResponseFields(str, Enum):
     RETRIEVE_FILES = "files/retrieve"
 
 
-class DataFlowFileTransferData(FileTransferData):
+class MiriaFile(ArchiveFile):
     """Model for representing a singular object transfer."""
 
     _metadata = None
@@ -50,7 +50,7 @@ class DataFlowFileTransferData(FileTransferData):
     source: str
 
     @classmethod
-    def from_models(cls, file: File, sample: Sample):
+    def from_file_and_sample(cls, file: File, sample: Sample) -> "MiriaFile":
         """Instantiates the class from a File and Sample object."""
         return cls(destination=sample.internal_id, source=file.path)
 
@@ -71,27 +71,27 @@ class DataFlowFileTransferData(FileTransferData):
 class TransferPayload(BaseModel):
     """Model for representing a Dataflow transfer task."""
 
-    files_to_transfer: List[DataFlowFileTransferData]
+    files_to_transfer: List[MiriaFile]
     osType: str = OSTYPE
     createFolder: bool = False
 
     def trim_paths(self, attribute_to_trim: str):
         """Trims the source path from its root directory for all objects in the transfer."""
-        for transfer_data in self.files_to_transfer:
-            transfer_data.trim_path(attribute_to_trim=attribute_to_trim)
+        for miria_file in self.files_to_transfer:
+            miria_file.trim_path(attribute_to_trim=attribute_to_trim)
 
     def add_repositories(self, source_prefix: str, destination_prefix: str):
         """Prepends the given repositories to the source and destination paths all objects in the
         transfer."""
-        for transfer_data in self.files_to_transfer:
-            transfer_data.add_repositories(
+        for miria_file in self.files_to_transfer:
+            miria_file.add_repositories(
                 source_prefix=source_prefix, destination_prefix=destination_prefix
             )
 
     def dict(self, **kwargs) -> dict:
         """Creates a correctly structured dict to be used as the request payload."""
         payload: dict = super().dict(exclude={"files_to_transfer"})
-        payload["pathInfo"] = [transfer_data.dict() for transfer_data in self.files_to_transfer]
+        payload["pathInfo"] = [miria_file.dict() for miria_file in self.files_to_transfer]
         payload["metadataList"] = []
         return payload
 
@@ -129,7 +129,7 @@ class AuthResponse(BaseModel):
     refresh: Optional[str]
 
 
-class DDNDataFlowClient(ArchiveHandler):
+class DDNDataFlowClient(ArchiveInterface):
     """Class for archiving and retrieving folders via DDN Dataflow."""
 
     def __init__(self, config: DDNDataFlowConfig):
@@ -197,11 +197,11 @@ class DDNDataFlowClient(ArchiveHandler):
 
     def archive_folders(self, sources_and_destinations: Dict[Path, Path]) -> bool:
         """Archives all folders provided, to their corresponding destination, as given by sources and destination parameter."""
-        transfer_data: List[DataFlowFileTransferData] = [
-            DataFlowFileTransferData(source=source.as_posix(), destination=destination.as_posix())
+        miria_file: List[MiriaFile] = [
+            MiriaFile(source=source.as_posix(), destination=destination.as_posix())
             for source, destination in sources_and_destinations.items()
         ]
-        transfer_request: TransferPayload = TransferPayload(files_to_transfer=transfer_data)
+        transfer_request: TransferPayload = TransferPayload(files_to_transfer=miria_file)
         transfer_request.trim_paths(attribute_to_trim=SOURCE_ATTRIBUTE)
         transfer_request.add_repositories(
             source_prefix=self.local_storage, destination_prefix=self.archive_repository
@@ -213,11 +213,11 @@ class DDNDataFlowClient(ArchiveHandler):
 
     def retrieve_folders(self, sources_and_destinations: Dict[Path, Path]) -> bool:
         """Retrieves all folders provided, to their corresponding destination, as given by the sources and destination parameter."""
-        transfer_data: List[DataFlowFileTransferData] = [
-            DataFlowFileTransferData(source=source.as_posix(), destination=destination.as_posix())
+        miria_file: List[MiriaFile] = [
+            MiriaFile(source=source.as_posix(), destination=destination.as_posix())
             for source, destination in sources_and_destinations.items()
         ]
-        transfer_request: TransferPayload = TransferPayload(files_to_transfer=transfer_data)
+        transfer_request: TransferPayload = TransferPayload(files_to_transfer=miria_file)
         transfer_request.trim_paths(attribute_to_trim=DESTINATION_ATTRIBUTE)
         transfer_request.add_repositories(
             source_prefix=self.archive_repository, destination_prefix=self.local_storage

--- a/cg/meta/archive/ddn_dataflow.py
+++ b/cg/meta/archive/ddn_dataflow.py
@@ -197,11 +197,11 @@ class DDNDataFlowClient(ArchiveInterface):
 
     def archive_folders(self, sources_and_destinations: Dict[Path, Path]) -> bool:
         """Archives all folders provided, to their corresponding destination, as given by sources and destination parameter."""
-        miria_file: List[MiriaFile] = [
+        miria_files: List[MiriaFile] = [
             MiriaFile(source=source.as_posix(), destination=destination.as_posix())
             for source, destination in sources_and_destinations.items()
         ]
-        transfer_request: TransferPayload = TransferPayload(files_to_transfer=miria_file)
+        transfer_request: TransferPayload = TransferPayload(files_to_transfer=miria_files)
         transfer_request.trim_paths(attribute_to_trim=SOURCE_ATTRIBUTE)
         transfer_request.add_repositories(
             source_prefix=self.local_storage, destination_prefix=self.archive_repository
@@ -213,11 +213,11 @@ class DDNDataFlowClient(ArchiveInterface):
 
     def retrieve_folders(self, sources_and_destinations: Dict[Path, Path]) -> bool:
         """Retrieves all folders provided, to their corresponding destination, as given by the sources and destination parameter."""
-        miria_file: List[MiriaFile] = [
+        miria_files: List[MiriaFile] = [
             MiriaFile(source=source.as_posix(), destination=destination.as_posix())
             for source, destination in sources_and_destinations.items()
         ]
-        transfer_request: TransferPayload = TransferPayload(files_to_transfer=miria_file)
+        transfer_request: TransferPayload = TransferPayload(files_to_transfer=miria_files)
         transfer_request.trim_paths(attribute_to_trim=DESTINATION_ATTRIBUTE)
         transfer_request.add_repositories(
             source_prefix=self.archive_repository, destination_prefix=self.local_storage

--- a/cg/meta/archive/ddn_dataflow.py
+++ b/cg/meta/archive/ddn_dataflow.py
@@ -95,7 +95,7 @@ class TransferPayload(BaseModel):
         payload["metadataList"] = []
         return payload
 
-    def post_request(self, url: str, headers: dict) -> Response:
+    def post_request(self, url: str, headers: dict) -> bool:
         """Sends a request to the given url with, the given headers, and its own content as
         payload."""
         return APIRequest.api_request_from_content(
@@ -103,7 +103,7 @@ class TransferPayload(BaseModel):
             url=url,
             headers=headers,
             json=self.dict(),
-        )
+        ).ok
 
 
 class AuthPayload(BaseModel):
@@ -195,39 +195,34 @@ class DDNDataFlowClient(ArchiveHandler):
             self._refresh_auth_token()
         return {"Authorization": f"Bearer {self.auth_token}"}
 
-    def archive_folders(self, sources_and_destinations: List[DataFlowFileTransferData]) -> int:
-        """Archives all folders provided, to their corresponding destination,
-        as given by sources and destination parameter."""
-        transfer_request: TransferPayload = TransferPayload(
-            files_to_transfer=sources_and_destinations
-        )
+    def archive_folders(self, sources_and_destinations: Dict[Path, Path]) -> bool:
+        """Archives all folders provided, to their corresponding destination, as given by sources and destination parameter."""
+        transfer_data: List[DataFlowFileTransferData] = [
+            DataFlowFileTransferData(source=source.as_posix(), destination=destination.as_posix())
+            for source, destination in sources_and_destinations.items()
+        ]
+        transfer_request: TransferPayload = TransferPayload(files_to_transfer=transfer_data)
         transfer_request.trim_paths(attribute_to_trim=SOURCE_ATTRIBUTE)
         transfer_request.add_repositories(
             source_prefix=self.local_storage, destination_prefix=self.archive_repository
         )
-        response: Response = transfer_request.post_request(
+        return transfer_request.post_request(
             headers=dict(self.headers, **self.auth_header),
             url=urljoin(base=self.url, url=DataflowEndpoints.ARCHIVE_FILES),
         )
-        if response.ok:
-            return response.json()["job_id"]
-        else:
-            raise IOError(response.text)
 
-    def retrieve_folders(self, sources_and_destinations: List[DataFlowFileTransferData]) -> int:
+    def retrieve_folders(self, sources_and_destinations: Dict[Path, Path]) -> bool:
         """Retrieves all folders provided, to their corresponding destination, as given by the sources and destination parameter."""
-        transfer_request: TransferPayload = TransferPayload(
-            files_to_transfer=sources_and_destinations
-        )
+        transfer_data: List[DataFlowFileTransferData] = [
+            DataFlowFileTransferData(source=source.as_posix(), destination=destination.as_posix())
+            for source, destination in sources_and_destinations.items()
+        ]
+        transfer_request: TransferPayload = TransferPayload(files_to_transfer=transfer_data)
         transfer_request.trim_paths(attribute_to_trim=DESTINATION_ATTRIBUTE)
         transfer_request.add_repositories(
             source_prefix=self.archive_repository, destination_prefix=self.local_storage
         )
-        response: Response = transfer_request.post_request(
+        return transfer_request.post_request(
             headers=dict(self.headers, **self.auth_header),
             url=urljoin(base=self.url, url=DataflowEndpoints.RETRIEVE_FILES),
         )
-        if response.ok:
-            return response.json()["job_id"]
-        else:
-            raise IOError(response.text)

--- a/cg/meta/archive/models.py
+++ b/cg/meta/archive/models.py
@@ -1,4 +1,5 @@
 """Contains base models to be inherited from in other archive software files."""
+from abc import abstractmethod, ABC
 from typing import List
 
 from housekeeper.store.models import File
@@ -7,24 +8,27 @@ from pydantic.v1 import BaseModel
 from cg.store.models import Sample
 
 
-class FileTransferData(BaseModel):
+class ArchiveFile(ABC, BaseModel):
     """Base class for classes representing files to be archived."""
 
     @classmethod
-    def from_models(cls, file: File, sample: Sample):
+    @abstractmethod
+    def from_file_and_sample(cls, file: File, sample: Sample) -> "ArchiveFile":
         """Instantiates the class from a File and Sample object."""
         raise NotImplementedError
 
 
-class ArchiveHandler:
+class ArchiveInterface(ABC):
     """Base class for classes handling different archiving programs."""
 
-    def archive_folders(self, sources_and_destinations: List[FileTransferData]):
+    @abstractmethod
+    def archive_folders(self, sources_and_destinations: List[ArchiveFile]):
         """Archives all folders provided, to their corresponding destination,
         as given by sources and destination parameter."""
         raise NotImplementedError
 
-    def retrieve_folders(self, sources_and_destinations: List[FileTransferData]):
+    @abstractmethod
+    def retrieve_folders(self, sources_and_destinations: List[ArchiveFile]):
         """Retrieves all folders provided, to their corresponding destination, as given by the
         sources and destination parameter."""
         raise NotImplementedError

--- a/cg/meta/archive/models.py
+++ b/cg/meta/archive/models.py
@@ -1,0 +1,30 @@
+"""Contains base models to be inherited from in other archive software files."""
+from typing import List
+
+from housekeeper.store.models import File
+from pydantic.v1 import BaseModel
+
+from cg.store.models import Sample
+
+
+class FileTransferData(BaseModel):
+    """Base class for classes representing files to be archived."""
+
+    @classmethod
+    def from_models(cls, file: File, sample: Sample):
+        """Instantiates the class from a File and Sample object."""
+        raise NotImplementedError
+
+
+class ArchiveHandler:
+    """Base class for classes handling different archiving programs."""
+
+    def archive_folders(self, sources_and_destinations: List[FileTransferData]):
+        """Archives all folders provided, to their corresponding destination,
+        as given by sources and destination parameter."""
+        raise NotImplementedError
+
+    def retrieve_folders(self, sources_and_destinations: List[FileTransferData]):
+        """Retrieves all folders provided, to their corresponding destination, as given by the
+        sources and destination parameter."""
+        raise NotImplementedError

--- a/tests/meta/archive/conftest.py
+++ b/tests/meta/archive/conftest.py
@@ -12,7 +12,12 @@ from cg.constants.constants import FileFormat
 from cg.constants.subject import Gender
 from cg.io.controller import WriteStream
 from cg.meta.archive.archive import SpringArchiveAPI
-from cg.meta.archive.ddn_dataflow import ROOT_TO_TRIM, DDNDataFlowApi, TransferData, TransferPayload
+from cg.meta.archive.ddn_dataflow import (
+    ROOT_TO_TRIM,
+    DDNDataFlowApi,
+    DataFlowFileTransferData,
+    TransferPayload,
+)
 from cg.models.cg_config import DDNDataFlowConfig
 from cg.store import Store
 from cg.store.models import Customer, Sample
@@ -35,6 +40,12 @@ def fixture_ddn_dataflow_config(
     )
 
 
+@pytest.fixture(name="ok_ddn_response")
+def fixture_ok_ddn_response(ok_response: Response):
+    ok_response._content = b'{"job_id": "123"}'
+    return ok_response
+
+
 @pytest.fixture(name="ddn_dataflow_api")
 def fixture_ddn_dataflow_api(ddn_dataflow_config: DDNDataFlowConfig) -> DDNDataFlowApi:
     """Returns a DDNApi without tokens being set."""
@@ -55,16 +66,32 @@ def fixture_ddn_dataflow_api(ddn_dataflow_config: DDNDataFlowConfig) -> DDNDataF
         return DDNDataFlowApi(ddn_dataflow_config)
 
 
-@pytest.fixture(name="transfer_data")
-def fixture_transfer_data(local_directory: Path, remote_path: Path) -> TransferData:
-    """Return a TransferData object."""
-    return TransferData(source=local_directory.as_posix(), destination=remote_path.as_posix())
+@pytest.fixture(name="transfer_data_archive")
+def fixture_transfer_data_archive(
+    local_directory: Path, remote_path: Path
+) -> DataFlowFileTransferData:
+    """Return a DataFlowFileTransferData object for archiving."""
+    return DataFlowFileTransferData(
+        source=local_directory.as_posix(), destination=remote_path.as_posix()
+    )
+
+
+@pytest.fixture(name="transfer_data_retrieve")
+def fixture_transfer_data_retrieve(
+    local_directory: Path, remote_path: Path
+) -> DataFlowFileTransferData:
+    """Return a DataFlowFileTransferData object for retrieval."""
+    return DataFlowFileTransferData(
+        source=remote_path.as_posix(), destination=local_directory.as_posix()
+    )
 
 
 @pytest.fixture(name="transfer_payload")
-def fixture_transfer_payload(transfer_data: TransferData) -> TransferPayload:
-    """Return a TransferPayload object containing two identical TransferData object.."""
-    return TransferPayload(files_to_transfer=[transfer_data, transfer_data.copy(deep=True)])
+def fixture_transfer_payload(transfer_data_archive: DataFlowFileTransferData) -> TransferPayload:
+    """Return a TransferPayload object containing two identical DataFlowFileTransferData object."""
+    return TransferPayload(
+        files_to_transfer=[transfer_data_archive, transfer_data_archive.copy(deep=True)]
+    )
 
 
 @pytest.fixture(name="remote_path")

--- a/tests/meta/archive/conftest.py
+++ b/tests/meta/archive/conftest.py
@@ -15,7 +15,7 @@ from cg.meta.archive.archive import SpringArchiveAPI
 from cg.meta.archive.ddn_dataflow import (
     ROOT_TO_TRIM,
     DDNDataFlowClient,
-    DataFlowFileTransferData,
+    MiriaFile,
     TransferPayload,
 )
 from cg.models.cg_config import DDNDataFlowConfig
@@ -60,18 +60,16 @@ def fixture_ddn_dataflow_client(ddn_dataflow_config: DDNDataFlowConfig) -> DDNDa
         return DDNDataFlowClient(ddn_dataflow_config)
 
 
-@pytest.fixture(name="transfer_data")
-def fixture_transfer_data(local_directory: Path, remote_path: Path) -> DataFlowFileTransferData:
+@pytest.fixture(name="miria_file")
+def fixture_miria_file(local_directory: Path, remote_path: Path) -> MiriaFile:
     """Return a TransferData object."""
-    return DataFlowFileTransferData(
-        source=local_directory.as_posix(), destination=remote_path.as_posix()
-    )
+    return MiriaFile(source=local_directory.as_posix(), destination=remote_path.as_posix())
 
 
 @pytest.fixture(name="transfer_payload")
-def fixture_transfer_payload(transfer_data: DataFlowFileTransferData) -> TransferPayload:
-    """Return a TransferPayload object containing two identical DataFlowFileTransferData object."""
-    return TransferPayload(files_to_transfer=[transfer_data, transfer_data.copy(deep=True)])
+def fixture_transfer_payload(miria_file: MiriaFile) -> TransferPayload:
+    """Return a TransferPayload object containing two identical MiriaFile object."""
+    return TransferPayload(files_to_transfer=[miria_file, miria_file.copy(deep=True)])
 
 
 @pytest.fixture(name="remote_path")

--- a/tests/meta/archive/conftest.py
+++ b/tests/meta/archive/conftest.py
@@ -60,32 +60,18 @@ def fixture_ddn_dataflow_client(ddn_dataflow_config: DDNDataFlowConfig) -> DDNDa
         return DDNDataFlowClient(ddn_dataflow_config)
 
 
-@pytest.fixture(name="transfer_data_archive")
-def fixture_transfer_data_archive(
-    local_directory: Path, remote_path: Path
-) -> DataFlowFileTransferData:
-    """Return a DataFlowFileTransferData object for archiving."""
+@pytest.fixture(name="transfer_data")
+def fixture_transfer_data(local_directory: Path, remote_path: Path) -> DataFlowFileTransferData:
+    """Return a TransferData object."""
     return DataFlowFileTransferData(
         source=local_directory.as_posix(), destination=remote_path.as_posix()
     )
 
 
-@pytest.fixture(name="transfer_data_retrieve")
-def fixture_transfer_data_retrieve(
-    local_directory: Path, remote_path: Path
-) -> DataFlowFileTransferData:
-    """Return a DataFlowFileTransferData object for retrieval."""
-    return DataFlowFileTransferData(
-        source=remote_path.as_posix(), destination=local_directory.as_posix()
-    )
-
-
 @pytest.fixture(name="transfer_payload")
-def fixture_transfer_payload(transfer_data_archive: DataFlowFileTransferData) -> TransferPayload:
+def fixture_transfer_payload(transfer_data: DataFlowFileTransferData) -> TransferPayload:
     """Return a TransferPayload object containing two identical DataFlowFileTransferData object."""
-    return TransferPayload(
-        files_to_transfer=[transfer_data_archive, transfer_data_archive.copy(deep=True)]
-    )
+    return TransferPayload(files_to_transfer=[transfer_data, transfer_data.copy(deep=True)])
 
 
 @pytest.fixture(name="remote_path")

--- a/tests/meta/archive/conftest.py
+++ b/tests/meta/archive/conftest.py
@@ -40,12 +40,6 @@ def fixture_ddn_dataflow_config(
     )
 
 
-@pytest.fixture(name="ok_ddn_response")
-def fixture_ok_ddn_response(ok_response: Response):
-    ok_response._content = b'{"job_id": "123"}'
-    return ok_response
-
-
 @pytest.fixture(name="ddn_dataflow_client")
 def fixture_ddn_dataflow_client(ddn_dataflow_config: DDNDataFlowConfig) -> DDNDataFlowClient:
     """Returns a DDNApi without tokens being set."""

--- a/tests/meta/archive/conftest.py
+++ b/tests/meta/archive/conftest.py
@@ -14,7 +14,7 @@ from cg.io.controller import WriteStream
 from cg.meta.archive.archive import SpringArchiveAPI
 from cg.meta.archive.ddn_dataflow import (
     ROOT_TO_TRIM,
-    DDNDataFlowApi,
+    DDNDataFlowClient,
     DataFlowFileTransferData,
     TransferPayload,
 )
@@ -46,8 +46,8 @@ def fixture_ok_ddn_response(ok_response: Response):
     return ok_response
 
 
-@pytest.fixture(name="ddn_dataflow_api")
-def fixture_ddn_dataflow_api(ddn_dataflow_config: DDNDataFlowConfig) -> DDNDataFlowApi:
+@pytest.fixture(name="ddn_dataflow_client")
+def fixture_ddn_dataflow_client(ddn_dataflow_config: DDNDataFlowConfig) -> DDNDataFlowClient:
     """Returns a DDNApi without tokens being set."""
     mock_ddn_auth_success_response = Response()
     mock_ddn_auth_success_response.status_code = 200
@@ -63,7 +63,7 @@ def fixture_ddn_dataflow_api(ddn_dataflow_config: DDNDataFlowConfig) -> DDNDataF
         "cg.meta.archive.ddn_dataflow.APIRequest.api_request_from_content",
         return_value=mock_ddn_auth_success_response,
     ):
-        return DDNDataFlowApi(ddn_dataflow_config)
+        return DDNDataFlowClient(ddn_dataflow_config)
 
 
 @pytest.fixture(name="transfer_data_archive")
@@ -201,8 +201,8 @@ def fixture_spring_archive_api(
     father_sample_id: str,
     helpers,
 ) -> SpringArchiveAPI:
-    """Returns an ArchiveAPI with a populated housekeeper store and a DDNDataFlowApi.
-    Also adds /home/ as a prefix for each SPRING file for the DDNDataFlowApi to accept them."""
+    """Returns an ArchiveAPI with a populated housekeeper store and a DDNDataFlowClient.
+    Also adds /home/ as a prefix for each SPRING file for the DDNDataFlowClient to accept them."""
     for spring_file in populated_housekeeper_api.files(tags=[SequencingFileTag.SPRING]):
         spring_file.path = f"/home/{spring_file.path}"
     populated_housekeeper_api.commit()

--- a/tests/meta/archive/test_archiving.py
+++ b/tests/meta/archive/test_archiving.py
@@ -25,65 +25,57 @@ FUNCTION_TO_MOCK = "cg.meta.archive.ddn_dataflow.APIRequest.api_request_from_con
 
 
 def test_correct_source_root(
-    local_directory: Path,
-    transfer_data_archive: DataFlowFileTransferData,
-    trimmed_local_directory: Path,
+    local_directory: Path, transfer_data: DataFlowFileTransferData, trimmed_local_directory: Path
 ):
     """Tests the method for trimming the source directory."""
 
     # GIVEN a source path and a destination path
 
     # WHEN creating the correctly formatted dictionary
-    transfer_data_archive.trim_path(attribute_to_trim=SOURCE_ATTRIBUTE)
+    transfer_data.trim_path(attribute_to_trim=SOURCE_ATTRIBUTE)
 
     # THEN the destination path should be the local directory minus the /home part
-    assert transfer_data_archive.source == trimmed_local_directory.as_posix()
+    assert transfer_data.source == trimmed_local_directory.as_posix()
 
 
 def test_correct_destination_root(
-    local_directory: Path,
-    transfer_data_retrieve: DataFlowFileTransferData,
-    trimmed_local_directory: Path,
+    local_directory: Path, transfer_data: DataFlowFileTransferData, trimmed_local_directory: Path
 ):
     """Tests the method for trimming the destination directory."""
 
     # GIVEN a source path and a destination path
+    transfer_data.destination = local_directory
 
     # WHEN creating the correctly formatted dictionary
-    transfer_data_retrieve.trim_path(attribute_to_trim=DESTINATION_ATTRIBUTE)
+    transfer_data.trim_path(attribute_to_trim=DESTINATION_ATTRIBUTE)
 
     # THEN the destination path should be the local directory minus the /home part
-    assert transfer_data_retrieve.destination == trimmed_local_directory.as_posix()
+    assert transfer_data.destination == trimmed_local_directory.as_posix()
 
 
 def test_add_repositories(
-    ddn_dataflow_config,
-    local_directory,
-    remote_path,
-    transfer_data_archive: DataFlowFileTransferData,
+    ddn_dataflow_config, local_directory, remote_path, transfer_data: DataFlowFileTransferData
 ):
     """Tests the method for adding the repositories to the source and destination paths."""
 
-    # GIVEN a TransferData object
+    # GIVEN a DataFlowFileTransferData object
 
     # WHEN adding the repositories
-    transfer_data_archive.add_repositories(
+    transfer_data.add_repositories(
         source_prefix=ddn_dataflow_config.local_storage,
         destination_prefix=ddn_dataflow_config.archive_repository,
     )
 
     # THEN the repositories should be prepended to the paths
-    assert transfer_data_archive.source == ddn_dataflow_config.local_storage + str(local_directory)
-    assert transfer_data_archive.destination == ddn_dataflow_config.archive_repository + str(
-        remote_path
-    )
+    assert transfer_data.source == ddn_dataflow_config.local_storage + str(local_directory)
+    assert transfer_data.destination == ddn_dataflow_config.archive_repository + str(remote_path)
 
 
 def test_transfer_payload_dict(transfer_payload: TransferPayload):
     """Tests that the dict structure returned by TransferPayload.dict() is compatible with the
     Dataflow API."""
 
-    # GIVEN a TransferPayload object with two TransferData objects
+    # GIVEN a TransferPayload object with two DataFlowFileTransferData objects
 
     # WHEN obtaining the dict representation
     dict_representation: dict = transfer_payload.dict()
@@ -183,7 +175,7 @@ def test_transfer_payload_correct_source_root(transfer_payload: TransferPayload)
     """Tests that the dict structure returned by TransferPayload.dict() is compatible with the
     Dataflow API."""
 
-    # GIVEN a TransferPayload object with two TransferData objects with untrimmed source paths
+    # GIVEN a TransferPayload object with two DataFlowFileTransferData objects with untrimmed source paths
     for transfer_data in transfer_payload.files_to_transfer:
         assert transfer_data.source.startswith(ROOT_TO_TRIM)
 
@@ -199,7 +191,7 @@ def test_transfer_payload_correct_destination_root(transfer_payload: TransferPay
     """Tests that the dict structure returned by TransferPayload.dict() is compatible with the
     Dataflow API."""
 
-    # GIVEN a TransferPayload object with two TransferData objects with untrimmed destination paths
+    # GIVEN a TransferPayload object with two DataFlowFileTransferData objects with untrimmed destination paths
     for transfer_data in transfer_payload.files_to_transfer:
         transfer_data.destination = ROOT_TO_TRIM + transfer_data.destination
         assert transfer_data.destination.startswith(ROOT_TO_TRIM)
@@ -279,7 +271,6 @@ def test_archive_folders(
     full_remote_path: str,
     full_local_path: str,
     ok_response: Response,
-    transfer_data_archive: DataFlowFileTransferData,
 ):
     """Tests that the archiving function correctly formats the input and sends API request."""
 
@@ -319,7 +310,6 @@ def test_retrieve_folders(
     full_remote_path: str,
     full_local_path: str,
     ok_response: Response,
-    transfer_data_retrieve: DataFlowFileTransferData,
 ):
     """Tests that the retrieve function correctly formats the input and sends API request."""
 

--- a/tests/meta/archive/test_archiving.py
+++ b/tests/meta/archive/test_archiving.py
@@ -274,9 +274,11 @@ def test__refresh_auth_token(ddn_dataflow_client: DDNDataFlowClient, ok_response
 
 def test_archive_folders(
     ddn_dataflow_client: DDNDataFlowClient,
+    local_directory: Path,
+    remote_path: Path,
     full_remote_path: str,
     full_local_path: str,
-    ok_ddn_response: Response,
+    ok_response: Response,
     transfer_data_archive: DataFlowFileTransferData,
 ):
     """Tests that the archiving function correctly formats the input and sends API request."""
@@ -287,9 +289,11 @@ def test_archive_folders(
     with mock.patch.object(
         APIRequest,
         "api_request_from_content",
-        return_value=ok_ddn_response,
+        return_value=ok_response,
     ) as mock_request_submitter:
-        response: int = ddn_dataflow_client.archive_folders([transfer_data_archive])
+        response: bool = ddn_dataflow_client.archive_folders(
+            {Path(local_directory): Path(remote_path)}
+        )
 
     # THEN a boolean response should be returned
     assert response
@@ -310,9 +314,11 @@ def test_archive_folders(
 
 def test_retrieve_folders(
     ddn_dataflow_client: DDNDataFlowClient,
+    local_directory: Path,
+    remote_path: Path,
     full_remote_path: str,
     full_local_path: str,
-    ok_ddn_response: Response,
+    ok_response: Response,
     transfer_data_retrieve: DataFlowFileTransferData,
 ):
     """Tests that the retrieve function correctly formats the input and sends API request."""
@@ -321,9 +327,13 @@ def test_retrieve_folders(
 
     # WHEN running the retrieve method and providing two paths
     with mock.patch.object(
-        APIRequest, "api_request_from_content", return_value=ok_ddn_response
+        APIRequest,
+        "api_request_from_content",
+        return_value=ok_response,
     ) as mock_request_submitter:
-        response: int = ddn_dataflow_client.retrieve_folders([transfer_data_retrieve])
+        response: bool = ddn_dataflow_client.retrieve_folders(
+            {Path(remote_path): Path(local_directory)}
+        )
 
     # THEN the response returned should be true
     assert response


### PR DESCRIPTION
## Description
To allow for easy integration of other archiving locations and software, this PR creates parent models for the handlers to inherit from so as to have common methods and signatures. It also adds the method `from_models` which instantiates the model with different input than the normal one for BaseModels.

### Added

- Method to initiate a file model with Sample and File as input
- Interface models to inherit from

### Changed

- Naming of old models




### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
