### PR TITLE
added command to decrypt, added process test

### DIFF
--- a/cg/cli/backup.py
+++ b/cg/cli/backup.py
@@ -46,7 +46,7 @@ def decrypt_flow_cell(
     encryption_api = EncryptionAPI(binary_path=context.encryption.binary_path, dry_run=dry_run)
     tar_api = TarAPI(binary_path=context.tar.binary_path, dry_run=dry_run)
     status_api: Store = context.status_db
-    backup_api = BackupAPI(
+    backup_api: BackupAPI = BackupAPI(
         encryption_api=encryption_api,
         encrypt_dir=context.backup.encrypt_dir.dict(),
         status=status_api,
@@ -62,8 +62,8 @@ def decrypt_flow_cell(
 
     backup_api._process_flow_cell(
         flow_cell=flow_cell,
-        archived_key=encrypted_key_path,
-        archived_flow_cell=encrypted_dir_path,
+        archived_key=Path(encrypted_key_path),
+        archived_flow_cell=Path(encrypted_dir_path),
         already_fetched=True,
     )
 

--- a/cg/cli/backup.py
+++ b/cg/cli/backup.py
@@ -55,7 +55,7 @@ def decrypt_flow_cell(
         root_dir=context.backup.root.dict(),
         dry_run=dry_run,
     )
-    flow_cell: Flowcell = status_api.get_flow_cell_by_name(flow_cell_name=flow_cell_id)
+    flow_cell: Optional[Flowcell] = status_api.get_flow_cell_by_name(flow_cell_id)
     if not flow_cell and flow_cell_id:
         LOG.error(f"{flow_cell_id}: not found in database")
         raise click.Abort

--- a/cg/meta/backup/backup.py
+++ b/cg/meta/backup/backup.py
@@ -103,16 +103,18 @@ class BackupAPI:
             )
 
     def _process_flow_cell(
-        self, flow_cell: Flowcell, archived_key: Path, archived_flow_cell: Path
+        self, flow_cell: Flowcell, archived_key: Path, archived_flow_cell: Path, already_fetched: bool = False
     ) -> float:
         """Process a flow cell from backup. Return elapsed time."""
         start_time: float = get_start_time()
         run_dir: Path = Path(self.root_dir[flow_cell.sequencer_type])
-        self.retrieve_archived_key(archived_key=archived_key, flow_cell=flow_cell, run_dir=run_dir)
-        self.retrieve_archived_flow_cell(
-            archived_flow_cell=archived_flow_cell, flow_cell=flow_cell, run_dir=run_dir
-        )
-
+        if not already_fetched:
+            self.retrieve_archived_key(archived_key=archived_key, flow_cell=flow_cell, run_dir=run_dir)
+            self.retrieve_archived_flow_cell(
+                archived_flow_cell=archived_flow_cell, flow_cell=flow_cell, run_dir=run_dir
+            )
+        else:
+            self._set_flow_cell_status_to_retrieved(flow_cell=flow_cell)
         try:
             (
                 decrypted_flow_cell,

--- a/cg/meta/backup/backup.py
+++ b/cg/meta/backup/backup.py
@@ -103,13 +103,19 @@ class BackupAPI:
             )
 
     def _process_flow_cell(
-        self, flow_cell: Flowcell, archived_key: Path, archived_flow_cell: Path, already_fetched: bool = False
+        self,
+        flow_cell: Flowcell,
+        archived_key: Path,
+        archived_flow_cell: Path,
+        already_fetched: bool = False,
     ) -> float:
         """Process a flow cell from backup. Return elapsed time."""
         start_time: float = get_start_time()
         run_dir: Path = Path(self.root_dir[flow_cell.sequencer_type])
         if not already_fetched:
-            self.retrieve_archived_key(archived_key=archived_key, flow_cell=flow_cell, run_dir=run_dir)
+            self.retrieve_archived_key(
+                archived_key=archived_key, flow_cell=flow_cell, run_dir=run_dir
+            )
             self.retrieve_archived_flow_cell(
                 archived_flow_cell=archived_flow_cell, flow_cell=flow_cell, run_dir=run_dir
             )

--- a/tests/meta/backup/test_meta_backup.py
+++ b/tests/meta/backup/test_meta_backup.py
@@ -451,7 +451,7 @@ def test_process_flow_cell(
     )
 
     # THEN when done the status of that flow cell is set to "retrieved"
-    
+
     assert (
         f"Status for flow cell {mock_flow_cell.name} set to {FlowCellStatus.RETRIEVED}"
         in caplog.text


### PR DESCRIPTION
## Description

The aim of this PR is to implement the functionality to decipher a fetched flow cell. 

If for some reason the automatic fetching of flow cells did now work we do not have a manual way to skip the fetch. By calling the `BackupAPI._process_flow_cell()` function with the added `already_fetched` argument the user is now able to process a flow cell after fetching is completed.

To check its functionality there was a test implemented to check if the process command would still do its step despite the added argument.

### Added

- Command to decrypt fetched flow cells
- Test for the `BackupAPI._process_flow_cell` command

### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [x] `cg backup decrypt-flow-cell --encrypted-dir-path <encripted_dir_path> --encrypted-key-path <encrypted-key-path> --flow-cell-id <flow-cell-id>`

### Expected test outcome

- [ ] Check that flow cell directory is decrypted
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
