### PR TITLE
Fix create content of sample sheet for novaseq6000

### DIFF
--- a/cg/apps/demultiplex/sample_sheet/sample_sheet_creator.py
+++ b/cg/apps/demultiplex/sample_sheet/sample_sheet_creator.py
@@ -12,11 +12,11 @@ from cg.apps.demultiplex.sample_sheet.index import (
     is_dual_index,
     is_reverse_complement,
 )
+from cg.apps.demultiplex.sample_sheet.models import FlowCellSample
 from cg.apps.demultiplex.sample_sheet.read_sample_sheet import (
     get_samples_by_lane,
     get_validated_sample_sheet,
 )
-from cg.apps.demultiplex.sample_sheet.models import FlowCellSample
 from cg.constants.demultiplexing import (
     BclConverter,
     SampleSheetBcl2FastqSections,
@@ -92,13 +92,9 @@ class SampleSheetCreator:
     def create_sample_sheet_content(self) -> List[List[str]]:
         """Create sample sheet content with samples."""
         LOG.info("Creating sample sheet content")
-        sample_sheet_content: List[List[str]] = []
-        if (
-            self.flow_cell.sequencer_type == Sequencers.NOVASEQ
-            and self.bcl_converter == BclConverter.BCL2FASTQ
-        ):
-            sample_sheet_content: List[List[str]] = self.get_additional_sections_sample_sheet()
-        sample_sheet_content += self.get_data_section_header_and_columns()
+        sample_sheet_content: List[List[str]] = (
+            self.get_additional_sections_sample_sheet() + self.get_data_section_header_and_columns()
+        )
         for sample in self.lims_samples:
             sample_sheet_content.append(
                 self.convert_sample_to_header_dict(

--- a/cg/apps/demultiplex/sample_sheet/sample_sheet_creator.py
+++ b/cg/apps/demultiplex/sample_sheet/sample_sheet_creator.py
@@ -205,7 +205,12 @@ class SampleSheetCreatorBCLConvert(SampleSheetCreator):
             [SampleSheetBCLConvertSections.Header.HEADER.value],
             SampleSheetBCLConvertSections.Header.FILE_FORMAT.value,
             [SampleSheetBCLConvertSections.Header.RUN_NAME.value, self.flow_cell_id],
-            SampleSheetBCLConvertSections.Header.INSTRUMENT_PLATFORM.value,
+            [
+                SampleSheetBCLConvertSections.Header.INSTRUMENT_PLATFORM_TITLE.value,
+                SampleSheetBCLConvertSections.Header.INSTRUMENT_PLATFORM_VALUE.value[
+                    self.flow_cell.sequencer_type
+                ],
+            ],
             SampleSheetBCLConvertSections.Header.INDEX_ORIENTATION_FORWARD.value,
         ]
         reads_section: List[List[str]] = [

--- a/cg/constants/demultiplexing.py
+++ b/cg/constants/demultiplexing.py
@@ -1,7 +1,9 @@
 """Constants related to demultiplexing."""
 from pathlib import Path
-from typing import List
+from typing import Dict, List
+
 import click
+from cg.constants.sequencing import Sequencers
 from cg.utils.enums import Enum, StrEnum
 
 
@@ -109,7 +111,11 @@ class SampleSheetBCLConvertSections:
         HEADER: str = "[Header]"
         FILE_FORMAT: List[str] = ["FileFormatVersion", "2"]
         RUN_NAME: str = "RunName"
-        INSTRUMENT_PLATFORM: List[str] = ["InstrumentPlatform", "NovaSeqXSeries"]
+        INSTRUMENT_PLATFORM_TITLE: str = "InstrumentPlatform"
+        INSTRUMENT_PLATFORM_VALUE: Dict[str, str] = {
+            Sequencers.NOVASEQ: "NovaSeq6000",
+            Sequencers.NOVASEQX: "NovaSeqXSeries",
+        }
         INDEX_ORIENTATION_FORWARD: List[str] = ["IndexOrientation", "Forward"]
 
     class Reads(StrEnum):


### PR DESCRIPTION
## Description
The NovaSeq6000 sample sheets for demultiplex with BclConvert are currently generated without a header, which is needed

### Fixed

- Removed an if statement that excluded NovaSeq6000 to have a header


### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b fix-header-samplesheet -a
    ```

### How to test

- [x] Do `cg demultiplex samplesheet create` for a NOvaSeq6000 and NovaSeqX

### Expected test outcome

- [x] Check that the headers are correct for each case

## Review

- [x] Tests executed by SD
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Deploy this branch on
  - [ ] stage
  - [ ] production
