### PR TITLE
Migrate demux results

### DIFF
--- a/cg/models/demultiplex/demux_results.py
+++ b/cg/models/demultiplex/demux_results.py
@@ -4,7 +4,7 @@ import socket
 from pathlib import Path
 from typing import Iterable, Optional, Union
 
-from pydantic.v1 import BaseModel
+from pydantic import BaseModel
 from typing_extensions import Literal
 
 from cg.apps.cgstats.parsers.adapter_metrics import AdapterMetrics


### PR DESCRIPTION
## Description
This PR migrates the `DemuxResults` model to Pydantic v2. 
- Update import

### Fixed
- Migrate demultiplexing model to Pydantic v2


### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
