### PR TITLE
Hotfix for setting sequenced at in temp finish

### DIFF
--- a/cg/cli/demultiplex/finish.py
+++ b/cg/cli/demultiplex/finish.py
@@ -2,13 +2,12 @@
 import logging
 
 import click
-
 from cg.constants.constants import DRY_RUN
 from cg.constants.demultiplexing import OPTION_BCL_CONVERTER, BclConverter
 from cg.meta.demultiplex.demux_post_processing import (
     DemuxPostProcessingAPI,
-    DemuxPostProcessingNovaseqAPI,
     DemuxPostProcessingHiseqXAPI,
+    DemuxPostProcessingNovaseqAPI,
 )
 from cg.models.cg_config import CGConfig
 

--- a/cg/meta/demultiplex/status_db_storage_functions.py
+++ b/cg/meta/demultiplex/status_db_storage_functions.py
@@ -1,12 +1,13 @@
 """Functions interacting with statusdb in the DemuxPostProcessingAPI."""
+import datetime
 import logging
 from pathlib import Path
 from typing import List, Optional, Set
 
-from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.apps.demultiplex.sample_sheet.read_sample_sheet import (
     get_sample_internal_ids_from_sample_sheet,
 )
+from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.apps.sequencing_metrics_parser.api import (
     create_sample_lane_sequencing_metrics_for_flow_cell,
 )
@@ -14,9 +15,7 @@ from cg.exc import HousekeeperFileMissingError
 from cg.meta.demultiplex.utils import get_q30_threshold
 from cg.models.demultiplex.flow_cell import FlowCellDirectoryData
 from cg.store import Store
-from cg.store.models import Flowcell, SampleLaneSequencingMetrics
-from cg.store.models import Sample
-
+from cg.store.models import Flowcell, Sample, SampleLaneSequencingMetrics
 from housekeeper.store.models import File
 
 LOG = logging.getLogger(__name__)
@@ -146,7 +145,10 @@ def update_sample_read_count(sample_id: str, q30_threshold: int, store: Store) -
             sample_internal_id=sample_id,
             q30_threshold=q30_threshold,
         )
-        LOG.debug(f"Updating sample {sample_id} with read count {sample_read_count}")
+        LOG.debug(
+            f"Updating sample {sample_id} with read count {sample_read_count} and setting sequenced at."
+        )
         sample.reads = sample_read_count
+        sample.sequenced_at = datetime.datetime.now()
     else:
         LOG.warning(f"Cannot find {sample_id} in status_db when adding read counts. Skipping.")

--- a/cg/meta/demultiplex/status_db_storage_functions.py
+++ b/cg/meta/demultiplex/status_db_storage_functions.py
@@ -149,6 +149,7 @@ def update_sample_read_count(sample_id: str, q30_threshold: int, store: Store) -
             f"Updating sample {sample_id} with read count {sample_read_count} and setting sequenced at."
         )
         sample.reads = sample_read_count
-        sample.sequenced_at = datetime.datetime.now()
+        if not sample.sequenced_at:
+            sample.sequenced_at = datetime.datetime.now()
     else:
         LOG.warning(f"Cannot find {sample_id} in status_db when adding read counts. Skipping.")


### PR DESCRIPTION
## Description

The new finish flow cell command misses setting "sequenced_at" on sample level, blocking analyses from starting. This is a quick hot fix which sets the sequenced_at in the update_sample_read_count method, although this should be done more properly in a less urgent issue.


### Fixed

- Sequenced_at is set on sample level during `demultiplex finish temporary`.


### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
