### PR TITLE
Add exception catching for demultiplex finish-all commands

### DIFF
--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -1,4 +1,4 @@
-"""Post-processing Demultiiplex API."""
+"""Post-processing Demultiplex API."""
 import logging
 from contextlib import redirect_stdout
 from pathlib import Path

--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -289,11 +289,15 @@ class DemuxPostProcessingHiseqXAPI(DemuxPostProcessingAPI):
     def finish_all_flow_cells(self, bcl_converter: str) -> None:
         """Loop over all flow cells and post process those that need it."""
         for flow_cell_dir in self.get_all_demultiplexed_flow_cell_dirs():
-            self.finish_flow_cell(
-                bcl_converter=bcl_converter,
-                flow_cell_name=flow_cell_dir.name,
-                flow_cell_path=flow_cell_dir,
-            )
+            try:
+                self.finish_flow_cell(
+                    bcl_converter=bcl_converter,
+                    flow_cell_name=flow_cell_dir.name,
+                    flow_cell_path=flow_cell_dir,
+                )
+            except Exception as error:
+                LOG.error(f"Failed to finish flow cell {flow_cell_dir.name}: {str(error)}")
+                continue
 
 
 class DemuxPostProcessingNovaseqAPI(DemuxPostProcessingAPI):
@@ -455,4 +459,10 @@ class DemuxPostProcessingNovaseqAPI(DemuxPostProcessingAPI):
     def finish_all_flow_cells(self, bcl_converter: str) -> None:
         """Loop over all flow cells and post-process those that need it."""
         for flow_cell_dir in self.get_all_demultiplexed_flow_cell_dirs():
-            self.finish_flow_cell(flow_cell_name=flow_cell_dir.name, bcl_converter=bcl_converter)
+            try:
+                self.finish_flow_cell(
+                    flow_cell_name=flow_cell_dir.name, bcl_converter=bcl_converter
+                )
+            except Exception as error:
+                LOG.error(f"Failed to finish flow cell {flow_cell_dir.name}: {str(error)}")
+                continue

--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -87,7 +87,7 @@ class DemuxPostProcessingAPI:
             flow_cell_directory_name (str): The name of the flow cell directory to be finalized.
             force (bool): If True, the flow cell will be finalized even when it is already marked for delivery.
         Raises:
-            FlowCellError: If the flow cell directory or the data it contains is not valid.
+            FlowCellError: If the flow cell directory or the data it contains is invalid.
         """
         if self.dry_run:
             LOG.info(f"Dry run will not finish flow cell {flow_cell_directory_name}")

--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -87,7 +87,7 @@ class DemuxPostProcessingAPI:
             flow_cell_directory_name (str): The name of the flow cell directory to be finalized.
             force (bool): If True, the flow cell will be finalized even when it is already marked for delivery.
         Raises:
-            FlowCellError: If the flow cell directory or the data it contains is invalid.
+            FlowCellError: If the flow cell directory or the data it contains is not valid.
         """
         if self.dry_run:
             LOG.info(f"Dry run will not finish flow cell {flow_cell_directory_name}")


### PR DESCRIPTION
## Description

Adds a try-except statement when calling `finish_flow_cell` inside the `finish-all` commands to avoid the process crashing.

### Added

- A try-except statement inside the `finish-all` command of each DemultiplexPostProcessing subclass

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
