### PR TITLE
Hotfix for flow cell error

### DIFF
--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -3,16 +3,17 @@ from datetime import datetime
 from gettext import gettext
 from typing import List, Union
 
-from cg.constants.constants import CaseActions, DataDelivery
-from cg.server.ext import db
-from cg.store.models import Sample
-from cg.utils.flask.enum import SelectEnumField
 from cgmodels.cg.constants import Pipeline
 from flask import flash, redirect, request, session, url_for
 from flask_admin.actions import action
 from flask_admin.contrib.sqla import ModelView
 from flask_dance.contrib.google import google
 from markupsafe import Markup
+
+from cg.constants.constants import CaseActions, DataDelivery
+from cg.server.ext import db
+from cg.store.models import Sample
+from cg.utils.flask.enum import SelectEnumField
 
 
 class BaseView(ModelView):
@@ -287,7 +288,7 @@ class FamilyView(BaseView):
 class FlowcellView(BaseView):
     """Admin view for Model.Flowcell"""
 
-    column_default_sort = ("reads_updated_at", True)
+    column_default_sort = ("sequenced_at", True)
     column_editable_list = ["status"]
     column_exclude_list = ["archived_at"]
     column_filters = ["sequencer_type", "sequencer_name", "status"]


### PR DESCRIPTION
## Description

When deploying #2414 the flow cell view broke due to Flow cell still using sequenced_at instead of reads_updated_at, but the auto-refactoring slipped such a change by.

### Fixed

- Flow cell view references sequenced_at 


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
