### PR TITLE
Migrate scout tags

### DIFF
--- a/cg/meta/upload/scout/hk_tags.py
+++ b/cg/meta/upload/scout/hk_tags.py
@@ -2,7 +2,7 @@
 
 from typing import Optional, Set
 
-from pydantic.v1 import BaseModel, Field
+from pydantic import BaseModel, Field
 
 
 class CaseTags(BaseModel):


### PR DESCRIPTION
## Description
This PR migrates the scout tags models to Pydantic v2.
- Replace imports

### Fixed
- Migrate scout tag models to Pydantic v2

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
