### PR TITLE
refactor(move finish flow cell all temp to utils)

### DIFF
--- a/cg/cli/demultiplex/finish.py
+++ b/cg/cli/demultiplex/finish.py
@@ -10,6 +10,7 @@ from cg.meta.demultiplex.demux_post_processing import (
     DemuxPostProcessingNovaseqAPI,
     DemuxPostProcessingHiseqXAPI,
 )
+from cg.meta.demultiplex.utils import finish_all_flow_cells_temp
 from cg.models.cg_config import CGConfig
 
 LOG = logging.getLogger(__name__)
@@ -35,7 +36,10 @@ def finish_all_cmd(context: CGConfig, bcl_converter: str, dry_run: bool) -> None
     # Temporary finish flow cell logic will replace logic above when validated
     demux_post_processing_api_temp: DemuxPostProcessingAPI = DemuxPostProcessingAPI(config=context)
     demux_post_processing_api_temp.set_dry_run(dry_run=dry_run)
-    is_error_raised: bool = demux_post_processing_api_temp.finish_all_flow_cells_temp()
+    is_error_raised: bool = finish_all_flow_cells_temp(
+        demux_api=demux_post_processing_api_temp.demux_api,
+        demux_post_processing_api=demux_post_processing_api_temp,
+    )
     if is_error_raised:
         raise click.Abort
 
@@ -87,7 +91,10 @@ def finish_flow_cell_temporary_all(context: CGConfig, dry_run: bool):
     # Temporary finish flow cell logic will replace logic above when validated
     demux_post_processing_api_temp: DemuxPostProcessingAPI = DemuxPostProcessingAPI(config=context)
     demux_post_processing_api_temp.set_dry_run(dry_run=dry_run)
-    demux_post_processing_api_temp.finish_all_flow_cells_temp()
+    finish_all_flow_cells_temp(
+        demux_api=demux_post_processing_api_temp.demux_api,
+        demux_post_processing_api=demux_post_processing_api_temp,
+    )
 
 
 @finish_group.command(name="all-hiseq-x")

--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -128,19 +128,6 @@ class DemuxPostProcessingAPI:
             raise
         create_delivery_file_in_flow_cell_directory(flow_cell_out_directory)
 
-    def finish_all_flow_cells_temp(self) -> bool:
-        """Finish all flow cells that need it."""
-        flow_cell_dirs = self.demux_api.get_all_demultiplexed_flow_cell_dirs()
-        is_error_raised: bool = False
-        for flow_cell_dir in flow_cell_dirs:
-            try:
-                self.finish_flow_cell_temp(flow_cell_dir.name)
-            except Exception as error:
-                LOG.error(f"Failed to finish flow cell {flow_cell_dir.name}: {str(error)}")
-                is_error_raised = True
-                continue
-        return is_error_raised
-
     def store_flow_cell_data(self, parsed_flow_cell: FlowCellDirectoryData) -> None:
         """Store data from the flow cell directory in status db and housekeeper."""
         store_flow_cell_data_in_status_db(parsed_flow_cell=parsed_flow_cell, store=self.status_db)


### PR DESCRIPTION
## Description

This PR moves the `finish_all_flow_cells_temp ` from `cg.meta.demultiplex.demux_post_processing` into the `cg.meta.demultiplex.utils`

Currently we use the `DemultiplexingAPI` in the `DemuxPostProcessingApi`

The reason for this is to fetch `run_dir` and `out_dir` for flow cells and make use of the function `get_all_demultixplexed_flow_cell_dirs`.

The run_dir and out_dir information is present in the config, we can fetch it from there. 

By moving the `finish_all_flow_cells_temp` to utils we can remove the DemultiplexingAPI from DemuxPostProcessingAPI. 

This can make writing tests easier and the code more contained.

### Added

-

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
