### PR TITLE
patch(Flask Admin view) Fix Set Action functionality

### DIFF
--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -264,7 +264,7 @@ class FamilyView(BaseView):
     def set_action_for_cases(self, action: Union[CaseActions, None], case_entry_ids: List[str]):
         try:
             for entry_id in case_entry_ids:
-                family = self.get_case_by_entry_id(entry_id=entry_id)
+                family = db.get_case_by_entry_id(entry_id=entry_id)
                 if family:
                     family.action = action
 


### PR DESCRIPTION
## Description
It was discovered by @beatrizsavinhas that the Set Action buttons in the Family page was were causing server errors.

### Fixed

- Fixed the `get_case_by_entry_id` method call to be made to the right object


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
