### PR TITLE
fix(fetch HK sample sheet for validation new demux post processing flow)

### DIFF
--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -105,17 +105,6 @@ class DemuxPostProcessingAPI:
         flow_cell_run_directory: Path = Path(
             self.demux_api.flow_cells_dir, flow_cell_directory_name
         )
-
-        try:
-            is_flow_cell_ready_for_postprocessing(
-                flow_cell_output_directory=flow_cell_out_directory,
-                flow_cell_run_directory=flow_cell_run_directory,
-                force=force,
-            )
-        except FlowCellError as e:
-            LOG.error(f"Flow cell {flow_cell_directory_name} will be skipped: {e}")
-            return
-
         parsed_flow_cell: FlowCellDirectoryData = parse_flow_cell_directory_data(
             flow_cell_directory=flow_cell_out_directory,
             bcl_converter=bcl_converter,
@@ -128,6 +117,16 @@ class DemuxPostProcessingAPI:
         )
         parsed_flow_cell.set_sample_sheet_path_hk(hk_path=sample_sheet_path)
         LOG.debug("Set path for Housekeeper sample sheet in flow cell")
+
+        try:
+            is_flow_cell_ready_for_postprocessing(
+                flow_cell_output_directory=flow_cell_out_directory,
+                flow_cell=parsed_flow_cell,
+                force=force,
+            )
+        except FlowCellError as e:
+            LOG.error(f"Flow cell {flow_cell_directory_name} will be skipped: {e}")
+            return
 
         try:
             self.store_flow_cell_data(parsed_flow_cell)

--- a/cg/meta/demultiplex/validation.py
+++ b/cg/meta/demultiplex/validation.py
@@ -1,11 +1,12 @@
 import re
 from pathlib import Path
-
-from cg.apps.housekeeper.hk import HousekeeperAPI
+import logging
 from cg.constants.constants import FileExtensions
 from cg.constants.demultiplexing import DemultiplexingDirsAndFiles
 from cg.exc import FlowCellError
 from cg.models.demultiplex.flow_cell import FlowCellDirectoryData
+
+LOG = logging.getLogger(__name__)
 
 
 def is_valid_sample_fastq_file(sample_fastq: Path, sample_internal_id: str) -> bool:
@@ -63,6 +64,7 @@ def validate_sample_sheet_exists(flow_cell: FlowCellDirectoryData) -> None:
     sample_sheet_path: Path = flow_cell.get_sample_sheet_path_hk()
     if not sample_sheet_path.exists():
         raise FlowCellError(f"Sample sheet {sample_sheet_path} does not exist in housekeeper.")
+    LOG.debug(f"Found sample sheet {sample_sheet_path} in housekeeper.")
 
 
 def validate_demultiplexing_complete(flow_cell_output_directory: Path) -> None:

--- a/cg/meta/demultiplex/validation.py
+++ b/cg/meta/demultiplex/validation.py
@@ -1,9 +1,11 @@
 import re
 from pathlib import Path
 
+from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.constants.constants import FileExtensions
 from cg.constants.demultiplexing import DemultiplexingDirsAndFiles
 from cg.exc import FlowCellError
+from cg.models.demultiplex.flow_cell import FlowCellDirectoryData
 
 
 def is_valid_sample_fastq_file(sample_fastq: Path, sample_internal_id: str) -> bool:
@@ -57,14 +59,10 @@ def is_flow_cell_ready_for_delivery(flow_cell_directory: Path) -> bool:
     return Path(flow_cell_directory, DemultiplexingDirsAndFiles.DELIVERY).exists()
 
 
-def validate_sample_sheet_exists(flow_cell_run_directory: Path) -> None:
-    sample_sheet_path: Path = Path(
-        flow_cell_run_directory, DemultiplexingDirsAndFiles.SAMPLE_SHEET_FILE_NAME
-    )
+def validate_sample_sheet_exists(flow_cell: FlowCellDirectoryData) -> None:
+    sample_sheet_path: Path = flow_cell.get_sample_sheet_path_hk()
     if not sample_sheet_path.exists():
-        raise FlowCellError(
-            f"Sample sheet {sample_sheet_path} does not exist in flow cell run directory."
-        )
+        raise FlowCellError(f"Sample sheet {sample_sheet_path} does not exist in housekeeper.")
 
 
 def validate_demultiplexing_complete(flow_cell_output_directory: Path) -> None:
@@ -83,8 +81,10 @@ def validate_flow_cell_delivery_status(flow_cell_output_directory: Path, force: 
 
 
 def is_flow_cell_ready_for_postprocessing(
-    flow_cell_output_directory: Path, flow_cell_run_directory: Path, force: bool = False
+    flow_cell_output_directory: Path,
+    flow_cell: FlowCellDirectoryData,
+    force: bool = False,
 ) -> None:
-    validate_sample_sheet_exists(flow_cell_run_directory)
+    validate_sample_sheet_exists(flow_cell)
     validate_demultiplexing_complete(flow_cell_output_directory)
     validate_flow_cell_delivery_status(flow_cell_output_directory, force=force)

--- a/cg/meta/demultiplex/validation.py
+++ b/cg/meta/demultiplex/validation.py
@@ -62,7 +62,7 @@ def is_flow_cell_ready_for_delivery(flow_cell_directory: Path) -> bool:
 
 def validate_sample_sheet_exists(flow_cell: FlowCellDirectoryData) -> None:
     sample_sheet_path: Path = flow_cell.get_sample_sheet_path_hk()
-    if not sample_sheet_path.exists():
+    if not sample_sheet_path or not sample_sheet_path.exists():
         raise FlowCellError(f"Sample sheet {sample_sheet_path} does not exist in housekeeper.")
     LOG.debug(f"Found sample sheet {sample_sheet_path} in housekeeper.")
 

--- a/tests/meta/demultiplex/test_validation.py
+++ b/tests/meta/demultiplex/test_validation.py
@@ -183,7 +183,7 @@ def test_validate_sample_sheet_exists_raises_error(bcl2fastq_flow_cell_dir: Path
         validate_sample_sheet_exists(flow_cell=flow_cell)
 
 
-def test_validate_sample_sheet_exists_no_error(bcl2fastq_flow_cell_dir: Path):
+def test_validate_sample_sheet_exists(bcl2fastq_flow_cell_dir: Path):
     # GIVEN a path with a sample sheet
     # GIVEN a flow cell without a sample sheet in housekeeper
     flow_cell = FlowCellDirectoryData(flow_cell_path=bcl2fastq_flow_cell_dir)

--- a/tests/meta/demultiplex/test_validation.py
+++ b/tests/meta/demultiplex/test_validation.py
@@ -16,6 +16,7 @@ from cg.meta.demultiplex.validation import (
     validate_flow_cell_delivery_status,
     validate_sample_sheet_exists,
 )
+from cg.models.demultiplex.flow_cell import FlowCellDirectoryData
 
 
 def test_validate_sample_fastq_with_valid_file():
@@ -172,22 +173,29 @@ def test_is_flow_cell_ready_for_delivery_false(tmp_path: Path):
     assert result == False
 
 
-def test_validate_sample_sheet_exists_raises_error(tmp_path: Path):
-    # GIVEN a path with no sample sheet
-
+def test_validate_sample_sheet_exists_raises_error(bcl2fastq_flow_cell_dir: Path):
+    # GIVEN a flow cell without a sample sheet in housekeeper
+    flow_cell = FlowCellDirectoryData(flow_cell_path=bcl2fastq_flow_cell_dir)
+    flow_cell._sample_sheet_path_hk = None
     # WHEN validating the existence of the sample sheet
     # THEN it should raise a FlowCellError
     with pytest.raises(FlowCellError):
-        validate_sample_sheet_exists(tmp_path)
+        validate_sample_sheet_exists(flow_cell=flow_cell)
 
 
-def test_validate_sample_sheet_exists_no_error(tmp_path: Path):
+def test_validate_sample_sheet_exists_no_error(bcl2fastq_flow_cell_dir: Path):
     # GIVEN a path with a sample sheet
-    (tmp_path / DemultiplexingDirsAndFiles.SAMPLE_SHEET_FILE_NAME).touch()
+    # GIVEN a flow cell without a sample sheet in housekeeper
+    flow_cell = FlowCellDirectoryData(flow_cell_path=bcl2fastq_flow_cell_dir)
+    sample_sheet_path = Path(
+        bcl2fastq_flow_cell_dir, DemultiplexingDirsAndFiles.SAMPLE_SHEET_FILE_NAME
+    )
+    sample_sheet_path.touch()
+    flow_cell._sample_sheet_path_hk = sample_sheet_path
 
     # WHEN validating the existence of the sample sheet
     # THEN it should not raise an error
-    assert validate_sample_sheet_exists(tmp_path) is None
+    assert validate_sample_sheet_exists(flow_cell=flow_cell) is None
 
 
 def test_validate_demultiplexing_complete_raises_error(tmp_path: Path):


### PR DESCRIPTION
## Description

This PR changes the location of the sample sheet used in validation during the new demultuplexing post processing flow.
With these changes the sample sheet location is in housekeeper and not the `flow_cells/flow_cell_dir_name`. 

These changes go paired with that upon sample sheet creation for a given flow cell, the sample sheet is directly stored in housekeeper.

### Added

-

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
