### PR TITLE
Patch(post-processing) Change NumberReads validation from > to >=

### DIFF
--- a/cg/apps/sequencing_metrics_parser/models/bcl2fastq_metrics.py
+++ b/cg/apps/sequencing_metrics_parser/models/bcl2fastq_metrics.py
@@ -18,7 +18,7 @@ class DemuxResult(BaseModel):
     """
 
     sample_id: str = Field(..., alias="SampleId", min_length=1)
-    number_reads: int = Field(..., alias="NumberReads", gt=0)
+    number_reads: int = Field(..., alias="NumberReads", ge=0)
     yield_: int = Field(..., alias="Yield", ge=0)
     read_metrics: List[ReadMetric] = Field(..., alias="ReadMetrics")
 


### PR DESCRIPTION
## Description
The NumberReads field in the `DemuxResult` class raises a validation error if the field is smaller or equal to 0. Since 0 is a valid number (if rare) this causes issues when running the post-processing flow.

This PR changes the behaviour from only allowing values > 0 to allowing values >= 0
### Changed

- Change NumberReads validation from > to >=


### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
