### PR TITLE
Rename fluffy fixture

### DIFF
--- a/tests/cli/workflow/fluffy/conftest.py
+++ b/tests/cli/workflow/fluffy/conftest.py
@@ -63,7 +63,7 @@ def samplesheet_path():
 
 
 @pytest.fixture(scope="function")
-def fastq_file_path(config_root_dir):
+def fluffy_fastq_file_path(config_root_dir):
     path = Path(config_root_dir)
     path.mkdir(parents=True, exist_ok=True)
     fastq_path = Path(path, "fastq.fastq.gz")
@@ -108,14 +108,14 @@ def fluffy_hermes_deliverables_response_data(
 
 
 @pytest.fixture(scope="function")
-def fluffy_fastq_hk_bundle_data(fastq_file_path, fluffy_sample_lims_id) -> dict:
+def fluffy_fastq_hk_bundle_data(fluffy_fastq_file_path, fluffy_sample_lims_id) -> dict:
     return {
         "name": fluffy_sample_lims_id,
         "created": dt.datetime.now(),
         "version": "1.0",
         "files": [
             {
-                "path": fastq_file_path.as_posix(),
+                "path": fluffy_fastq_file_path.as_posix(),
                 "tags": ["fastq", "flowcell"],
                 "archive": False,
             }

--- a/tests/cli/workflow/fluffy/test_cli_link.py
+++ b/tests/cli/workflow/fluffy/test_cli_link.py
@@ -42,7 +42,7 @@ def test_cli_link(
     fluffy_case_id_existing,
     fluffy_sample_lims_id,
     fluffy_context: CGConfig,
-    fastq_file_path,
+    fluffy_fastq_file_path,
     caplog,
 ):
     caplog.set_level("INFO")
@@ -78,7 +78,7 @@ def test_cli_link_dir_exists(
     fluffy_case_id_existing,
     fluffy_sample_lims_id,
     fluffy_context: CGConfig,
-    fastq_file_path,
+    fluffy_fastq_file_path,
     caplog,
 ):
     caplog.set_level("INFO")

--- a/tests/meta/demultiplex/test_utils.py
+++ b/tests/meta/demultiplex/test_utils.py
@@ -331,27 +331,27 @@ def test_is_syncing_complete_false(
     assert not is_directory_synced
 
 
-def test_add_flow_cell_name_to_fastq_file_path(bcl2fastq_flow_cell_id: str, fluffy_fastq_file_path):
+def test_add_flow_cell_name_to_fastq_file_path(bcl2fastq_flow_cell_id: str, fastq_file_path):
     # GIVEN a fastq file path and a flow cell name
 
     # WHEN adding the flow cell name to the fastq file path
     rename_fastq_file_path: Path = add_flow_cell_name_to_fastq_file_path(
-        fastq_file_path=fluffy_fastq_file_path, flow_cell_name=bcl2fastq_flow_cell_id
+        fastq_file_path=fastq_file_path, flow_cell_name=bcl2fastq_flow_cell_id
     )
 
     # THEN the fastq file path should be returned with the flow cell name added
     assert rename_fastq_file_path == Path(
-        fluffy_fastq_file_path.parent, f"{bcl2fastq_flow_cell_id}_{fluffy_fastq_file_path.name}"
+        fastq_file_path.parent, f"{bcl2fastq_flow_cell_id}_{fastq_file_path.name}"
     )
 
 
 def test_add_flow_cell_name_to_fastq_file_path_when_flow_cell_name_already_in_name(
-    bcl2fastq_flow_cell_id: str, fluffy_fastq_file_path
+    bcl2fastq_flow_cell_id: str, fastq_file_path
 ):
     # GIVEN a fastq file path and a flow cell name
 
     # GIVEN that the flow cell name is already in the fastq file path
-    fluffy_fastq_file_path = Path(f"{bcl2fastq_flow_cell_id}_{fluffy_fastq_file_path.name}")
+    fastq_file_path = Path(f"{bcl2fastq_flow_cell_id}_{fastq_file_path.name}")
 
     # WHEN adding the flow cell name to the fastq file path
     renamed_fastq_file_path: Path = add_flow_cell_name_to_fastq_file_path(

--- a/tests/meta/demultiplex/test_utils.py
+++ b/tests/meta/demultiplex/test_utils.py
@@ -332,7 +332,7 @@ def test_is_syncing_complete_false(
     assert not is_directory_synced
 
 
-def test_add_flow_cell_name_to_fastq_file_path(bcl2fastq_flow_cell_id: str, fastq_file_path):
+def test_add_flow_cell_name_to_fastq_file_path(bcl2fastq_flow_cell_id: str, fastq_file_path: Path):
     # GIVEN a fastq file path and a flow cell name
 
     # WHEN adding the flow cell name to the fastq file path
@@ -347,7 +347,7 @@ def test_add_flow_cell_name_to_fastq_file_path(bcl2fastq_flow_cell_id: str, fast
 
 
 def test_add_flow_cell_name_to_fastq_file_path_when_flow_cell_name_already_in_name(
-    bcl2fastq_flow_cell_id: str, fastq_file_path
+    bcl2fastq_flow_cell_id: str, fastq_file_path: Path
 ):
     # GIVEN a fastq file path and a flow cell name
 

--- a/tests/meta/demultiplex/test_utils.py
+++ b/tests/meta/demultiplex/test_utils.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from typing import List
+
 import pytest
 from cg.constants.constants import FileExtensions
 from cg.constants.demultiplexing import DemultiplexingDirsAndFiles
@@ -12,13 +13,13 @@ from cg.meta.demultiplex.utils import (
     get_q30_threshold,
     get_sample_sheet_path,
     is_file_path_compressed_fastq,
+    is_file_relevant_for_demultiplexing,
     is_lane_in_fastq_file_name,
     is_sample_id_in_directory_name,
+    is_syncing_complete,
     is_valid_sample_fastq_file,
     parse_flow_cell_directory_data,
-    is_file_relevant_for_demultiplexing,
     parse_manifest_file,
-    is_syncing_complete,
 )
 from cg.models.demultiplex.flow_cell import FlowCellDirectoryData
 
@@ -330,27 +331,27 @@ def test_is_syncing_complete_false(
     assert not is_directory_synced
 
 
-def test_add_flow_cell_name_to_fastq_file_path(bcl2fastq_flow_cell_id: str, fastq_file_path: Path):
+def test_add_flow_cell_name_to_fastq_file_path(bcl2fastq_flow_cell_id: str, fluffy_fastq_file_path):
     # GIVEN a fastq file path and a flow cell name
 
     # WHEN adding the flow cell name to the fastq file path
     rename_fastq_file_path: Path = add_flow_cell_name_to_fastq_file_path(
-        fastq_file_path=fastq_file_path, flow_cell_name=bcl2fastq_flow_cell_id
+        fastq_file_path=fluffy_fastq_file_path, flow_cell_name=bcl2fastq_flow_cell_id
     )
 
     # THEN the fastq file path should be returned with the flow cell name added
     assert rename_fastq_file_path == Path(
-        fastq_file_path.parent, f"{bcl2fastq_flow_cell_id}_{fastq_file_path.name}"
+        fluffy_fastq_file_path.parent, f"{bcl2fastq_flow_cell_id}_{fluffy_fastq_file_path.name}"
     )
 
 
 def test_add_flow_cell_name_to_fastq_file_path_when_flow_cell_name_already_in_name(
-    bcl2fastq_flow_cell_id: str, fastq_file_path: Path
+    bcl2fastq_flow_cell_id: str, fluffy_fastq_file_path
 ):
     # GIVEN a fastq file path and a flow cell name
 
     # GIVEN that the flow cell name is already in the fastq file path
-    fastq_file_path = Path(f"{bcl2fastq_flow_cell_id}_{fastq_file_path.name}")
+    fluffy_fastq_file_path = Path(f"{bcl2fastq_flow_cell_id}_{fluffy_fastq_file_path.name}")
 
     # WHEN adding the flow cell name to the fastq file path
     renamed_fastq_file_path: Path = add_flow_cell_name_to_fastq_file_path(


### PR DESCRIPTION
## Description
Fluffy fixture `fastq_file_path` in `tests/cli/workflow/fluffy/conftest.py` shadows another fixture of the same name in `tests/meta/demultiplex/conftest.py`


### Changed

- Name of fixture `fastq_file_path` to `fluffy_fastq_file_path`


## Review

- [x] "Merge and deploy" approved by IO
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Deploy this branch on
  - [ ] stage
  - [ ] production 
