### PR TITLE
feat(retrieve demux run dir by flow cell type) 

### DIFF
--- a/cg/apps/demultiplex/demultiplex_api.py
+++ b/cg/apps/demultiplex/demultiplex_api.py
@@ -32,7 +32,7 @@ class DemultiplexingAPI:
         self.slurm_api = SlurmAPI()
         self.slurm_account: str = config["demultiplex"]["slurm"]["account"]
         self.mail: str = config["demultiplex"]["slurm"]["mail_user"]
-        self.run_dir: Path = self.get_run_dir_by_sequencer_type()
+        self.run_dir: Path = self.get_run_dir_by_sequencer_type(config=config)
         self.out_dir: Path = out_dir or Path(config["demultiplex"]["out_dir"])
         self.environment: str = config.get("environment", "stage")
         LOG.info(f"Set environment to {self.environment}")
@@ -43,11 +43,10 @@ class DemultiplexingAPI:
         """Return SLURM quality of service."""
         return SlurmQos.LOW if self.environment == "stage" else SlurmQos.HIGH
 
-    @property
-    def set_run_dir_by_sequencer_type(
-        self,
+    @staticmethod
+    def get_run_dir_by_sequencer_type(
         config: dict,
-        sequencer_type: str = None,
+        sequencer_type: Optional[str] = None,
     ) -> Path:
         """Return run dir for sequencer type.
         Defaults to novaseq flow cell runs dir."""

--- a/cg/apps/demultiplex/demultiplex_api.py
+++ b/cg/apps/demultiplex/demultiplex_api.py
@@ -52,12 +52,12 @@ class DemultiplexingAPI:
         """Return run dir for sequencer type.
         Defaults to novaseq flow cell runs dir."""
         if sequencer_types[sequencer_type] == Sequencers.HISEQX:
-            return Path(config["demultiplex"]["run_dir_hiseqx"])
+            return Path(config["demultiplex"]["run_dir"]["hiseqx"])
         elif sequencer_types[sequencer_type] == Sequencers.HISEQGA:
-            return Path(config["demultiplex"]["run_dir_hiseqga"])
+            return Path(config["demultiplex"]["run_dir"]["hiseqga"])
         elif sequencer_types[sequencer_type] == Sequencers.NOVASEQX:
-            return Path(config["demultiplex"]["run_dir_novaseqx"])
-        return Path(config["demultiplex"]["run_dir_novaseq"])
+            return Path(config["demultiplex"]["run_dir"]["novaseqx"])
+        return Path(config["demultiplex"]["run_dir"]["novaseq"])
 
     def set_dry_run(self, dry_run: bool) -> None:
         """Set dry run."""

--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -97,7 +97,15 @@ class DemuxPostProcessingAPI:
         LOG.info(f"Finish flow cell {flow_cell_directory_name}")
 
         flow_cell_out_directory: Path = Path(self.demux_api.out_dir, flow_cell_directory_name)
-        flow_cell_run_directory: Path = Path(self.demux_api.run_dir, flow_cell_directory_name)
+        bcl_converter: str = get_bcl_converter_name(flow_cell_out_directory)
+        parsed_flow_cell: FlowCellDirectoryData = parse_flow_cell_directory_data(
+            flow_cell_directory=flow_cell_out_directory,
+            bcl_converter=bcl_converter,
+        )
+
+        flow_cell_run_directory: Path = self.demux_api.get_run_dir_by_sequencer_type(
+            sequencer_type=parsed_flow_cell.sequencer_type
+        )
 
         try:
             is_flow_cell_ready_for_postprocessing(
@@ -108,13 +116,6 @@ class DemuxPostProcessingAPI:
         except FlowCellError as e:
             LOG.error(f"Flow cell {flow_cell_directory_name} will be skipped: {e}")
             return
-
-        bcl_converter: str = get_bcl_converter_name(flow_cell_out_directory)
-
-        parsed_flow_cell: FlowCellDirectoryData = parse_flow_cell_directory_data(
-            flow_cell_directory=flow_cell_out_directory,
-            bcl_converter=bcl_converter,
-        )
 
         copy_sample_sheet(
             sample_sheet_source_directory=flow_cell_run_directory,


### PR DESCRIPTION
## Description

Adds the logic to retriece a flow cell run dir by sequencer type. 
Issue: #2316

PR for server config:
```
demultiplex:
  run_dirs:
    hiseqx: "/home/proj/production/flowcells/hiseqx"
    hiseqga: "/home/proj/production/flowcells/2500/runs/"
    novaseq: "/home/proj/production/flowcells/novaseq/runs/"
    novaseqx: "/home/proj/production/flowcells/novaseqx/runs/"
```

### Added

-

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
