### PR TITLE
fix(gisaid-upload) Change validator structure for GisaidSample

### DIFF
--- a/cg/meta/upload/gisaid/models.py
+++ b/cg/meta/upload/gisaid/models.py
@@ -66,7 +66,7 @@ class GisaidSample(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def set_generated_fields(cls, data: Any):
+    def set_generated_fields(cls, data: Any) -> Any:
         """Constructs the fields that are generated from other fields."""
         if isinstance(data, dict):
             data.setdefault("covv_location", _generate_covv_location(data.get("region")))
@@ -86,14 +86,14 @@ class GisaidSample(BaseModel):
         return data
 
 
-def _generate_covv_location(region):
+def _generate_covv_location(region: str) -> str:
     return f"Europe/Sweden/{region}"
 
 
-def _generate_covv_subm_sample_id(subm_sample_id, region_code):
+def _generate_covv_subm_sample_id(subm_sample_id: str, region_code: str) -> str:
     return f"{region_code}_SE100_{subm_sample_id}"
 
 
-def _generate_covv_virus_name(covv_subm_sample_id, covv_collection_date):
-    datetime_date = datetime.strptime(covv_collection_date, "%Y-%m-%d")
+def _generate_covv_virus_name(covv_subm_sample_id: str, covv_collection_date: str) -> str:
+    datetime_date: datetime = datetime.strptime(covv_collection_date, "%Y-%m-%d")
     return f"hCoV-19/Sweden/{covv_subm_sample_id}/{datetime_date.year}"

--- a/cg/meta/upload/gisaid/models.py
+++ b/cg/meta/upload/gisaid/models.py
@@ -1,7 +1,13 @@
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Any
 from typing_extensions import Annotated
-from pydantic import BaseModel, BeforeValidator, FieldValidationInfo, field_validator
+from pydantic import (
+    BaseModel,
+    BeforeValidator,
+    FieldValidationInfo,
+    field_validator,
+    model_validator,
+)
 from datetime import datetime
 
 from cg.meta.upload.gisaid.constants import AUTHORS
@@ -58,22 +64,35 @@ class GisaidSample(BaseModel):
     covv_subm_lab_addr: Optional[str] = "171 76 Stockholm, Sweden"
     covv_authors: Optional[str] = " ,".join(AUTHORS)
 
-    @field_validator("covv_location")
+    @model_validator(mode="before")
     @classmethod
-    def parse_location(cls, _, info: FieldValidationInfo):
-        region: str = info.data.get("region")
-        return f"Europe/Sweden/{region}"
+    def set_generated_fields(cls, data: Any):
+        if isinstance(data, dict):
+            data.setdefault("covv_location", _generate_covv_location(data.get("region")))
+            data["covv_subm_sample_id"] = _generate_covv_subm_sample_id(
+                subm_sample_id=data.get(
+                    "covv_subm_sample_id",
+                ),
+                region_code=data.get("region_code"),
+            )
+            data.setdefault(
+                "covv_virus_name",
+                _generate_covv_virus_name(
+                    covv_subm_sample_id=data.get("covv_subm_sample_id"),
+                    covv_collection_date=data.get("covv_collection_date"),
+                ),
+            )
+        return data
 
-    @field_validator("covv_subm_sample_id")
-    @classmethod
-    def parse_subm_sample_id(cls, v: str, info: FieldValidationInfo):
-        region_code = info.data.get("region_code")
-        return f"{region_code}_SE100_{v}"
 
-    @field_validator("covv_virus_name")
-    @classmethod
-    def parse_virus_name(cls, _, info: FieldValidationInfo):
-        sample_name = info.data.get("covv_subm_sample_id")
-        date = info.data.get("covv_collection_date")
-        datetime_date = datetime.strptime(date, "%Y-%m-%d")
-        return f"hCoV-19/Sweden/{sample_name}/{datetime_date.year}"
+def _generate_covv_location(region):
+    return f"Europe/Sweden/{region}"
+
+
+def _generate_covv_subm_sample_id(subm_sample_id, region_code):
+    return f"{region_code}_SE100_{subm_sample_id}"
+
+
+def _generate_covv_virus_name(covv_subm_sample_id, covv_collection_date):
+    datetime_date = datetime.strptime(covv_collection_date, "%Y-%m-%d")
+    return f"hCoV-19/Sweden/{covv_subm_sample_id}/{datetime_date.year}"

--- a/cg/meta/upload/gisaid/models.py
+++ b/cg/meta/upload/gisaid/models.py
@@ -23,15 +23,22 @@ class GisaidAccession(BaseModel):
     accession_nr: Optional[str] = None
     sample_id: Optional[str] = None
 
-    @field_validator("accession_nr")
+    @model_validator(mode="before")
     @classmethod
-    def parse_accession(cls, _, info: FieldValidationInfo):
-        return info.data.get("log_message").split(";")[-1]
+    def set_generated_fields(cls, data: Any) -> Any:
+        """Constructs the fields that are generated from other fields."""
+        if isinstance(data, dict):
+            data.setdefault("accession_nr", _parse_accession_nr(data["log_message"]))
+            data.setdefault("sample_id", _parse_sample_id_from_log(data["log_message"]))
+        return data
 
-    @field_validator("sample_id")
-    @classmethod
-    def parse_sample_id(cls, _, info: FieldValidationInfo):
-        return info.data.get("log_message").split("/")[2].split("_")[2]
+
+def _parse_accession_nr(log_message: str) -> str:
+    return log_message.split(";")[-1]
+
+
+def _parse_sample_id_from_log(log_message: str) -> str:
+    return log_message.split("/")[2].split("_")[2]
 
 
 class UploadFiles(BaseModel):

--- a/cg/meta/upload/gisaid/models.py
+++ b/cg/meta/upload/gisaid/models.py
@@ -67,6 +67,7 @@ class GisaidSample(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def set_generated_fields(cls, data: Any):
+        """Constructs the fields that are generated from other fields."""
         if isinstance(data, dict):
             data.setdefault("covv_location", _generate_covv_location(data.get("region")))
             data["covv_subm_sample_id"] = _generate_covv_subm_sample_id(


### PR DESCRIPTION
## Description
The upload of Covid samples to Gisaid is failing after the pydantic migration. The validators where not run as the default value was used.

The PR removes the non-functioning validators and replaces them with a model_validator which sets the fields.


### Fixed

- GisaidSample validation is now done via model_validator instead of field_validator
- GisaidAccession validation is now done via model_validator instead of field_validator

### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
