### PR TITLE
Migrate sbatch to Pydantic v2

### DIFF
--- a/cg/models/demultiplex/sbatch.py
+++ b/cg/models/demultiplex/sbatch.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic.v1 import BaseModel
+from pydantic import BaseModel
 from typing_extensions import Literal
 
 
@@ -15,7 +15,7 @@ class SbatchError(BaseModel):
 class SbatchCommand(BaseModel):
     run_dir: str  # path/to/a_flowcell/
     demux_dir: str  # path/to/output_dir/
-    unaligned_dir: Optional[str]  # path/to/output_dir/Unaligned/
+    unaligned_dir: Optional[str] = None  # path/to/output_dir/Unaligned/
     sample_sheet: str  # path/to/SampleSheet.csv
     demux_completed_file: str  # path/to/demuxcomplete.txt
     environment: Literal["stage", "production"]


### PR DESCRIPTION
## Description

### Fixed
- Migrate sbatch model to Pydantic v2.

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
