### PR TITLE
Migrate lims models to Pydantic v2

### DIFF
--- a/cg/models/lims/sample.py
+++ b/cg/models/lims/sample.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic.v1 import BaseModel, validator
+from pydantic import field_validator, BaseModel
 from typing_extensions import Literal
 
 from cg.constants import Priority
@@ -10,49 +10,50 @@ SEX_MAP = {"male": "M", "female": "F"}
 
 class Udf(BaseModel):
     application: str
-    capture_kit: Optional[str]
-    collection_date: Optional[str]
-    comment: Optional[str]
-    concentration: Optional[str]
-    concentration_sample: Optional[str]
+    capture_kit: Optional[str] = None
+    collection_date: Optional[str] = None
+    comment: Optional[str] = None
+    concentration: Optional[str] = None
+    concentration_sample: Optional[str] = None
     customer: str
-    control: Optional[str]
-    data_analysis: Optional[str]
-    data_delivery: Optional[str]
-    elution_buffer: Optional[str]
-    extraction_method: Optional[str]
+    control: Optional[str] = None
+    data_analysis: Optional[str] = None
+    data_delivery: Optional[str] = None
+    elution_buffer: Optional[str] = None
+    extraction_method: Optional[str] = None
     family_name: str = "NA"
-    formalin_fixation_time: Optional[str]
-    index: Optional[str]
-    index_number: Optional[str]
-    lab_code: Optional[str]
-    organism: Optional[str]
-    organism_other: Optional[str]
-    original_lab: Optional[str]
-    original_lab_address: Optional[str]
-    pool: Optional[str]
-    post_formalin_fixation_time: Optional[str]
-    pre_processing_method: Optional[str]
-    primer: Optional[str]
+    formalin_fixation_time: Optional[str] = None
+    index: Optional[str] = None
+    index_number: Optional[str] = None
+    lab_code: Optional[str] = None
+    organism: Optional[str] = None
+    organism_other: Optional[str] = None
+    original_lab: Optional[str] = None
+    original_lab_address: Optional[str] = None
+    pool: Optional[str] = None
+    post_formalin_fixation_time: Optional[str] = None
+    pre_processing_method: Optional[str] = None
+    primer: Optional[str] = None
     priority: str = Priority.standard.name
-    quantity: Optional[str]
-    reference_genome: Optional[str]
-    region: Optional[str]
-    region_code: Optional[str]
+    quantity: Optional[str] = None
+    reference_genome: Optional[str] = None
+    region: Optional[str] = None
+    region_code: Optional[str] = None
     require_qc_ok: bool = False
-    rml_plate_name: Optional[str]
-    selection_criteria: Optional[str]
+    rml_plate_name: Optional[str] = None
+    selection_criteria: Optional[str] = None
     sex: Literal["M", "F", "unknown"] = "unknown"
     skip_reception_control: Optional[bool] = None
     source: str = "NA"
-    tissue_block_size: Optional[str]
+    tissue_block_size: Optional[str] = None
     tumour: Optional[bool] = False
-    tumour_purity: Optional[str]
-    volume: Optional[str]
-    well_position_rml: Optional[str]
-    verified_organism: Optional[bool]
+    tumour_purity: Optional[str] = None
+    volume: Optional[str] = None
+    well_position_rml: Optional[str] = None
+    verified_organism: Optional[bool] = None
 
-    @validator("sex", pre=True)
+    @field_validator("sex", mode="before")
+    @classmethod
     def validate_sex(cls, value: str):
         return SEX_MAP.get(value, "unknown")
 
@@ -60,14 +61,14 @@ class Udf(BaseModel):
 class LimsSample(BaseModel):
     name: str
     container: str = "Tube"
-    container_name: Optional[str]
-    well_position: Optional[str]
-    index_sequence: Optional[str]
-    udfs: Optional[Udf]
+    container_name: Optional[str] = None
+    well_position: Optional[str] = None
+    index_sequence: Optional[str] = None
+    udfs: Optional[Udf] = None
 
     @classmethod
     def parse_obj(cls, obj: dict):
-        parsed_obj: LimsSample = super().parse_obj(obj)
-        udf: Udf = Udf.parse_obj(obj)
+        parsed_obj: LimsSample = super().model_validate(obj)
+        udf: Udf = Udf.model_validate(obj)
         parsed_obj.udfs = udf
         return parsed_obj

--- a/cg/models/lims/sample.py
+++ b/cg/models/lims/sample.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
-from pydantic import field_validator, BaseModel
-from typing_extensions import Literal
+from pydantic import BeforeValidator, field_validator, BaseModel
+from typing_extensions import Annotated, Literal
 
 from cg.constants import Priority
 
@@ -13,8 +13,8 @@ class Udf(BaseModel):
     capture_kit: Optional[str] = None
     collection_date: Optional[str] = None
     comment: Optional[str] = None
-    concentration: Optional[str] = None
-    concentration_sample: Optional[str] = None
+    concentration: Annotated[Optional[str], BeforeValidator(lambda v: str(v))] = None
+    concentration_sample: Annotated[Optional[str], BeforeValidator(lambda v: str(v))] = None
     customer: str
     control: Optional[str] = None
     data_analysis: Optional[str] = None
@@ -22,7 +22,7 @@ class Udf(BaseModel):
     elution_buffer: Optional[str] = None
     extraction_method: Optional[str] = None
     family_name: str = "NA"
-    formalin_fixation_time: Optional[str] = None
+    formalin_fixation_time: Annotated[Optional[str], BeforeValidator(lambda v: str(v))] = None
     index: Optional[str] = None
     index_number: Optional[str] = None
     lab_code: Optional[str] = None
@@ -31,11 +31,11 @@ class Udf(BaseModel):
     original_lab: Optional[str] = None
     original_lab_address: Optional[str] = None
     pool: Optional[str] = None
-    post_formalin_fixation_time: Optional[str] = None
+    post_formalin_fixation_time: Annotated[Optional[str], BeforeValidator(lambda v: str(v))] = None
     pre_processing_method: Optional[str] = None
     primer: Optional[str] = None
     priority: str = Priority.standard.name
-    quantity: Optional[str] = None
+    quantity: Annotated[Optional[str], BeforeValidator(lambda v: str(v))] = None
     reference_genome: Optional[str] = None
     region: Optional[str] = None
     region_code: Optional[str] = None
@@ -47,8 +47,8 @@ class Udf(BaseModel):
     source: str = "NA"
     tissue_block_size: Optional[str] = None
     tumour: Optional[bool] = False
-    tumour_purity: Optional[str] = None
-    volume: Optional[str] = None
+    tumour_purity: Annotated[Optional[str], BeforeValidator(lambda v: str(v))] = None
+    volume: Annotated[Optional[str], BeforeValidator(lambda v: str(v))] = None
     well_position_rml: Optional[str] = None
     verified_organism: Optional[bool] = None
 

--- a/tests/meta/orders/test_meta_orders_lims.py
+++ b/tests/meta/orders/test_meta_orders_lims.py
@@ -139,7 +139,7 @@ def test_to_lims_balsamic(balsamic_order_to_submit, project):
     container_names = {sample.container_name for sample in samples if sample.container_name}
 
     # ... and pick out relevant UDFs
-    first_sample = samples[0].dict()
+    first_sample = samples[0].model_dump()
     assert first_sample["name"] == "s1"
     assert {sample.container for sample in samples} == set(["96 well plate"])
     assert first_sample["udfs"]["data_analysis"] in [


### PR DESCRIPTION
## Description
This PR migrates the LIMS models to Pydantic v2.
- Update imports
- Initialise optional fields as None
- Replace deprecated `validator` decorator
- Replace deprecated `parse_obj` with `model_validate`
- Ensure non string values typed as strings are coerced to strings

### Fixed
- Migrate LIMS models to Pydantic v2

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions