### PR TITLE
feat(move to new demux flow)

### DIFF
--- a/cg/cli/demultiplex/finish.py
+++ b/cg/cli/demultiplex/finish.py
@@ -23,7 +23,9 @@ def finish_group():
 @DRY_RUN
 @click.pass_obj
 def finish_all_cmd_old_flow(context: CGConfig, dry_run: bool) -> None:
-    """Command to post-process all demultiplexed flow cells."""
+    """Command to post-process all demultiplexed flow cells.
+    The old flow uses the DemuxPostProcessingNovaseqAPI.
+    """
     demux_post_processing_api: DemuxPostProcessingNovaseqAPI = DemuxPostProcessingNovaseqAPI(
         config=context
     )
@@ -41,8 +43,8 @@ def finish_flow_cell_old_flow(
     context: CGConfig, flow_cell_name: str, bcl_converter: str, dry_run: bool, force: bool
 ) -> None:
     """Command to finish up a flow cell after demultiplexing.
-
     flow-cell-name is full flow cell name, e.g. '201203_D00483_0200_AHVKJCDRXX'.
+    The old flow uses the DemuxPostProcessingNovaseqAPI.
     """
     demux_post_processing_api: DemuxPostProcessingNovaseqAPI = DemuxPostProcessingNovaseqAPI(
         config=context

--- a/cg/cli/demultiplex/finish.py
+++ b/cg/cli/demultiplex/finish.py
@@ -3,7 +3,7 @@ import logging
 
 import click
 from cg.constants.constants import DRY_RUN
-from cg.constants.demultiplexing import OPTION_BCL_CONVERTER, BclConverter
+from cg.constants.demultiplexing import OPTION_BCL_CONVERTER
 from cg.meta.demultiplex.demux_post_processing import (
     DemuxPostProcessingAPI,
     DemuxPostProcessingHiseqXAPI,
@@ -19,10 +19,10 @@ def finish_group():
     """Finish up after demultiplexing."""
 
 
-@finish_group.command(name="all")
+@finish_group.command(name="all-old-flow")
 @DRY_RUN
 @click.pass_obj
-def finish_all_cmd(context: CGConfig, dry_run: bool) -> None:
+def finish_all_cmd_old_flow(context: CGConfig, dry_run: bool) -> None:
     """Command to post-process all demultiplexed flow cells."""
     demux_post_processing_api: DemuxPostProcessingNovaseqAPI = DemuxPostProcessingNovaseqAPI(
         config=context
@@ -30,21 +30,14 @@ def finish_all_cmd(context: CGConfig, dry_run: bool) -> None:
     demux_post_processing_api.set_dry_run(dry_run=dry_run)
     demux_post_processing_api.finish_all_flow_cells()
 
-    # Temporary finish flow cell logic will replace logic above when validated
-    demux_post_processing_api_temp: DemuxPostProcessingAPI = DemuxPostProcessingAPI(config=context)
-    demux_post_processing_api_temp.set_dry_run(dry_run=dry_run)
-    is_error_raised: bool = demux_post_processing_api_temp.finish_all_flow_cells_temp()
-    if is_error_raised:
-        raise click.Abort
 
-
-@finish_group.command(name="flow-cell")
+@finish_group.command(name="flow-cell-old-flow")
 @click.argument("flow-cell-name")
 @OPTION_BCL_CONVERTER
 @DRY_RUN
 @click.option("--force", is_flag=True)
 @click.pass_obj
-def finish_flow_cell(
+def finish_flow_cell_old_flow(
     context: CGConfig, flow_cell_name: str, bcl_converter: str, dry_run: bool, force: bool
 ) -> None:
     """Command to finish up a flow cell after demultiplexing.
@@ -58,20 +51,14 @@ def finish_flow_cell(
     demux_post_processing_api.finish_flow_cell(
         flow_cell_name=flow_cell_name, force=force, bcl_converter=bcl_converter
     )
-    # Temporary finish flow cell logic will replace logic above when validated
-    demux_post_processing_api_temp: DemuxPostProcessingAPI = DemuxPostProcessingAPI(config=context)
-    demux_post_processing_api_temp.set_dry_run(dry_run)
-    demux_post_processing_api_temp.finish_flow_cell_temp(
-        flow_cell_directory_name=flow_cell_name, bcl_converter=bcl_converter, force=force
-    )
 
 
-@finish_group.command(name="temporary")
+@finish_group.command(name="flow-cell")
 @click.argument("flow-cell-directory-name")
 @OPTION_BCL_CONVERTER
 @click.option("--force", is_flag=True)
 @click.pass_obj
-def finish_flow_cell_temporary(
+def finish_flow_cell(
     context: CGConfig, flow_cell_directory_name: str, bcl_converter: str, force: bool
 ):
     demux_post_processing_api: DemuxPostProcessingAPI = DemuxPostProcessingAPI(config=context)
@@ -80,10 +67,10 @@ def finish_flow_cell_temporary(
     )
 
 
-@finish_group.command(name="temporary-all")
+@finish_group.command(name="all")
 @click.pass_obj
 @DRY_RUN
-def finish_flow_cell_temporary_all(context: CGConfig, dry_run: bool):
+def finish_all_cmd(context: CGConfig, dry_run: bool):
     # Temporary finish flow cell logic will replace logic above when validated
     demux_post_processing_api_temp: DemuxPostProcessingAPI = DemuxPostProcessingAPI(config=context)
     demux_post_processing_api_temp.set_dry_run(dry_run=dry_run)

--- a/cg/cli/demultiplex/finish.py
+++ b/cg/cli/demultiplex/finish.py
@@ -61,6 +61,10 @@ def finish_flow_cell_old_flow(
 def finish_flow_cell(
     context: CGConfig, flow_cell_directory_name: str, bcl_converter: str, force: bool
 ):
+    """Command to finish up a flow cell after demultiplexing.
+
+    flow-cell-name is full flow cell name, e.g. '201203_D00483_0200_AHVKJCDRXX'.
+    """
     demux_post_processing_api: DemuxPostProcessingAPI = DemuxPostProcessingAPI(config=context)
     demux_post_processing_api.finish_flow_cell_temp(
         flow_cell_directory_name=flow_cell_directory_name, bcl_converter=bcl_converter, force=force
@@ -71,7 +75,8 @@ def finish_flow_cell(
 @click.pass_obj
 @DRY_RUN
 def finish_all_cmd(context: CGConfig, dry_run: bool):
-    # Temporary finish flow cell logic will replace logic above when validated
+    """Command to finish up all demultiplexed flow cells."""
+
     demux_post_processing_api_temp: DemuxPostProcessingAPI = DemuxPostProcessingAPI(config=context)
     demux_post_processing_api_temp.set_dry_run(dry_run=dry_run)
     demux_post_processing_api_temp.finish_all_flow_cells_temp()

--- a/tests/cli/demultiplex/test_finish_demux.py
+++ b/tests/cli/demultiplex/test_finish_demux.py
@@ -4,7 +4,11 @@ from pathlib import Path
 
 from click import testing
 
-from cg.cli.demultiplex.finish import finish_all_hiseq_x, finish_all_cmd, finish_flow_cell
+from cg.cli.demultiplex.finish import (
+    finish_all_hiseq_x,
+    finish_all_cmd_old_flow,
+    finish_flow_cell_old_flow,
+)
 from cg.constants import EXIT_SUCCESS
 from cg.models.cg_config import CGConfig
 
@@ -23,7 +27,7 @@ def test_finish_all_cmd_dry_run(
 
     # WHEN starting post-processing for new demultiplexing from the CLI with dry run flag
     result: testing.Result = cli_runner.invoke(
-        finish_all_cmd,
+        finish_all_cmd_old_flow,
         ["--dry-run"],
         obj=demultiplex_context,
     )
@@ -49,7 +53,7 @@ def test_finish_flow_cell_dry_run(
 
     # WHEN starting post-processing for new demultiplexing from the CLI with dry run flag
     result: testing.Result = cli_runner.invoke(
-        finish_flow_cell,
+        finish_flow_cell_old_flow,
         ["--dry-run", bcl2fastq_flow_cell_id],
         obj=demultiplex_context,
     )


### PR DESCRIPTION
## Description

This PR fully enables the new demultiplexing post processing flow in the `cg demultiplex finish flow-cell` and ``cg demultiplex finish all` commands.

The old demultiplexing post processing flow will still be accessible under `cg demultiplex finish flow-cell-old-flow` and `cg demultiplex finish all-old-flow

### Added

-

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
