### PR TITLE
Patch sample sheet sample id property

### DIFF
--- a/cg/apps/demultiplex/sample_sheet/models.py
+++ b/cg/apps/demultiplex/sample_sheet/models.py
@@ -1,6 +1,6 @@
 import logging
 from collections import defaultdict
-from typing import List
+from typing import List, Optional
 
 from pydantic import BaseModel, ConfigDict, Extra, Field
 
@@ -20,6 +20,11 @@ class FlowCellSample(BaseModel):
     index: str
     index2: str = ""
     model_config = ConfigDict(populate_by_name=True, extra=Extra.ignore)
+
+    def get_valid_sample_id(self) -> Optional[str]:
+        sample_id: str = self.sample_id.split("_")[0]  # Remove any trailing index
+        if is_valid_sample_internal_id(sample_id):
+            return sample_id
 
 
 class FlowCellSampleBcl2Fastq(FlowCellSample):

--- a/cg/meta/workflow/fluffy.py
+++ b/cg/meta/workflow/fluffy.py
@@ -191,7 +191,11 @@ class FluffyAnalysisAPI(AnalysisAPI):
         fluffy_sample_sheet_rows = []
 
         for sample in sample_sheet.samples:
-            sample_id: str = sample.sample_id
+            sample_id: Optional[str] = sample.get_valid_sample_id()
+
+            if not sample_id:
+                continue
+
             db_sample: Sample = self.status_db.get_sample_by_internal_id(sample_id)
 
             sample_sheet_row = FluffySample(


### PR DESCRIPTION
## Description
The sample id attribute on the `FlowCellSample` is not always a sample id, but might include a trailing sequence which should be discarded.

### Added
- Method on sample sheet model for retrieving the sample id

### Fixed
- Fluffy sample sheet generation uses the formatted and validated sample id

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
