### PR TITLE
fix(demultiplexing post-processing) Set flow cell status to ondisk

### DIFF
--- a/cg/meta/demultiplex/status_db_storage_functions.py
+++ b/cg/meta/demultiplex/status_db_storage_functions.py
@@ -9,6 +9,7 @@ from cg.apps.demultiplex.sample_sheet.read_sample_sheet import (
 from cg.apps.sequencing_metrics_parser.api import (
     create_sample_lane_sequencing_metrics_for_flow_cell,
 )
+from cg.constants import FlowCellStatus
 from cg.meta.demultiplex.utils import get_q30_threshold
 from cg.models.demultiplex.flow_cell import FlowCellDirectoryData
 from cg.store import Store
@@ -36,6 +37,7 @@ def store_flow_cell_data_in_status_db(
         LOG.info(f"Flow cell added to status db: {parsed_flow_cell.id}.")
     else:
         LOG.info(f"Flow cell already exists in status db: {parsed_flow_cell.id}.")
+        flow_cell.status = FlowCellStatus.ON_DISK
 
     sample_internal_ids = get_sample_internal_ids_from_sample_sheet(
         sample_sheet_path=parsed_flow_cell.get_sample_sheet_path_hk(),


### PR DESCRIPTION
## Description
When post-processing a flow cell which exists in statusdb, the status of the flow cell is not changed. Maintaing the status of retrieved or processing (statuses from PDC-fetching).

This PR adds a line to change the status to on-disk which signifies all files from the flow-cell are available on hasta

### Fixed

- post-processing a flow cell now always sets its status to ondisk


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
