### PR TITLE
Fix(post-processing) Division by zero fix when calculating metrics

### DIFF
--- a/cg/apps/sequencing_metrics_parser/sequencing_metrics_calculator.py
+++ b/cg/apps/sequencing_metrics_parser/sequencing_metrics_calculator.py
@@ -7,7 +7,7 @@ def calculate_q30_bases_percentage(q30_yield: int, total_yield: int) -> float:
     Returns:
         float: Percentage of bases with Q30.
     """
-    return round(q30_yield / total_yield, 2) * 100
+    return round(q30_yield / total_yield, 2) * 100 if total_yield else 0
 
 
 def calculate_average_quality_score(total_quality_score: int, total_yield: int) -> float:
@@ -19,4 +19,4 @@ def calculate_average_quality_score(total_quality_score: int, total_yield: int) 
     Returns:
         float: Average quality score of all bases.
     """
-    return round(total_quality_score / total_yield, 2)
+    return round(total_quality_score / total_yield, 2) if total_yield else 0

--- a/tests/apps/sequencing_metrics_parser/test_sequencing_metrics_calculator.py
+++ b/tests/apps/sequencing_metrics_parser/test_sequencing_metrics_calculator.py
@@ -1,32 +1,40 @@
+import pytest
+
 from cg.apps.sequencing_metrics_parser.sequencing_metrics_calculator import (
     calculate_q30_bases_percentage,
     calculate_average_quality_score,
 )
 
 
-def test_calculate_bases_with_q30_percentage():
+@pytest.mark.parametrize(
+    "q30_yield, total_yield, expected_result", [(100, 200, 100 / 200 * 100), (0, 0, 0)]
+)
+def test_calculate_bases_with_q30_percentage(
+    q30_yield: int, total_yield: int, expected_result: float
+):
     """Test calculating q30 ratio."""
     # GIVEN a number of bases with q30 and a total number of bases
-    q30_yield: int = 100
-    total_yield: int = 200
 
     # WHEN calculating the q30 ratio
     q30_percentage = calculate_q30_bases_percentage(q30_yield=q30_yield, total_yield=total_yield)
 
     # THEN the q30 ratio should be the number of bases with q30 divided by the total number of bases
-    assert q30_percentage == (q30_yield / total_yield) * 100
+    assert q30_percentage == expected_result
 
 
-def test_calculate_lane_mean_quality_score():
+@pytest.mark.parametrize(
+    "total_quality, total_yield, expected_result", [(100, 200, 100 / 200), (0, 0, 0)]
+)
+def test_calculate_lane_mean_quality_score(
+    total_quality: int, total_yield: int, expected_result: float
+):
     """Test calculating the average quality score."""
     # GIVEN a total quality score and a total yield
-    total_quality_score: int = 100
-    total_yield: int = 200
 
     # WHEN calculating the average quality score
     avg_quality_score: float = calculate_average_quality_score(
-        total_quality_score=total_quality_score, total_yield=total_yield
+        total_quality_score=total_quality, total_yield=total_yield
     )
 
     # THEN the average quality score should be the total quality score divided by the total yield
-    assert avg_quality_score == total_quality_score / total_yield
+    assert avg_quality_score == expected_result

--- a/tests/apps/sequencing_metrics_parser/test_sequencing_metrics_calculator.py
+++ b/tests/apps/sequencing_metrics_parser/test_sequencing_metrics_calculator.py
@@ -23,17 +23,17 @@ def test_calculate_bases_with_q30_percentage(
 
 
 @pytest.mark.parametrize(
-    "total_quality, total_yield, expected_result", [(100, 200, 100 / 200), (0, 0, 0)]
+    "total_quality_score, total_yield, expected_result", [(100, 200, 100 / 200), (0, 0, 0)]
 )
 def test_calculate_lane_mean_quality_score(
-    total_quality: int, total_yield: int, expected_result: float
+    total_quality_score: int, total_yield: int, expected_result: float
 ):
     """Test calculating the average quality score."""
     # GIVEN a total quality score and a total yield
 
     # WHEN calculating the average quality score
     avg_quality_score: float = calculate_average_quality_score(
-        total_quality_score=total_quality, total_yield=total_yield
+        total_quality_score=total_quality_score, total_yield=total_yield
     )
 
     # THEN the average quality score should be the total quality score divided by the total yield

--- a/tests/apps/sequencing_metrics_parser/test_sequencing_metrics_calculator.py
+++ b/tests/apps/sequencing_metrics_parser/test_sequencing_metrics_calculator.py
@@ -7,7 +7,7 @@ from cg.apps.sequencing_metrics_parser.sequencing_metrics_calculator import (
 
 
 @pytest.mark.parametrize(
-    "q30_yield, total_yield, expected_result", [(100, 200, 100 / 200 * 100), (0, 0, 0)]
+    "q30_yield, total_yield, expected_result", [(100, 200, (100 / 200) * 100), (0, 0, 0)]
 )
 def test_calculate_bases_with_q30_percentage(
     q30_yield: int, total_yield: int, expected_result: float


### PR DESCRIPTION
## Description
When calculating some metrics for the bcl2fastq flow we allow some fields to be zero and then divide by them which raises `ZeroDivisionError`.

This PR makes it so that the functions returns 0 in those cases, and also adds tests to for the edge cases.

### Added

- Tests for cases where `total_yield` is 0

### Changed

- `calculate_q30_bases_percentage` and `calculate_average_quality_score` return 0 if `total_yield` is 0




### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
