### PR TITLE
Refactor sample sheet property

### DIFF
--- a/cg/apps/demultiplex/demultiplex_api.py
+++ b/cg/apps/demultiplex/demultiplex_api.py
@@ -242,7 +242,7 @@ class DemultiplexingAPI:
         commands: str = self.get_sbatch_command(
             run_dir=flow_cell.path,
             demux_dir=demux_dir,
-            sample_sheet=flow_cell.run_dir_sample_sheet_path,
+            sample_sheet=flow_cell.sample_sheet_path,
             demux_completed=self.demultiplexing_completed_path(flow_cell=flow_cell),
             flow_cell=flow_cell,
             environment=self.environment,

--- a/cg/apps/demultiplex/demultiplex_api.py
+++ b/cg/apps/demultiplex/demultiplex_api.py
@@ -242,7 +242,7 @@ class DemultiplexingAPI:
         commands: str = self.get_sbatch_command(
             run_dir=flow_cell.path,
             demux_dir=demux_dir,
-            sample_sheet=flow_cell.sample_sheet_path,
+            sample_sheet=flow_cell.run_dir_sample_sheet_path,
             demux_completed=self.demultiplexing_completed_path(flow_cell=flow_cell),
             flow_cell=flow_cell,
             environment=self.environment,

--- a/cg/apps/demultiplex/demultiplex_api.py
+++ b/cg/apps/demultiplex/demultiplex_api.py
@@ -242,7 +242,7 @@ class DemultiplexingAPI:
         commands: str = self.get_sbatch_command(
             run_dir=flow_cell.path,
             demux_dir=demux_dir,
-            sample_sheet=flow_cell.old_sample_sheet_path,
+            sample_sheet=flow_cell.run_dir_sample_sheet_path,
             demux_completed=self.demultiplexing_completed_path(flow_cell=flow_cell),
             flow_cell=flow_cell,
             environment=self.environment,

--- a/cg/apps/demultiplex/demultiplex_api.py
+++ b/cg/apps/demultiplex/demultiplex_api.py
@@ -242,7 +242,7 @@ class DemultiplexingAPI:
         commands: str = self.get_sbatch_command(
             run_dir=flow_cell.path,
             demux_dir=demux_dir,
-            sample_sheet=flow_cell.sample_sheet_path,
+            sample_sheet=flow_cell.old_sample_sheet_path,
             demux_completed=self.demultiplexing_completed_path(flow_cell=flow_cell),
             flow_cell=flow_cell,
             environment=self.environment,

--- a/cg/apps/demultiplex/sample_sheet/models.py
+++ b/cg/apps/demultiplex/sample_sheet/models.py
@@ -63,7 +63,7 @@ class SampleSheet(BaseModel):
     samples: List[FlowCellSample]
 
     def get_sample_ids(self) -> List[str]:
-        """Return ids for samples in sheet."""
+        """Return all unique sample ids in sheet."""
         sample_internal_ids: List[str] = []
         for sample in self.samples:
             sample_internal_id: str = sample.sample_id.split("_")[0]

--- a/cg/apps/demultiplex/sample_sheet/read_sample_sheet.py
+++ b/cg/apps/demultiplex/sample_sheet/read_sample_sheet.py
@@ -102,13 +102,3 @@ def get_samples_by_lane(
             sample_by_lane[sample.lane] = []
         sample_by_lane[sample.lane].append(sample)
     return sample_by_lane
-
-
-def get_sample_internal_ids_from_sample_sheet(
-    sample_sheet_path: Path, flow_cell_sample_type: Type[FlowCellSample]
-) -> List[str]:
-    """Return the sample internal ids for samples in the sample sheet."""
-    sample_sheet = get_sample_sheet_from_file(
-        infile=sample_sheet_path, flow_cell_sample_type=flow_cell_sample_type
-    )
-    return sample_sheet.get_sample_ids()

--- a/cg/cli/demultiplex/demux.py
+++ b/cg/cli/demultiplex/demux.py
@@ -54,7 +54,7 @@ def demultiplex_all(context: CGConfig, flow_cells_directory: click.Path, dry_run
 
         if not flow_cell.validate_sample_sheet():
             LOG.warning(
-                f"Malformed sample sheet. Run cg demultiplex samplesheet validate {flow_cell.old_sample_sheet_path}",
+                f"Malformed sample sheet. Run cg demultiplex samplesheet validate {flow_cell.run_dir_sample_sheet_path}",
             )
             continue
 
@@ -102,7 +102,7 @@ def demultiplex_flow_cell(
 
     if not flow_cell.validate_sample_sheet():
         LOG.warning(
-            f"Malformed sample sheet. Run cg demultiplex samplesheet validate {flow_cell.old_sample_sheet_path}"
+            f"Malformed sample sheet. Run cg demultiplex samplesheet validate {flow_cell.run_dir_sample_sheet_path}"
         )
         raise click.Abort
 

--- a/cg/cli/demultiplex/demux.py
+++ b/cg/cli/demultiplex/demux.py
@@ -54,7 +54,7 @@ def demultiplex_all(context: CGConfig, flow_cells_directory: click.Path, dry_run
 
         if not flow_cell.validate_sample_sheet():
             LOG.warning(
-                f"Malformed sample sheet. Run cg demultiplex samplesheet validate {flow_cell.sample_sheet_path}",
+                f"Malformed sample sheet. Run cg demultiplex samplesheet validate {flow_cell.run_dir_sample_sheet_path}",
             )
             continue
 
@@ -102,7 +102,7 @@ def demultiplex_flow_cell(
 
     if not flow_cell.validate_sample_sheet():
         LOG.warning(
-            f"Malformed sample sheet. Run cg demultiplex samplesheet validate {flow_cell.sample_sheet_path}"
+            f"Malformed sample sheet. Run cg demultiplex samplesheet validate {flow_cell.run_dir_sample_sheet_path}"
         )
         raise click.Abort
 

--- a/cg/cli/demultiplex/demux.py
+++ b/cg/cli/demultiplex/demux.py
@@ -54,7 +54,7 @@ def demultiplex_all(context: CGConfig, flow_cells_directory: click.Path, dry_run
 
         if not flow_cell.validate_sample_sheet():
             LOG.warning(
-                f"Malformed sample sheet. Run cg demultiplex samplesheet validate {flow_cell.run_dir_sample_sheet_path}",
+                f"Malformed sample sheet. Run cg demultiplex samplesheet validate {flow_cell.sample_sheet_path}",
             )
             continue
 
@@ -102,7 +102,7 @@ def demultiplex_flow_cell(
 
     if not flow_cell.validate_sample_sheet():
         LOG.warning(
-            f"Malformed sample sheet. Run cg demultiplex samplesheet validate {flow_cell.run_dir_sample_sheet_path}"
+            f"Malformed sample sheet. Run cg demultiplex samplesheet validate {flow_cell.sample_sheet_path}"
         )
         raise click.Abort
 

--- a/cg/cli/demultiplex/demux.py
+++ b/cg/cli/demultiplex/demux.py
@@ -54,7 +54,7 @@ def demultiplex_all(context: CGConfig, flow_cells_directory: click.Path, dry_run
 
         if not flow_cell.validate_sample_sheet():
             LOG.warning(
-                f"Malformed sample sheet. Run cg demultiplex samplesheet validate {flow_cell.sample_sheet_path}",
+                f"Malformed sample sheet. Run cg demultiplex samplesheet validate {flow_cell.old_sample_sheet_path}",
             )
             continue
 
@@ -102,7 +102,7 @@ def demultiplex_flow_cell(
 
     if not flow_cell.validate_sample_sheet():
         LOG.warning(
-            f"Malformed sample sheet. Run cg demultiplex samplesheet validate {flow_cell.sample_sheet_path}"
+            f"Malformed sample sheet. Run cg demultiplex samplesheet validate {flow_cell.old_sample_sheet_path}"
         )
         raise click.Abort
 

--- a/cg/cli/demultiplex/sample_sheet.py
+++ b/cg/cli/demultiplex/sample_sheet.py
@@ -105,7 +105,7 @@ def create_sheet(
             "Sample sheet already exists in Housekeeper. Hard-linking it to flow cell directory"
         )
         if not dry_run:
-            os.link(src=sample_sheets_hk[0].full_path, dst=flow_cell.run_dir_sample_sheet_path)
+            os.link(src=sample_sheets_hk[0].full_path, dst=flow_cell.sample_sheet_path)
         return
     lims_samples: List[FlowCellSample] = list(
         get_flow_cell_samples(
@@ -133,11 +133,11 @@ def create_sheet(
             )
         )
         return
-    LOG.info(f"Writing sample sheet to {flow_cell.run_dir_sample_sheet_path.resolve()}")
+    LOG.info(f"Writing sample sheet to {flow_cell.sample_sheet_path.resolve()}")
     WriteFile.write_file_from_content(
         content=sample_sheet_content,
         file_format=FileFormat.CSV,
-        file_path=flow_cell.run_dir_sample_sheet_path,
+        file_path=flow_cell.sample_sheet_path,
     )
     LOG.info("Adding sample sheet to Housekeeper")
     add_sample_sheet_path_to_housekeeper(
@@ -180,7 +180,7 @@ def create_all_sheets(context: CGConfig, dry_run: bool):
                 "Sample sheet already exists in Housekeeper. Copying it to flow cell directory"
             )
             if not dry_run:
-                os.link(src=sample_sheets_hk[0].full_path, dst=flow_cell.run_dir_sample_sheet_path)
+                os.link(src=sample_sheets_hk[0].full_path, dst=flow_cell.sample_sheet_path)
             continue
         LOG.info(f"Creating sample sheet for flow cell {flow_cell.id}")
         lims_samples: List[FlowCellSample] = list(
@@ -209,11 +209,11 @@ def create_all_sheets(context: CGConfig, dry_run: bool):
                 )
             )
             continue
-        LOG.info(f"Writing sample sheet to {flow_cell.run_dir_sample_sheet_path.resolve()}")
+        LOG.info(f"Writing sample sheet to {flow_cell.sample_sheet_path.resolve()}")
         WriteFile.write_file_from_content(
             content=sample_sheet_content,
             file_format=FileFormat.CSV,
-            file_path=flow_cell.run_dir_sample_sheet_path,
+            file_path=flow_cell.sample_sheet_path,
         )
         LOG.info("Adding sample sheet to Housekeeper")
         add_sample_sheet_path_to_housekeeper(

--- a/cg/cli/demultiplex/sample_sheet.py
+++ b/cg/cli/demultiplex/sample_sheet.py
@@ -105,7 +105,7 @@ def create_sheet(
             "Sample sheet already exists in Housekeeper. Hard-linking it to flow cell directory"
         )
         if not dry_run:
-            os.link(src=sample_sheets_hk[0].full_path, dst=flow_cell.sample_sheet_path)
+            os.link(src=sample_sheets_hk[0].full_path, dst=flow_cell.old_sample_sheet_path)
         return
     lims_samples: List[FlowCellSample] = list(
         get_flow_cell_samples(
@@ -133,11 +133,11 @@ def create_sheet(
             )
         )
         return
-    LOG.info(f"Writing sample sheet to {flow_cell.sample_sheet_path.resolve()}")
+    LOG.info(f"Writing sample sheet to {flow_cell.old_sample_sheet_path.resolve()}")
     WriteFile.write_file_from_content(
         content=sample_sheet_content,
         file_format=FileFormat.CSV,
-        file_path=flow_cell.sample_sheet_path,
+        file_path=flow_cell.old_sample_sheet_path,
     )
     LOG.info("Adding sample sheet to Housekeeper")
     add_sample_sheet_path_to_housekeeper(
@@ -180,7 +180,7 @@ def create_all_sheets(context: CGConfig, dry_run: bool):
                 "Sample sheet already exists in Housekeeper. Copying it to flow cell directory"
             )
             if not dry_run:
-                os.link(src=sample_sheets_hk[0].full_path, dst=flow_cell.sample_sheet_path)
+                os.link(src=sample_sheets_hk[0].full_path, dst=flow_cell.old_sample_sheet_path)
             continue
         LOG.info(f"Creating sample sheet for flow cell {flow_cell.id}")
         lims_samples: List[FlowCellSample] = list(
@@ -209,11 +209,11 @@ def create_all_sheets(context: CGConfig, dry_run: bool):
                 )
             )
             continue
-        LOG.info(f"Writing sample sheet to {flow_cell.sample_sheet_path.resolve()}")
+        LOG.info(f"Writing sample sheet to {flow_cell.old_sample_sheet_path.resolve()}")
         WriteFile.write_file_from_content(
             content=sample_sheet_content,
             file_format=FileFormat.CSV,
-            file_path=flow_cell.sample_sheet_path,
+            file_path=flow_cell.old_sample_sheet_path,
         )
         LOG.info("Adding sample sheet to Housekeeper")
         add_sample_sheet_path_to_housekeeper(

--- a/cg/cli/demultiplex/sample_sheet.py
+++ b/cg/cli/demultiplex/sample_sheet.py
@@ -105,7 +105,7 @@ def create_sheet(
             "Sample sheet already exists in Housekeeper. Hard-linking it to flow cell directory"
         )
         if not dry_run:
-            os.link(src=sample_sheets_hk[0].full_path, dst=flow_cell.sample_sheet_path)
+            os.link(src=sample_sheets_hk[0].full_path, dst=flow_cell.run_dir_sample_sheet_path)
         return
     lims_samples: List[FlowCellSample] = list(
         get_flow_cell_samples(
@@ -133,11 +133,11 @@ def create_sheet(
             )
         )
         return
-    LOG.info(f"Writing sample sheet to {flow_cell.sample_sheet_path.resolve()}")
+    LOG.info(f"Writing sample sheet to {flow_cell.run_dir_sample_sheet_path.resolve()}")
     WriteFile.write_file_from_content(
         content=sample_sheet_content,
         file_format=FileFormat.CSV,
-        file_path=flow_cell.sample_sheet_path,
+        file_path=flow_cell.run_dir_sample_sheet_path,
     )
     LOG.info("Adding sample sheet to Housekeeper")
     add_sample_sheet_path_to_housekeeper(
@@ -180,7 +180,7 @@ def create_all_sheets(context: CGConfig, dry_run: bool):
                 "Sample sheet already exists in Housekeeper. Copying it to flow cell directory"
             )
             if not dry_run:
-                os.link(src=sample_sheets_hk[0].full_path, dst=flow_cell.sample_sheet_path)
+                os.link(src=sample_sheets_hk[0].full_path, dst=flow_cell.run_dir_sample_sheet_path)
             continue
         LOG.info(f"Creating sample sheet for flow cell {flow_cell.id}")
         lims_samples: List[FlowCellSample] = list(
@@ -209,11 +209,11 @@ def create_all_sheets(context: CGConfig, dry_run: bool):
                 )
             )
             continue
-        LOG.info(f"Writing sample sheet to {flow_cell.sample_sheet_path.resolve()}")
+        LOG.info(f"Writing sample sheet to {flow_cell.run_dir_sample_sheet_path.resolve()}")
         WriteFile.write_file_from_content(
             content=sample_sheet_content,
             file_format=FileFormat.CSV,
-            file_path=flow_cell.sample_sheet_path,
+            file_path=flow_cell.run_dir_sample_sheet_path,
         )
         LOG.info("Adding sample sheet to Housekeeper")
         add_sample_sheet_path_to_housekeeper(

--- a/cg/cli/demultiplex/sample_sheet.py
+++ b/cg/cli/demultiplex/sample_sheet.py
@@ -105,7 +105,7 @@ def create_sheet(
             "Sample sheet already exists in Housekeeper. Hard-linking it to flow cell directory"
         )
         if not dry_run:
-            os.link(src=sample_sheets_hk[0].full_path, dst=flow_cell.old_sample_sheet_path)
+            os.link(src=sample_sheets_hk[0].full_path, dst=flow_cell.run_dir_sample_sheet_path)
         return
     lims_samples: List[FlowCellSample] = list(
         get_flow_cell_samples(
@@ -133,11 +133,11 @@ def create_sheet(
             )
         )
         return
-    LOG.info(f"Writing sample sheet to {flow_cell.old_sample_sheet_path.resolve()}")
+    LOG.info(f"Writing sample sheet to {flow_cell.run_dir_sample_sheet_path.resolve()}")
     WriteFile.write_file_from_content(
         content=sample_sheet_content,
         file_format=FileFormat.CSV,
-        file_path=flow_cell.old_sample_sheet_path,
+        file_path=flow_cell.run_dir_sample_sheet_path,
     )
     LOG.info("Adding sample sheet to Housekeeper")
     add_sample_sheet_path_to_housekeeper(
@@ -180,7 +180,7 @@ def create_all_sheets(context: CGConfig, dry_run: bool):
                 "Sample sheet already exists in Housekeeper. Copying it to flow cell directory"
             )
             if not dry_run:
-                os.link(src=sample_sheets_hk[0].full_path, dst=flow_cell.old_sample_sheet_path)
+                os.link(src=sample_sheets_hk[0].full_path, dst=flow_cell.run_dir_sample_sheet_path)
             continue
         LOG.info(f"Creating sample sheet for flow cell {flow_cell.id}")
         lims_samples: List[FlowCellSample] = list(
@@ -209,11 +209,11 @@ def create_all_sheets(context: CGConfig, dry_run: bool):
                 )
             )
             continue
-        LOG.info(f"Writing sample sheet to {flow_cell.old_sample_sheet_path.resolve()}")
+        LOG.info(f"Writing sample sheet to {flow_cell.run_dir_sample_sheet_path.resolve()}")
         WriteFile.write_file_from_content(
             content=sample_sheet_content,
             file_format=FileFormat.CSV,
-            file_path=flow_cell.old_sample_sheet_path,
+            file_path=flow_cell.run_dir_sample_sheet_path,
         )
         LOG.info("Adding sample sheet to Housekeeper")
         add_sample_sheet_path_to_housekeeper(

--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -14,7 +14,7 @@ from cg.constants.demultiplexing import DemultiplexingDirsAndFiles
 from cg.exc import FlowCellError, MissingFilesError
 from cg.meta.demultiplex import files
 from cg.meta.demultiplex.housekeeper_storage_functions import (
-    get_sample_sheets_from_latest_version,
+    get_sample_sheet_path_hk,
     store_flow_cell_data_in_housekeeper,
 )
 from cg.meta.demultiplex.status_db_storage_functions import (
@@ -24,7 +24,7 @@ from cg.meta.demultiplex.status_db_storage_functions import (
 )
 from cg.meta.demultiplex.utils import (
     create_delivery_file_in_flow_cell_directory,
-    parse_flow_cell_directory_data,
+    get_flow_cell_id,
 )
 from cg.meta.demultiplex.validation import is_flow_cell_ready_for_postprocessing
 from cg.meta.transfer import TransferFlowCell
@@ -99,22 +99,14 @@ class DemuxPostProcessingAPI:
 
         LOG.info(f"Finish flow cell {flow_cell_directory_name}")
 
-        flow_cell_out_directory: Path = Path(
-            self.demux_api.demultiplexed_runs_dir, flow_cell_directory_name
-        )
+        flow_cell_out_directory: Path = self.get_flow_cell_path(flow_cell_directory_name)
+        sample_sheet_path: Path = self.get_sample_sheet_path(flow_cell_directory_name)
 
-        parsed_flow_cell: FlowCellDirectoryData = parse_flow_cell_directory_data(
-            flow_cell_directory=flow_cell_out_directory,
+        parsed_flow_cell = FlowCellDirectoryData(
+            flow_cell_path=flow_cell_out_directory,
             bcl_converter=bcl_converter,
+            sample_sheet_path=sample_sheet_path,
         )
-
-        sample_sheet_path: Path = Path(
-            get_sample_sheets_from_latest_version(
-                flow_cell_id=parsed_flow_cell.id, hk_api=self.hk_api
-            )[0].full_path
-        )
-        parsed_flow_cell.set_sample_sheet_path_hk(hk_path=sample_sheet_path)
-        LOG.debug("Set path for Housekeeper sample sheet in flow cell")
 
         try:
             is_flow_cell_ready_for_postprocessing(
@@ -171,6 +163,13 @@ class DemuxPostProcessingAPI:
                 LOG.debug(f"Found directory {flow_cell_dir}")
                 demultiplex_flow_cells.append(flow_cell_dir)
         return demultiplex_flow_cells
+
+    def get_sample_sheet_path(self, flow_cell_dir_name: str) -> Path:
+        flow_cell_id: str = get_flow_cell_id(flow_cell_dir_name)
+        return get_sample_sheet_path_hk(flow_cell_id=flow_cell_id, hk_api=self.hk_api)
+
+    def get_flow_cell_path(self, flow_cell_dir_name: str) -> Path:
+        return Path(self.demux_api.demultiplexed_runs_dir, flow_cell_dir_name)
 
 
 class DemuxPostProcessingHiseqXAPI(DemuxPostProcessingAPI):

--- a/cg/meta/demultiplex/demux_post_processing.py
+++ b/cg/meta/demultiplex/demux_post_processing.py
@@ -99,7 +99,9 @@ class DemuxPostProcessingAPI:
 
         LOG.info(f"Finish flow cell {flow_cell_directory_name}")
 
-        flow_cell_out_directory: Path = self.get_flow_cell_path(flow_cell_directory_name)
+        flow_cell_out_directory: Path = self.get_demultiplexed_runs_flow_cell_path(
+            flow_cell_directory_name
+        )
         sample_sheet_path: Path = self.get_sample_sheet_path(flow_cell_directory_name)
 
         parsed_flow_cell = FlowCellDirectoryData(
@@ -168,7 +170,7 @@ class DemuxPostProcessingAPI:
         flow_cell_id: str = get_flow_cell_id(flow_cell_dir_name)
         return get_sample_sheet_path_hk(flow_cell_id=flow_cell_id, hk_api=self.hk_api)
 
-    def get_flow_cell_path(self, flow_cell_dir_name: str) -> Path:
+    def get_demultiplexed_runs_flow_cell_path(self, flow_cell_dir_name: str) -> Path:
         return Path(self.demux_api.demultiplexed_runs_dir, flow_cell_dir_name)
 
 

--- a/cg/meta/demultiplex/housekeeper_storage_functions.py
+++ b/cg/meta/demultiplex/housekeeper_storage_functions.py
@@ -5,9 +5,6 @@ from typing import List, Optional
 
 from housekeeper.store.models import File, Version
 
-from cg.apps.demultiplex.sample_sheet.read_sample_sheet import (
-    get_sample_internal_ids_from_sample_sheet,
-)
 from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.constants.housekeeper_tags import SequencingFileTag
 from cg.constants.sequencing import Sequencers
@@ -72,11 +69,7 @@ def add_sample_fastq_files_to_housekeeper(
     flow_cell: FlowCellDirectoryData, hk_api: HousekeeperAPI, store: Store
 ) -> None:
     """Add sample fastq files from flow cell to Housekeeper."""
-    sample_internal_ids: List[str] = get_sample_internal_ids_from_sample_sheet(
-        sample_sheet_path=flow_cell.sample_sheet_path,
-        flow_cell_sample_type=flow_cell.sample_type,
-    )
-
+    sample_internal_ids: List[str] = flow_cell.sample_sheet.get_sample_ids()
     for sample_internal_id in sample_internal_ids:
         sample_fastq_paths: Optional[List[Path]] = get_sample_fastqs_from_flow_cell(
             flow_cell_directory=flow_cell.path, sample_internal_id=sample_internal_id

--- a/cg/meta/demultiplex/housekeeper_storage_functions.py
+++ b/cg/meta/demultiplex/housekeeper_storage_functions.py
@@ -73,7 +73,7 @@ def add_sample_fastq_files_to_housekeeper(
 ) -> None:
     """Add sample fastq files from flow cell to Housekeeper."""
     sample_internal_ids: List[str] = get_sample_internal_ids_from_sample_sheet(
-        sample_sheet_path=flow_cell.get_sample_sheet_path_hk(),
+        sample_sheet_path=flow_cell.sample_sheet_path,
         flow_cell_sample_type=flow_cell.sample_type,
     )
 
@@ -238,3 +238,13 @@ def get_sample_sheets_from_latest_version(flow_cell_id: str, hk_api: Housekeeper
     except HousekeeperBundleVersionMissingError:
         sample_sheet_files: List = []
     return sample_sheet_files
+
+
+def get_sample_sheet_path_hk(flow_cell_id: str, hk_api: HousekeeperAPI) -> Path:
+    """Returns the path to the sample sheet for the given bundle."""
+    sample_sheet_files: List[File] = get_sample_sheets_from_latest_version(
+        flow_cell_id=flow_cell_id, hk_api=hk_api
+    )
+    if not sample_sheet_files:
+        raise FileNotFoundError(f"No sample sheet found for flow cell {flow_cell_id}")
+    return Path(sample_sheet_files[0].full_path)

--- a/cg/meta/demultiplex/status_db_storage_functions.py
+++ b/cg/meta/demultiplex/status_db_storage_functions.py
@@ -3,7 +3,6 @@ import datetime
 import logging
 from typing import List, Optional, Set
 
-
 from cg.apps.sequencing_metrics_parser.api import (
     create_sample_lane_sequencing_metrics_for_flow_cell,
 )

--- a/cg/meta/demultiplex/status_db_storage_functions.py
+++ b/cg/meta/demultiplex/status_db_storage_functions.py
@@ -3,9 +3,7 @@ import datetime
 import logging
 from typing import List, Optional, Set
 
-from cg.apps.demultiplex.sample_sheet.read_sample_sheet import (
-    get_sample_internal_ids_from_sample_sheet,
-)
+
 from cg.apps.sequencing_metrics_parser.api import (
     create_sample_lane_sequencing_metrics_for_flow_cell,
 )
@@ -37,10 +35,7 @@ def store_flow_cell_data_in_status_db(
     else:
         LOG.info(f"Flow cell already exists in status db: {parsed_flow_cell.id}.")
 
-    sample_internal_ids = get_sample_internal_ids_from_sample_sheet(
-        sample_sheet_path=parsed_flow_cell.sample_sheet_path,
-        flow_cell_sample_type=parsed_flow_cell.sample_type,
-    )
+    sample_internal_ids = parsed_flow_cell.sample_sheet.get_sample_ids()
     add_samples_to_flow_cell_in_status_db(
         flow_cell=flow_cell,
         sample_internal_ids=sample_internal_ids,
@@ -124,10 +119,7 @@ def update_sample_read_counts_in_status_db(
 ) -> None:
     """Update samples in status db with the sum of all read counts for the sample in the sequencing metrics table."""
     q30_threshold: int = get_q30_threshold(flow_cell_data.sequencer_type)
-    sample_internal_ids: List[str] = get_sample_internal_ids_from_sample_sheet(
-        sample_sheet_path=flow_cell_data.sample_sheet_path,
-        flow_cell_sample_type=flow_cell_data.sample_type,
-    )
+    sample_internal_ids: List[str] = flow_cell_data.sample_sheet.get_sample_ids()
     for sample_id in sample_internal_ids:
         update_sample_read_count(sample_id=sample_id, q30_threshold=q30_threshold, store=store)
     store.session.commit()

--- a/cg/meta/demultiplex/status_db_storage_functions.py
+++ b/cg/meta/demultiplex/status_db_storage_functions.py
@@ -34,7 +34,7 @@ def store_flow_cell_data_in_status_db(
     else:
         LOG.info(f"Flow cell already exists in status db: {parsed_flow_cell.id}.")
 
-    sample_internal_ids = parsed_flow_cell.sample_sheet.get_sample_ids()
+    sample_internal_ids: List[str] = parsed_flow_cell.sample_sheet.get_sample_ids()
     add_samples_to_flow_cell_in_status_db(
         flow_cell=flow_cell,
         sample_internal_ids=sample_internal_ids,

--- a/cg/meta/demultiplex/status_db_storage_functions.py
+++ b/cg/meta/demultiplex/status_db_storage_functions.py
@@ -38,7 +38,7 @@ def store_flow_cell_data_in_status_db(
         LOG.info(f"Flow cell already exists in status db: {parsed_flow_cell.id}.")
 
     sample_internal_ids = get_sample_internal_ids_from_sample_sheet(
-        sample_sheet_path=parsed_flow_cell.get_sample_sheet_path_hk(),
+        sample_sheet_path=parsed_flow_cell.sample_sheet_path,
         flow_cell_sample_type=parsed_flow_cell.sample_type,
     )
     add_samples_to_flow_cell_in_status_db(
@@ -125,7 +125,7 @@ def update_sample_read_counts_in_status_db(
     """Update samples in status db with the sum of all read counts for the sample in the sequencing metrics table."""
     q30_threshold: int = get_q30_threshold(flow_cell_data.sequencer_type)
     sample_internal_ids: List[str] = get_sample_internal_ids_from_sample_sheet(
-        sample_sheet_path=flow_cell_data.get_sample_sheet_path_hk(),
+        sample_sheet_path=flow_cell_data.sample_sheet_path,
         flow_cell_sample_type=flow_cell_data.sample_type,
     )
     for sample_id in sample_internal_ids:

--- a/cg/meta/demultiplex/utils.py
+++ b/cg/meta/demultiplex/utils.py
@@ -212,3 +212,8 @@ def is_syncing_complete(source_directory: Path, target_directory: Path) -> bool:
             )
             return False
     return True
+
+
+def get_flow_cell_id(flow_cell_dir_name: str) -> str:
+    """Return the flow cell id from the flow cell directory name."""
+    return flow_cell_dir_name.split("_")[-1][1:]

--- a/cg/meta/demultiplex/utils.py
+++ b/cg/meta/demultiplex/utils.py
@@ -150,13 +150,6 @@ def get_sample_sheet_path(
     return get_file_in_directory(directory=flow_cell_directory, file_name=sample_sheet_file_name)
 
 
-def parse_flow_cell_directory_data(
-    flow_cell_directory: Path, bcl_converter: Optional[str] = None
-) -> FlowCellDirectoryData:
-    """Return flow cell data from the flow cell directory."""
-    return FlowCellDirectoryData(flow_cell_path=flow_cell_directory, bcl_converter=bcl_converter)
-
-
 def add_flow_cell_name_to_fastq_file_path(fastq_file_path: Path, flow_cell_name: str) -> Path:
     """Add the flow cell name to the fastq file path if missing."""
     if is_pattern_in_file_path_name(file_path=fastq_file_path, pattern=flow_cell_name):

--- a/cg/meta/demultiplex/validation.py
+++ b/cg/meta/demultiplex/validation.py
@@ -2,9 +2,6 @@ import logging
 from pathlib import Path
 from typing import List, Optional
 
-from cg.apps.demultiplex.sample_sheet.read_sample_sheet import (
-    get_sample_internal_ids_from_sample_sheet,
-)
 from cg.constants.demultiplexing import DemultiplexingDirsAndFiles
 from cg.exc import FlowCellError, MissingFilesError
 from cg.meta.demultiplex.utils import get_sample_fastqs_from_flow_cell
@@ -48,10 +45,7 @@ def validate_samples_have_fastq_files(flow_cell: FlowCellDirectoryData) -> None:
     Raises: MissingFilesError
         When one of the samples does not have enough fastq files in the flow cell
     """
-    sample_ids: List[str] = get_sample_internal_ids_from_sample_sheet(
-        sample_sheet_path=flow_cell.sample_sheet_path,
-        flow_cell_sample_type=flow_cell.sample_type,
-    )
+    sample_ids: List[str] = flow_cell.sample_sheet.get_sample_ids()
     for sample_id in sample_ids:
         fastq_files: Optional[List[Path]] = get_sample_fastqs_from_flow_cell(
             flow_cell_directory=flow_cell.path, sample_internal_id=sample_id

--- a/cg/meta/demultiplex/validation.py
+++ b/cg/meta/demultiplex/validation.py
@@ -19,7 +19,7 @@ def is_flow_cell_ready_for_delivery(flow_cell_directory: Path) -> bool:
 
 
 def validate_sample_sheet_exists(flow_cell: FlowCellDirectoryData) -> None:
-    sample_sheet_path: Path = flow_cell.sample_sheet_path_hk
+    sample_sheet_path: Path = flow_cell.sample_sheet_path
     if not sample_sheet_path or not sample_sheet_path.exists():
         raise FlowCellError(f"Sample sheet {sample_sheet_path} does not exist in housekeeper.")
     LOG.debug(f"Found sample sheet {sample_sheet_path} in housekeeper.")

--- a/cg/meta/demultiplex/validation.py
+++ b/cg/meta/demultiplex/validation.py
@@ -22,7 +22,7 @@ def is_flow_cell_ready_for_delivery(flow_cell_directory: Path) -> bool:
 
 
 def validate_sample_sheet_exists(flow_cell: FlowCellDirectoryData) -> None:
-    sample_sheet_path: Path = flow_cell.get_sample_sheet_path_hk()
+    sample_sheet_path: Path = flow_cell.sample_sheet_path
     if not sample_sheet_path or not sample_sheet_path.exists():
         raise FlowCellError(f"Sample sheet {sample_sheet_path} does not exist in housekeeper.")
     LOG.debug(f"Found sample sheet {sample_sheet_path} in housekeeper.")
@@ -49,7 +49,7 @@ def validate_samples_have_fastq_files(flow_cell: FlowCellDirectoryData) -> None:
         When one of the samples does not have enough fastq files in the flow cell
     """
     sample_ids: List[str] = get_sample_internal_ids_from_sample_sheet(
-        sample_sheet_path=flow_cell.get_sample_sheet_path_hk(),
+        sample_sheet_path=flow_cell.sample_sheet_path,
         flow_cell_sample_type=flow_cell.sample_type,
     )
     for sample_id in sample_ids:

--- a/cg/meta/demultiplex/validation.py
+++ b/cg/meta/demultiplex/validation.py
@@ -19,7 +19,7 @@ def is_flow_cell_ready_for_delivery(flow_cell_directory: Path) -> bool:
 
 
 def validate_sample_sheet_exists(flow_cell: FlowCellDirectoryData) -> None:
-    sample_sheet_path: Path = flow_cell.sample_sheet_path
+    sample_sheet_path: Path = flow_cell.sample_sheet_path_hk
     if not sample_sheet_path or not sample_sheet_path.exists():
         raise FlowCellError(f"Sample sheet {sample_sheet_path} does not exist in housekeeper.")
     LOG.debug(f"Found sample sheet {sample_sheet_path} in housekeeper.")

--- a/cg/models/demultiplex/demux_results.py
+++ b/cg/models/demultiplex/demux_results.py
@@ -129,7 +129,7 @@ class DemuxResults:
     @property
     def sample_sheet_path(self) -> Path:
         """Return the path to where the original sample sheet is"""
-        return self.flow_cell.old_sample_sheet_path
+        return self.flow_cell.run_dir_sample_sheet_path
 
     @property
     def barcode_report(self) -> Path:

--- a/cg/models/demultiplex/demux_results.py
+++ b/cg/models/demultiplex/demux_results.py
@@ -129,7 +129,7 @@ class DemuxResults:
     @property
     def sample_sheet_path(self) -> Path:
         """Return the path to where the original sample sheet is"""
-        return self.flow_cell.sample_sheet_path
+        return self.flow_cell.run_dir_sample_sheet_path
 
     @property
     def barcode_report(self) -> Path:

--- a/cg/models/demultiplex/demux_results.py
+++ b/cg/models/demultiplex/demux_results.py
@@ -129,7 +129,7 @@ class DemuxResults:
     @property
     def sample_sheet_path(self) -> Path:
         """Return the path to where the original sample sheet is"""
-        return self.flow_cell.run_dir_sample_sheet_path
+        return self.flow_cell.sample_sheet_path
 
     @property
     def barcode_report(self) -> Path:

--- a/cg/models/demultiplex/demux_results.py
+++ b/cg/models/demultiplex/demux_results.py
@@ -129,7 +129,7 @@ class DemuxResults:
     @property
     def sample_sheet_path(self) -> Path:
         """Return the path to where the original sample sheet is"""
-        return self.flow_cell.sample_sheet_path
+        return self.flow_cell.old_sample_sheet_path
 
     @property
     def barcode_report(self) -> Path:

--- a/cg/models/demultiplex/flow_cell.py
+++ b/cg/models/demultiplex/flow_cell.py
@@ -50,7 +50,7 @@ class FlowCellDirectoryData:
         self.position: Literal["A", "B"] = "A"
         self.parse_flow_cell_dir_name()
         self.bcl_converter: Optional[str] = self.get_bcl_converter(bcl_converter)
-        self.sample_sheet_path: Optional[Path] = sample_sheet_path
+        self.sample_sheet_path_hk: Optional[Path] = sample_sheet_path
 
     def parse_flow_cell_dir_name(self):
         """Parse relevant information from flow cell name.
@@ -83,16 +83,16 @@ class FlowCellDirectoryData:
     @property
     def sample_sheet(self) -> SampleSheet:
         """Return sample sheet object."""
-        if not self.sample_sheet_path:
+        if not self.sample_sheet_path_hk:
             raise FlowCellError("Sample sheet path not set")
 
         return get_sample_sheet_from_file(
-            infile=self.sample_sheet_path,
+            infile=self.sample_sheet_path_hk,
             flow_cell_sample_type=self.sample_type,
         )
 
     @property
-    def run_dir_sample_sheet_path(self) -> Path:
+    def sample_sheet_path(self) -> Path:
         """
         Return sample sheet path.
         """
@@ -225,13 +225,13 @@ class FlowCellDirectoryData:
     def sample_sheet_exists(self) -> bool:
         """Check if sample sheet exists."""
         LOG.info("Check if sample sheet exists")
-        return self.run_dir_sample_sheet_path.exists()
+        return self.sample_sheet_path.exists()
 
     def validate_sample_sheet(self) -> bool:
         """Validate if sample sheet is on correct format."""
         try:
             get_sample_sheet_from_file(
-                infile=self.run_dir_sample_sheet_path,
+                infile=self.sample_sheet_path,
                 flow_cell_sample_type=self.sample_type,
             )
         except (SampleSheetError, ValidationError) as error:
@@ -243,7 +243,7 @@ class FlowCellDirectoryData:
     def get_sample_sheet(self) -> SampleSheet:
         """Return sample sheet object."""
         return get_sample_sheet_from_file(
-            infile=self.run_dir_sample_sheet_path,
+            infile=self.sample_sheet_path,
             flow_cell_sample_type=self.sample_type,
         )
 

--- a/cg/models/demultiplex/flow_cell.py
+++ b/cg/models/demultiplex/flow_cell.py
@@ -51,6 +51,7 @@ class FlowCellDirectoryData:
         self.parse_flow_cell_dir_name()
         self.bcl_converter: Optional[str] = self.get_bcl_converter(bcl_converter)
         self.sample_sheet_path_hk: Optional[Path] = sample_sheet_path
+        self._sample_sheet: Optional[SampleSheet] = None
 
     def parse_flow_cell_dir_name(self):
         """Parse relevant information from flow cell name.
@@ -83,9 +84,13 @@ class FlowCellDirectoryData:
     @property
     def sample_sheet(self) -> SampleSheet:
         """Return sample sheet object."""
+        if not self._sample_sheet:
+            self._sample_sheet = self._read_sample_sheet()
+        return self._sample_sheet
+
+    def _read_sample_sheet(self) -> SampleSheet:
         if not self.sample_sheet_path_hk:
             raise FlowCellError("Sample sheet path not set")
-
         return get_sample_sheet_from_file(
             infile=self.sample_sheet_path_hk,
             flow_cell_sample_type=self.sample_type,

--- a/cg/models/demultiplex/flow_cell.py
+++ b/cg/models/demultiplex/flow_cell.py
@@ -50,7 +50,7 @@ class FlowCellDirectoryData:
         self.position: Literal["A", "B"] = "A"
         self.parse_flow_cell_dir_name()
         self.bcl_converter: Optional[str] = self.get_bcl_converter(bcl_converter)
-        self.sample_sheet_path_hk: Optional[Path] = sample_sheet_path
+        self.sample_sheet_path: Optional[Path] = sample_sheet_path
         self._sample_sheet: Optional[SampleSheet] = None
 
     def parse_flow_cell_dir_name(self):
@@ -89,15 +89,15 @@ class FlowCellDirectoryData:
         return self._sample_sheet
 
     def _read_sample_sheet(self) -> SampleSheet:
-        if not self.sample_sheet_path_hk:
+        if not self.sample_sheet_path:
             raise FlowCellError("Sample sheet path not set")
         return get_sample_sheet_from_file(
-            infile=self.sample_sheet_path_hk,
+            infile=self.sample_sheet_path,
             flow_cell_sample_type=self.sample_type,
         )
 
     @property
-    def sample_sheet_path(self) -> Path:
+    def run_dir_sample_sheet_path(self) -> Path:
         """
         Return sample sheet path.
         """
@@ -230,13 +230,13 @@ class FlowCellDirectoryData:
     def sample_sheet_exists(self) -> bool:
         """Check if sample sheet exists."""
         LOG.info("Check if sample sheet exists")
-        return self.sample_sheet_path.exists()
+        return self.run_dir_sample_sheet_path.exists()
 
     def validate_sample_sheet(self) -> bool:
         """Validate if sample sheet is on correct format."""
         try:
             get_sample_sheet_from_file(
-                infile=self.sample_sheet_path,
+                infile=self.run_dir_sample_sheet_path,
                 flow_cell_sample_type=self.sample_type,
             )
         except (SampleSheetError, ValidationError) as error:
@@ -248,7 +248,7 @@ class FlowCellDirectoryData:
     def get_sample_sheet(self) -> SampleSheet:
         """Return sample sheet object."""
         return get_sample_sheet_from_file(
-            infile=self.sample_sheet_path,
+            infile=self.run_dir_sample_sheet_path,
             flow_cell_sample_type=self.sample_type,
         )
 

--- a/cg/models/demultiplex/flow_cell.py
+++ b/cg/models/demultiplex/flow_cell.py
@@ -92,7 +92,7 @@ class FlowCellDirectoryData:
         )
 
     @property
-    def old_sample_sheet_path(self) -> Path:
+    def run_dir_sample_sheet_path(self) -> Path:
         """
         Return sample sheet path.
         """
@@ -225,13 +225,13 @@ class FlowCellDirectoryData:
     def sample_sheet_exists(self) -> bool:
         """Check if sample sheet exists."""
         LOG.info("Check if sample sheet exists")
-        return self.old_sample_sheet_path.exists()
+        return self.run_dir_sample_sheet_path.exists()
 
     def validate_sample_sheet(self) -> bool:
         """Validate if sample sheet is on correct format."""
         try:
             get_sample_sheet_from_file(
-                infile=self.old_sample_sheet_path,
+                infile=self.run_dir_sample_sheet_path,
                 flow_cell_sample_type=self.sample_type,
             )
         except (SampleSheetError, ValidationError) as error:
@@ -243,7 +243,7 @@ class FlowCellDirectoryData:
     def get_sample_sheet(self) -> SampleSheet:
         """Return sample sheet object."""
         return get_sample_sheet_from_file(
-            infile=self.old_sample_sheet_path,
+            infile=self.run_dir_sample_sheet_path,
             flow_cell_sample_type=self.sample_type,
         )
 

--- a/tests/apps/cgstats/crud/test_create_novaseq.py
+++ b/tests/apps/cgstats/crud/test_create_novaseq.py
@@ -5,7 +5,7 @@ from cg.models.demultiplex.demux_results import DemuxResults
 
 def test_create_novaseq_flowcell(stats_api: StatsAPI, bcl2fastq_demux_results: DemuxResults):
     # GIVEN a setup with an existing sample sheet with information
-    assert bcl2fastq_demux_results.flow_cell.sample_sheet_path.read_text()
+    assert bcl2fastq_demux_results.flow_cell.run_dir_sample_sheet_path.read_text()
     # GIVEN that the flowcell does not exist in the database
     assert not stats_api.find_handler.get_flow_cell_by_name(
         flow_cell_name=bcl2fastq_demux_results.flow_cell.id

--- a/tests/apps/cgstats/crud/test_create_novaseq.py
+++ b/tests/apps/cgstats/crud/test_create_novaseq.py
@@ -5,7 +5,7 @@ from cg.models.demultiplex.demux_results import DemuxResults
 
 def test_create_novaseq_flowcell(stats_api: StatsAPI, bcl2fastq_demux_results: DemuxResults):
     # GIVEN a setup with an existing sample sheet with information
-    assert bcl2fastq_demux_results.flow_cell.sample_sheet_path.read_text()
+    assert bcl2fastq_demux_results.flow_cell.old_sample_sheet_path.read_text()
     # GIVEN that the flowcell does not exist in the database
     assert not stats_api.find_handler.get_flow_cell_by_name(
         flow_cell_name=bcl2fastq_demux_results.flow_cell.id

--- a/tests/apps/cgstats/crud/test_create_novaseq.py
+++ b/tests/apps/cgstats/crud/test_create_novaseq.py
@@ -5,7 +5,7 @@ from cg.models.demultiplex.demux_results import DemuxResults
 
 def test_create_novaseq_flowcell(stats_api: StatsAPI, bcl2fastq_demux_results: DemuxResults):
     # GIVEN a setup with an existing sample sheet with information
-    assert bcl2fastq_demux_results.flow_cell.run_dir_sample_sheet_path.read_text()
+    assert bcl2fastq_demux_results.flow_cell.sample_sheet_path.read_text()
     # GIVEN that the flowcell does not exist in the database
     assert not stats_api.find_handler.get_flow_cell_by_name(
         flow_cell_name=bcl2fastq_demux_results.flow_cell.id

--- a/tests/apps/cgstats/crud/test_create_novaseq.py
+++ b/tests/apps/cgstats/crud/test_create_novaseq.py
@@ -5,7 +5,7 @@ from cg.models.demultiplex.demux_results import DemuxResults
 
 def test_create_novaseq_flowcell(stats_api: StatsAPI, bcl2fastq_demux_results: DemuxResults):
     # GIVEN a setup with an existing sample sheet with information
-    assert bcl2fastq_demux_results.flow_cell.old_sample_sheet_path.read_text()
+    assert bcl2fastq_demux_results.flow_cell.run_dir_sample_sheet_path.read_text()
     # GIVEN that the flowcell does not exist in the database
     assert not stats_api.find_handler.get_flow_cell_by_name(
         flow_cell_name=bcl2fastq_demux_results.flow_cell.id

--- a/tests/apps/demultiplex/test_read_sample_sheet.py
+++ b/tests/apps/demultiplex/test_read_sample_sheet.py
@@ -183,7 +183,7 @@ def test_get_sample_internal_ids_from_sample_sheet(
     flow_cell_type: Type[FlowCellSample] = FlowCellSampleBCLConvert,
 ):
     """Test that getting sample internal ids from a sample sheet returns a unique list of strings."""
-    # GIVEN a path to a sample sheet with only valid samples
+    # GIVEN a sample sheet with only valid samples
     sample_sheet: SampleSheet = get_sample_sheet_from_file(
         infile=novaseq6000_bcl_convert_sample_sheet_path,
         flow_cell_sample_type=flow_cell_type,

--- a/tests/apps/demultiplex/test_read_sample_sheet.py
+++ b/tests/apps/demultiplex/test_read_sample_sheet.py
@@ -11,9 +11,9 @@ from cg.apps.demultiplex.sample_sheet.models import (
     FlowCellSampleBCLConvert,
 )
 from cg.apps.demultiplex.sample_sheet.read_sample_sheet import (
+    get_sample_sheet_from_file,
     validate_samples_are_unique,
     get_samples_by_lane,
-    get_sample_internal_ids_from_sample_sheet,
     get_validated_sample_sheet,
     get_raw_samples,
 )
@@ -184,12 +184,13 @@ def test_get_sample_internal_ids_from_sample_sheet(
 ):
     """Test that getting sample internal ids from a sample sheet returns a unique list of strings."""
     # GIVEN a path to a sample sheet with only valid samples
-
-    # WHEN getting the valid sample internal ids
-    sample_internal_ids: List[str] = get_sample_internal_ids_from_sample_sheet(
-        sample_sheet_path=novaseq6000_bcl_convert_sample_sheet_path,
+    sample_sheet: SampleSheet = get_sample_sheet_from_file(
+        infile=novaseq6000_bcl_convert_sample_sheet_path,
         flow_cell_sample_type=flow_cell_type,
     )
+
+    # WHEN getting the valid sample internal ids
+    sample_internal_ids: List[str] = sample_sheet.get_sample_ids()
 
     # THEN the returned value is a list
     assert isinstance(sample_internal_ids, List)

--- a/tests/meta/demultiplex/test_housekeeper_storage_functions.py
+++ b/tests/meta/demultiplex/test_housekeeper_storage_functions.py
@@ -122,7 +122,7 @@ def test_add_fastq_files_without_sample_id(
             flow_cell_id=bcl_convert_flow_cell.id, hk_api=demultiplex_context.housekeeper_api
         )[0].full_path
     )
-    bcl_convert_flow_cell.sample_sheet_path = sample_sheet_path
+    bcl_convert_flow_cell.sample_sheet_path_hk = sample_sheet_path
 
     # WHEN add_fastq_files is called
 

--- a/tests/meta/demultiplex/test_housekeeper_storage_functions.py
+++ b/tests/meta/demultiplex/test_housekeeper_storage_functions.py
@@ -122,7 +122,7 @@ def test_add_fastq_files_without_sample_id(
             flow_cell_id=bcl_convert_flow_cell.id, hk_api=demultiplex_context.housekeeper_api
         )[0].full_path
     )
-    bcl_convert_flow_cell.sample_sheet_path_hk = sample_sheet_path
+    bcl_convert_flow_cell.sample_sheet_path = sample_sheet_path
 
     # WHEN add_fastq_files is called
 

--- a/tests/meta/demultiplex/test_housekeeper_storage_functions.py
+++ b/tests/meta/demultiplex/test_housekeeper_storage_functions.py
@@ -122,7 +122,7 @@ def test_add_fastq_files_without_sample_id(
             flow_cell_id=bcl_convert_flow_cell.id, hk_api=demultiplex_context.housekeeper_api
         )[0].full_path
     )
-    bcl_convert_flow_cell.set_sample_sheet_path_hk(hk_path=sample_sheet_path)
+    bcl_convert_flow_cell.sample_sheet_path = sample_sheet_path
 
     # WHEN add_fastq_files is called
 

--- a/tests/meta/demultiplex/test_utils.py
+++ b/tests/meta/demultiplex/test_utils.py
@@ -15,7 +15,6 @@ from cg.meta.demultiplex.utils import (
     is_lane_in_fastq_file_name,
     is_sample_id_in_directory_name,
     is_valid_sample_fastq_file,
-    parse_flow_cell_directory_data,
     is_file_relevant_for_demultiplexing,
     parse_manifest_file,
     is_syncing_complete,
@@ -250,14 +249,14 @@ def test_get_sample_sheet_path_not_found(tmp_path: Path):
 
 def test_parse_flow_cell_directory_data_invalid():
     with pytest.raises(FlowCellError):
-        parse_flow_cell_directory_data(Path("dummy_path"), "dummy_bcl_converter")
+        FlowCellDirectoryData(Path("dummy_path"), "dummy_bcl_converter")
 
 
 def test_parse_flow_cell_directory_data_valid():
     # GIVEN a flow cell directory which is valid
     # WHEN parsing the flow cell directory data
     flow_cell_run_directory = "20230508_LH00188_0003_A22522YLT3"
-    result = parse_flow_cell_directory_data(Path(flow_cell_run_directory), "dummy_bcl_converter")
+    result = FlowCellDirectoryData(Path(flow_cell_run_directory), "dummy_bcl_converter")
 
     # THEN a FlowCellDirectoryData object should be returned
     assert isinstance(result, FlowCellDirectoryData)

--- a/tests/meta/demultiplex/test_validation.py
+++ b/tests/meta/demultiplex/test_validation.py
@@ -59,7 +59,7 @@ def test_is_flow_cell_ready_for_delivery_false(tmp_path: Path):
 def test_validate_sample_sheet_exists_raises_error(bcl2fastq_flow_cell_dir: Path):
     # GIVEN a flow cell without a sample sheet in housekeeper
     flow_cell = FlowCellDirectoryData(flow_cell_path=bcl2fastq_flow_cell_dir)
-    flow_cell._sample_sheet_path_hk = None
+    flow_cell.sample_sheet_path = None
     # WHEN validating the existence of the sample sheet
     # THEN it should raise a FlowCellError
     with pytest.raises(FlowCellError):
@@ -74,7 +74,7 @@ def test_validate_sample_sheet_exists(bcl2fastq_flow_cell_dir: Path):
         bcl2fastq_flow_cell_dir, DemultiplexingDirsAndFiles.SAMPLE_SHEET_FILE_NAME
     )
     sample_sheet_path.touch()
-    flow_cell._sample_sheet_path_hk = sample_sheet_path
+    flow_cell.sample_sheet_path = sample_sheet_path
 
     # WHEN validating the existence of the sample sheet
     # THEN it should not raise an error
@@ -130,7 +130,7 @@ def test_validate_flow_cell_delivery_status_forced(tmp_path: Path):
     )
 
 
-def test_validate_samples_have_fastq_files_passes(mocker, novaseqx_demultiplexed_flow_cell: Path):
+def test_validate_samples_have_fastq_files_passes(novaseqx_demultiplexed_flow_cell: Path):
     """Test the check of a flow cells with fastq files does not raise an error."""
     # GIVEN a demultiplexed flow cell with fastq files
     flow_cell_with_fastq = FlowCellDirectoryData(flow_cell_path=novaseqx_demultiplexed_flow_cell)
@@ -139,10 +139,7 @@ def test_validate_samples_have_fastq_files_passes(mocker, novaseqx_demultiplexed
     sample_sheet_path = Path(
         novaseqx_demultiplexed_flow_cell, DemultiplexingDirsAndFiles.SAMPLE_SHEET_FILE_NAME
     )
-    mocker.patch.object(
-        flow_cell_with_fastq, "get_sample_sheet_path_hk", return_value=sample_sheet_path
-    )
-    assert flow_cell_with_fastq.get_sample_sheet_path_hk()
+    flow_cell_with_fastq.sample_sheet_path = sample_sheet_path
 
     # WHEN checking if the flow cell has fastq files for teh samples
     validate_samples_have_fastq_files(flow_cell=flow_cell_with_fastq)
@@ -151,7 +148,7 @@ def test_validate_samples_have_fastq_files_passes(mocker, novaseqx_demultiplexed
 
 
 def test_validate_samples_have_fastq_files_fails(
-    mocker, bcl_convert_demultiplexed_flow_cell: Path, bcl_convert_flow_cell_dir: Path
+    bcl_convert_demultiplexed_flow_cell: Path, bcl_convert_flow_cell_dir: Path
 ):
     """Test the check of a flow cells with no fastq files raises an error."""
     # GIVEN a demultiplexed flow cell with no fastq files
@@ -163,10 +160,7 @@ def test_validate_samples_have_fastq_files_fails(
     sample_sheet_path = Path(
         bcl_convert_flow_cell_dir, DemultiplexingDirsAndFiles.SAMPLE_SHEET_FILE_NAME
     )
-    mocker.patch.object(
-        flow_cell_without_fastq, "get_sample_sheet_path_hk", return_value=sample_sheet_path
-    )
-    assert flow_cell_without_fastq.get_sample_sheet_path_hk()
+    flow_cell_without_fastq.sample_sheet_path = sample_sheet_path
 
     # WHEN checking if the flow cell has fastq files for teh samples
     with pytest.raises(MissingFilesError):

--- a/tests/meta/demultiplex/test_validation.py
+++ b/tests/meta/demultiplex/test_validation.py
@@ -59,7 +59,7 @@ def test_is_flow_cell_ready_for_delivery_false(tmp_path: Path):
 def test_validate_sample_sheet_exists_raises_error(bcl2fastq_flow_cell_dir: Path):
     # GIVEN a flow cell without a sample sheet in housekeeper
     flow_cell = FlowCellDirectoryData(flow_cell_path=bcl2fastq_flow_cell_dir)
-    flow_cell.sample_sheet_path = None
+    flow_cell.sample_sheet_path_hk = None
     # WHEN validating the existence of the sample sheet
     # THEN it should raise a FlowCellError
     with pytest.raises(FlowCellError):
@@ -74,7 +74,7 @@ def test_validate_sample_sheet_exists(bcl2fastq_flow_cell_dir: Path):
         bcl2fastq_flow_cell_dir, DemultiplexingDirsAndFiles.SAMPLE_SHEET_FILE_NAME
     )
     sample_sheet_path.touch()
-    flow_cell.sample_sheet_path = sample_sheet_path
+    flow_cell.sample_sheet_path_hk = sample_sheet_path
 
     # WHEN validating the existence of the sample sheet
     # THEN it should not raise an error
@@ -139,7 +139,7 @@ def test_validate_samples_have_fastq_files_passes(novaseqx_demultiplexed_flow_ce
     sample_sheet_path = Path(
         novaseqx_demultiplexed_flow_cell, DemultiplexingDirsAndFiles.SAMPLE_SHEET_FILE_NAME
     )
-    flow_cell_with_fastq.sample_sheet_path = sample_sheet_path
+    flow_cell_with_fastq.sample_sheet_path_hk = sample_sheet_path
 
     # WHEN checking if the flow cell has fastq files for teh samples
     validate_samples_have_fastq_files(flow_cell=flow_cell_with_fastq)
@@ -160,7 +160,7 @@ def test_validate_samples_have_fastq_files_fails(
     sample_sheet_path = Path(
         bcl_convert_flow_cell_dir, DemultiplexingDirsAndFiles.SAMPLE_SHEET_FILE_NAME
     )
-    flow_cell_without_fastq.sample_sheet_path = sample_sheet_path
+    flow_cell_without_fastq.sample_sheet_path_hk = sample_sheet_path
 
     # WHEN checking if the flow cell has fastq files for teh samples
     with pytest.raises(MissingFilesError):

--- a/tests/meta/demultiplex/test_validation.py
+++ b/tests/meta/demultiplex/test_validation.py
@@ -59,7 +59,7 @@ def test_is_flow_cell_ready_for_delivery_false(tmp_path: Path):
 def test_validate_sample_sheet_exists_raises_error(bcl2fastq_flow_cell_dir: Path):
     # GIVEN a flow cell without a sample sheet in housekeeper
     flow_cell = FlowCellDirectoryData(flow_cell_path=bcl2fastq_flow_cell_dir)
-    flow_cell.sample_sheet_path_hk = None
+    flow_cell.sample_sheet_path = None
     # WHEN validating the existence of the sample sheet
     # THEN it should raise a FlowCellError
     with pytest.raises(FlowCellError):
@@ -74,7 +74,7 @@ def test_validate_sample_sheet_exists(bcl2fastq_flow_cell_dir: Path):
         bcl2fastq_flow_cell_dir, DemultiplexingDirsAndFiles.SAMPLE_SHEET_FILE_NAME
     )
     sample_sheet_path.touch()
-    flow_cell.sample_sheet_path_hk = sample_sheet_path
+    flow_cell.sample_sheet_path = sample_sheet_path
 
     # WHEN validating the existence of the sample sheet
     # THEN it should not raise an error
@@ -139,7 +139,7 @@ def test_validate_samples_have_fastq_files_passes(novaseqx_demultiplexed_flow_ce
     sample_sheet_path = Path(
         novaseqx_demultiplexed_flow_cell, DemultiplexingDirsAndFiles.SAMPLE_SHEET_FILE_NAME
     )
-    flow_cell_with_fastq.sample_sheet_path_hk = sample_sheet_path
+    flow_cell_with_fastq.sample_sheet_path = sample_sheet_path
 
     # WHEN checking if the flow cell has fastq files for teh samples
     validate_samples_have_fastq_files(flow_cell=flow_cell_with_fastq)
@@ -160,7 +160,7 @@ def test_validate_samples_have_fastq_files_fails(
     sample_sheet_path = Path(
         bcl_convert_flow_cell_dir, DemultiplexingDirsAndFiles.SAMPLE_SHEET_FILE_NAME
     )
-    flow_cell_without_fastq.sample_sheet_path_hk = sample_sheet_path
+    flow_cell_without_fastq.sample_sheet_path = sample_sheet_path
 
     # WHEN checking if the flow cell has fastq files for teh samples
     with pytest.raises(MissingFilesError):


### PR DESCRIPTION
## Description
This PR refactors how the sample sheet path property is set and accessed on the flow cell directory data object since it was a bit complicated (getters and setters for attributes are not commonly used in Python). The `sample_sheet_path` is now provided as an optional argument to the constructor.

Changes:
- Pass `sample_sheet_path` to `FlowCellDirectoryData` constructor
- Rename existing `sample_sheet_path` property to `run_dir_sample_sheet_path`
- Remove `get_sample_sheet_path_hk` and `set_sample_sheet_path_hk` on `FlowCellDirectoryData`
- Replace `get_sample_internal_ids_from_sample_sheet` with `sample_sheet` property
- Add helper function `get_sample_sheet_path` for retrieving sample sheet path from housekeeper
- Remove unnecessary helper function `parse_flow_cell_directory_data`
- Refactor tests

### Fixed
- Pass sample sheet path to flow cell directory data constructor

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
