### PR TITLE
Remove old demux post processing flow from cli

### DIFF
--- a/cg/cli/demultiplex/finish.py
+++ b/cg/cli/demultiplex/finish.py
@@ -7,7 +7,6 @@ from cg.constants.constants import DRY_RUN
 from cg.constants.demultiplexing import OPTION_BCL_CONVERTER, BclConverter
 from cg.meta.demultiplex.demux_post_processing import (
     DemuxPostProcessingAPI,
-    DemuxPostProcessingNovaseqAPI,
     DemuxPostProcessingHiseqXAPI,
 )
 from cg.models.cg_config import CGConfig
@@ -26,16 +25,10 @@ def finish_group():
 @click.pass_obj
 def finish_all_cmd(context: CGConfig, bcl_converter: str, dry_run: bool) -> None:
     """Command to post-process all demultiplexed flow cells."""
-    demux_post_processing_api: DemuxPostProcessingNovaseqAPI = DemuxPostProcessingNovaseqAPI(
-        config=context
-    )
-    demux_post_processing_api.set_dry_run(dry_run=dry_run)
-    demux_post_processing_api.finish_all_flow_cells(bcl_converter=bcl_converter)
+    demux_post_processing_api = DemuxPostProcessingAPI(context)
+    demux_post_processing_api.set_dry_run(dry_run)
+    is_error_raised: bool = demux_post_processing_api.finish_all_flow_cells_temp()
 
-    # Temporary finish flow cell logic will replace logic above when validated
-    demux_post_processing_api_temp: DemuxPostProcessingAPI = DemuxPostProcessingAPI(config=context)
-    demux_post_processing_api_temp.set_dry_run(dry_run=dry_run)
-    is_error_raised: bool = demux_post_processing_api_temp.finish_all_flow_cells_temp()
     if is_error_raised:
         raise click.Abort
 
@@ -53,41 +46,11 @@ def finish_flow_cell(
 
     flow-cell-name is full flow cell name, e.g. '201203_A00689_0200_AHVKJCDRXX'.
     """
-
-    demux_post_processing_api: DemuxPostProcessingNovaseqAPI = DemuxPostProcessingNovaseqAPI(
-        config=context
-    )
+    demux_post_processing_api: DemuxPostProcessingAPI = DemuxPostProcessingAPI(context)
     demux_post_processing_api.set_dry_run(dry_run)
-    demux_post_processing_api.finish_flow_cell(
-        flow_cell_name=flow_cell_name, force=force, bcl_converter=bcl_converter
-    )
-    # Temporary finish flow cell logic will replace logic above when validated
-    demux_post_processing_api_temp: DemuxPostProcessingAPI = DemuxPostProcessingAPI(config=context)
-    demux_post_processing_api_temp.set_dry_run(dry_run)
-    demux_post_processing_api_temp.finish_flow_cell_temp(
+    demux_post_processing_api.finish_flow_cell_temp(
         flow_cell_directory_name=flow_cell_name, force=force
     )
-
-
-@finish_group.command(name="temporary")
-@click.argument("flow-cell-directory-name")
-@click.option("--force", is_flag=True)
-@click.pass_obj
-def finish_flow_cell_temporary(context: CGConfig, flow_cell_directory_name: str, force: bool):
-    demux_post_processing_api: DemuxPostProcessingAPI = DemuxPostProcessingAPI(config=context)
-    demux_post_processing_api.finish_flow_cell_temp(
-        flow_cell_directory_name=flow_cell_directory_name, force=force
-    )
-
-
-@finish_group.command(name="temporary-all")
-@click.pass_obj
-@DRY_RUN
-def finish_flow_cell_temporary_all(context: CGConfig, dry_run: bool):
-    # Temporary finish flow cell logic will replace logic above when validated
-    demux_post_processing_api_temp: DemuxPostProcessingAPI = DemuxPostProcessingAPI(config=context)
-    demux_post_processing_api_temp.set_dry_run(dry_run=dry_run)
-    demux_post_processing_api_temp.finish_all_flow_cells_temp()
 
 
 @finish_group.command(name="all-hiseq-x")
@@ -100,4 +63,4 @@ def finish_all_hiseq_x(context: CGConfig, dry_run: bool) -> None:
         config=context
     )
     demux_post_processing_api.set_dry_run(dry_run=dry_run)
-    demux_post_processing_api.finish_all_flow_cells(bcl_converter=BclConverter.BCL2FASTQ.value)
+    demux_post_processing_api.finish_all_flow_cells_temp()


### PR DESCRIPTION
## Description
This PR removes the usage of the old demultiplex post processing flow from the cli, ensuring that we stop relying on cgstats for any parts related to the demux post processing.

### Fixed
- Remove old demux post processing flow from cli

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes


