### PR TITLE
Move retrieval of sample sheets into housekeeper api

### DIFF
--- a/cg/apps/demultiplex/demultiplex_api.py
+++ b/cg/apps/demultiplex/demultiplex_api.py
@@ -14,7 +14,6 @@ from cg.constants.constants import FileFormat
 from cg.constants.demultiplexing import DemultiplexingDirsAndFiles, BclConverter
 from cg.constants.priority import SlurmQos
 from cg.io.controller import WriteFile
-from cg.meta.demultiplex.housekeeper_storage_functions import get_sample_sheets_from_latest_version
 from cg.models.demultiplex.flow_cell import FlowCellDirectoryData
 from cg.models.demultiplex.sbatch import SbatchCommand, SbatchError
 from cg.models.slurm.sbatch import Sbatch, SbatchDragen
@@ -121,9 +120,7 @@ class DemultiplexingAPI:
 
     def is_sample_sheet_in_housekeeper(self, flow_cell_id: str) -> bool:
         """Returns True if the sample sheet for the flow cell exists in Housekeeper."""
-        return bool(
-            get_sample_sheets_from_latest_version(flow_cell_id=flow_cell_id, hk_api=self.hk_api)
-        )
+        return bool(self.hk_api.get_sample_sheets_from_latest_version(flow_cell_id=flow_cell_id))
 
     def get_flow_cell_unaligned_dir(self, flow_cell: FlowCellDirectoryData) -> Path:
         """Returns the path to where the demultiplexed result are located."""

--- a/cg/apps/housekeeper/hk.py
+++ b/cg/apps/housekeeper/hk.py
@@ -482,3 +482,18 @@ class HousekeeperAPI:
             raise ValueError(f"No Archive entry found for file with id {file_id}.")
         self._store.update_retrieval_task_id(archive=archive, retrieval_task_id=retrieval_task_id)
         self.commit()
+
+    def get_sample_sheets_from_latest_version(self, flow_cell_id: str) -> List[File]:
+        """Returns the files tagged with 'samplesheet' or 'archived_sample_sheet' for the given bundle."""
+        try:
+            sheets_with_normal_tag: List[File] = self.get_files_from_latest_version(
+                bundle_name=flow_cell_id, tags=[flow_cell_id, SequencingFileTag.SAMPLE_SHEET]
+            ).all()
+            sheets_with_archive_tag: List[File] = self.get_files_from_latest_version(
+                bundle_name=flow_cell_id,
+                tags=[flow_cell_id, SequencingFileTag.ARCHIVED_SAMPLE_SHEET],
+            ).all()
+            sample_sheet_files: List[File] = sheets_with_normal_tag + sheets_with_archive_tag
+        except HousekeeperBundleVersionMissingError:
+            sample_sheet_files: List = []
+        return sample_sheet_files

--- a/cg/cli/demultiplex/sample_sheet.py
+++ b/cg/cli/demultiplex/sample_sheet.py
@@ -16,7 +16,6 @@ from cg.exc import FlowCellError
 from cg.io.controller import WriteFile, WriteStream
 from cg.meta.demultiplex.housekeeper_storage_functions import (
     add_sample_sheet_path_to_housekeeper,
-    get_sample_sheets_from_latest_version,
 )
 from cg.models.cg_config import CGConfig
 from cg.models.demultiplex.flow_cell import FlowCellDirectoryData
@@ -90,9 +89,7 @@ def create_sheet(
     except FlowCellError as error:
         raise click.Abort from error
     flow_cell_id: str = flow_cell.id
-    sample_sheets_hk: List[File] = get_sample_sheets_from_latest_version(
-        flow_cell_id=flow_cell_id, hk_api=hk_api
-    )
+    sample_sheets_hk: List[File] = hk_api.get_sample_sheets_from_latest_version(flow_cell_id)
     if flow_cell.sample_sheet_exists():
         LOG.info("Sample sheet already exists in flow cell directory")
         if not dry_run:
@@ -165,9 +162,7 @@ def create_all_sheets(context: CGConfig, dry_run: bool):
         except FlowCellError:
             continue
         flow_cell_id: str = flow_cell.id
-        sample_sheets_hk: List[File] = get_sample_sheets_from_latest_version(
-            flow_cell_id=flow_cell_id, hk_api=hk_api
-        )
+        sample_sheets_hk: List[File] = hk_api.get_sample_sheets_from_latest_version(flow_cell_id)
         if flow_cell.sample_sheet_exists():
             LOG.debug("Sample sheet already exists in flow cell directory")
             if not dry_run:

--- a/cg/meta/clean/flow_cell_run_directories.py
+++ b/cg/meta/clean/flow_cell_run_directories.py
@@ -11,7 +11,6 @@ from cg.constants import FlowCellStatus
 from cg.constants.demultiplexing import DemultiplexingDirsAndFiles
 from cg.constants.housekeeper_tags import SequencingFileTag
 from cg.constants.symbols import UNDERSCORE
-from cg.meta.demultiplex.housekeeper_storage_functions import get_sample_sheets_from_latest_version
 from cg.store import Store
 from cg.store.models import Flowcell
 from cg.utils.date import get_timedelta_from_date
@@ -107,9 +106,8 @@ class RunDirFlowCell:
         if self.hk.bundle(name=self.id) is None:
             LOG.info(f"Creating bundle with name {self.id}")
             self.hk.create_new_bundle_and_version(name=self.id)
-        sample_sheets_from_latest_version: List[File] = get_sample_sheets_from_latest_version(
+        sample_sheets_from_latest_version: List[File] = self.hk.get_sample_sheets_from_latest_version(
             flow_cell_id=self.id,
-            hk_api=self.hk,
         )
         for file in sample_sheets_from_latest_version:
             if file.is_included:

--- a/cg/meta/clean/flow_cell_run_directories.py
+++ b/cg/meta/clean/flow_cell_run_directories.py
@@ -106,7 +106,9 @@ class RunDirFlowCell:
         if self.hk.bundle(name=self.id) is None:
             LOG.info(f"Creating bundle with name {self.id}")
             self.hk.create_new_bundle_and_version(name=self.id)
-        sample_sheets_from_latest_version: List[File] = self.hk.get_sample_sheets_from_latest_version(
+        sample_sheets_from_latest_version: List[
+            File
+        ] = self.hk.get_sample_sheets_from_latest_version(
             flow_cell_id=self.id,
         )
         for file in sample_sheets_from_latest_version:

--- a/cg/meta/demultiplex/delete_demultiplex_api.py
+++ b/cg/meta/demultiplex/delete_demultiplex_api.py
@@ -9,7 +9,6 @@ from cg.apps.demultiplex.demultiplex_api import DemultiplexingAPI
 from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.constants.housekeeper_tags import SequencingFileTag
 from cg.exc import DeleteDemuxError
-from cg.meta.demultiplex.housekeeper_storage_functions import get_sample_sheets_from_latest_version
 from cg.models.cg_config import CGConfig
 from cg.store import Store
 from cg.store.models import Sample, Flowcell
@@ -78,8 +77,8 @@ class DeleteDemuxAPI:
 
     def _delete_sample_sheet_housekeeper(self) -> None:
         """Delete the presence of all sample sheets related to a flow cell in Housekeeper."""
-        sample_sheet_files: List[File] = get_sample_sheets_from_latest_version(
-            flow_cell_id=self.flow_cell_name, hk_api=self.housekeeper_api
+        sample_sheet_files: List[File] = self.housekeeper_api.get_sample_sheets_from_latest_version(
+            flow_cell_id=self.flow_cell_name
         )
         if sample_sheet_files:
             for file in sample_sheet_files:

--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -14,7 +14,6 @@ from cg.constants.demultiplexing import DemultiplexingDirsAndFiles
 from cg.exc import FlowCellError, MissingFilesError
 from cg.meta.demultiplex import files
 from cg.meta.demultiplex.housekeeper_storage_functions import (
-    get_sample_sheets_from_latest_version,
     store_flow_cell_data_in_housekeeper,
 )
 from cg.meta.demultiplex.status_db_storage_functions import (
@@ -109,9 +108,7 @@ class DemuxPostProcessingAPI:
         )
 
         sample_sheet_path: Path = Path(
-            get_sample_sheets_from_latest_version(
-                flow_cell_id=parsed_flow_cell.id, hk_api=self.hk_api
-            )[0].full_path
+            self.hk_api.get_sample_sheets_from_latest_version(parsed_flow_cell.id)[0].full_path
         )
         parsed_flow_cell.set_sample_sheet_path_hk(hk_path=sample_sheet_path)
         LOG.debug("Set path for Housekeeper sample sheet in flow cell")

--- a/cg/meta/demultiplex/housekeeper_storage_functions.py
+++ b/cg/meta/demultiplex/housekeeper_storage_functions.py
@@ -223,18 +223,3 @@ def file_exists_in_latest_version_for_bundle(
     return any(
         file_path.name == Path(bundle_file.path).name for bundle_file in latest_version.files
     )
-
-
-def get_sample_sheets_from_latest_version(flow_cell_id: str, hk_api: HousekeeperAPI) -> List[File]:
-    """Returns the files tagged with 'samplesheet' or 'archived_sample_sheet' for the given bundle."""
-    try:
-        sheets_with_normal_tag: List[File] = hk_api.get_files_from_latest_version(
-            bundle_name=flow_cell_id, tags=[flow_cell_id, SequencingFileTag.SAMPLE_SHEET]
-        ).all()
-        sheets_with_archive_tag: List[File] = hk_api.get_files_from_latest_version(
-            bundle_name=flow_cell_id, tags=[flow_cell_id, SequencingFileTag.ARCHIVED_SAMPLE_SHEET]
-        ).all()
-        sample_sheet_files: List[File] = sheets_with_normal_tag + sheets_with_archive_tag
-    except HousekeeperBundleVersionMissingError:
-        sample_sheet_files: List = []
-    return sample_sheet_files

--- a/cg/meta/workflow/fluffy.py
+++ b/cg/meta/workflow/fluffy.py
@@ -11,7 +11,6 @@ from cg.constants.constants import FileFormat
 from cg.constants.demultiplexing import SampleSheetBcl2FastqSections
 from cg.exc import HousekeeperFileMissingError
 from cg.io.controller import ReadFile
-from cg.meta.demultiplex.housekeeper_storage_functions import get_sample_sheets_from_latest_version
 from cg.meta.workflow.analysis import AnalysisAPI
 from cg.models.cg_config import CGConfig
 from cg.store.models import Family, Flowcell, Sample
@@ -253,8 +252,8 @@ class FluffyAnalysisAPI(AnalysisAPI):
 
     def get_sample_sheet_housekeeper_path(self, flowcell_name: str) -> Path:
         """Returns the path to original sample sheet file that is added to Housekeeper."""
-        sample_sheet_files: list = get_sample_sheets_from_latest_version(
-            flow_cell_id=flowcell_name, hk_api=self.housekeeper_api
+        sample_sheet_files: list = self.housekeeper_api.get_sample_sheets_from_latest_version(
+            flow_cell_id=flowcell_name
         )
         if not sample_sheet_files:
             LOG.error(

--- a/tests/cli/demultiplex/test_create_sample_sheet.py
+++ b/tests/cli/demultiplex/test_create_sample_sheet.py
@@ -10,7 +10,6 @@ from cg.cli.demultiplex.sample_sheet import create_sheet
 from cg.constants.demultiplexing import BclConverter
 from cg.constants.process import EXIT_SUCCESS
 
-from cg.meta.demultiplex.housekeeper_storage_functions import get_sample_sheets_from_latest_version
 from cg.models.cg_config import CGConfig
 from cg.models.demultiplex.flow_cell import FlowCellDirectoryData
 
@@ -74,8 +73,8 @@ def test_create_bcl2fastq_sample_sheet(
     assert not flow_cell.sample_sheet_exists()
 
     # GIVEN that there are no sample sheet in Housekeeper
-    assert not get_sample_sheets_from_latest_version(
-        flow_cell_id=flow_cell.id, hk_api=sample_sheet_context.housekeeper_api
+    assert not sample_sheet_context.housekeeper_api.get_sample_sheets_from_latest_version(
+        flow_cell_id=flow_cell.id
     )
 
     # GIVEN flow cell samples
@@ -102,8 +101,8 @@ def test_create_bcl2fastq_sample_sheet(
     assert flow_cell.validate_sample_sheet()
 
     # THEN the sample sheet is in Housekeeper
-    assert get_sample_sheets_from_latest_version(
-        flow_cell_id=flow_cell.id, hk_api=sample_sheet_context.housekeeper_api
+    assert sample_sheet_context.housekeeper_api.get_sample_sheets_from_latest_version(
+        flow_cell_id=flow_cell.id
     )
 
 
@@ -125,8 +124,8 @@ def test_create_dragen_sample_sheet(
     assert not flow_cell.sample_sheet_exists()
 
     # GIVEN that there are no sample sheet in Housekeeper
-    assert not get_sample_sheets_from_latest_version(
-        flow_cell_id=flow_cell.id, hk_api=sample_sheet_context.housekeeper_api
+    assert not sample_sheet_context.housekeeper_api.get_sample_sheets_from_latest_version(
+        flow_cell_id=flow_cell.id
     )
 
     # GIVEN flow cell samples
@@ -153,6 +152,6 @@ def test_create_dragen_sample_sheet(
     assert flow_cell.validate_sample_sheet()
 
     # THEN the sample sheet is in Housekeeper
-    assert get_sample_sheets_from_latest_version(
-        flow_cell_id=flow_cell.id, hk_api=sample_sheet_context.housekeeper_api
+    assert sample_sheet_context.housekeeper_api.get_sample_sheets_from_latest_version(
+        flow_cell_id=flow_cell.id
     )

--- a/tests/meta/demultiplex/test_housekeeper_storage_functions.py
+++ b/tests/meta/demultiplex/test_housekeeper_storage_functions.py
@@ -15,7 +15,6 @@ from cg.meta.demultiplex.housekeeper_storage_functions import (
     add_sample_fastq_files_to_housekeeper,
     add_sample_sheet_path_to_housekeeper,
     add_demux_logs_to_housekeeper,
-    get_sample_sheets_from_latest_version,
 )
 from cg.store import Store
 from tests.store_helpers import StoreHelpers
@@ -118,8 +117,8 @@ def test_add_fastq_files_without_sample_id(
         hk_api=demultiplex_context.housekeeper_api,
     )
     sample_sheet_path: Path = Path(
-        get_sample_sheets_from_latest_version(
-            flow_cell_id=bcl_convert_flow_cell.id, hk_api=demultiplex_context.housekeeper_api
+        demultiplex_context.housekeeper_api.get_sample_sheets_from_latest_version(
+            flow_cell_id=bcl_convert_flow_cell.id
         )[0].full_path
     )
     bcl_convert_flow_cell.set_sample_sheet_path_hk(hk_path=sample_sheet_path)


### PR DESCRIPTION
## Description
This PR moves a function used to retrieve sample sheets for a flow cell from a utils module into the housekeeper api.
Many of the functions in this module should probably be moved into the housekeeper api

### Fixed
- Move housekeeper function into housekeeper api

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

