### PR TITLE
fix(add samples to flow cell if it already exists)

### DIFF
--- a/cg/meta/demultiplex/status_db_storage_functions.py
+++ b/cg/meta/demultiplex/status_db_storage_functions.py
@@ -44,7 +44,7 @@ def store_flow_cell_data_in_status_db(
         sample_sheet_path=parsed_flow_cell.sample_sheet_path,
         flow_cell_sample_type=parsed_flow_cell.sample_type,
     )
-    flow_cell = add_samples_to_flow_cell_in_status_db(
+    flow_cell: Flowcell = add_samples_to_flow_cell_in_status_db(
         flow_cell=flow_cell,
         sample_internal_ids=sample_internal_ids,
         store=store,

--- a/cg/meta/demultiplex/status_db_storage_functions.py
+++ b/cg/meta/demultiplex/status_db_storage_functions.py
@@ -29,7 +29,7 @@ def store_flow_cell_data_in_status_db(
     Create flow cell from the parsed and validated flow cell data.
     And add the samples on the flow cell to the model.
     """
-    flow_cell: Flowcell = store.get_flow_cell_by_name(flow_cell_name=parsed_flow_cell.id)
+    flow_cell: Optional[Flowcell] = store.get_flow_cell_by_name(flow_cell_name=parsed_flow_cell.id)
     if not flow_cell:
         flow_cell: Flowcell = Flowcell(
             name=parsed_flow_cell.id,
@@ -44,7 +44,7 @@ def store_flow_cell_data_in_status_db(
         sample_sheet_path=parsed_flow_cell.sample_sheet_path,
         flow_cell_sample_type=parsed_flow_cell.sample_type,
     )
-    flow_cell: Flowcell = add_samples_to_flow_cell_in_status_db(
+    add_samples_to_flow_cell_in_status_db(
         flow_cell=flow_cell,
         sample_internal_ids=sample_internal_ids,
         store=store,

--- a/cg/meta/demultiplex/status_db_storage_functions.py
+++ b/cg/meta/demultiplex/status_db_storage_functions.py
@@ -25,28 +25,33 @@ LOG = logging.getLogger(__name__)
 def store_flow_cell_data_in_status_db(
     parsed_flow_cell: FlowCellDirectoryData, store: Store
 ) -> None:
-    """Create flow cell from the parsed and validated flow cell data."""
-    if not store.get_flow_cell_by_name(flow_cell_name=parsed_flow_cell.id):
+    """
+    Create flow cell from the parsed and validated flow cell data.
+    And add the samples on the flow cell to the model.
+    """
+    flow_cell: Flowcell = store.get_flow_cell_by_name(flow_cell_name=parsed_flow_cell.id)
+    if not flow_cell:
         flow_cell: Flowcell = Flowcell(
             name=parsed_flow_cell.id,
             sequencer_type=parsed_flow_cell.sequencer_type,
             sequencer_name=parsed_flow_cell.machine_name,
             sequenced_at=parsed_flow_cell.run_date,
         )
-        sample_internal_ids = get_sample_internal_ids_from_sample_sheet(
-            sample_sheet_path=parsed_flow_cell.sample_sheet_path,
-            flow_cell_sample_type=parsed_flow_cell.sample_type,
-        )
-        flow_cell = add_samples_to_flow_cell_in_status_db(
-            flow_cell=flow_cell,
-            sample_internal_ids=sample_internal_ids,
-            store=store,
-        )
-        store.session.add(flow_cell)
-        store.session.commit()
         LOG.info(f"Flow cell added to status db: {parsed_flow_cell.id}.")
     else:
-        LOG.info(f"Flow cell already exists in status db: {parsed_flow_cell.id}. Skipping.")
+        LOG.info(f"Flow cell already exists in status db: {parsed_flow_cell.id}.")
+    sample_internal_ids = get_sample_internal_ids_from_sample_sheet(
+        sample_sheet_path=parsed_flow_cell.sample_sheet_path,
+        flow_cell_sample_type=parsed_flow_cell.sample_type,
+    )
+    flow_cell = add_samples_to_flow_cell_in_status_db(
+        flow_cell=flow_cell,
+        sample_internal_ids=sample_internal_ids,
+        store=store,
+    )
+    LOG.info(f"Added samples to flow cell: {parsed_flow_cell.id}.")
+    store.session.add(flow_cell)
+    store.session.commit()
 
 
 def add_samples_to_flow_cell_in_status_db(


### PR DESCRIPTION
## Description

This PR changes the behaviour of the `store_flow_cell_data_in_status_db` so that samples can be added to an existing flow cell.

This behaviour is wanted to avoid the need to delete flow cells in the associated samples need to be altered in cases of re-demultiplexing of flow cells.

### Added

-

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
