### PR TITLE
Refactor logic for retrieving sample ids from sample sheet

### DIFF
--- a/cg/apps/demultiplex/sample_sheet/models.py
+++ b/cg/apps/demultiplex/sample_sheet/models.py
@@ -64,12 +64,12 @@ class SampleSheet(BaseModel):
 
     def get_sample_ids(self) -> List[str]:
         """Return ids for samples in sheet."""
-        sample_ids: List[str] = []
+        sample_internal_ids: List[str] = []
         for sample in self.samples:
-            sample_id: str = sample.sample_id.split("_")[0]
-            if is_valid_sample_internal_id(sample_id):
-                sample_ids.append(sample_id)
-        return list(set(sample_ids))
+            sample_internal_id: str = sample.sample_id.split("_")[0]
+            if is_valid_sample_internal_id(sample_internal_id):
+                sample_internal_ids.append(sample_internal_id)
+        return list(set(sample_internal_ids))
 
 
 class SampleSheetBcl2Fastq(SampleSheet):

--- a/cg/apps/demultiplex/sample_sheet/models.py
+++ b/cg/apps/demultiplex/sample_sheet/models.py
@@ -4,6 +4,7 @@ from typing import List
 
 from cg.constants.constants import GenomeVersion
 from cg.constants.demultiplexing import SampleSheetBcl2FastqSections, SampleSheetBCLConvertSections
+from cg.apps.demultiplex.sample_sheet.validators import is_valid_sample_internal_id
 
 LOG = logging.getLogger(__name__)
 
@@ -60,6 +61,15 @@ class FlowCellSampleBCLConvert(FlowCellSample):
 
 class SampleSheet(BaseModel):
     samples: List[FlowCellSample]
+
+    def get_sample_ids(self) -> List[str]:
+        """Return ids for samples in sheet."""
+        sample_ids: List[str] = []
+        for sample in self.samples:
+            sample_id: str = sample.sample_id.split("_")[0]
+            if is_valid_sample_internal_id(sample_id):
+                sample_ids.append(sample_id)
+        return list(set(sample_ids))
 
 
 class SampleSheetBcl2Fastq(SampleSheet):

--- a/cg/apps/demultiplex/sample_sheet/read_sample_sheet.py
+++ b/cg/apps/demultiplex/sample_sheet/read_sample_sheet.py
@@ -4,7 +4,6 @@ from typing import Dict, List, Type
 from pydantic import TypeAdapter
 
 from cg.apps.demultiplex.sample_sheet.models import FlowCellSample, SampleSheet
-from cg.apps.demultiplex.sample_sheet.validators import is_valid_sample_internal_id
 from cg.constants.constants import FileFormat
 from cg.constants.demultiplexing import (
     SampleSheetBcl2FastqSections,
@@ -13,7 +12,6 @@ from cg.constants.demultiplexing import (
 
 from cg.exc import SampleSheetError
 from cg.io.controller import ReadFile
-import re
 
 LOG = logging.getLogger(__name__)
 
@@ -112,10 +110,6 @@ def get_sample_internal_ids_from_sample_sheet(
     """Return the sample internal ids for samples in the sample sheet."""
     sample_sheet = get_sample_sheet_from_file(
         infile=sample_sheet_path, flow_cell_sample_type=flow_cell_sample_type
-    )
-    sample_internal_ids: List[str] = []
-    for sample in sample_sheet.samples:
-        sample_internal_id = sample.sample_id.split("_")[0]
-        if is_valid_sample_internal_id(sample_internal_id=sample_internal_id):
-            sample_internal_ids.append(sample_internal_id)
-    return list(set(sample_internal_ids))
+    )    
+    return sample_sheet.get_sample_ids()
+

--- a/cg/apps/demultiplex/sample_sheet/read_sample_sheet.py
+++ b/cg/apps/demultiplex/sample_sheet/read_sample_sheet.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Type
 from pydantic import TypeAdapter
 
 from cg.apps.demultiplex.sample_sheet.models import FlowCellSample, SampleSheet
+from cg.apps.demultiplex.sample_sheet.validators import is_valid_sample_internal_id
 from cg.constants.constants import FileFormat
 from cg.constants.demultiplexing import (
     SampleSheetBcl2FastqSections,
@@ -35,14 +36,6 @@ def validate_samples_unique_per_lane(samples: List[FlowCellSample]) -> None:
     for lane, lane_samples in sample_by_lane.items():
         LOG.debug(f"Validate that samples are unique in lane: {lane}")
         validate_samples_are_unique(samples=lane_samples)
-
-
-def is_valid_sample_internal_id(sample_internal_id: str) -> bool:
-    """
-    Check if a sample internal id has the correct structure:
-    starts with three letters followed by at least three digits.
-    """
-    return bool(re.search(r"^[A-Za-z]{3}\d{3}", sample_internal_id))
 
 
 def get_sample_sheet_from_file(

--- a/cg/apps/demultiplex/sample_sheet/read_sample_sheet.py
+++ b/cg/apps/demultiplex/sample_sheet/read_sample_sheet.py
@@ -110,6 +110,5 @@ def get_sample_internal_ids_from_sample_sheet(
     """Return the sample internal ids for samples in the sample sheet."""
     sample_sheet = get_sample_sheet_from_file(
         infile=sample_sheet_path, flow_cell_sample_type=flow_cell_sample_type
-    )    
+    )
     return sample_sheet.get_sample_ids()
-

--- a/cg/apps/demultiplex/sample_sheet/validators.py
+++ b/cg/apps/demultiplex/sample_sheet/validators.py
@@ -1,0 +1,9 @@
+import re
+
+
+def is_valid_sample_internal_id(sample_internal_id: str) -> bool:
+    """
+    Check if a sample internal id has the correct structure:
+    starts with three letters followed by at least three digits.
+    """
+    return bool(re.search(r"^[A-Za-z]{3}\d{3}", sample_internal_id))

--- a/cg/apps/sequencing_metrics_parser/parsers/bcl_convert.py
+++ b/cg/apps/sequencing_metrics_parser/parsers/bcl_convert.py
@@ -17,7 +17,7 @@ from cg.apps.sequencing_metrics_parser.models.bcl_convert import (
     BclConvertDemuxMetrics,
     BclConvertQualityMetrics,
 )
-from cg.apps.demultiplex.sample_sheet.read_sample_sheet import (
+from cg.apps.demultiplex.sample_sheet.validators import (
     is_valid_sample_internal_id,
 )
 from cg.utils.files import get_file_in_directory

--- a/cg/meta/demultiplex/status_db_storage_functions.py
+++ b/cg/meta/demultiplex/status_db_storage_functions.py
@@ -1,22 +1,18 @@
 """Functions interacting with statusdb in the DemuxPostProcessingAPI."""
 import datetime
 import logging
-from pathlib import Path
 from typing import List, Optional, Set
 
 from cg.apps.demultiplex.sample_sheet.read_sample_sheet import (
     get_sample_internal_ids_from_sample_sheet,
 )
-from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.apps.sequencing_metrics_parser.api import (
     create_sample_lane_sequencing_metrics_for_flow_cell,
 )
-from cg.exc import HousekeeperFileMissingError
 from cg.meta.demultiplex.utils import get_q30_threshold
 from cg.models.demultiplex.flow_cell import FlowCellDirectoryData
 from cg.store import Store
 from cg.store.models import Flowcell, Sample, SampleLaneSequencingMetrics
-from housekeeper.store.models import File
 
 LOG = logging.getLogger(__name__)
 

--- a/tests/apps/demultiplex/test_read_sample_sheet.py
+++ b/tests/apps/demultiplex/test_read_sample_sheet.py
@@ -2,6 +2,7 @@ import logging
 from typing import List, Dict, Type
 import pytest
 from pathlib import Path
+from cg.apps.demultiplex.sample_sheet.validators import is_valid_sample_internal_id
 from cg.exc import SampleSheetError
 from cg.apps.demultiplex.sample_sheet.models import (
     SampleSheet,
@@ -11,7 +12,6 @@ from cg.apps.demultiplex.sample_sheet.models import (
 )
 from cg.apps.demultiplex.sample_sheet.read_sample_sheet import (
     validate_samples_are_unique,
-    is_valid_sample_internal_id,
     get_samples_by_lane,
     get_sample_internal_ids_from_sample_sheet,
     get_validated_sample_sheet,

--- a/tests/apps/demultiplex/test_read_sample_sheet.py
+++ b/tests/apps/demultiplex/test_read_sample_sheet.py
@@ -55,36 +55,6 @@ def test_validate_samples_are_unique_when_not_unique(
     )
 
 
-def test_is_valid_sample_internal_id(
-    novaseq6000_flow_cell_sample_1: FlowCellSampleBcl2Fastq,
-    novaseq6000_flow_cell_sample_2: FlowCellSampleBcl2Fastq,
-):
-    """Test that validating two different samples finishes successfully."""
-    # GIVEN two different NovaSeq samples with valid internal IDs
-
-    # WHEN validating the sample internal ids
-    for sample in [novaseq6000_flow_cell_sample_1, novaseq6000_flow_cell_sample_2]:
-        # THEN no error is raised
-        assert is_valid_sample_internal_id(sample_internal_id=sample.sample_id)
-
-
-def test_is_valid_sample_internal_id_invalid_sample_internal_ids(
-    novaseq6000_flow_cell_sample_1: FlowCellSampleBcl2Fastq,
-    novaseq6000_flow_cell_sample_2: FlowCellSampleBcl2Fastq,
-):
-    """Test that validating two different samples finishes successfully."""
-    # GIVEN two different NovaSeq samples with valid internal IDs
-
-    # WHEN setting the sample internal ids to invalid values
-    novaseq6000_flow_cell_sample_1.sample_id = "invalid_sample_id"
-    novaseq6000_flow_cell_sample_2.sample_id = "invalid_sample_id"
-
-    # WHEN validating the sample internal ids
-    # THEN no error is raised
-    for sample in [novaseq6000_flow_cell_sample_1, novaseq6000_flow_cell_sample_2]:
-        assert not is_valid_sample_internal_id(sample_internal_id=sample.sample_id)
-
-
 def test_get_samples_by_lane(
     novaseq6000_flow_cell_sample_1: FlowCellSampleBcl2Fastq,
     novaseq6000_flow_cell_sample_2: FlowCellSampleBcl2Fastq,

--- a/tests/apps/demultiplex/test_validate.py
+++ b/tests/apps/demultiplex/test_validate.py
@@ -1,0 +1,32 @@
+from cg.apps.demultiplex.sample_sheet.models import FlowCellSampleBcl2Fastq
+from cg.apps.demultiplex.sample_sheet.validators import is_valid_sample_internal_id
+
+
+def test_is_valid_sample_internal_id(
+    novaseq6000_flow_cell_sample_1: FlowCellSampleBcl2Fastq,
+    novaseq6000_flow_cell_sample_2: FlowCellSampleBcl2Fastq,
+):
+    """Test that validating two different samples finishes successfully."""
+    # GIVEN two different NovaSeq samples with valid internal IDs
+
+    # WHEN validating the sample internal ids
+    for sample in [novaseq6000_flow_cell_sample_1, novaseq6000_flow_cell_sample_2]:
+        # THEN no error is raised
+        assert is_valid_sample_internal_id(sample_internal_id=sample.sample_id)
+
+
+def test_is_valid_sample_internal_id_invalid_sample_internal_ids(
+    novaseq6000_flow_cell_sample_1: FlowCellSampleBcl2Fastq,
+    novaseq6000_flow_cell_sample_2: FlowCellSampleBcl2Fastq,
+):
+    """Test that validating two different samples finishes successfully."""
+    # GIVEN two different NovaSeq samples with valid internal IDs
+
+    # WHEN setting the sample internal ids to invalid values
+    novaseq6000_flow_cell_sample_1.sample_id = "invalid_sample_id"
+    novaseq6000_flow_cell_sample_2.sample_id = "invalid_sample_id"
+
+    # WHEN validating the sample internal ids
+    # THEN no error is raised
+    for sample in [novaseq6000_flow_cell_sample_1, novaseq6000_flow_cell_sample_2]:
+        assert not is_valid_sample_internal_id(sample_internal_id=sample.sample_id)


### PR DESCRIPTION
## Description
The logic for extracting the sample ids from a sample sheet belongs on the `SampleSheet` model.
This PR does not contain any functional changes, it only moves logic from one spot to another.

### Fixed
- Extract logic for retrieving sample ids to the `SampleSheet` object


### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

