### PR TITLE
Archiving make spring archive api agnostic

### DIFF
--- a/cg/constants/archiving.py
+++ b/cg/constants/archiving.py
@@ -1,7 +1,7 @@
 from cg.utils.enums import StrEnum
 
 
-class ArchiveLocationsInUse(StrEnum):
+class ArchiveLocations(StrEnum):
     """Demultiplexing related directories and files."""
 
     KAROLINSKA_BUCKET: str = "karolinska_bucket"

--- a/cg/meta/archive/archive.py
+++ b/cg/meta/archive/archive.py
@@ -2,7 +2,7 @@ import logging
 from typing import Callable, Dict, List, Optional
 
 from cg.apps.housekeeper.hk import HousekeeperAPI
-from cg.constants.archiving import ArchiveLocationsInUse
+from cg.constants.archiving import ArchiveLocations
 from cg.meta.archive.ddn_dataflow import DDNDataFlowClient, MiriaFile
 from cg.meta.archive.models import ArchiveHandler, FileTransferData
 from cg.store import Store
@@ -28,7 +28,7 @@ class ArchiveModels(BaseModel):
 
 
 def filter_files_on_archive_location(
-    files_and_samples: List[FileAndSample], archive_location: ArchiveLocationsInUse
+    files_and_samples: List[FileAndSample], archive_location: ArchiveLocations
 ) -> List[FileAndSample]:
     """
     Returns a list of FileAndSample where the associated sample has a specific archive location.
@@ -54,13 +54,13 @@ class SpringArchiveAPI:
         self.ddn_client: DDNDataFlowClient = ddn_dataflow_client
         self.status_db: Store = status_db
         self.handler_map: Dict[str, ArchiveModels] = {
-            ArchiveLocationsInUse.KAROLINSKA_BUCKET: ArchiveModels(
+            ArchiveLocations.KAROLINSKA_BUCKET: ArchiveModels(
                 file_model=MiriaFile.from_file_and_sample, handler=self.ddn_client
             )
         }
 
     def call_corresponding_archiving_method(
-        self, files: List[FileTransferData], archive_location: ArchiveLocationsInUse
+        self, files: List[FileTransferData], archive_location: ArchiveLocations
     ) -> int:
         return self.handler_map[archive_location].handler.archive_folders(
             sources_and_destinations=files
@@ -88,7 +88,7 @@ class SpringArchiveAPI:
         return files_and_samples
 
     def convert_files_into_transfer_data(
-        self, files_and_samples: List[FileAndSample], archive_location: ArchiveLocationsInUse
+        self, files_and_samples: List[FileAndSample], archive_location: ArchiveLocations
     ) -> List[FileTransferData]:
         return [
             self.handler_map[archive_location].file_model(

--- a/cg/meta/archive/archive.py
+++ b/cg/meta/archive/archive.py
@@ -35,7 +35,7 @@ def filter_files_on_archive_location(
     ]
 
 
-archive_handlers: Dict[str, Callable] = {ArchiveLocations.KAROLINSKA_BUCKET: DDNDataFlowClient}
+ARCHIVE_HANDLERS: Dict[str, Callable] = {ArchiveLocations.KAROLINSKA_BUCKET: DDNDataFlowClient}
 
 
 class SpringArchiveAPI:
@@ -50,7 +50,7 @@ class SpringArchiveAPI:
         self.data_flow_config: DataFlowConfig = data_flow_config
 
     def archive_files(self, files: List[FileAndSample], archive_location: ArchiveLocations) -> int:
-        archive_handler: ArchiveHandler = archive_handlers[archive_location](self.data_flow_config)
+        archive_handler: ArchiveHandler = ARCHIVE_HANDLERS[archive_location](self.data_flow_config)
         return archive_handler.archive_folders(files_and_samples=files)
 
     def get_sample(self, file: File) -> Optional[Sample]:

--- a/cg/meta/archive/archive.py
+++ b/cg/meta/archive/archive.py
@@ -3,6 +3,7 @@ from typing import Callable, Dict, List, Optional
 
 from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.constants.archiving import ArchiveLocations
+from cg.meta.archive.ddn_dataflow import DDNDataFlowClient
 from cg.meta.archive.models import ArchiveHandler, FileAndSample
 from cg.models.cg_config import DataFlowConfig
 from cg.store import Store

--- a/cg/meta/archive/archive.py
+++ b/cg/meta/archive/archive.py
@@ -59,7 +59,7 @@ class SpringArchiveAPI:
             )
         }
 
-    def call_corresponding_archiving_function(
+    def call_corresponding_archiving_method(
         self, files: List[FileTransferData], archive_location: ArchiveLocationsInUse
     ) -> int:
         return self.handler_map[archive_location].handler.archive_folders(
@@ -87,9 +87,9 @@ class SpringArchiveAPI:
                 files_and_samples.append(FileAndSample(file=file, sample=sample))
         return files_and_samples
 
-    def convert_into_correct_model(
+    def convert_files_into_transfer_data(
         self, files_and_samples: List[FileAndSample], archive_location: ArchiveLocationsInUse
-    ) -> List[MiriaFile]:
+    ) -> List[FileTransferData]:
         return [
             self.handler_map[archive_location].file_model(
                 file=file_and_sample.file, sample=file_and_sample.sample

--- a/cg/meta/archive/archive.py
+++ b/cg/meta/archive/archive.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Dict, List, Optional, Type
 
 from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.constants.archiving import ArchiveLocations
@@ -35,7 +35,9 @@ def filter_files_on_archive_location(
     ]
 
 
-ARCHIVE_HANDLERS: Dict[str, Callable] = {ArchiveLocations.KAROLINSKA_BUCKET: DDNDataFlowClient}
+ARCHIVE_HANDLERS: Dict[str, Type[ArchiveHandler]] = {
+    ArchiveLocations.KAROLINSKA_BUCKET: DDNDataFlowClient
+}
 
 
 class SpringArchiveAPI:

--- a/cg/meta/archive/archive.py
+++ b/cg/meta/archive/archive.py
@@ -3,20 +3,15 @@ from typing import Callable, Dict, List, Optional
 
 from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.constants.archiving import ArchiveLocations
-from cg.meta.archive.ddn_dataflow import DDNDataFlowClient, MiriaFile
-from cg.meta.archive.models import ArchiveHandler, FileTransferData
+from cg.meta.archive.ddn_dataflow import DDNDataFlowClient
+from cg.meta.archive.models import ArchiveHandler, FileAndSample
+from cg.models.cg_config import DataFlowConfig
 from cg.store import Store
 from cg.store.models import Sample
 from housekeeper.store.models import File
 from pydantic import BaseModel, ConfigDict
 
 LOG = logging.getLogger(__name__)
-
-
-class FileAndSample(BaseModel):
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-    file: File
-    sample: Sample
 
 
 class ArchiveModels(BaseModel):
@@ -40,31 +35,23 @@ def filter_files_on_archive_location(
     ]
 
 
+archive_handlers: Dict[str, Callable] = {ArchiveLocations.KAROLINSKA_BUCKET: DDNDataFlowClient}
+
+
 class SpringArchiveAPI:
     """Class handling the archiving of sample SPRING files to an off-premise location for long
     term storage."""
 
     def __init__(
-        self,
-        ddn_dataflow_client: DDNDataFlowClient,
-        housekeeper_api: HousekeeperAPI,
-        status_db: Store,
+        self, housekeeper_api: HousekeeperAPI, status_db: Store, data_flow_config: DataFlowConfig
     ):
         self.housekeeper_api: HousekeeperAPI = housekeeper_api
-        self.ddn_client: DDNDataFlowClient = ddn_dataflow_client
         self.status_db: Store = status_db
-        self.handler_map: Dict[str, ArchiveModels] = {
-            ArchiveLocations.KAROLINSKA_BUCKET: ArchiveModels(
-                file_model=MiriaFile.from_file_and_sample, handler=self.ddn_client
-            )
-        }
+        self.data_flow_config: DataFlowConfig = data_flow_config
 
-    def call_corresponding_archiving_method(
-        self, files: List[FileTransferData], archive_location: ArchiveLocations
-    ) -> int:
-        return self.handler_map[archive_location].handler.archive_folders(
-            sources_and_destinations=files
-        )
+    def archive_files(self, files: List[FileAndSample], archive_location: ArchiveLocations) -> int:
+        archive_handler: ArchiveHandler = archive_handlers[archive_location](self.data_flow_config)
+        return archive_handler.archive_folders(files_and_samples=files)
 
     def get_sample(self, file: File) -> Optional[Sample]:
         sample: Optional[Sample] = self.status_db.get_sample_by_internal_id(
@@ -86,13 +73,3 @@ class SpringArchiveAPI:
             if sample:
                 files_and_samples.append(FileAndSample(file=file, sample=sample))
         return files_and_samples
-
-    def convert_files_into_transfer_data(
-        self, files_and_samples: List[FileAndSample], archive_location: ArchiveLocations
-    ) -> List[FileTransferData]:
-        return [
-            self.handler_map[archive_location].file_model(
-                file=file_and_sample.file, sample=file_and_sample.sample
-            )
-            for file_and_sample in files_and_samples
-        ]

--- a/cg/meta/archive/ddn_dataflow.py
+++ b/cg/meta/archive/ddn_dataflow.py
@@ -1,21 +1,19 @@
 """Module for archiving and retrieving folders via DDN Dataflow."""
+from datetime import datetime
 from enum import Enum
 from pathlib import Path
 from typing import Dict, List, Optional
 from urllib.parse import urljoin
 
-from housekeeper.store.models import File
-
-from datetime import datetime
 from cg.constants.constants import APIMethods
 from cg.exc import DdnDataflowAuthenticationError
-from cg.meta.archive.models import ArchiveInterface, ArchiveFile
 from cg.io.controller import APIRequest
+from cg.meta.archive.models import ArchiveHandler, FileTransferData
 from cg.models.cg_config import DDNDataFlowConfig
+from cg.store.models import Sample
+from housekeeper.store.models import File
 from pydantic import BaseModel
 from requests.models import Response
-
-from cg.store.models import Sample
 
 OSTYPE: str = "Unix/MacOS"
 ROOT_TO_TRIM: str = "/home"
@@ -33,7 +31,7 @@ class DataflowEndpoints(str, Enum):
     RETRIEVE_FILES = "files/retrieve"
 
 
-class MiriaFile(ArchiveFile):
+class MiriaFile(FileTransferData):
     """Model for representing a singular object transfer."""
 
     _metadata = None
@@ -132,7 +130,7 @@ class TransferJob(BaseModel):
     job_id: int
 
 
-class DDNDataFlowClient(ArchiveInterface):
+class DDNDataFlowClient(ArchiveHandler):
     """Class for archiving and retrieving folders via DDN Dataflow."""
 
     def __init__(self, config: DDNDataFlowConfig):

--- a/cg/meta/archive/ddn_dataflow.py
+++ b/cg/meta/archive/ddn_dataflow.py
@@ -14,6 +14,7 @@ from cg.store.models import Sample
 from housekeeper.store.models import File
 from pydantic import BaseModel
 from requests.models import Response
+
 OSTYPE: str = "Unix/MacOS"
 ROOT_TO_TRIM: str = "/home"
 

--- a/cg/meta/archive/ddn_dataflow.py
+++ b/cg/meta/archive/ddn_dataflow.py
@@ -8,8 +8,8 @@ from urllib.parse import urljoin
 from cg.constants.constants import APIMethods
 from cg.exc import DdnDataflowAuthenticationError
 from cg.io.controller import APIRequest
-from cg.meta.archive.models import ArchiveHandler, FileTransferData
-from cg.models.cg_config import DDNDataFlowConfig
+from cg.meta.archive.models import ArchiveHandler, FileAndSample, FileTransferData
+from cg.models.cg_config import DataFlowConfig
 from cg.store.models import Sample
 from housekeeper.store.models import File
 from pydantic import BaseModel
@@ -39,9 +39,13 @@ class MiriaFile(FileTransferData):
     source: str
 
     @classmethod
-    def from_file_and_sample(cls, file: File, sample: Sample) -> "MiriaFile":
+    def from_file_and_sample(
+        cls, file: File, sample: Sample, is_archiving: bool = True
+    ) -> "MiriaFile":
         """Instantiates the class from a File and Sample object."""
-        return cls(destination=sample.internal_id, source=file.path)
+        if is_archiving:
+            return cls(destination=sample.internal_id, source=file.path)
+        return cls(destination=file.path, source=sample.internal_id)
 
     def trim_path(self, attribute_to_trim: str):
         """Trims the given attribute (source or destination) from its root directory."""
@@ -133,7 +137,7 @@ class TransferJob(BaseModel):
 class DDNDataFlowClient(ArchiveHandler):
     """Class for archiving and retrieving folders via DDN Dataflow."""
 
-    def __init__(self, config: DDNDataFlowConfig):
+    def __init__(self, config: DataFlowConfig):
         self.database_name: str = config.database_name
         self.user: str = config.user
         self.password: str = config.password
@@ -162,7 +166,7 @@ class DDNDataFlowClient(ArchiveHandler):
             ).model_dump(),
         )
         if not response.ok:
-            raise DdnDataflowAuthenticationError(message=response.content)
+            raise DdnDataflowAuthenticationError(message=response.text)
         response_content: AuthToken = AuthToken.model_validate_json(response.content.decode())
         self.refresh_token: str = response_content.refresh
         self.auth_token: str = response_content.access
@@ -188,11 +192,14 @@ class DDNDataFlowClient(ArchiveHandler):
             self._refresh_auth_token()
         return {"Authorization": f"Bearer {self.auth_token}"}
 
-    def archive_folders(self, sources_and_destinations: List[MiriaFile]) -> int:
+    def archive_folders(self, files_and_samples: List[FileAndSample]) -> int:
         """Archives all folders provided, to their corresponding destination, as given by sources
         and destination in TransferData. Returns the job ID of the archiving task."""
+        miria_file_data: List[MiriaFile] = self.convert_into_transfer_data(
+            files_and_samples, is_archiving=True
+        )
         transfer_request: TransferPayload = self.create_transfer_request(
-            sources_and_destinations, is_archiving_request=True
+            miria_file_data=miria_file_data, is_archiving_request=True
         )
         job_id: int = transfer_request.post_request(
             headers=dict(self.headers, **self.auth_header),
@@ -200,11 +207,14 @@ class DDNDataFlowClient(ArchiveHandler):
         )
         return job_id
 
-    def retrieve_folders(self, sources_and_destinations: List[MiriaFile]) -> bool:
+    def retrieve_folders(self, files_and_samples: List[FileAndSample]) -> int:
         """Retrieves all folders provided, to their corresponding destination, as given by sources
         and destination in TransferData. Returns the job ID of the retrieval task."""
+        miria_file_data: List[MiriaFile] = self.convert_into_transfer_data(
+            files_and_samples, is_archiving=False
+        )
         transfer_request: TransferPayload = self.create_transfer_request(
-            sources_and_destinations, is_archiving_request=False
+            miria_file_data=miria_file_data, is_archiving_request=False
         )
         job_id: int = transfer_request.post_request(
             headers=dict(self.headers, **self.auth_header),
@@ -213,7 +223,7 @@ class DDNDataFlowClient(ArchiveHandler):
         return job_id
 
     def create_transfer_request(
-        self, sources_and_destinations: List[MiriaFile], is_archiving_request: bool
+        self, miria_file_data: List[MiriaFile], is_archiving_request: bool
     ) -> TransferPayload:
         """Performs the necessary curation of paths for the request to be valid, depending on if
         it is an archiving or a retrieve request.
@@ -228,11 +238,19 @@ class DDNDataFlowClient(ArchiveHandler):
             else (self.archive_repository, self.local_storage, DESTINATION_ATTRIBUTE)
         )
 
-        transfer_request: TransferPayload = TransferPayload(
-            files_to_transfer=sources_and_destinations
-        )
+        transfer_request: TransferPayload = TransferPayload(files_to_transfer=miria_file_data)
         transfer_request.trim_paths(attribute_to_trim=attribute)
         transfer_request.add_repositories(
             source_prefix=source_prefix, destination_prefix=destination_prefix
         )
         return transfer_request
+
+    def convert_into_transfer_data(
+        self, files_and_samples: List[FileAndSample], is_archiving: bool = True
+    ) -> List[MiriaFile]:
+        return [
+            MiriaFile.from_file_and_sample(
+                file=file_and_sample.file, sample=file_and_sample.sample, is_archiving=is_archiving
+            )
+            for file_and_sample in files_and_samples
+        ]

--- a/cg/meta/archive/models.py
+++ b/cg/meta/archive/models.py
@@ -1,34 +1,33 @@
 """Contains base models to be inherited from in other archive software files."""
-from abc import abstractmethod, ABC
+from abc import abstractmethod
 from typing import List
 
+from cg.store.models import Sample
 from housekeeper.store.models import File
 from pydantic import BaseModel
 
-from cg.store.models import Sample
 
-
-class ArchiveFile(ABC, BaseModel):
+class FileTransferData(BaseModel):
     """Base class for classes representing files to be archived."""
 
     @classmethod
     @abstractmethod
     def from_file_and_sample(cls, file: File, sample: Sample) -> "ArchiveFile":
         """Instantiates the class from a File and Sample object."""
-        raise NotImplementedError
+        pass
 
 
-class ArchiveInterface(ABC):
+class ArchiveHandler:
     """Base class for classes handling different archiving programs."""
 
     @abstractmethod
-    def archive_folders(self, sources_and_destinations: List[ArchiveFile]):
+    def archive_folders(self, sources_and_destinations: List[FileTransferData]):
         """Archives all folders provided, to their corresponding destination,
         as given by sources and destination parameter."""
-        raise NotImplementedError
+        pass
 
     @abstractmethod
-    def retrieve_folders(self, sources_and_destinations: List[ArchiveFile]):
+    def retrieve_folders(self, sources_and_destinations: List[FileTransferData]):
         """Retrieves all folders provided, to their corresponding destination, as given by the
         sources and destination parameter."""
-        raise NotImplementedError
+        pass

--- a/cg/meta/archive/models.py
+++ b/cg/meta/archive/models.py
@@ -28,7 +28,9 @@ class FileTransferData(BaseModel):
 class ArchiveHandler:
     """Base class for classes handling different archiving programs."""
 
+    @abstractmethod
     def __init__(self, config: DataFlowConfig):
+        """Initiates the ArchiveHandler based on the provided configuration."""
         pass
 
     @abstractmethod
@@ -46,5 +48,6 @@ class ArchiveHandler:
     @abstractmethod
     def convert_into_transfer_data(
         self, files_and_samples: List[FileAndSample], is_archiving: bool = True
-    ):
+    ) -> List[FileTransferData]:
+        """Converts the provided files_and_samples into a list of objects formatted for the specific archiving flow."""
         pass

--- a/cg/meta/archive/models.py
+++ b/cg/meta/archive/models.py
@@ -8,7 +8,6 @@ from housekeeper.store.models import File
 from pydantic import BaseModel
 from pydantic.v1 import ConfigDict
 
-from cg.store.models import Sample
 
 class FileAndSample(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/cg/meta/archive/models.py
+++ b/cg/meta/archive/models.py
@@ -2,9 +2,17 @@
 from abc import abstractmethod
 from typing import List
 
+from cg.models.cg_config import DataFlowConfig
 from cg.store.models import Sample
 from housekeeper.store.models import File
 from pydantic import BaseModel
+from pydantic.v1 import ConfigDict
+
+
+class FileAndSample(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    file: File
+    sample: Sample
 
 
 class FileTransferData(BaseModel):
@@ -12,7 +20,7 @@ class FileTransferData(BaseModel):
 
     @classmethod
     @abstractmethod
-    def from_file_and_sample(cls, file: File, sample: Sample) -> "ArchiveFile":
+    def from_file_and_sample(cls, file: File, sample: Sample, is_archiving: bool) -> "ArchiveFile":
         """Instantiates the class from a File and Sample object."""
         pass
 
@@ -20,8 +28,11 @@ class FileTransferData(BaseModel):
 class ArchiveHandler:
     """Base class for classes handling different archiving programs."""
 
+    def __init__(self, config: DataFlowConfig):
+        pass
+
     @abstractmethod
-    def archive_folders(self, sources_and_destinations: List[FileTransferData]):
+    def archive_folders(self, files_and_samples: List[FileAndSample]):
         """Archives all folders provided, to their corresponding destination,
         as given by sources and destination parameter."""
         pass
@@ -30,4 +41,10 @@ class ArchiveHandler:
     def retrieve_folders(self, sources_and_destinations: List[FileTransferData]):
         """Retrieves all folders provided, to their corresponding destination, as given by the
         sources and destination parameter."""
+        pass
+
+    @abstractmethod
+    def convert_into_transfer_data(
+        self, files_and_samples: List[FileAndSample], is_archiving: bool = True
+    ):
         pass

--- a/cg/models/cg_config.py
+++ b/cg/models/cg_config.py
@@ -1,9 +1,6 @@
 import logging
 from typing import Optional
 
-from pydantic.v1 import BaseModel, EmailStr, Field
-from typing_extensions import Literal
-
 from cg.apps.cgstats.stats import StatsAPI
 from cg.apps.coverage import ChanjoAPI
 from cg.apps.crunchy import CrunchyAPI
@@ -21,6 +18,8 @@ from cg.apps.tb import TrailblazerAPI
 from cg.constants.observations import LoqusdbInstance
 from cg.constants.priority import SlurmQos
 from cg.store import Store
+from pydantic.v1 import BaseModel, EmailStr, Field
+from typing_extensions import Literal
 
 LOG = logging.getLogger(__name__)
 
@@ -226,7 +225,7 @@ class ExternalConfig(BaseModel):
     caesar: str
 
 
-class DDNDataFlowConfig(BaseModel):
+class DataFlowConfig(BaseModel):
     database_name: str
     user: str
     password: str
@@ -258,7 +257,7 @@ class CGConfig(BaseModel):
     crunchy: CrunchyConfig = None
     crunchy_api_: CrunchyAPI = None
     data_delivery: DataDeliveryConfig = Field(None, alias="data-delivery")
-    ddn: Optional[DDNDataFlowConfig] = None
+    data_flow_config: Optional[DataFlowConfig] = None
     demultiplex: DemultiplexConfig = None
     demultiplex_api_: DemultiplexingAPI = None
     encryption: Optional[CommonAppConfig] = None

--- a/tests/meta/archive/conftest.py
+++ b/tests/meta/archive/conftest.py
@@ -6,7 +6,7 @@ from unittest import mock
 import pytest
 from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.constants import SequencingFileTag
-from cg.constants.archiving import ArchiveLocationsInUse
+from cg.constants.archiving import ArchiveLocations
 from cg.constants.constants import FileFormat
 from cg.constants.subject import Gender
 from cg.io.controller import WriteStream
@@ -138,7 +138,7 @@ def fixture_archive_store(
         invoice_reference="Sherlock Holmes",
         name="Sherlock Holmes",
         is_clinical=True,
-        data_archive_location=ArchiveLocationsInUse.KAROLINSKA_BUCKET,
+        data_archive_location=ArchiveLocations.KAROLINSKA_BUCKET,
     )
     customer_without_ddn: Customer = base_store.add_customer(
         internal_id="CustWithoutDDN",

--- a/tests/meta/archive/conftest.py
+++ b/tests/meta/archive/conftest.py
@@ -12,9 +12,11 @@ from cg.constants.subject import Gender
 from cg.io.controller import WriteStream
 from cg.meta.archive.archive import SpringArchiveAPI
 from cg.meta.archive.ddn_dataflow import ROOT_TO_TRIM, DDNDataFlowClient, MiriaFile, TransferPayload
-from cg.models.cg_config import DDNDataFlowConfig
+from cg.meta.archive.models import FileAndSample
+from cg.models.cg_config import DataFlowConfig
 from cg.store import Store
 from cg.store.models import Customer, Sample
+from housekeeper.store.models import File
 from requests import Response
 from tests.store_helpers import StoreHelpers
 
@@ -22,9 +24,9 @@ from tests.store_helpers import StoreHelpers
 @pytest.fixture(name="ddn_dataflow_config")
 def fixture_ddn_dataflow_config(
     local_storage_repository: str, remote_storage_repository: str
-) -> DDNDataFlowConfig:
+) -> DataFlowConfig:
     """Returns a mock DDN Dataflow config."""
-    return DDNDataFlowConfig(
+    return DataFlowConfig(
         database_name="test_db",
         user="test_user",
         password="DummyPassword",
@@ -41,7 +43,7 @@ def fixture_ok_ddn_response(ok_response: Response):
 
 
 @pytest.fixture(name="ddn_dataflow_client")
-def fixture_ddn_dataflow_client(ddn_dataflow_config: DDNDataFlowConfig) -> DDNDataFlowClient:
+def fixture_ddn_dataflow_client(ddn_dataflow_config: DataFlowConfig) -> DDNDataFlowClient:
     """Returns a DDNApi without tokens being set."""
     mock_ddn_auth_success_response = Response()
     mock_ddn_auth_success_response.status_code = 200
@@ -64,6 +66,20 @@ def fixture_ddn_dataflow_client(ddn_dataflow_config: DDNDataFlowConfig) -> DDNDa
 def fixture_miria_file(local_directory: Path, remote_path: Path) -> MiriaFile:
     """Return a MiriaFile for archiving."""
     return MiriaFile(source=local_directory.as_posix(), destination=remote_path.as_posix())
+
+
+@pytest.fixture(name="file_and_sample")
+def fixture_file_and_sample(spring_archive_api: SpringArchiveAPI, sample_id: str):
+    return FileAndSample(
+        file=spring_archive_api.housekeeper_api.get_files(bundle=sample_id).first(),
+        sample=spring_archive_api.status_db.get_sample_by_internal_id(sample_id),
+    )
+
+
+@pytest.fixture(name="trimmed_local_path")
+def fixture_trimmed_local_path(spring_archive_api: SpringArchiveAPI, sample_id: str):
+    file: File = spring_archive_api.housekeeper_api.get_files(bundle=sample_id).first()
+    return file.path[5:]
 
 
 @pytest.fixture(name="miria_file_retrieve")
@@ -107,7 +123,7 @@ def fixture_local_storage_repository() -> str:
 @pytest.fixture(name="remote_storage_repository")
 def fixture_remote_storage_repository() -> str:
     """Returns a remote storage repository."""
-    return "archive@repisitory:"
+    return "archive@repository:"
 
 
 @pytest.fixture(name="full_remote_path")
@@ -131,7 +147,7 @@ def fixture_archive_store(
     mother_sample_id,
     sample_name,
 ) -> Store:
-    """Returns a store with samples for both a DDN customer as well as a non-DDN customer."""
+    """Returns a store with samples for both a DDN customer and a non-DDN customer."""
     customer_ddn: Customer = base_store.add_customer(
         internal_id="CustWithDDN",
         invoice_address="Baker Street 221B",
@@ -184,7 +200,7 @@ def fixture_archive_store(
 def fixture_spring_archive_api(
     populated_housekeeper_api: HousekeeperAPI,
     archive_store: Store,
-    ddn_dataflow_client: DDNDataFlowClient,
+    ddn_dataflow_config: DataFlowConfig,
     father_sample_id: str,
     helpers,
 ) -> SpringArchiveAPI:
@@ -196,5 +212,5 @@ def fixture_spring_archive_api(
     return SpringArchiveAPI(
         housekeeper_api=populated_housekeeper_api,
         status_db=archive_store,
-        ddn_dataflow_client=ddn_dataflow_client,
+        data_flow_config=ddn_dataflow_config,
     )

--- a/tests/meta/archive/conftest.py
+++ b/tests/meta/archive/conftest.py
@@ -4,7 +4,6 @@ from typing import List
 from unittest import mock
 
 import pytest
-
 from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.constants import SequencingFileTag
 from cg.constants.archiving import ArchiveLocationsInUse
@@ -12,12 +11,7 @@ from cg.constants.constants import FileFormat
 from cg.constants.subject import Gender
 from cg.io.controller import WriteStream
 from cg.meta.archive.archive import SpringArchiveAPI
-from cg.meta.archive.ddn_dataflow import (
-    ROOT_TO_TRIM,
-    DDNDataFlowClient,
-    MiriaFile,
-    TransferPayload,
-)
+from cg.meta.archive.ddn_dataflow import ROOT_TO_TRIM, DDNDataFlowClient, MiriaFile, TransferPayload
 from cg.models.cg_config import DDNDataFlowConfig
 from cg.store import Store
 from cg.store.models import Customer, Sample
@@ -190,6 +184,7 @@ def fixture_archive_store(
 def fixture_spring_archive_api(
     populated_housekeeper_api: HousekeeperAPI,
     archive_store: Store,
+    ddn_dataflow_client: DDNDataFlowClient,
     father_sample_id: str,
     helpers,
 ) -> SpringArchiveAPI:
@@ -201,4 +196,5 @@ def fixture_spring_archive_api(
     return SpringArchiveAPI(
         housekeeper_api=populated_housekeeper_api,
         status_db=archive_store,
+        ddn_dataflow_client=ddn_dataflow_client,
     )

--- a/tests/meta/archive/test_archive_api.py
+++ b/tests/meta/archive/test_archive_api.py
@@ -139,7 +139,7 @@ def test_convert_into_transfer_data(
     )
 
     # THEN the returned object should be of the correct type
-    assert type(transferdata[0]) == MiriaFile
+    assert isinstance(transferdata[0], MiriaFile)
 
 
 def test_call_corresponding_archiving_method(spring_archive_api: SpringArchiveAPI, sample_id: str):

--- a/tests/meta/archive/test_archive_api.py
+++ b/tests/meta/archive/test_archive_api.py
@@ -3,9 +3,9 @@ from unittest import mock
 
 from cg.constants.archiving import ArchiveLocations
 from cg.meta.archive.archive import (
+    ARCHIVE_HANDLERS,
     FileAndSample,
     SpringArchiveAPI,
-    archive_handlers,
     filter_files_on_archive_location,
 )
 from cg.meta.archive.ddn_dataflow import DDNDataFlowClient, MiriaFile
@@ -130,7 +130,7 @@ def test_convert_into_transfer_data(
         return_value=123,
     ):
         # WHEN calling the corresponding archive method
-        data_flow_client: ArchiveHandler = archive_handlers[ArchiveLocations.KAROLINSKA_BUCKET](
+        data_flow_client: ArchiveHandler = ARCHIVE_HANDLERS[ArchiveLocations.KAROLINSKA_BUCKET](
             config=ddn_dataflow_config
         )
     # WHEN using it to instantiate the correct class

--- a/tests/meta/archive/test_archive_api.py
+++ b/tests/meta/archive/test_archive_api.py
@@ -1,7 +1,7 @@
 from typing import List
 from unittest import mock
 
-from cg.constants.archiving import ArchiveLocationsInUse
+from cg.constants.archiving import ArchiveLocations
 from cg.meta.archive.archive import (
     FileAndSample,
     SpringArchiveAPI,
@@ -26,13 +26,13 @@ def test_get_files_by_archive_location(
     ]
     # WHEN fetching the files by archive location
     selected_files: List[FileAndSample] = filter_files_on_archive_location(
-        files_and_samples, ArchiveLocationsInUse.KAROLINSKA_BUCKET
+        files_and_samples, ArchiveLocations.KAROLINSKA_BUCKET
     )
 
     # THEN every file returned should have that archive location
     assert selected_files
     for selected_file in selected_files:
-        assert selected_file.sample.archive_location == ArchiveLocationsInUse.KAROLINSKA_BUCKET
+        assert selected_file.sample.archive_location == ArchiveLocations.KAROLINSKA_BUCKET
 
 
 def test_add_samples_to_files(spring_archive_api: SpringArchiveAPI):
@@ -117,7 +117,7 @@ def test_convert_into_transfer_data(sample_id: str, spring_archive_api: SpringAr
     # WHEN using it to instantiate the correct class
     transferdata: List[FileTransferData] = spring_archive_api.convert_files_into_transfer_data(
         files_and_samples=[file_and_sample],
-        archive_location=ArchiveLocationsInUse.KAROLINSKA_BUCKET,
+        archive_location=ArchiveLocations.KAROLINSKA_BUCKET,
     )
 
     # THEN the returned object should be of the correct type
@@ -137,7 +137,7 @@ def test_call_corresponding_archiving_method(
     ) as mock_request_submitter:
         # WHEN calling the corresponding archive method
         spring_archive_api.call_corresponding_archiving_method(
-            files=[miria_file_archive], archive_location=ArchiveLocationsInUse.KAROLINSKA_BUCKET
+            files=[miria_file_archive], archive_location=ArchiveLocations.KAROLINSKA_BUCKET
         )
 
     # THEN the correct archive function should have been called once

--- a/tests/meta/archive/test_archive_api.py
+++ b/tests/meta/archive/test_archive_api.py
@@ -107,7 +107,7 @@ def test_get_sample_not_exists(
     assert file.path in caplog.text
 
 
-def test_convert_into_correct_model(sample_id: str, spring_archive_api: SpringArchiveAPI):
+def test_convert_into_transfer_data(sample_id: str, spring_archive_api: SpringArchiveAPI):
     """Tests instantiating the correct dataclass for a sample."""
     # GIVEN file and Sample
     file_and_sample = FileAndSample(
@@ -115,7 +115,7 @@ def test_convert_into_correct_model(sample_id: str, spring_archive_api: SpringAr
         sample=spring_archive_api.status_db.get_sample_by_internal_id(sample_id),
     )
     # WHEN using it to instantiate the correct class
-    transferdata: List[FileTransferData] = spring_archive_api.convert_into_correct_model(
+    transferdata: List[FileTransferData] = spring_archive_api.convert_files_into_transfer_data(
         files_and_samples=[file_and_sample],
         archive_location=ArchiveLocationsInUse.KAROLINSKA_BUCKET,
     )
@@ -124,10 +124,10 @@ def test_convert_into_correct_model(sample_id: str, spring_archive_api: SpringAr
     assert type(transferdata[0]) == MiriaFile
 
 
-def test_call_corresponding_archiving_function(
+def test_call_corresponding_archiving_method(
     spring_archive_api: SpringArchiveAPI, miria_file_archive: MiriaFile
 ):
-    """Tests so that the correct archiving function is used when"""
+    """Tests so that the correct archiving function is used when providing a Karolinska customer."""
     # GIVEN a file to be transferred
     # GIVEN a spring_archive_api with a mocked archive function
     with mock.patch.object(
@@ -136,7 +136,7 @@ def test_call_corresponding_archiving_function(
         return_value=123,
     ) as mock_request_submitter:
         # WHEN calling the corresponding archive method
-        spring_archive_api.call_corresponding_archiving_function(
+        spring_archive_api.call_corresponding_archiving_method(
             files=[miria_file_archive], archive_location=ArchiveLocationsInUse.KAROLINSKA_BUCKET
         )
 


### PR DESCRIPTION
## Description

This PR aims to address some issues raised in PR #2302 and aims to make the SpringArchiveAPI agnostic of the implementation. This entails moving functionality from SpringArchiveAPI to the different ArchiveHandlers. Also, in the process some issues with the tests were addressed.

### Added

- Fixture for a FileAndSample object.
- Fixture for a trimmed local path.

### Changed

- Moved class FileAndSample to cg.meta.archive.models
- Moved the handler dictionary out of the instantiation of the SpringArchiveAPI
- Instead of a DDNDataFlowClient, you give a DataFlowConfig as input to the SpringArchiveAPI. This config is used to instantiate an arbitrary ArchiveHandler.
- Renamed "call_corresponding_archiving_method" to "archive_files".
- Moved convert_files_into_transfer_data from SpringArchiveAPI to ArchiveHandler.
-  Added support for creating file transfer data which adapts to whether you are archiving or retrieving files. This is needed as the source and destination given in the request reverses between the two.
- Renamed DDNDataFlowConfig to DataFlowConfig, which is intended to be a config which can be used to instantiate the DDN archive handler, but also any other, should we add some in the future.
- archive_folders and retrieve_folders now take a list of files and samples as input, and conversion to the correct format for the handler is done within the ArchiveHandler within this flow.
- Renamed sources_and_destinations to miria_file_data within the DDNDataFlowClient.

### Fixed

- Some typos and imports.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
