### PR TITLE
Start adding start command

### DIFF
--- a/cg/cli/workflow/taxprofiler/base.py
+++ b/cg/cli/workflow/taxprofiler/base.py
@@ -165,7 +165,7 @@ def start(
     nf_tower_id: Optional[str],
     dry_run: bool,
 ) -> None:
-    """Start full workflow for CASE ID."""
+    """Start full workflow for case id."""
     LOG.info(f"Starting analysis for {case_id}")
 
     try:

--- a/tests/cli/workflow/taxprofiler/test_cli_taxprofiler_compound_commands.py
+++ b/tests/cli/workflow/taxprofiler/test_cli_taxprofiler_compound_commands.py
@@ -1,9 +1,13 @@
+import logging
+from _pytest.logging import LogCaptureFixture
 from click.testing import CliRunner
 from cg.cli.workflow.taxprofiler.base import (
     taxprofiler,
+    start,
 )
 from cg.constants import EXIT_SUCCESS
 from cg.models.cg_config import CGConfig
+from cg.meta.workflow.taxprofiler import TaxprofilerAnalysisAPI
 
 
 def test_taxprofiler_no_args(cli_runner: CliRunner, taxprofiler_context: CGConfig):
@@ -17,3 +21,31 @@ def test_taxprofiler_no_args(cli_runner: CliRunner, taxprofiler_context: CGConfi
 
     ## THEN help should be printed
     assert "help" in result.output
+
+
+def test_taxprofiler_start(
+    cli_runner: CliRunner,
+    taxprofiler_context: CGConfig,
+    caplog: LogCaptureFixture,
+    taxprofiler_case_id: str,
+):
+    """Test to ensure all parts of start command will run successfully given ideal conditions."""
+    caplog.set_level(logging.INFO)
+
+    # GIVEN case id
+    case_id: str = taxprofiler_case_id
+
+    # GIVEN a mocked config
+
+    # GIVEN decompression is not needed
+    TaxprofilerAnalysisAPI.resolve_decompression.return_value = None
+
+    # WHEN dry running with dry specified
+    result = cli_runner.invoke(start, [case_id, "--dry-run"], obj=taxprofiler_context)
+
+    # THEN command should execute successfully
+    assert result.exit_code == EXIT_SUCCESS
+    assert case_id in caplog.text
+
+    # THEN command should not include resume flag
+    assert "-resume" not in caplog.text


### PR DESCRIPTION
## Description

### Added

-  `cg workflow taxprofiler start`

### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b taxprofiler_start -a
    ```

### How to test

- [x] `cg workflow taxprofiler start richurchin -d`
<img width="1370" alt="Screenshot 2023-09-04 at 16 36 10" src="https://github.com/Clinical-Genomics/cg/assets/91951607/8855e1b3-9482-489e-acfb-3c6b44668b0f">

- [x] `cg workflow taxprofiler start richurchin`-Make sure that config case is created and analysis is being run sussessfully with tower.
![Screenshot 2023-09-05 at 11 41 41](https://github.com/Clinical-Genomics/cg/assets/91951607/5203789b-8d6a-4748-a2cc-f4f2eb3ee9eb)
![Screenshot 2023-09-05 at 11 39 49](https://github.com/Clinical-Genomics/cg/assets/91951607/d9d95215-571d-4cda-b552-734d7dfcfa24)
- [x] `cg workflow taxprofiler start richurchin --use-nextflow`
![Screenshot 2023-09-05 at 15 28 43](https://github.com/Clinical-Genomics/cg/assets/91951607/b12f2662-2996-4a9d-a7b5-ba10f9592605)

## Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
