### PR TITLE
refactor(NfAnalysisAPI) avoid code duplication between rnafusion and taxprofiler

### DIFF
--- a/cg/meta/workflow/fastq.py
+++ b/cg/meta/workflow/fastq.py
@@ -303,23 +303,3 @@ class StandardFastqHandler(FastqHandler):
         flow_cell: str = f"{flow_cell}-undetermined" if undetermined else flow_cell
         date: str = date if isinstance(date, str) else date.strftime("%y%m%d")
         return f"{lane}_{date}_{flow_cell}_{sample}_{index}_{read}.fastq.gz"
-
-
-class TaxprofilerFastqHandler(FastqHandler):
-    """Handles Taxprofiler fastq file linking."""
-
-    @staticmethod
-    def create_fastq_name(
-        lane: str,
-        flow_cell: str,
-        sample: str,
-        read: str,
-        date: dt.datetime = DEFAULT_DATE_STR,
-        index: str = DEFAULT_INDEX,
-        undetermined: Optional[str] = None,
-        meta: Optional[str] = None,
-    ) -> str:
-        """Name a FASTQ file, no naming constrains from pipeline."""
-        flow_cell: str = f"{flow_cell}-undetermined" if undetermined else flow_cell
-        date: str = date if isinstance(date, str) else date.strftime("%y%m%d")
-        return f"{lane}_{date}_{flow_cell}_{sample}_{index}_{read}.fastq.gz"

--- a/cg/meta/workflow/fastq.py
+++ b/cg/meta/workflow/fastq.py
@@ -166,15 +166,19 @@ class FastqHandler:
     @staticmethod
     def create_fastq_name(
         lane: str,
-        flowcell: str,
+        flow_cell: str,
         sample: str,
         read: str,
         date: dt.datetime = DEFAULT_DATE_STR,
         index: str = DEFAULT_INDEX,
         undetermined: Optional[str] = None,
         meta: Optional[str] = None,
-    ):
-        raise NotImplementedError
+    ) -> str:
+        """Name a FASTQ file with standard conventions and
+        no naming constrains from pipeline."""
+        flow_cell: str = f"{flow_cell}-undetermined" if undetermined else flow_cell
+        date: str = date if isinstance(date, str) else date.strftime("%y%m%d")
+        return f"{lane}_{date}_{flow_cell}_{sample}_{index}_{read}.fastq.gz"
 
 
 class BalsamicFastqHandler(FastqHandler):
@@ -284,22 +288,3 @@ class MutantFastqHandler(FastqHandler):
                 "flowcell": header_info["flowcell"],
             }
             return data
-
-
-class StandardFastqHandler(FastqHandler):
-    @staticmethod
-    def create_fastq_name(
-        lane: str,
-        flow_cell: str,
-        sample: str,
-        read: str,
-        date: dt.datetime = DEFAULT_DATE_STR,
-        index: str = DEFAULT_INDEX,
-        undetermined: Optional[str] = None,
-        meta: Optional[str] = None,
-    ) -> str:
-        """Name a FASTQ file with standard conventions and
-        no naming constrains from pipeline."""
-        flow_cell: str = f"{flow_cell}-undetermined" if undetermined else flow_cell
-        date: str = date if isinstance(date, str) else date.strftime("%y%m%d")
-        return f"{lane}_{date}_{flow_cell}_{sample}_{index}_{read}.fastq.gz"

--- a/cg/meta/workflow/fastq.py
+++ b/cg/meta/workflow/fastq.py
@@ -14,7 +14,6 @@ import shutil
 from pathlib import Path
 from typing import List, Optional
 
-
 LOG = logging.getLogger(__name__)
 
 DEFAULT_DATE_STR = (
@@ -285,6 +284,25 @@ class MutantFastqHandler(FastqHandler):
                 "flowcell": header_info["flowcell"],
             }
             return data
+
+
+class StandardFastqHandler(FastqHandler):
+    @staticmethod
+    def create_fastq_name(
+        lane: str,
+        flow_cell: str,
+        sample: str,
+        read: str,
+        date: dt.datetime = DEFAULT_DATE_STR,
+        index: str = DEFAULT_INDEX,
+        undetermined: Optional[str] = None,
+        meta: Optional[str] = None,
+    ) -> str:
+        """Name a FASTQ file with the following conventions and
+        no naming constrains from pipeline."""
+        flow_cell: str = f"{flow_cell}-undetermined" if undetermined else flow_cell
+        date: str = date if isinstance(date, str) else date.strftime("%y%m%d")
+        return f"{lane}_{date}_{flow_cell}_{sample}_{index}_{read}.fastq.gz"
 
 
 class RnafusionFastqHandler(FastqHandler):

--- a/cg/meta/workflow/fastq.py
+++ b/cg/meta/workflow/fastq.py
@@ -298,26 +298,7 @@ class StandardFastqHandler(FastqHandler):
         undetermined: Optional[str] = None,
         meta: Optional[str] = None,
     ) -> str:
-        """Name a FASTQ file with the following conventions and
-        no naming constrains from pipeline."""
-        flow_cell: str = f"{flow_cell}-undetermined" if undetermined else flow_cell
-        date: str = date if isinstance(date, str) else date.strftime("%y%m%d")
-        return f"{lane}_{date}_{flow_cell}_{sample}_{index}_{read}.fastq.gz"
-
-
-class RnafusionFastqHandler(FastqHandler):
-    @staticmethod
-    def create_fastq_name(
-        lane: str,
-        flow_cell: str,
-        sample: str,
-        read: str,
-        date: dt.datetime = DEFAULT_DATE_STR,
-        index: str = DEFAULT_INDEX,
-        undetermined: Optional[str] = None,
-        meta: Optional[str] = None,
-    ) -> str:
-        """Name a FASTQ file following MIP conventions,
+        """Name a FASTQ file with standard conventions and
         no naming constrains from pipeline."""
         flow_cell: str = f"{flow_cell}-undetermined" if undetermined else flow_cell
         date: str = date if isinstance(date, str) else date.strftime("%y%m%d")

--- a/cg/meta/workflow/nextflow_common.py
+++ b/cg/meta/workflow/nextflow_common.py
@@ -35,16 +35,6 @@ class NextflowAnalysisAPI:
         return Path(root_dir, case_id)
 
     @classmethod
-    def verify_case_config_file_exists(
-        cls, case_id: str, root_dir: str, dry_run: bool = False
-    ) -> None:
-        if (
-            not dry_run
-            and not Path(cls.get_case_config_path(case_id=case_id, root_dir=root_dir)).exists()
-        ):
-            raise ValueError(f"No config file found for case {case_id}")
-
-    @classmethod
     def get_case_config_path(cls, case_id: str, root_dir: str) -> str:
         """Return a path where the sample sheet for the case_id should be located."""
         return (
@@ -218,11 +208,6 @@ class NextflowAnalysisAPI:
             file_format=FileFormat.YAML,
             file_path=file_bundle_template,
         )
-
-    @classmethod
-    def verify_deliverables_file_exists(cls, case_id, root_dir):
-        if not Path(cls.get_deliverables_file_path(case_id=case_id, root_dir=root_dir)).exists():
-            raise CgError(f"No deliverables file found for case {case_id}")
 
     @classmethod
     def add_bundle_header(cls, deliverables_content: dict) -> dict:

--- a/cg/meta/workflow/nf_analysis.py
+++ b/cg/meta/workflow/nf_analysis.py
@@ -6,7 +6,7 @@ from cg.constants import Pipeline
 from cg.constants.constants import FileFormat, WorkflowManager
 from cg.io.controller import WriteFile
 from cg.meta.workflow.analysis import AnalysisAPI
-from cg.meta.workflow.fastq import StandardFastqHandler
+from cg.meta.workflow.fastq import FastqHandler
 from cg.meta.workflow.nextflow_common import NextflowAnalysisAPI
 from cg.models.cg_config import CGConfig
 from cg.utils import Process
@@ -45,7 +45,7 @@ class NfAnalysisAPI(AnalysisAPI):
 
     @property
     def fastq_handler(self):
-        return StandardFastqHandler
+        return FastqHandler
 
     @property
     def process(self):

--- a/cg/meta/workflow/nf_analysis.py
+++ b/cg/meta/workflow/nf_analysis.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Optional
 
 from cg.constants import Pipeline
-from cg.constants.constants import FileFormat, WorkflowManager
+from cg.constants.constants import FileExtensions, FileFormat, WorkflowManager
 from cg.io.controller import WriteFile
 from cg.meta.workflow.analysis import AnalysisAPI
 from cg.meta.workflow.fastq import FastqHandler
@@ -15,15 +15,9 @@ LOG = logging.getLogger(__name__)
 
 
 class NfAnalysisAPI(AnalysisAPI):
-    """
-    Parent class for handling nf-core analyses.
-    """
+    """Parent class for handling NF-core analyses."""
 
-    def __init__(
-        self,
-        config: CGConfig,
-        pipeline: Pipeline,
-    ):
+    def __init__(self, config: CGConfig, pipeline: Pipeline):
         super().__init__(config=config, pipeline=pipeline)
         self.pipeline: Pipeline = pipeline
         self.root_dir: Optional[str] = None
@@ -63,7 +57,7 @@ class NfAnalysisAPI(AnalysisAPI):
         return profile or self.profile
 
     def get_workflow_manager(self) -> str:
-        """Get workflow manager for rnafusion."""
+        """Get workflow manager from Tower."""
         return WorkflowManager.Tower.value
 
     def get_case_path(self, case_id: str) -> Path:
@@ -74,12 +68,12 @@ class NfAnalysisAPI(AnalysisAPI):
         return NextflowAnalysisAPI.get_case_config_path(case_id=case_id, root_dir=self.root_dir)
 
     def get_trailblazer_config_path(self, case_id: str) -> Path:
-        """Return the path to a trailblazer config file containing Tower IDs."""
-        return Path(self.root_dir, case_id, "tower_ids.yaml")
+        """Return the path to a Trailblazer config file containing Tower IDs."""
+        return Path(self.root_dir, case_id, "tower_ids").with_suffix(FileExtensions.YAML)
 
     def write_trailblazer_config(self, case_id: str, tower_id: str) -> None:
-        """Write Tower IDs to a .YAML file used as the trailblazer config."""
-        config_path = self.get_trailblazer_config_path(case_id=case_id)
+        """Write Tower IDs to a file used as the Trailblazer config."""
+        config_path: Path = self.get_trailblazer_config_path(case_id=case_id)
         LOG.info(f"Writing Tower ID to {config_path.as_posix()}")
         WriteFile.write_file_from_content(
             content={case_id: [tower_id]},
@@ -102,4 +96,6 @@ class NfAnalysisAPI(AnalysisAPI):
 
     def get_metrics_deliverables_path(self, case_id: str) -> Path:
         """Return a path where the <case>_metrics_deliverables.yaml file should be located."""
-        return Path(self.root_dir, case_id, f"{case_id}_metrics_deliverables.yaml")
+        return Path(self.root_dir, case_id, f"{case_id}_metrics_deliverables").with_suffix(
+            FileExtensions.YAML
+        )

--- a/cg/meta/workflow/nf_analysis.py
+++ b/cg/meta/workflow/nf_analysis.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from cg.constants import Pipeline
 from cg.constants.constants import FileExtensions, FileFormat, WorkflowManager
+from cg.exc import CgError
 from cg.io.controller import WriteFile
 from cg.meta.workflow.analysis import AnalysisAPI
 from cg.meta.workflow.fastq import FastqHandler
@@ -82,17 +83,20 @@ class NfAnalysisAPI(AnalysisAPI):
         )
 
     def verify_case_config_file_exists(self, case_id: str, dry_run: bool = False) -> None:
-        NextflowAnalysisAPI.verify_case_config_file_exists(
-            case_id=case_id, root_dir=self.root_dir, dry_run=dry_run
-        )
+        """Raise an error if config file is not found."""
+        if not dry_run and not Path(self.get_case_config_path(case_id=case_id)).exists():
+            raise ValueError(f"No config file found for case {case_id}")
 
     def get_deliverables_file_path(self, case_id: str) -> Path:
+        """Returns a path where the deliverables file for a case should be located."""
         return NextflowAnalysisAPI.get_deliverables_file_path(
             case_id=case_id, root_dir=self.root_dir
         )
 
     def verify_deliverables_file_exists(self, case_id: str) -> None:
-        NextflowAnalysisAPI.verify_deliverables_file_exists(case_id=case_id, root_dir=self.root_dir)
+        """Raise an error if deliverables files file is not found."""
+        if not Path(self.get_deliverables_file_path(case_id=case_id)).exists():
+            raise CgError(f"No deliverables file found for case {case_id}")
 
     def get_metrics_deliverables_path(self, case_id: str) -> Path:
         """Return a path where the <case>_metrics_deliverables.yaml file should be located."""

--- a/cg/meta/workflow/taxprofiler.py
+++ b/cg/meta/workflow/taxprofiler.py
@@ -15,11 +15,10 @@ from cg.constants.taxprofiler import (
     TAXPROFILER_SAMPLE_SHEET_HEADERS,
 )
 from cg.meta.workflow.analysis import AnalysisAPI
-from cg.meta.workflow.fastq import TaxprofilerFastqHandler
 from cg.meta.workflow.nextflow_common import NextflowAnalysisAPI
 from cg.models.cg_config import CGConfig
 from cg.models.taxprofiler.taxprofiler_sample import TaxprofilerSample
-from cg.store.models import Family, Sample
+from cg.store.models import Family
 
 LOG = logging.getLogger(__name__)
 
@@ -35,17 +34,6 @@ class TaxprofilerAnalysisAPI(AnalysisAPI):
     ):
         super().__init__(config=config, pipeline=pipeline)
         self.root_dir: str = config.taxprofiler.root
-
-    @property
-    def root(self) -> str:
-        return self.root_dir
-
-    @property
-    def fastq_handler(self):
-        return TaxprofilerFastqHandler
-
-    def get_case_config_path(self, case_id):
-        return NextflowAnalysisAPI.get_case_config_path(case_id=case_id, root_dir=self.root_dir)
 
     @staticmethod
     def build_sample_sheet_content(


### PR DESCRIPTION
## Description

Part 1 of:  https://github.com/Clinical-Genomics/cg/issues/2044

It adds NfAnalysisAPI class from which rnafusion and taxprofiler inherit

### Added

- NfAnalysisAPI class (child of AnalysisAPI)
- StandardFastqHandler to name fastq files without naming restrictions

### Changed

- refactored rnafusion and taxprofile. Common methods have been moved to NfAnalysisAPI from which they inherit
- removed rnafusion- and taxprofile-specific fastq handler


### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b refactor_nfanalysisapi -a
    ```

### How to test

Test that rnafusion is still functional
- [x] `cg workflow rnafusion config-case <case_id>`. Sample sheet and params files are created.
- [x] `cg workflow rnafusion run <case_id>`. Case is started in tower.
- [x] `cg workflow rnafusion store <case_id>`. metrics and deliverable files are created and case is stored.

Test that taxprofiler is still functional
- [x] `cg workflow taxprofiler config-case <case_id>`. Sample sheet is created.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
