### PR TITLE
Patch analysis type

### DIFF
--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -131,7 +131,7 @@ class Application(Model):
     @property
     def analysis_type(self):
         if self.prep_category == PrepCategory.WHOLE_TRANSCRIPTOME_SEQUENCING.value:
-            return self.prep_category
+            return PrepCategory.WHOLE_TRANSCRIPTOME_SEQUENCING.value
 
         return (
             PrepCategory.WHOLE_GENOME_SEQUENCING.value

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -129,7 +129,7 @@ class Application(Model):
         return self.target_reads * self.percent_reads_guaranteed / 100
 
     @property
-    def analysis_type(self):
+    def analysis_type(self) -> str:
         if self.prep_category == PrepCategory.WHOLE_TRANSCRIPTOME_SEQUENCING.value:
             return PrepCategory.WHOLE_TRANSCRIPTOME_SEQUENCING.value
 


### PR DESCRIPTION
## Description
When migrating a Pydantic model, some tests started failing due to this model returning an enum field instead of the enum value. The diff should be pretty clear.

The `analysis_type` property still does not make sense since it seems to assume it is `WHOLE_EXOME_SEQUENCING` if it is not `WHOLE_TRANSCRIPTOME_SEQUENCING` or `WHOLE_GENOME_SEQUENCING`.

### Fixed
- Fix analysis_type return type on Application model

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

