### PR TITLE
fix(remove bcl converter option from demultiplex all)

### DIFF
--- a/cg/cli/demultiplex/demux.py
+++ b/cg/cli/demultiplex/demux.py
@@ -48,7 +48,6 @@ def demultiplex_all(context: CGConfig, flow_cells_directory: click.Path, dry_run
         if not flow_cell.validate_sample_sheet():
             LOG.warning(
                 f"Malformed sample sheet. Run cg demultiplex samplesheet validate {flow_cell.sample_sheet_path}",
-
             )
             continue
 
@@ -156,8 +155,8 @@ def delete_flow_cell(
         f"Are you sure you want to delete the flow cell from the following databases:\n"
         f"cg-stats={True if status_db else cg_stats}\nDemultiplexing-dir={True if status_db else demultiplexing_dir}\n"
         f"Housekeeper={True if status_db else housekeeper}\nInit_files={True if status_db else init_files}\n"
-        f"Run-dir={True if status_db else run_dir}\nStatusdb={status_db}"
-        f"\nSample-lane-sequencing-metrics={True if sample_lane_sequencing_metrics else sample_lane_sequencing_metrics}\n"
+        f"Run-dir={True if status_db else run_dir}\nStatusdb={status_db}\n"
+        f"\nSample-lane-sequencing-metrics={True if sample_lane_sequencing_metrics else sample_lane_sequencing_metrics}"
     ):
         delete_demux_api.delete_flow_cell(
             cg_stats=cg_stats,

--- a/cg/cli/demultiplex/demux.py
+++ b/cg/cli/demultiplex/demux.py
@@ -18,8 +18,8 @@ DRY_RUN = click.option("--dry-run", is_flag=True)
 
 
 @click.command(name="all")
-@DRY_RUN
 @click.option("--flow-cells-directory", type=click.Path(exists=True, file_okay=False))
+@DRY_RUN
 @click.pass_obj
 def demultiplex_all(context: CGConfig, flow_cells_directory: click.Path, dry_run: bool):
     """Demultiplex all flow cells that are ready under the flow cells directory."""

--- a/cg/cli/demultiplex/demux.py
+++ b/cg/cli/demultiplex/demux.py
@@ -18,15 +18,12 @@ DRY_RUN = click.option("--dry-run", is_flag=True)
 
 
 @click.command(name="all")
-@OPTION_BCL_CONVERTER
 @DRY_RUN
 @click.option("--flow-cells-directory", type=click.Path(exists=True, file_okay=False))
 @click.pass_obj
-def demultiplex_all(
-    context: CGConfig, bcl_converter: str, flow_cells_directory: click.Path, dry_run: bool
-):
+def demultiplex_all(context: CGConfig, flow_cells_directory: click.Path, dry_run: bool):
     """Demultiplex all flow cells that are ready under the flow cells directory."""
-    LOG.info(f"Running cg demultiplex all, using {bcl_converter}.")
+    LOG.info("Running cg demultiplex all ...")
     if flow_cells_directory:
         flow_cells_directory: Path = Path(str(flow_cells_directory))
     else:
@@ -40,7 +37,8 @@ def demultiplex_all(
             continue
         LOG.info(f"Found directory {sub_dir}")
         try:
-            flow_cell = FlowCellDirectoryData(flow_cell_path=sub_dir, bcl_converter=bcl_converter)
+            flow_cell = FlowCellDirectoryData(flow_cell_path=sub_dir)
+            LOG.info(f"Using {flow_cell.bcl_converter} for demultiplexing.")
         except FlowCellError:
             continue
 
@@ -49,7 +47,7 @@ def demultiplex_all(
 
         if not flow_cell.validate_sample_sheet():
             LOG.warning(
-                f"Malformed sample sheet. Run cg demultiplex samplesheet validate {flow_cell.sample_sheet_path}",
+                f"Malformed sample sheet. Run cg demultiplex sample sheet validate {flow_cell.sample_sheet_path}",
             )
             continue
 

--- a/cg/meta/demultiplex/housekeeper_storage_functions.py
+++ b/cg/meta/demultiplex/housekeeper_storage_functions.py
@@ -71,7 +71,6 @@ def add_sample_fastq_files_to_housekeeper(
     flow_cell: FlowCellDirectoryData, hk_api: HousekeeperAPI, store: Store
 ) -> None:
     """Add sample fastq files from flow cell to Housekeeper."""
-
     sample_internal_ids: List[str] = get_sample_internal_ids_from_sample_sheet(
         sample_sheet_path=flow_cell.sample_sheet_path,
         flow_cell_sample_type=flow_cell.sample_type,


### PR DESCRIPTION
## Description

Removes the bcl converter option from demultiplex all so that it can automaticallt decided by the flowcelldirectory class which uses the flow cell dir name and machine type to do so.

This is in preparation to allow for a flat flow cell run directory structure where multiple flow cells from different sequencer types are stored.

### Added

-

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
