### PR TITLE
Fix complicated comparison code smell

### DIFF
--- a/cg/meta/demultiplex/housekeeper_storage_functions.py
+++ b/cg/meta/demultiplex/housekeeper_storage_functions.py
@@ -57,7 +57,7 @@ def store_undetermined_fastq_files(
     ] = flow_cell.sample_sheet.get_non_pooled_lanes_and_samples()
 
     undetermined_dir_path: Path = flow_cell.path
-    if not flow_cell.bcl_converter == BclConverter.BCL2FASTQ:
+    if flow_cell.bcl_converter != BclConverter.BCL2FASTQ:
         undetermined_dir_path = Path(flow_cell.path, DemultiplexingDirsAndFiles.UNALIGNED_DIR_NAME)
 
     for lane, sample_id in non_pooled_lanes_and_samples:


### PR DESCRIPTION
## Description
Missed a flagged code smell where a comparison was needlessly complicated.

### Fixed
- Simplify conditional flagged as code smell

- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
