### PR TITLE
Revert "Migrate sample sheet models to Pydantic v2 (#2394)(patch)"

### DIFF
--- a/cg/apps/demultiplex/sample_sheet/models.py
+++ b/cg/apps/demultiplex/sample_sheet/models.py
@@ -1,5 +1,5 @@
 import logging
-from pydantic import ConfigDict, BaseModel, Extra, Field
+from pydantic.v1 import BaseModel, Extra, Field
 from typing import List
 
 from cg.constants.constants import GenomeVersion
@@ -15,7 +15,10 @@ class FlowCellSample(BaseModel):
     sample_id: str
     index: str
     index2: str = ""
-    model_config = ConfigDict(populate_by_name=True, extra=Extra.ignore)
+
+    class Config:
+        allow_population_by_field_name = True
+        extra = Extra.ignore
 
 
 class FlowCellSampleNovaSeq6000(FlowCellSample):

--- a/cg/apps/demultiplex/sample_sheet/read_sample_sheet.py
+++ b/cg/apps/demultiplex/sample_sheet/read_sample_sheet.py
@@ -1,7 +1,7 @@
 import logging
 from pathlib import Path
 from typing import Dict, List, Type
-from pydantic import TypeAdapter
+from pydantic.v1 import parse_obj_as
 
 from cg.apps.demultiplex.sample_sheet.models import FlowCellSample, SampleSheet
 from cg.constants.constants import FileFormat
@@ -65,8 +65,7 @@ def get_validated_sample_sheet(
 ) -> SampleSheet:
     """Return a validated sample sheet object."""
     raw_samples: List[Dict[str, str]] = get_raw_samples(sample_sheet_content=sample_sheet_content)
-    adapter = TypeAdapter(List[sample_type])
-    samples = adapter.validate_python(raw_samples)
+    samples = parse_obj_as(List[sample_type], raw_samples)
     validate_samples_unique_per_lane(samples=samples)
     return SampleSheet(samples=samples)
 

--- a/cg/cli/demultiplex/sample_sheet.py
+++ b/cg/cli/demultiplex/sample_sheet.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from pathlib import Path
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 from typing import List
 
 import click

--- a/cg/models/demultiplex/flow_cell.py
+++ b/cg/models/demultiplex/flow_cell.py
@@ -4,7 +4,7 @@ import logging
 from pathlib import Path
 from typing import List, Optional, Type, Union
 
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 from typing_extensions import Literal
 
 from cg.apps.demultiplex.sample_sheet.models import (


### PR DESCRIPTION
This reverts commit 58f715562287febf9fdff614a5d18455c8398c3f.

## Description

### Added

-

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
