### PR TITLE
Remove verbose doc strings

### DIFF
--- a/cg/apps/sequencing_metrics_parser/parsers/bcl2fastq.py
+++ b/cg/apps/sequencing_metrics_parser/parsers/bcl2fastq.py
@@ -46,7 +46,7 @@ def parse_bcl2fastq_raw_tile_metrics(
 def aggregate_tile_metrics_per_sample_and_lane(
     tile_metrics: List[Bcl2FastqSampleLaneTileMetrics],
 ) -> List[Bcl2FastqSampleLaneMetrics]:
-    """Aggregate the tile metrics resolved per sample and lane instead."""
+    """Aggregate the tile metrics per sample and lane instead."""
     metrics = {}
 
     for tile_metric in tile_metrics:
@@ -90,10 +90,10 @@ def discard_index_sequence(sample_id_with_index: str) -> str:
 def get_bcl2fastq_stats_paths(demultiplex_result_directory: Path) -> List[Path]:
     """Find metrics files in Bcl2fastq demultiplex result directory."""
     stats_json_paths = []
-    lane_tile_dir_pattern = re.compile(r"l\d+t\d+")
+    pattern = re.compile(r"l\d+t\d+")
 
     for subdir in os.listdir(demultiplex_result_directory):
-        if lane_tile_dir_pattern.match(subdir):
+        if pattern.match(subdir):
             stats_json_path = (
                 demultiplex_result_directory
                 / subdir
@@ -103,8 +103,4 @@ def get_bcl2fastq_stats_paths(demultiplex_result_directory: Path) -> List[Path]:
             if stats_json_path.is_file():
                 stats_json_paths.append(stats_json_path)
 
-    if not stats_json_paths:
-        raise FileNotFoundError(
-            f"Could not find any stats.json files in {demultiplex_result_directory}."
-        )
     return stats_json_paths

--- a/cg/apps/sequencing_metrics_parser/parsers/bcl2fastq.py
+++ b/cg/apps/sequencing_metrics_parser/parsers/bcl2fastq.py
@@ -13,50 +13,21 @@ from cg.constants.demultiplexing import (
 )
 
 
-def parse_bcl2fastq_sequencing_metrics(
-    flow_cell_dir: Path,
-) -> List[Bcl2FastqSampleLaneMetrics]:
+def parse_bcl2fastq_sequencing_metrics(flow_cell_dir: Path) -> List[Bcl2FastqSampleLaneMetrics]:
     """
-    Parse stats.json files in specified Bcl2fastq demultiplex result directory.
-
-    This function navigates through subdirectories in the given path, identifies
-    and parses the Stats.json files from Bcl2fastq specifying metrics per sample, lane and tile
-    on the flow cell and returns a list of parsed sequencing metrics resolved per tile.
-
-    Parameters:
-    demultiplex_result_directory (Path): Path to the demultiplexing results.
-
-    Returns:
-    List[Bcl2FastqSampleLaneMetrics]: List of parsed sequencing metrics per sample and lane.
+    Parse metrics for a flow cell demultiplexed with Bcl2fastq.
     """
     tile_sequencing_metrics: List[
         Bcl2FastqSampleLaneTileMetrics
-    ] = parse_bcl2fastq_raw_tile_metrics(demultiplex_result_directory=flow_cell_dir)
+    ] = parse_bcl2fastq_raw_tile_metrics(flow_cell_dir)
 
-    sample_lane_sequencing_metrics: List[
-        Bcl2FastqSampleLaneMetrics
-    ] = aggregate_tile_metrics_per_sample_and_lane(tile_metrics=tile_sequencing_metrics)
-
-    return sample_lane_sequencing_metrics
+    return aggregate_tile_metrics_per_sample_and_lane(tile_sequencing_metrics)
 
 
 def parse_bcl2fastq_raw_tile_metrics(
     demultiplex_result_directory: Path,
 ) -> List[Bcl2FastqSampleLaneTileMetrics]:
-    """
-    Parse stats.json files in specified Bcl2fastq demultiplex result directory.
-
-    This function navigates through subdirectories in the given path, identifies
-    and parses the Stats.json files from Bcl2fastq specifying metrics per sample, lane and tile
-    on the flow cell and returns a list of parsed sequencing metrics resolved per tile.
-
-    Parameters:
-    demultiplex_result_directory (Path): Path to the demultiplexing results.
-
-    Returns:
-    List[Bcl2FastqTileSequencingMetrics]: List of parsed sequencing metrics per tile.
-    """
-
+    """Parse metrics for each tile on a flow cell demultiplexed with Bcl2fastq."""
     tile_sequencing_metrics: List[Bcl2FastqSampleLaneTileMetrics] = []
 
     stats_json_paths: List[Path] = get_bcl2fastq_stats_paths(
@@ -75,7 +46,7 @@ def parse_bcl2fastq_raw_tile_metrics(
 def aggregate_tile_metrics_per_sample_and_lane(
     tile_metrics: List[Bcl2FastqSampleLaneTileMetrics],
 ) -> List[Bcl2FastqSampleLaneMetrics]:
-    """Aggregate the metrics parsed per sample and tile to be per sample and lane instead."""
+    """Aggregate the tile metrics resolved per sample and lane instead."""
     metrics = {}
 
     for tile_metric in tile_metrics:
@@ -117,24 +88,12 @@ def discard_index_sequence(sample_id_with_index: str) -> str:
 
 
 def get_bcl2fastq_stats_paths(demultiplex_result_directory: Path) -> List[Path]:
-    """
-    Identify and return paths to stats.json files in Bcl2fastq demultiplex result directory.
-
-    This function looks through subdirectories in the given demultiplex directory,
-    matching specific naming pattern (l<num>t<num>), and collects paths
-    to any stats.json files found within a "Stats" subdirectory.
-
-    Parameters:
-    demultiplex_result_directory (Path): Path to the demultiplexing results.
-
-    Returns:
-    List[Path]: List of paths to identified stats.json files.
-    """
+    """Find metrics files in Bcl2fastq demultiplex result directory."""
     stats_json_paths = []
-    pattern = re.compile(r"l\d+t\d+")
+    lane_tile_dir_pattern = re.compile(r"l\d+t\d+")
 
     for subdir in os.listdir(demultiplex_result_directory):
-        if pattern.match(subdir):
+        if lane_tile_dir_pattern.match(subdir):
             stats_json_path = (
                 demultiplex_result_directory
                 / subdir
@@ -144,4 +103,8 @@ def get_bcl2fastq_stats_paths(demultiplex_result_directory: Path) -> List[Path]:
             if stats_json_path.is_file():
                 stats_json_paths.append(stats_json_path)
 
+    if not stats_json_paths:
+        raise FileNotFoundError(
+            f"Could not find any stats.json files in {demultiplex_result_directory}."
+        )
     return stats_json_paths

--- a/cg/apps/sequencing_metrics_parser/parsers/bcl2fastq.py
+++ b/cg/apps/sequencing_metrics_parser/parsers/bcl2fastq.py
@@ -14,9 +14,7 @@ from cg.constants.demultiplexing import (
 
 
 def parse_bcl2fastq_sequencing_metrics(flow_cell_dir: Path) -> List[Bcl2FastqSampleLaneMetrics]:
-    """
-    Parse metrics for a flow cell demultiplexed with Bcl2fastq.
-    """
+    """Parse metrics for a flow cell demultiplexed with Bcl2fastq."""
     tile_sequencing_metrics: List[
         Bcl2FastqSampleLaneTileMetrics
     ] = parse_bcl2fastq_raw_tile_metrics(flow_cell_dir)

--- a/cg/apps/sequencing_metrics_parser/parsers/bcl2fastq_to_sequencing_statistics.py
+++ b/cg/apps/sequencing_metrics_parser/parsers/bcl2fastq_to_sequencing_statistics.py
@@ -16,13 +16,6 @@ def create_sample_lane_sequencing_metrics_from_bcl2fastq_for_flow_cell(
 ) -> List[SampleLaneSequencingMetrics]:
     """
     Parses the Bcl2fastq generated stats.json files and aggregates and calculates metrics for each sample in each lane.
-
-    Args:
-        flow_cell_dir (Path): Demultiplexed flow cell directory containing output from bcl2fastq
-
-    Returns:
-        List[SampleLaneSequencingMetrics]: A list of SampleLaneSequencingMetrics representing the sequencing
-        metrics for each sample in each lane on the flow cell.
     """
 
     sample_lane_sequencing_metrics: List[SampleLaneSequencingMetrics] = []
@@ -43,16 +36,7 @@ def create_sample_lane_sequencing_metrics_from_bcl2fastq_for_flow_cell(
 def create_sample_lane_sequencing_metrics_from_bcl2fastq(
     bcl2fastq_sample_metrics: Bcl2FastqSampleLaneMetrics,
 ) -> SampleLaneSequencingMetrics:
-    """
-    Generates a SampleLaneSequencingMetrics based on the provided raw results.
-
-    Args:
-        raw_sample_metrics: Bcl2FastqSampleLaneMetrics: The raw sequencing metrics for a sample in a lane.
-
-    Returns:
-        SampleLaneSequencingMetrics: SampleLaneSequencingMetrics encapsulates the statistics for a sample
-        in a lane on the flow cell.
-    """
+    """Generates a SampleLaneSequencingMetrics based on the provided raw results."""
 
     sample_base_percentage_passing_q30: float = calculate_q30_bases_percentage(
         q30_yield=bcl2fastq_sample_metrics.sample_total_yield_q30_in_lane,


### PR DESCRIPTION
## Description
Found some overly verbose doc strings.

### Fixed
- Shorten verbose doc strings

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions