### PR TITLE
Remove alchy from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 # database
-Alchy
 alembic
 SQLAlchemy<1.4
 pymysql


### PR DESCRIPTION
## Description
There are no references to Alchy in cg, so we can remove it as a dependency.

### Fixed
- Remove alchy as a dependency

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
