### PR TITLE
Replace deprecated parse_file

### DIFF
--- a/cg/apps/sequencing_metrics_parser/parsers/bcl2fastq.py
+++ b/cg/apps/sequencing_metrics_parser/parsers/bcl2fastq.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import os
 from pathlib import Path

--- a/cg/apps/sequencing_metrics_parser/parsers/bcl2fastq.py
+++ b/cg/apps/sequencing_metrics_parser/parsers/bcl2fastq.py
@@ -37,9 +37,8 @@ def parse_bcl2fastq_raw_tile_metrics(
 
     for stats_json_path in stats_json_paths:
         LOG.debug(f"Parsing stats.json file {stats_json_path}")
-        sequencing_metrics = Bcl2FastqSampleLaneTileMetrics.model_validate_json(
-            stats_json_path.open()
-        )
+        data = read_json(stats_json_path)
+        sequencing_metrics = Bcl2FastqSampleLaneTileMetrics.model_validate(data)
         tile_sequencing_metrics.append(sequencing_metrics)
 
     return tile_sequencing_metrics

--- a/cg/apps/sequencing_metrics_parser/parsers/bcl2fastq.py
+++ b/cg/apps/sequencing_metrics_parser/parsers/bcl2fastq.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 from pathlib import Path
@@ -11,6 +12,7 @@ from cg.constants.demultiplexing import (
     BCL2FASTQ_METRICS_DIRECTORY_NAME,
     BCL2FASTQ_METRICS_FILE_NAME,
 )
+from cg.io.json import read_json
 
 LOG = logging.getLogger(__name__)
 
@@ -36,7 +38,8 @@ def parse_bcl2fastq_raw_tile_metrics(
 
     for stats_json_path in stats_json_paths:
         LOG.debug(f"Parsing stats.json file {stats_json_path}")
-        sequencing_metrics = Bcl2FastqSampleLaneTileMetrics.parse_file(stats_json_path)
+        data = read_json(stats_json_path)
+        sequencing_metrics = Bcl2FastqSampleLaneTileMetrics.model_validate(data)
         tile_sequencing_metrics.append(sequencing_metrics)
 
     return tile_sequencing_metrics

--- a/cg/apps/sequencing_metrics_parser/parsers/bcl2fastq.py
+++ b/cg/apps/sequencing_metrics_parser/parsers/bcl2fastq.py
@@ -37,7 +37,9 @@ def parse_bcl2fastq_raw_tile_metrics(
 
     for stats_json_path in stats_json_paths:
         LOG.debug(f"Parsing stats.json file {stats_json_path}")
-        sequencing_metrics = Bcl2FastqSampleLaneTileMetrics.model_validate_json(stats_json_path.open())
+        sequencing_metrics = Bcl2FastqSampleLaneTileMetrics.model_validate_json(
+            stats_json_path.open()
+        )
         tile_sequencing_metrics.append(sequencing_metrics)
 
     return tile_sequencing_metrics

--- a/cg/apps/sequencing_metrics_parser/parsers/bcl2fastq.py
+++ b/cg/apps/sequencing_metrics_parser/parsers/bcl2fastq.py
@@ -37,8 +37,7 @@ def parse_bcl2fastq_raw_tile_metrics(
 
     for stats_json_path in stats_json_paths:
         LOG.debug(f"Parsing stats.json file {stats_json_path}")
-        data = read_json(stats_json_path)
-        sequencing_metrics = Bcl2FastqSampleLaneTileMetrics.model_validate(data)
+        sequencing_metrics = Bcl2FastqSampleLaneTileMetrics.model_validate_json(stats_json_path.open())
         tile_sequencing_metrics.append(sequencing_metrics)
 
     return tile_sequencing_metrics


### PR DESCRIPTION
## Description
This PR replaces a deprecated function call on a Pydantic model (noticed a warning in my editor).

This syntax was deprecated in Pydantic 2
```python
model.parse_file(json_path)
```

And should be replaced with `model_validate`, see [docs](https://docs.pydantic.dev/2.0/migration/#changes-to-pydanticbasemodel). It was only used in one place in the code base.

### Fixed
- Replace deprecated Pydantic json parsing


### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions