### PR TITLE
Move file existence check into hk api

### DIFF
--- a/cg/apps/housekeeper/hk.py
+++ b/cg/apps/housekeeper/hk.py
@@ -482,3 +482,11 @@ class HousekeeperAPI:
             raise ValueError(f"No Archive entry found for file with id {file_id}.")
         self._store.update_retrieval_task_id(archive=archive, retrieval_task_id=retrieval_task_id)
         self.commit()
+
+    def file_exists_in_latest_version_for_bundle(self, file_path: Path, bundle_name: str) -> bool:
+        """Check if a file exists in the latest version for bundle."""
+        latest_version: Version = self.get_latest_bundle_version(bundle_name)
+
+        return any(
+            file_path.name == Path(bundle_file.path).name for bundle_file in latest_version.files
+        )

--- a/cg/meta/demultiplex/housekeeper_storage_functions.py
+++ b/cg/meta/demultiplex/housekeeper_storage_functions.py
@@ -201,8 +201,8 @@ def add_file_to_bundle_if_non_existent(
         LOG.warning(f"File does not exist: {file_path}")
         return
 
-    if not file_exists_in_latest_version_for_bundle(
-        file_path=file_path, bundle_name=bundle_name, hk_api=hk_api
+    if not hk_api.file_exists_in_latest_version_for_bundle(
+        file_path=file_path, bundle_name=bundle_name
     ):
         hk_api.add_and_include_file_to_latest_version(
             bundle_name=bundle_name,
@@ -212,17 +212,6 @@ def add_file_to_bundle_if_non_existent(
         LOG.info(f"File added to Housekeeper bundle {bundle_name}")
     else:
         LOG.info(f"Bundle {bundle_name} already has a file with the same name as {file_path}")
-
-
-def file_exists_in_latest_version_for_bundle(
-    file_path: Path, bundle_name: str, hk_api: HousekeeperAPI
-) -> bool:
-    """Check if a file exists in the latest version for bundle."""
-    latest_version: Version = hk_api.get_latest_bundle_version(bundle_name=bundle_name)
-
-    return any(
-        file_path.name == Path(bundle_file.path).name for bundle_file in latest_version.files
-    )
 
 
 def get_sample_sheets_from_latest_version(flow_cell_id: str, hk_api: HousekeeperAPI) -> List[File]:


### PR DESCRIPTION
## Description
This PR moves a function which checks whether a file has been added to a bundle into the housekeeper api.
Many of the functions in this module should probably be moved into the housekeeper api.

### Fixed
- Move housekeeper functionality into housekeeper api

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
