### PR TITLE
Remove unused fixtures

### DIFF
--- a/tests/apps/demultiplex/conftest.py
+++ b/tests/apps/demultiplex/conftest.py
@@ -17,30 +17,6 @@ from cg.constants.demultiplexing import BclConverter, SampleSheetNovaSeq6000Sect
 from cg.models.demultiplex.flow_cell import FlowCellDirectoryData
 
 
-@pytest.fixture(name="output_dirs_bcl2fastq")
-def fixture_output_dirs_bcl2fastq(demultiplexed_runs: Path) -> Path:
-    """Return the output path a dir with flow cells that have finished demultiplexing using
-    bcl2fastq."""
-    return Path(demultiplexed_runs, BclConverter.BCL2FASTQ)
-
-
-@pytest.fixture(name="demux_run_dir_bcl2fastq")
-def fixture_demux_run_dir_bcl2fastq(flow_cell_runs_dir: Path) -> Path:
-    """Return the path to a dir with flowcells ready for demultiplexing"""
-    return Path(flow_cell_runs_dir, BclConverter.BCL2FASTQ)
-
-
-@pytest.fixture(name="demux_run_dir_dragen")
-def fixture_demux_run_dir_dragen(flow_cell_runs_dir: Path) -> Path:
-    """Return the path to a dir with flowcells ready for demultiplexing"""
-    return Path(flow_cell_runs_dir, BclConverter.DRAGEN)
-
-
-@pytest.fixture(name="index_obj")
-def fixture_index_obj() -> Index:
-    return Index(name="C07 - UDI0051", sequence="AACAGGTT-ATACCAAG")
-
-
 @pytest.fixture(name="valid_index")
 def fixture_valid_index_() -> Index:
     """Return a valid index."""
@@ -282,18 +258,6 @@ def fixture_sample_sheet_dragen_duplicate_different_lane(
         ]
     )
     return valid_sample_sheet_dragen
-
-
-@pytest.fixture(name="valid_sample_sheet_bcl2fastq_path")
-def fixture_valid_sample_sheet_bcl2fastq_path() -> Path:
-    """Return the path to a NovaSeq S2 sample sheet, used in bcl2fastq demultiplexing."""
-    return Path("tests", "fixtures", "apps", "demultiplexing", "SampleSheetS2_Bcl2Fastq.csv")
-
-
-@pytest.fixture(name="valid_sample_sheet_dragen_path")
-def fixture_valid_sample_sheet_dragen_path() -> Path:
-    """Return the path to a NovaSeq S2 sample sheet, used in dragen demultiplexing."""
-    return Path("tests", "fixtures", "apps", "demultiplexing", "SampleSheetS2_Dragen.csv")
 
 
 @pytest.fixture(name="novaseq6000_flow_cell_sample_1")

--- a/tests/apps/sequencing_metrics_parser/conftest.py
+++ b/tests/apps/sequencing_metrics_parser/conftest.py
@@ -118,25 +118,6 @@ def fixture_bcl_convert_quality_metric_model_with_data(
     )
 
 
-@pytest.fixture(name="bcl_convert_sample_sheet_model_with_data", scope="session")
-def fixture_bcl_convert_sample_sheet_model_with_data(
-    test_lane,
-    test_sample_internal_id,
-    test_sample_project,
-) -> BclConvertSampleSheetData:
-    """Return a BclConvertSampleSheetData model with data."""
-    return BclConvertSampleSheetData(
-        **{
-            SampleSheetNovaSeq6000Sections.Data.FLOW_CELL_ID.value: "HY7FFDRX2",
-            SampleSheetNovaSeq6000Sections.Data.LANE.value: test_lane,
-            SampleSheetNovaSeq6000Sections.Data.SAMPLE_INTERNAL_ID_BCLCONVERT.value: test_sample_internal_id,
-            SampleSheetNovaSeq6000Sections.Data.SAMPLE_NAME.value: "anonymous_1",
-            SampleSheetNovaSeq6000Sections.Data.CONTROL.value: "N",
-            SampleSheetNovaSeq6000Sections.Data.SAMPLE_PROJECT_BCLCONVERT.value: test_sample_project,
-        }
-    )
-
-
 @pytest.fixture(name="parsed_bcl_convert_metrics", scope="session")
 def fixture_parsed_bcl_convert_metrics(bcl_convert_metrics_dir_path) -> BclConvertMetricsParser:
     """Return an object with parsed BCLConvert metrics."""

--- a/tests/apps/sequencing_metrics_parser/conftest.py
+++ b/tests/apps/sequencing_metrics_parser/conftest.py
@@ -62,12 +62,6 @@ def fixture_bcl_convert_test_mean_quality_score() -> float:
     return 36.02
 
 
-@pytest.fixture(name="bcl_convert_test_flow_cell_name", scope="session")
-def fixture_bcl_convert_test_flow_cell_name() -> str:
-    """Return the flow cell name for the test sample."""
-    return "HY7FFDRX2"
-
-
 @pytest.fixture(name="bcl_convert_demux_metric_model_with_data", scope="session")
 def fixture_bcl_convert_demux_metric_model_with_data(
     test_lane,
@@ -147,23 +141,3 @@ def fixture_bcl_convert_sample_sheet_model_with_data(
 def fixture_parsed_bcl_convert_metrics(bcl_convert_metrics_dir_path) -> BclConvertMetricsParser:
     """Return an object with parsed BCLConvert metrics."""
     return BclConvertMetricsParser(bcl_convert_metrics_dir_path=bcl_convert_metrics_dir_path)
-
-
-@pytest.fixture(name="parsed_sequencing_statistics_from_bcl_convert", scope="session")
-def fixture_parsed_sequencing_statistics_from_bcl_convert(
-    test_sample_internal_id: str,
-    test_lane: int,
-    bcl_convert_test_flow_cell_name: str,
-    bcl_convert_reads_for_test_sample: int,
-    bcl_convert_test_mean_quality_score_per_lane: float,
-    bcl_convert_test_q30_bases_percent_per_lane: float,
-) -> SampleLaneSequencingMetrics:
-    return SampleLaneSequencingMetrics(
-        sample_internal_id=test_sample_internal_id,
-        flow_cell_lane_number=test_lane,
-        flow_cell_name=bcl_convert_test_flow_cell_name,
-        sample_total_reads_in_lane=bcl_convert_reads_for_test_sample * 2,
-        sample_base_mean_quality_score=bcl_convert_test_mean_quality_score_per_lane,
-        sample_base_percentage_passing_q30=bcl_convert_test_q30_bases_percent_per_lane,
-        created_at=datetime.now(),
-    )

--- a/tests/apps/sequencing_metrics_parser/parsers/conftest.py
+++ b/tests/apps/sequencing_metrics_parser/parsers/conftest.py
@@ -38,20 +38,3 @@ def valid_bcl2fastq_metrics_data() -> Dict:
             }
         ],
     }
-
-
-@pytest.fixture
-def conversion_result() -> ConversionResult:
-    return ConversionResult(
-        LaneNumber=1,
-        Yield=1000,
-        DemuxResults=[
-            DemuxResult(
-                SampleId="S1",
-                SampleName="Sample1",
-                NumberReads=1,
-                Yield=100,
-                ReadMetrics=[ReadMetric(ReadNumber=1, Yield=100, YieldQ30=90, QualityScoreSum=100)],
-            )
-        ],
-    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2997,13 +2997,6 @@ def fixture_flow_cell_name() -> str:
     """Return flow cell name."""
     return "HVKJCDRXX"
 
-
-@pytest.fixture(name="expected_average_q30")
-def fixture_expected_average_q30() -> float:
-    """Return expected average Q30."""
-    return 90.50
-
-
 @pytest.fixture(name="expected_average_q30_for_sample")
 def fixture_expected_average_q30_for_sample() -> float:
     """Return expected average Q30 for a sample."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -836,40 +836,10 @@ def fixture_flow_cell_working_directory_bclconvert(
     return Path(tmp_flow_cells_directory, bcl_convert_flow_cell_dir.name)
 
 
-@pytest.fixture(name="tmp_flow_cell_demux_all_directory_bcl2fastq")
-def fixture_flow_cell_demux_all_directory_bcl2fastq(
-    bcl2fastq_flow_cell_dir: Path, tmp_flow_cells_demux_all_directory: Path
-) -> Path:
-    """Return the path to a working directory that will be deleted after test is run.
-    Used to test functions in demultiplex flow cell.
-    This is a path to a flow cell directory with the run parameters present.
-    """
-    return Path(tmp_flow_cells_demux_all_directory, bcl2fastq_flow_cell_dir.name)
-
-
-@pytest.fixture(name="tmp_flow_cell_demux_all_directory_bclconvert")
-def fixture_flow_cell_demux_all_directory_bclconvert(
-    bcl_convert_flow_cell_dir: Path, tmp_flow_cells_demux_all_directory: Path
-) -> Path:
-    """Return the path to a working directory that will be deleted after test is run.
-    Used to test functions in demultiplex flow cell.
-    This is a path to a flow cell directory with the run parameters present.
-    """
-    return Path(tmp_flow_cells_demux_all_directory, bcl_convert_flow_cell_dir.name)
-
-
 @pytest.fixture(name="tmp_flow_cell_name_no_run_parameters")
 def fixture_tmp_flow_cell_name_no_run_parameters() -> str:
     """This is the name of a flow cell directory with the run parameters missing."""
     return "180522_A00689_0200_BHLCKNCCXY"
-
-
-@pytest.fixture(name="tmp_flow_cell_name_ready_for_demultiplexing_bcl_convert")
-def fixture_tmp_flow_cell_name_ready_for_demultiplexing_bcl_convert() -> str:
-    """ "Returns the name of a flow cell directory ready for demultiplexing with BCL convert.
-    Contains a sample sheet that is BCL convert compliant
-    """
-    return "211101_A00187_0615_AHLG5GDRZZ"
 
 
 @pytest.fixture(name="tmp_flow_cell_name_no_sample_sheet")
@@ -898,14 +868,6 @@ def fixture_tmp_flow_cells_directory_no_sample_sheet(
 ) -> Path:
     """This is a path to a flow cell directory with the sample sheet and run parameters missing."""
     return Path(tmp_flow_cells_directory, tmp_flow_cell_name_no_sample_sheet)
-
-
-@pytest.fixture(name="tmp_flow_cells_directory_ready_for_demultiplexing_bcl_convert")
-def fixture_tmp_flow_cells_directory_ready_for_demultiplexing_bcl_convert(
-    tmp_flow_cell_name_ready_for_demultiplexing_bcl_convert: str, tmp_flow_cells_directory: Path
-) -> Path:
-    """This is a path to a flow cell directory with the run parameters missing."""
-    return Path(tmp_flow_cells_directory, tmp_flow_cell_name_ready_for_demultiplexing_bcl_convert)
 
 
 @pytest.fixture(name="tmp_flow_cells_directory_ready_for_demultiplexing_bcl2fastq")
@@ -1034,16 +996,6 @@ def fixture_flow_cell_directory_name_demultiplexed_with_bcl_convert(
     flow_cell_name_demultiplexed_with_bcl_convert: str,
 ):
     return f"230504_A00689_0804_B{flow_cell_name_demultiplexed_with_bcl_convert}"
-
-
-@pytest.fixture(
-    name="flow_cell_directory_name_demultiplexed_with_bcl_convert_flat", scope="session"
-)
-def fixture_flow_cell_directory_name_demultiplexed_with_bcl_convert_flat(
-    flow_cell_name_demultiplexed_with_bcl_convert: str,
-):
-    """Return the name of a flow cell directory that has been demultiplexed with Bcl Convert using a flat output directory structure."""
-    return f"230505_A00689_0804_B{flow_cell_name_demultiplexed_with_bcl_convert}"
 
 
 # Fixtures for test demultiplex flow cell
@@ -3126,16 +3078,6 @@ def store_with_sequencing_metrics(
     store.session.commit()
 
     return store
-
-
-@pytest.fixture(name="demultiplexed_flow_cells_tmp_directory")
-def fixture_demultiplexed_flow_cells_tmp_directory(tmp_path) -> Path:
-    original_dir = Path(
-        Path(__file__).parent, "fixtures", "apps", "demultiplexing", "demultiplexed-runs"
-    )
-    tmp_dir = Path(tmp_path, "tmp_run_dir")
-
-    return Path(shutil.copytree(original_dir, tmp_dir))
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2991,6 +2991,7 @@ def fixture_flow_cell_name() -> str:
     """Return flow cell name."""
     return "HVKJCDRXX"
 
+
 @pytest.fixture(name="expected_average_q30_for_sample")
 def fixture_expected_average_q30_for_sample() -> float:
     """Return expected average Q30 for a sample."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -639,12 +639,6 @@ def fixture_rnafusion_analysis_dir(analysis_dir: Path) -> Path:
     return Path(analysis_dir, "rnafusion")
 
 
-@pytest.fixture(name="taxprofiler_analysis_dir")
-def fixture_taxprofiler_analysis_dir(analysis_dir: Path) -> Path:
-    """Return the path to the directory with taxprofiler analysis files."""
-    return Path(analysis_dir, "taxprofiler")
-
-
 @pytest.fixture(name="sample_cram")
 def fixture_sample_cram(mip_dna_analysis_dir: Path) -> Path:
     """Return the path to the cram file for a sample."""

--- a/tests/meta/archive/conftest.py
+++ b/tests/meta/archive/conftest.py
@@ -164,12 +164,6 @@ def fixture_full_remote_path(remote_storage_repository: str, remote_path: Path) 
     return remote_storage_repository + remote_path.as_posix()
 
 
-@pytest.fixture(name="full_local_path")
-def fixture_full_local_path(local_storage_repository: str, trimmed_local_directory: Path) -> str:
-    """Returns the merged local repository and trimmed path."""
-    return local_storage_repository + trimmed_local_directory.as_posix()
-
-
 @pytest.fixture(name="archive_store")
 def fixture_archive_store(
     base_store: Store,

--- a/tests/meta/demultiplex/conftest.py
+++ b/tests/meta/demultiplex/conftest.py
@@ -56,16 +56,6 @@ def fixture_tmp_samplesheet_path(tmp_demulitplexing_dir: Path) -> Path:
     return tmp_sample_sheet_path
 
 
-@pytest.fixture(name="tmp_flow_cell_run_path")
-def fixture_tmp_flow_cell_run_path(project_dir: Path, bcl2fastq_flow_cell_full_name: str) -> Path:
-    """Flow cell run directory in temporary folder."""
-
-    tmp_flow_cell_run_path: Path = Path(project_dir, "flow_cell_run", bcl2fastq_flow_cell_full_name)
-    tmp_flow_cell_run_path.mkdir(exist_ok=True, parents=True)
-
-    return tmp_flow_cell_run_path
-
-
 @pytest.fixture(name="tmp_flow_cell_run_base_path")
 def fixture_tmp_flow_cell_run_base_path(
     project_dir: Path, bcl2fastq_flow_cell_full_name: str

--- a/tests/meta/demultiplex/conftest.py
+++ b/tests/meta/demultiplex/conftest.py
@@ -445,29 +445,3 @@ def tmp_demultiplexing_init_files(
     for file in demultiplexing_init_files:
         file.touch()
     return demultiplexing_init_files
-
-
-@pytest.fixture(name="bcl2fastq_folder_structure", scope="session")
-def fixture_bcl2fastq_folder_structure(tmp_path_factory, cg_dir: Path) -> Path:
-    """Return a folder structure that resembles a bcl2fastq run folder."""
-    base_dir: Path = tmp_path_factory.mktemp("".join((str(cg_dir), "bcl2fastq")))
-    folders: List[str] = ["l1t21", "l1t11", "l2t11", "l2t21"]
-
-    for folder in folders:
-        new_dir: Path = Path(base_dir, folder)
-        new_dir.mkdir()
-
-    return base_dir
-
-
-@pytest.fixture(name="not_bcl2fastq_folder_structure", scope="function")
-def fixture_not_bcl2fastq_folder_structure(tmp_path_factory, cg_dir: Path) -> Path:
-    """Return a folder structure that does not resemble a bcl2fastq run folder."""
-    base_dir: Path = tmp_path_factory.mktemp("".join((str(cg_dir), "not_bcl2fastq")))
-    folders: List[str] = ["just", "some", "folders"]
-
-    for folder in folders:
-        new_dir: Path = Path(base_dir, folder)
-        new_dir.mkdir()
-
-    return base_dir


### PR DESCRIPTION
## Description
Remove unused fixtures found with `pytest --dead-fixtures`

### Fixed
- Remove unused fixtures

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
