### PR TITLE
#2362: Patch new flow cell dir structure

### DIFF
--- a/cg/apps/cgstats/stats.py
+++ b/cg/apps/cgstats/stats.py
@@ -151,7 +151,7 @@ class StatsAPI(alchy.Manager):
         alt_pattern = "*{}/Unaligned*/Project_*/Sample_{}_*/*.fastq.gz"
 
         # The default structure for flow cells demultiplexed with bclconvert
-        bcl_convert_pattern = "*{}/Unaligned*/*/Sample_{}_*/*.fastq.gz"
+        bcl_convert_pattern = "*{}/Unaligned*/*/{}_*/*.fastq.gz"
 
         for fastq_pattern in (base_pattern, alt_pattern, bcl_convert_pattern):
             pattern = fastq_pattern.format(flowcell, sample_obj.samplename)

--- a/cg/apps/cgstats/stats.py
+++ b/cg/apps/cgstats/stats.py
@@ -142,7 +142,7 @@ class StatsAPI(alchy.Manager):
         return flow_cell_reads_and_q30_summary
 
     def fastqs(self, flowcell: str, sample_obj: Sample) -> Iterator[Path]:
-        """Fetch FASTQ files for a sample."""
+        """Retrieve all fastq files for a specific sample in a flow cell directory."""
 
         # The default structure for flow cells demultiplexed with bcl2fastq
         base_pattern = "*{}/Unaligned*/Project_*/Sample_{}/*.fastq.gz"

--- a/cg/apps/cgstats/stats.py
+++ b/cg/apps/cgstats/stats.py
@@ -145,6 +145,8 @@ class StatsAPI(alchy.Manager):
         """Fetch FASTQ files for a sample."""
         base_pattern = "*{}/Unaligned*/Project_*/Sample_{}/*.fastq.gz"
         alt_pattern = "*{}/Unaligned*/Project_*/Sample_{}_*/*.fastq.gz"
-        for fastq_pattern in (base_pattern, alt_pattern):
+        bcl_convert_pattern = "*{}/Unaligned*/*/Sample_{}_*/*.fastq.gz"
+
+        for fastq_pattern in (base_pattern, alt_pattern, bcl_convert_pattern):
             pattern = fastq_pattern.format(flowcell, sample_obj.samplename)
             yield from self.root_dir.glob(pattern)

--- a/cg/apps/cgstats/stats.py
+++ b/cg/apps/cgstats/stats.py
@@ -143,8 +143,14 @@ class StatsAPI(alchy.Manager):
 
     def fastqs(self, flowcell: str, sample_obj: Sample) -> Iterator[Path]:
         """Fetch FASTQ files for a sample."""
+
+        # The default structure for flow cells demultiplexed with bcl2fastq
         base_pattern = "*{}/Unaligned*/Project_*/Sample_{}/*.fastq.gz"
+
+        # Alternative structure for flow cells demultiplexed with bcl2fastq and where the sample has a trailing sequence
         alt_pattern = "*{}/Unaligned*/Project_*/Sample_{}_*/*.fastq.gz"
+
+        # The default structure for flow cells demultiplexed with bclconvert
         bcl_convert_pattern = "*{}/Unaligned*/*/Sample_{}_*/*.fastq.gz"
 
         for fastq_pattern in (base_pattern, alt_pattern, bcl_convert_pattern):

--- a/cg/apps/cgstats/stats.py
+++ b/cg/apps/cgstats/stats.py
@@ -147,7 +147,7 @@ class StatsAPI(alchy.Manager):
         # The default structure for flow cells demultiplexed with bcl2fastq
         base_pattern = "*{}/Unaligned*/Project_*/Sample_{}/*.fastq.gz"
 
-        # Alternative structure for flow cells demultiplexed with bcl2fastq and where the sample has a trailing sequence
+        # Alternative structure for flow cells demultiplexed with bcl2fastq where the sample fastq files have a trailing sequence
         alt_pattern = "*{}/Unaligned*/Project_*/Sample_{}_*/*.fastq.gz"
 
         # The default structure for flow cells demultiplexed with bclconvert

--- a/cg/meta/demultiplex/utils.py
+++ b/cg/meta/demultiplex/utils.py
@@ -39,9 +39,17 @@ def get_sample_fastqs_from_flow_cell(
     flow_cell_directory: Path, sample_internal_id: str
 ) -> Optional[List[Path]]:
     """Retrieve sample FastQs from a flow cell directory."""
+
+    # The flat output structure for flow cells demultiplexed with bclconvert on the novaseqx machines
     root_pattern = f"{sample_internal_id}_S*_L*_R*_*{FileExtensions.FASTQ}{FileExtensions.GZIP}"
+
+    # The default structure for flow cells demultiplexed with bcl2fastq
     unaligned_pattern = f"Unaligned*/Project_*/Sample_{sample_internal_id}/*{FileExtensions.FASTQ}{FileExtensions.GZIP}"
+
+    # Alternative structure for flow cells demultiplexed with bcl2fastq and where the sample has a trailing sequence
     unaligned_alt_pattern = f"Unaligned*/Project_*/Sample_{sample_internal_id}_*/*{FileExtensions.FASTQ}{FileExtensions.GZIP}"
+
+    # The default structure for flow cells demultiplexed with bclconvert
     bcl_convert_pattern = (
         f"Unaligned*/*/Sample_{sample_internal_id}_*{FileExtensions.FASTQ}{FileExtensions.GZIP}"
     )

--- a/cg/meta/demultiplex/utils.py
+++ b/cg/meta/demultiplex/utils.py
@@ -51,7 +51,7 @@ def get_sample_fastqs_from_flow_cell(
 
     # The default structure for flow cells demultiplexed with bclconvert
     bcl_convert_pattern = (
-        f"Unaligned*/*/Sample_{sample_internal_id}_*{FileExtensions.FASTQ}{FileExtensions.GZIP}"
+        f"Unaligned*/*/{sample_internal_id}_*{FileExtensions.FASTQ}{FileExtensions.GZIP}"
     )
 
     for pattern in [root_pattern, unaligned_pattern, unaligned_alt_pattern, bcl_convert_pattern]:

--- a/cg/meta/demultiplex/utils.py
+++ b/cg/meta/demultiplex/utils.py
@@ -46,7 +46,7 @@ def get_sample_fastqs_from_flow_cell(
     # The default structure for flow cells demultiplexed with bcl2fastq
     unaligned_pattern = f"Unaligned*/Project_*/Sample_{sample_internal_id}/*{FileExtensions.FASTQ}{FileExtensions.GZIP}"
 
-    # Alternative structure for flow cells demultiplexed with bcl2fastq and where the sample has a trailing sequence
+    # Alternative structure for flow cells demultiplexed with bcl2fastq where the sample fastq files have a trailing sequence
     unaligned_alt_pattern = f"Unaligned*/Project_*/Sample_{sample_internal_id}_*/*{FileExtensions.FASTQ}{FileExtensions.GZIP}"
 
     # The default structure for flow cells demultiplexed with bclconvert

--- a/cg/meta/demultiplex/utils.py
+++ b/cg/meta/demultiplex/utils.py
@@ -38,7 +38,7 @@ def get_lane_from_sample_fastq(sample_fastq_path: Path) -> int:
 def get_sample_fastqs_from_flow_cell(
     flow_cell_directory: Path, sample_internal_id: str
 ) -> Optional[List[Path]]:
-    """Retrieve sample FastQs from a flow cell directory."""
+    """Retrieve all fastq files for a specific sample in a flow cell directory."""
 
     # The flat output structure for flow cells demultiplexed with bclconvert on the novaseqx machines
     root_pattern = f"{sample_internal_id}_S*_L*_R*_*{FileExtensions.FASTQ}{FileExtensions.GZIP}"

--- a/cg/meta/demultiplex/utils.py
+++ b/cg/meta/demultiplex/utils.py
@@ -42,8 +42,11 @@ def get_sample_fastqs_from_flow_cell(
     root_pattern = f"{sample_internal_id}_S*_L*_R*_*{FileExtensions.FASTQ}{FileExtensions.GZIP}"
     unaligned_pattern = f"Unaligned*/Project_*/Sample_{sample_internal_id}/*{FileExtensions.FASTQ}{FileExtensions.GZIP}"
     unaligned_alt_pattern = f"Unaligned*/Project_*/Sample_{sample_internal_id}_*/*{FileExtensions.FASTQ}{FileExtensions.GZIP}"
+    bcl_convert_pattern = (
+        f"Unaligned*/*/Sample_{sample_internal_id}_*{FileExtensions.FASTQ}{FileExtensions.GZIP}"
+    )
 
-    for pattern in [root_pattern, unaligned_pattern, unaligned_alt_pattern]:
+    for pattern in [root_pattern, unaligned_pattern, unaligned_alt_pattern, bcl_convert_pattern]:
         sample_fastqs: List[Path] = get_files_matching_pattern(
             directory=flow_cell_directory, pattern=pattern
         )


### PR DESCRIPTION
## Description
After removing the demux repo (?) we no longer restructure flow cells. We need to handle the pattern described in https://github.com/Clinical-Genomics/cg/issues/2362 to find the fastq files in a flow cell directory.


### Fixed
- Support new flow cell dir structure in old and new post processing flow


### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

