### PR TITLE
feat(archiving) Use File and Sample models for archiving

### DIFF
--- a/cg/apps/housekeeper/hk.py
+++ b/cg/apps/housekeeper/hk.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm import Query
 from housekeeper.include import checksum as hk_checksum
 from housekeeper.include import include_version
 from housekeeper.store import Store, models
-from housekeeper.store.models import Bundle, File, Version, Archive
+from housekeeper.store.models import Archive, Bundle, File, Version
 
 LOG = logging.getLogger(__name__)
 
@@ -159,7 +159,7 @@ class HousekeeperAPI:
 
     def get_files(
         self, bundle: str, tags: Optional[list] = None, version: Optional[int] = None
-    ) -> Iterable[File]:
+    ) -> Query:
         """Get all the files in housekeeper, optionally filtered by bundle and/or tags and/or
         version.
         """

--- a/cg/meta/archive/archive.py
+++ b/cg/meta/archive/archive.py
@@ -43,20 +43,8 @@ class SpringArchiveAPI:
         self.ddn_api: DDNDataFlowApi = ddn_dataflow_api
         self.status_db: Store = status_db
 
-    def get_files_by_archive_location(
-        self, file_data: List[FileAndSample], archive_location: ArchiveLocationsInUse
-    ) -> List[FileAndSample]:
-        """
-        Returns a list of PathAndSample where the associated sample has a specific archive location.
-        """
-        selected_files: List[FileAndSample] = []
-        for file in file_data:
-            sample: Optional[Sample] = self.get_sample(file)
-            if sample and sample.archive_location == archive_location:
-                selected_files.append(file)
-        return selected_files
-
     def get_sample(self, file: File) -> Optional[Sample]:
+        """Fetches the Sample corresponding to a File and logs if a Sample is not found."""
         sample: Optional[Sample] = self.status_db.get_sample_by_internal_id(
             file.version.bundle.name
         )
@@ -68,6 +56,8 @@ class SpringArchiveAPI:
         return sample
 
     def add_samples_to_files(self, files_to_archive: List[File]) -> List[FileAndSample]:
+        """Fetches the Sample corresponding to each File, instantiates a FileAndSample object and
+        adds it to the list which is returned."""
         files_and_samples: List[FileAndSample] = []
         for file in files_to_archive:
             sample: Optional[Sample] = self.get_sample(file)

--- a/cg/meta/archive/archive.py
+++ b/cg/meta/archive/archive.py
@@ -1,13 +1,12 @@
 import logging
 from typing import List, Optional
 
-from housekeeper.store.models import File
-from pydantic import BaseModel, ConfigDict
-
 from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.constants.archiving import ArchiveLocationsInUse
 from cg.store import Store
 from cg.store.models import Sample
+from housekeeper.store.models import File
+from pydantic import BaseModel, ConfigDict
 
 LOG = logging.getLogger(__name__)
 
@@ -18,7 +17,7 @@ class FileAndSample(BaseModel):
     sample: Sample
 
 
-def get_files_by_archive_location(
+def filter_files_on_archive_location(
     files_and_samples: List[FileAndSample], archive_location: ArchiveLocationsInUse
 ) -> List[FileAndSample]:
     """

--- a/cg/meta/archive/archive.py
+++ b/cg/meta/archive/archive.py
@@ -4,10 +4,10 @@ from typing import List, Optional
 from housekeeper.store.models import File
 from pydantic import BaseModel, ConfigDict
 
-from cg.apps.cgstats.db.models import Sample
 from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.constants.archiving import ArchiveLocationsInUse
 from cg.store import Store
+from cg.store.models import Sample
 
 LOG = logging.getLogger(__name__)
 

--- a/cg/meta/archive/archive.py
+++ b/cg/meta/archive/archive.py
@@ -2,12 +2,11 @@ import logging
 from typing import List, Optional
 
 from housekeeper.store.models import File
-from pydantic.v1 import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict
 
 from cg.apps.cgstats.db.models import Sample
 from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.constants.archiving import ArchiveLocationsInUse
-from cg.meta.archive.ddn_dataflow import DDNDataFlowApi
 from cg.store import Store
 
 LOG = logging.getLogger(__name__)
@@ -36,11 +35,8 @@ class SpringArchiveAPI:
     """Class handling the archiving of sample SPRING files to an off-premise location for long
     term storage."""
 
-    def __init__(
-        self, ddn_dataflow_api: DDNDataFlowApi, housekeeper_api: HousekeeperAPI, status_db: Store
-    ):
+    def __init__(self, housekeeper_api: HousekeeperAPI, status_db: Store):
         self.housekeeper_api: HousekeeperAPI = housekeeper_api
-        self.ddn_api: DDNDataFlowApi = ddn_dataflow_api
         self.status_db: Store = status_db
 
     def get_sample(self, file: File) -> Optional[Sample]:

--- a/tests/meta/archive/conftest.py
+++ b/tests/meta/archive/conftest.py
@@ -183,12 +183,3 @@ def fixture_spring_archive_api(
         housekeeper_api=populated_housekeeper_api,
         status_db=archive_store,
     )
-
-
-# @pytest.fixture(name="file_and_sample")
-# def fixture_file_and_sample(spring_archive_api: SpringArchiveAPI, sample_id):
-#     """Returns a FileAndSample object with a real File and Sample objects."""
-#     return FileAndSample(
-#         file=spring_archive_api.housekeeper_api.get_files(bundle=sample_id).first(),
-#         sample=spring_archive_api.status_db.get_sample_by_internal_id(sample_id),
-#     )

--- a/tests/meta/archive/conftest.py
+++ b/tests/meta/archive/conftest.py
@@ -183,3 +183,12 @@ def fixture_spring_archive_api(
         housekeeper_api=populated_housekeeper_api,
         status_db=archive_store,
     )
+
+
+# @pytest.fixture(name="file_and_sample")
+# def fixture_file_and_sample(spring_archive_api: SpringArchiveAPI, sample_id):
+#     """Returns a FileAndSample object with a real File and Sample objects."""
+#     return FileAndSample(
+#         file=spring_archive_api.housekeeper_api.get_files(bundle=sample_id).first(),
+#         sample=spring_archive_api.status_db.get_sample_by_internal_id(sample_id),
+#     )

--- a/tests/meta/archive/test_archive_api.py
+++ b/tests/meta/archive/test_archive_api.py
@@ -1,63 +1,110 @@
-from pathlib import Path
+from housekeeper.store.models import File
+
 from typing import List
 
-from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.constants.archiving import ArchiveLocationsInUse
-from cg.meta.archive.archive import SpringArchiveAPI, PathAndSample
+
+from cg.meta.archive.archive import (
+    SpringArchiveAPI,
+    FileAndSample,
+    get_files_by_archive_location,
+)
+
+
 from cg.store.models import Sample
 
 
 def test_get_files_by_archive_location(
-    spring_archive_api: SpringArchiveAPI, populated_housekeeper_api: HousekeeperAPI
+    spring_archive_api: SpringArchiveAPI, sample_id, father_sample_id
 ):
-    """Tests the fetching of sample/customer info from statusdb based on bundle_names
-    and returning the samples with the given Archive location."""
-    # GIVEN a populated status_db database with two customers, one DDN and one non-DDN,
-    # with the DDN customer having two samples, and the non-DDN having one sample.
-
-    # Given non-archived spring files
-    non_archived_spring_files: List[PathAndSample] = [
-        PathAndSample(path=path, sample_internal_id=sample)
-        for sample, path in populated_housekeeper_api.get_non_archived_spring_path_and_bundle_name()
-    ]
-    # WHEN extracting the files based on data archive
-    sorted_spring_files: List[PathAndSample] = spring_archive_api.get_files_by_archive_location(
-        non_archived_spring_files, archive_location=ArchiveLocationsInUse.KAROLINSKA_BUCKET
+    """Tests filtering out files and samples with the correct Archive location from a list."""
+    # GIVEN two Samples and two corresponding files
+    files_and_samples: List[FileAndSample] = []
+    for sample in [sample_id, father_sample_id]:
+        files_and_samples.append(
+            FileAndSample(
+                file=spring_archive_api.housekeeper_api.get_files(bundle=sample).first(),
+                sample=spring_archive_api.status_db.get_sample_by_internal_id(sample),
+            )
+        )
+    # WHEN fetching the files by archive location
+    selected_files: List[FileAndSample] = get_files_by_archive_location(
+        files_and_samples, ArchiveLocationsInUse.KAROLINSKA_BUCKET
     )
 
-    # THEN there should be spring files
-    assert sorted_spring_files
-    for file_and_sample in sorted_spring_files:
-        sample: Sample = spring_archive_api.status_db.get_sample_by_internal_id(
-            file_and_sample.sample_internal_id
-        )
-        # THEN each file should be correctly sorted on its archive location
-        assert sample.customer.data_archive_location == ArchiveLocationsInUse.KAROLINSKA_BUCKET
+    # THEN every file returned should have that archive location
+    assert selected_files
+    for selected_file in selected_files:
+        assert selected_file.sample.archive_location == ArchiveLocationsInUse.KAROLINSKA_BUCKET
 
 
-def test_get_sample_exists(sample_id: str, spring_archive_api: SpringArchiveAPI, spring_file: Path):
+def test_add_samples_to_files(spring_archive_api: SpringArchiveAPI):
+    """Tests matching Files to Samples when both files have a matching sample."""
+    # GIVEN a list of SPRING Files to archive
+    files_to_archive: List[
+        File
+    ] = spring_archive_api.housekeeper_api.get_all_non_archived_spring_files()
+
+    # WHEN adding the Sample objects
+    file_and_samples: List[FileAndSample] = spring_archive_api.add_samples_to_files(
+        files_to_archive
+    )
+
+    # THEN each file should have a matching sample
+    assert len(files_to_archive) == len(file_and_samples) > 0
+    for file_and_sample in file_and_samples:
+        # THEN the bundle name of each file should match the sample internal id
+        assert file_and_sample.file.version.bundle.name == file_and_sample.sample.internal_id
+
+
+def test_add_samples_to_files_missing_sample(spring_archive_api: SpringArchiveAPI):
+    """Tests matching Files to Samples when one of the files does not match a Sample."""
+    # GIVEN a list of SPRING Files to archive
+    files_to_archive: List[
+        File
+    ] = spring_archive_api.housekeeper_api.get_all_non_archived_spring_files()
+    # GIVEN one of the files does not match the
+    files_to_archive[0].version.bundle.name = "does-not-exist"
+    # WHEN adding the Sample objects
+    file_and_samples: List[FileAndSample] = spring_archive_api.add_samples_to_files(
+        files_to_archive
+    )
+
+    # THEN only one of the files should have a matching sample
+    assert len(files_to_archive) != len(file_and_samples) > 0
+    for file_and_sample in file_and_samples:
+        # THEN the bundle name of each file should match the sample internal id
+        assert file_and_sample.file.version.bundle.name == file_and_sample.sample.internal_id
+
+
+def test_get_sample_exists(sample_id: str, spring_archive_api: SpringArchiveAPI):
     """Tests fetching a sample when the sample exists."""
     # GIVEN a sample that exists in the database
-    file_info: PathAndSample = PathAndSample(spring_file, sample_id)
+    file: File = spring_archive_api.housekeeper_api.get_files(bundle=sample_id).first()
 
     # WHEN getting the sample
-    sample: Sample = spring_archive_api.get_sample(file_info)
+    sample: Sample = spring_archive_api.get_sample(file)
 
     # THEN the correct sample should be returned
     assert sample.internal_id == sample_id
 
 
-def test_get_sample_not_exists(caplog, spring_archive_api: SpringArchiveAPI, spring_file: Path):
+def test_get_sample_not_exists(
+    caplog,
+    spring_archive_api: SpringArchiveAPI,
+    sample_id,
+):
     """Tests fetching a sample when the sample does not exist."""
     # GIVEN a sample that does not exist in the database
+    file: File = spring_archive_api.housekeeper_api.get_files(bundle=sample_id).first()
     sample_id: str = "non-existent-sample"
-    file_info: PathAndSample = PathAndSample(spring_file, sample_id)
+    file.version.bundle.name = sample_id
 
     # WHEN getting the sample
-    sample: Sample = spring_archive_api.get_sample(file_info)
+    sample: Sample = spring_archive_api.get_sample(file)
 
     # THEN the no sample should be returned
     # THEN both sample_id and file path should be logged
     assert not sample
     assert sample_id in caplog.text
-    assert spring_file.as_posix() in caplog.text
+    assert file.path in caplog.text

--- a/tests/meta/archive/test_archive_api.py
+++ b/tests/meta/archive/test_archive_api.py
@@ -1,35 +1,28 @@
-from housekeeper.store.models import File
-
 from typing import List
 
 from cg.constants.archiving import ArchiveLocationsInUse
-
 from cg.meta.archive.archive import (
-    SpringArchiveAPI,
     FileAndSample,
-    get_files_by_archive_location,
+    SpringArchiveAPI,
+    filter_files_on_archive_location,
 )
-
-
 from cg.store.models import Sample
+from housekeeper.store.models import File
 
 
 def test_get_files_by_archive_location(
     spring_archive_api: SpringArchiveAPI, sample_id, father_sample_id
 ):
     """Tests filtering out files and samples with the correct Archive location from a list."""
-    # GIVEN two Samples and two corresponding files
-    files_and_samples: List[FileAndSample] = []
-    for sample in [sample_id, father_sample_id]:
-        files_and_samples.append(
-            FileAndSample(
-                file=spring_archive_api.housekeeper_api.get_files(bundle=sample).first(),
-                sample=spring_archive_api.status_db.get_sample_by_internal_id(sample),
-            )
+    files_and_samples: List[FileAndSample] = [
+        FileAndSample(
+            file=spring_archive_api.housekeeper_api.get_files(bundle=sample).first(),
+            sample=spring_archive_api.status_db.get_sample_by_internal_id(sample),
         )
-
+        for sample in [sample_id, father_sample_id]
+    ]
     # WHEN fetching the files by archive location
-    selected_files: List[FileAndSample] = get_files_by_archive_location(
+    selected_files: List[FileAndSample] = filter_files_on_archive_location(
         files_and_samples, ArchiveLocationsInUse.KAROLINSKA_BUCKET
     )
 

--- a/tests/meta/archive/test_archive_api.py
+++ b/tests/meta/archive/test_archive_api.py
@@ -27,6 +27,7 @@ def test_get_files_by_archive_location(
                 sample=spring_archive_api.status_db.get_sample_by_internal_id(sample),
             )
         )
+
     # WHEN fetching the files by archive location
     selected_files: List[FileAndSample] = get_files_by_archive_location(
         files_and_samples, ArchiveLocationsInUse.KAROLINSKA_BUCKET


### PR DESCRIPTION
## Description
To simplify the code for archiving (sending files to an off-premise location) it was suggested by @seallard to use the File model imported from housekeeper and the cg Sample model. This allows for less fetching from and fewer intermediate classes. 

### Added

- Class `FileAndSample` that stores on File and one Sample
- Function `add_samples_to_files` which instantiates aforementioned class for each File in a list
- Function `get_files_by_archive_location` which returns all FileAndSample in a list which match the given archive_location
- Tests for the functions


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
