### PR TITLE
Migrate archive

### DIFF
--- a/cg/meta/archive/models.py
+++ b/cg/meta/archive/models.py
@@ -6,7 +6,7 @@ from cg.models.cg_config import DataFlowConfig
 from cg.store.models import Sample
 from housekeeper.store.models import File
 from pydantic import BaseModel
-from pydantic.v1 import ConfigDict
+from pydantic import ConfigDict
 
 
 class FileAndSample(BaseModel):

--- a/cg/meta/archive/models.py
+++ b/cg/meta/archive/models.py
@@ -5,8 +5,7 @@ from typing import List
 from cg.models.cg_config import DataFlowConfig
 from cg.store.models import Sample
 from housekeeper.store.models import File
-from pydantic import BaseModel
-from pydantic import ConfigDict
+from pydantic import BaseModel, ConfigDict
 
 
 class FileAndSample(BaseModel):


### PR DESCRIPTION
## Description
This PR migrates the Archive to pydantic V2.
- Update ConfigDict import

### Fixed
- Migrate archive model to Pydantic v2

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


