### PR TITLE
Migrate trailblazer pydantic models

### DIFF
--- a/cg/apps/tb/api.py
+++ b/cg/apps/tb/api.py
@@ -93,9 +93,9 @@ class TrailblazerAPI:
         response = self.query_trailblazer(command="query-analyses", request_body=request_body)
         if response:
             if isinstance(response, list):
-                return [TrailblazerAnalysis.parse_obj(analysis) for analysis in response]
+                return [TrailblazerAnalysis.model_validate(analysis) for analysis in response]
             if isinstance(response, dict):
-                return [TrailblazerAnalysis.parse_obj(response)]
+                return [TrailblazerAnalysis.model_validate(response)]
         return response
 
     def get_latest_analysis(self, case_id: str) -> Optional[TrailblazerAnalysis]:
@@ -104,7 +104,7 @@ class TrailblazerAPI:
         }
         response = self.query_trailblazer(command="get-latest-analysis", request_body=request_body)
         if response:
-            return TrailblazerAnalysis.parse_obj(response)
+            return TrailblazerAnalysis.model_validate(response)
 
     def get_latest_analysis_status(self, case_id: str) -> Optional[str]:
         latest_analysis = self.get_latest_analysis(case_id=case_id)
@@ -133,9 +133,9 @@ class TrailblazerAPI:
         )
         if response:
             if isinstance(response, list):
-                return [TrailblazerAnalysis.parse_obj(analysis) for analysis in response]
+                return [TrailblazerAnalysis.model_validate(analysis) for analysis in response]
             if isinstance(response, dict):
-                return [TrailblazerAnalysis.parse_obj(response)]
+                return [TrailblazerAnalysis.model_validate(response)]
 
     def add_pending_analysis(
         self,
@@ -163,7 +163,7 @@ class TrailblazerAPI:
         LOG.debug("Submitting job to Trailblazer: %s", request_body)
         response = self.query_trailblazer(command="add-pending-analysis", request_body=request_body)
         if response:
-            return TrailblazerAnalysis.parse_obj(response)
+            return TrailblazerAnalysis.model_validate(response)
 
     def set_analysis_uploaded(self, case_id: str, uploaded_at: datetime) -> None:
         """Set a uploaded at date for a trailblazer analysis."""

--- a/cg/apps/tb/models.py
+++ b/cg/apps/tb/models.py
@@ -1,6 +1,8 @@
+import datetime as dt
+from pathlib import Path
 from typing import Optional
 
-from pydantic import AfterValidator, BaseModel, ConfigDict, FieldValidationInfo, field_validator
+from pydantic import BaseModel, BeforeValidator, ConfigDict, FieldValidationInfo, field_validator
 from typing_extensions import Annotated
 
 from cg.apps.tb.validators import parse_str_to_datetime, parse_str_to_path
@@ -17,13 +19,13 @@ class TrailblazerAnalysis(BaseModel):
         return info.data.get("family")
 
     version: Optional[str] = None
-    logged_at: Annotated[Optional[str], AfterValidator(parse_str_to_datetime)]
-    started_at: Annotated[Optional[str], AfterValidator(parse_str_to_datetime)]
-    completed_at: Annotated[Optional[str], AfterValidator(parse_str_to_datetime)]
+    logged_at: Annotated[Optional[dt.datetime], BeforeValidator(parse_str_to_datetime)]
+    started_at: Annotated[Optional[dt.datetime], BeforeValidator(parse_str_to_datetime)]
+    completed_at: Annotated[Optional[dt.datetime], BeforeValidator(parse_str_to_datetime)]
     status: Optional[str] = None
     priority: Optional[str] = None
-    out_dir: Annotated[Optional[str], AfterValidator(parse_str_to_path)]
-    config_path: Annotated[Optional[str], AfterValidator(parse_str_to_path)]
+    out_dir: Annotated[Optional[Path], BeforeValidator(parse_str_to_path)]
+    config_path: Annotated[Optional[Path], BeforeValidator(parse_str_to_path)]
     comment: Optional[str] = None
     is_deleted: Optional[bool] = None
     is_visible: Optional[bool] = None

--- a/cg/apps/tb/models.py
+++ b/cg/apps/tb/models.py
@@ -1,24 +1,24 @@
-import datetime as dt
-from pathlib import Path
 from typing import Optional
 
-from dateutil.parser import parse as parse_datestr
-from pydantic.v1 import BaseModel, validator
+from pydantic import AfterValidator, BaseModel
+from typing_extensions import Annotated
+
+from cg.apps.tb.validators import inherit_family_value, parse_str_to_datetime, parse_str_to_path
 
 
 class TrailblazerAnalysis(BaseModel):
     id: int
     family: str
-    case_id = Optional[str]
+    case_id: Annotated[Optional[str], AfterValidator(inherit_family_value)]
 
     version: Optional[str]
-    logged_at: Optional[str]
-    started_at: Optional[str]
-    completed_at: Optional[str]
+    logged_at: Annotated[Optional[str], AfterValidator(parse_str_to_datetime)]
+    started_at: Annotated[Optional[str], AfterValidator(parse_str_to_datetime)]
+    completed_at: Annotated[Optional[str], AfterValidator(parse_str_to_datetime)]
     status: Optional[str]
     priority: Optional[str]
-    out_dir: Optional[str]
-    config_path: Optional[str]
+    out_dir: Annotated[Optional[str], AfterValidator(parse_str_to_path)]
+    config_path: Annotated[Optional[str], AfterValidator(parse_str_to_path)]
     comment: Optional[str]
     is_deleted: Optional[bool]
     is_visible: Optional[bool]
@@ -29,21 +29,6 @@ class TrailblazerAnalysis(BaseModel):
     ticket: Optional[str]
     uploaded_at: Optional[str]
 
-    @validator("case_id")
-    def inherit_family_value(cls, value: str, values: dict) -> str:
-        return values.get("family")
-
-    @validator("logged_at", "started_at", "completed_at")
-    def parse_str_to_datetime(cls, value: str) -> Optional[dt.datetime]:
-        if value:
-            return parse_datestr(value)
-
-    @validator("out_dir", "config_path")
-    def parse_str_to_path(cls, value: str) -> Optional[Path]:
-        if value:
-            return Path(value)
-
     class Config:
-        extra = "allow"
-        validate_all = True
+        validate_default = True
         arbitrary_types_allowed = True

--- a/cg/apps/tb/models.py
+++ b/cg/apps/tb/models.py
@@ -12,6 +12,7 @@ class TrailblazerAnalysis(BaseModel):
     case_id: Optional[str] = None
 
     @field_validator("case_id")
+    @classmethod
     def inherit_family_value(cls, value: str, info: FieldValidationInfo) -> str:
         return info.data.get("family")
 

--- a/cg/apps/tb/models.py
+++ b/cg/apps/tb/models.py
@@ -1,33 +1,37 @@
 from typing import Optional
 
-from pydantic import AfterValidator, BaseModel, ConfigDict
+from pydantic import AfterValidator, BaseModel, ConfigDict, FieldValidationInfo, field_validator
 from typing_extensions import Annotated
 
-from cg.apps.tb.validators import inherit_family_value, parse_str_to_datetime, parse_str_to_path
+from cg.apps.tb.validators import parse_str_to_datetime, parse_str_to_path
 
 
 class TrailblazerAnalysis(BaseModel):
     id: int
     family: str
-    case_id: Annotated[Optional[str], AfterValidator(inherit_family_value)]
 
-    version: Optional[str]
+    @field_validator("case_id")
+    def inherit_family_value(cls, value: str, info: FieldValidationInfo) -> str:
+        return info.data.get("family")
+
+    version: Optional[str] = None
     logged_at: Annotated[Optional[str], AfterValidator(parse_str_to_datetime)]
     started_at: Annotated[Optional[str], AfterValidator(parse_str_to_datetime)]
     completed_at: Annotated[Optional[str], AfterValidator(parse_str_to_datetime)]
-    status: Optional[str]
-    priority: Optional[str]
+    status: Optional[str] = None
+    priority: Optional[str] = None
     out_dir: Annotated[Optional[str], AfterValidator(parse_str_to_path)]
     config_path: Annotated[Optional[str], AfterValidator(parse_str_to_path)]
-    comment: Optional[str]
-    is_deleted: Optional[bool]
-    is_visible: Optional[bool]
-    type: Optional[str]
-    user_id: Optional[int]
+    comment: Optional[str] = None
+    is_deleted: Optional[bool] = None
+    is_visible: Optional[bool] = None
+    type: Optional[str] = None
+    user_id: Optional[int] = None
     progress: Optional[float] = 0.0
-    data_analysis: Optional[str]
-    ticket: Optional[str]
-    uploaded_at: Optional[str]
+    data_analysis: Optional[str] = None
+    ticket: Optional[str] = None
+    uploaded_at: Optional[str] = None
+
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
         validate_default=True,

--- a/cg/apps/tb/models.py
+++ b/cg/apps/tb/models.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import AfterValidator, BaseModel
+from pydantic import AfterValidator, BaseModel, ConfigDict
 from typing_extensions import Annotated
 
 from cg.apps.tb.validators import inherit_family_value, parse_str_to_datetime, parse_str_to_path
@@ -28,7 +28,8 @@ class TrailblazerAnalysis(BaseModel):
     data_analysis: Optional[str]
     ticket: Optional[str]
     uploaded_at: Optional[str]
-
-    class Config:
-        validate_default = True
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        validate_default=True,
+        extra="allow",
+    )

--- a/cg/apps/tb/models.py
+++ b/cg/apps/tb/models.py
@@ -9,6 +9,7 @@ from cg.apps.tb.validators import parse_str_to_datetime, parse_str_to_path
 class TrailblazerAnalysis(BaseModel):
     id: int
     family: str
+    case_id: Optional[str] = None
 
     @field_validator("case_id")
     def inherit_family_value(cls, value: str, info: FieldValidationInfo) -> str:

--- a/cg/apps/tb/models.py
+++ b/cg/apps/tb/models.py
@@ -31,5 +31,5 @@ class TrailblazerAnalysis(BaseModel):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
         validate_default=True,
-        extra="allow",
+        extra="ignore",
     )

--- a/cg/apps/tb/validators.py
+++ b/cg/apps/tb/validators.py
@@ -1,6 +1,6 @@
 import datetime as dt
 from pathlib import Path
-from typing import Optional
+from typing import Dict, Optional
 
 from dateutil.parser import parse as parse_datestr
 
@@ -10,7 +10,7 @@ def parse_str_to_datetime(value: str) -> Optional[dt.datetime]:
         return parse_datestr(value)
 
 
-def inherit_family_value(value: str, values: dict) -> Optional[str]:
+def inherit_family_value(value: str, values: Dict) -> Optional[str]:
     return values.get("family")
 
 

--- a/cg/apps/tb/validators.py
+++ b/cg/apps/tb/validators.py
@@ -1,6 +1,6 @@
 import datetime as dt
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Optional
 
 from dateutil.parser import parse as parse_datestr
 
@@ -8,10 +8,6 @@ from dateutil.parser import parse as parse_datestr
 def parse_str_to_datetime(value: str) -> Optional[dt.datetime]:
     if value:
         return parse_datestr(value)
-
-
-def inherit_family_value(value: str, values: Dict) -> Optional[str]:
-    return values.get("family")
 
 
 def parse_str_to_path(value: str) -> Optional[Path]:

--- a/cg/apps/tb/validators.py
+++ b/cg/apps/tb/validators.py
@@ -1,0 +1,19 @@
+import datetime as dt
+from pathlib import Path
+from typing import Optional
+
+from dateutil.parser import parse as parse_datestr
+
+
+def parse_str_to_datetime(value: str) -> Optional[dt.datetime]:
+    if value:
+        return parse_datestr(value)
+
+
+def inherit_family_value(value: str, values: dict) -> Optional[str]:
+    return values.get("family")
+
+
+def parse_str_to_path(value: str) -> Optional[Path]:
+    if value:
+        return Path(value)

--- a/tests/mocks/tb_mock.py
+++ b/tests/mocks/tb_mock.py
@@ -31,13 +31,13 @@ class MockTB:
 
     def ensure_analyses_response(self, analyses_list: list) -> None:
         self.analyses_response = [
-            TrailblazerAnalysis.parse_obj(analysis) for analysis in analyses_list
+            TrailblazerAnalysis.model_validate(analysis) for analysis in analyses_list
         ]
 
     def ensure_get_latest_analysis_response(self, analysis_dict: dict) -> None:
-        self.get_latest_analysis_response[analysis_dict["family"]] = TrailblazerAnalysis.parse_obj(
-            analysis_dict
-        )
+        self.get_latest_analysis_response[
+            analysis_dict["family"]
+        ] = TrailblazerAnalysis.model_validate(analysis_dict)
 
     def is_latest_analysis_completed(self, case_id: str):
         return True


### PR DESCRIPTION
## Description
This PR migrates the Trailblazer Pydantic model to V2. Part of project https://github.com/Clinical-Genomics/project-planning/issues/514. 

The `case_id` is not using the pattern me and @islean settled on (`Annotated` with a validator in a separate file). This is because it inherits the `family` value, probably a temporary patch made in the past with the idea of renaming the field. The new way of accessing previously validated fields uses the `FieldValidationInfo` attribute ([docs](https://docs.pydantic.dev/2.0/migration/#changes-to-validators-allowed-signatures)).


### Fixed
- Replace deprecated `parse_obj` with `model_validate`
- Replace deprecated `validator` decorator with `Annotated` and `field_validator`

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
