### PR TITLE
Remove function for retrieving sample ids

### DIFF
--- a/cg/apps/demultiplex/sample_sheet/read_sample_sheet.py
+++ b/cg/apps/demultiplex/sample_sheet/read_sample_sheet.py
@@ -123,13 +123,3 @@ def get_samples_by_lane(
             sample_by_lane[sample.lane] = []
         sample_by_lane[sample.lane].append(sample)
     return sample_by_lane
-
-
-def get_sample_internal_ids_from_sample_sheet(
-    sample_sheet_path: Path, flow_cell_sample_type: Type[FlowCellSample]
-) -> List[str]:
-    """Return the sample internal ids for samples in the sample sheet."""
-    sample_sheet = get_sample_sheet_from_file(
-        infile=sample_sheet_path, flow_cell_sample_type=flow_cell_sample_type
-    )
-    return sample_sheet.get_sample_ids()

--- a/cg/meta/demultiplex/housekeeper_storage_functions.py
+++ b/cg/meta/demultiplex/housekeeper_storage_functions.py
@@ -5,9 +5,6 @@ from typing import List, Optional, Tuple
 
 from housekeeper.store.models import File, Version
 
-from cg.apps.demultiplex.sample_sheet.read_sample_sheet import (
-    get_sample_internal_ids_from_sample_sheet,
-)
 from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.constants.demultiplexing import BclConverter, DemultiplexingDirsAndFiles
 from cg.constants.housekeeper_tags import SequencingFileTag
@@ -108,10 +105,7 @@ def add_sample_fastq_files_to_housekeeper(
     flow_cell: FlowCellDirectoryData, hk_api: HousekeeperAPI, store: Store
 ) -> None:
     """Add sample fastq files from flow cell to Housekeeper."""
-    sample_internal_ids: List[str] = get_sample_internal_ids_from_sample_sheet(
-        sample_sheet_path=flow_cell.get_sample_sheet_path_hk(),
-        flow_cell_sample_type=flow_cell.sample_type,
-    )
+    sample_internal_ids: List[str] = flow_cell.sample_sheet.get_sample_ids()
 
     for sample_internal_id in sample_internal_ids:
         sample_fastq_paths: Optional[List[Path]] = get_sample_fastqs_from_flow_cell(

--- a/cg/meta/demultiplex/status_db_storage_functions.py
+++ b/cg/meta/demultiplex/status_db_storage_functions.py
@@ -3,9 +3,6 @@ import datetime
 import logging
 from typing import List, Optional, Set
 
-from cg.apps.demultiplex.sample_sheet.read_sample_sheet import (
-    get_sample_internal_ids_from_sample_sheet,
-)
 from cg.apps.sequencing_metrics_parser.api import (
     create_sample_lane_sequencing_metrics_for_flow_cell,
     create_undetermined_non_pooled_metrics,
@@ -41,10 +38,7 @@ def store_flow_cell_data_in_status_db(
         LOG.info(f"Flow cell already exists in status db: {parsed_flow_cell.id}.")
         flow_cell.status = FlowCellStatus.ON_DISK
 
-    sample_internal_ids = get_sample_internal_ids_from_sample_sheet(
-        sample_sheet_path=parsed_flow_cell.get_sample_sheet_path_hk(),
-        flow_cell_sample_type=parsed_flow_cell.sample_type,
-    )
+    sample_internal_ids: List[str] = parsed_flow_cell.sample_sheet.get_sample_ids()
     add_samples_to_flow_cell_in_status_db(
         flow_cell=flow_cell,
         sample_internal_ids=sample_internal_ids,
@@ -134,10 +128,7 @@ def update_sample_read_counts_in_status_db(
 ) -> None:
     """Update samples in status db with the sum of all read counts for the sample in the sequencing metrics table."""
     q30_threshold: int = get_q30_threshold(flow_cell_data.sequencer_type)
-    sample_internal_ids: List[str] = get_sample_internal_ids_from_sample_sheet(
-        sample_sheet_path=flow_cell_data.get_sample_sheet_path_hk(),
-        flow_cell_sample_type=flow_cell_data.sample_type,
-    )
+    sample_internal_ids: List[str] = flow_cell_data.sample_sheet.get_sample_ids()
     for sample_id in sample_internal_ids:
         update_sample_read_count(sample_id=sample_id, q30_threshold=q30_threshold, store=store)
     store.session.commit()

--- a/cg/meta/demultiplex/validation.py
+++ b/cg/meta/demultiplex/validation.py
@@ -2,9 +2,6 @@ import logging
 from pathlib import Path
 from typing import List, Optional
 
-from cg.apps.demultiplex.sample_sheet.read_sample_sheet import (
-    get_sample_internal_ids_from_sample_sheet,
-)
 from cg.constants.demultiplexing import DemultiplexingDirsAndFiles
 from cg.exc import FlowCellError, MissingFilesError
 from cg.meta.demultiplex.utils import get_sample_fastqs_from_flow_cell
@@ -48,10 +45,7 @@ def validate_flow_cell_has_fastq_files(flow_cell: FlowCellDirectoryData) -> None
     Raises: MissingFilesError
         When all samples have missing fastq files in the flow cell
     """
-    sample_ids: List[str] = get_sample_internal_ids_from_sample_sheet(
-        sample_sheet_path=flow_cell.get_sample_sheet_path_hk(),
-        flow_cell_sample_type=flow_cell.sample_type,
-    )
+    sample_ids: List[str] = flow_cell.sample_sheet.get_sample_ids()
     for sample_id in sample_ids:
         fastq_files: Optional[List[Path]] = get_sample_fastqs_from_flow_cell(
             flow_cell_directory=flow_cell.path, sample_internal_id=sample_id

--- a/tests/apps/demultiplex/test_read_sample_sheet.py
+++ b/tests/apps/demultiplex/test_read_sample_sheet.py
@@ -11,9 +11,9 @@ from cg.apps.demultiplex.sample_sheet.models import (
     FlowCellSampleBCLConvert,
 )
 from cg.apps.demultiplex.sample_sheet.read_sample_sheet import (
+    get_sample_sheet_from_file,
     validate_samples_are_unique,
     get_samples_by_lane,
-    get_sample_internal_ids_from_sample_sheet,
     get_validated_sample_sheet,
     get_raw_samples,
 )
@@ -183,13 +183,14 @@ def test_get_sample_internal_ids_from_sample_sheet(
     flow_cell_type: Type[FlowCellSample] = FlowCellSampleBCLConvert,
 ):
     """Test that getting sample internal ids from a sample sheet returns a unique list of strings."""
-    # GIVEN a path to a sample sheet with only valid samples
-
-    # WHEN getting the valid sample internal ids
-    sample_internal_ids: List[str] = get_sample_internal_ids_from_sample_sheet(
-        sample_sheet_path=novaseq6000_bcl_convert_sample_sheet_path,
+    # GIVEN a sample sheet with only valid samples
+    sample_sheet: SampleSheet = get_sample_sheet_from_file(
+        infile=novaseq6000_bcl_convert_sample_sheet_path,
         flow_cell_sample_type=flow_cell_type,
     )
+
+    # WHEN getting the valid sample internal ids
+    sample_internal_ids: List[str] = sample_sheet.get_sample_ids()
 
     # THEN the returned value is a list
     assert isinstance(sample_internal_ids, List)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1421,11 +1421,11 @@ def novaseqx_flow_cell_with_sample_sheet_no_fastq(
 ) -> FlowCellDirectoryData:
     """Return a flow cell from a tmp dir with a sample sheet and no sample fastq files."""
     novaseqx_flow_cell_directory.mkdir(parents=True, exist_ok=True)
-    flow_cell = FlowCellDirectoryData(flow_cell_path=novaseqx_flow_cell_directory)
+    flow_cell = FlowCellDirectoryData(novaseqx_flow_cell_directory)
     sample_sheet_path = Path(
         novaseqx_demultiplexed_flow_cell, DemultiplexingDirsAndFiles.SAMPLE_SHEET_FILE_NAME
     )
-    mocker.patch.object(flow_cell, "get_sample_sheet_path_hk", return_value=sample_sheet_path)
+    flow_cell._sample_sheet_path_hk = sample_sheet_path
     return flow_cell
 
 

--- a/tests/meta/demultiplex/test_validation.py
+++ b/tests/meta/demultiplex/test_validation.py
@@ -1,9 +1,8 @@
 from pathlib import Path
-
 import pytest
-from cg.apps.demultiplex.sample_sheet.read_sample_sheet import (
-    get_sample_internal_ids_from_sample_sheet,
-)
+from cg.apps.demultiplex.sample_sheet.models import SampleSheet
+from cg.apps.demultiplex.sample_sheet.read_sample_sheet import get_sample_sheet_from_file
+
 from cg.constants import FileExtensions
 from cg.constants.demultiplexing import DemultiplexingDirsAndFiles
 from cg.exc import FlowCellError, MissingFilesError
@@ -135,27 +134,21 @@ def test_validate_flow_cell_delivery_status_forced(tmp_path: Path):
 
 
 def test_validate_samples_have_fastq_files_passes(
-    novaseqx_flow_cell_with_sample_sheet_no_fastq,
+    novaseqx_flow_cell_with_sample_sheet_no_fastq: FlowCellDirectoryData,
 ):
     """Test the check of a flow cells with one sample fastq file does not raise an error."""
-    # GIVEN a demultiplexed flow cell with no fastq files
-
-    # GIVEN a that the flow cell has a sample sheet in Housekeeper
-    assert novaseqx_flow_cell_with_sample_sheet_no_fastq.get_sample_sheet_path_hk()
+    # GIVEN a demultiplexed flow cell with no fastq files and a sample sheet
 
     # GIVEN that a valid sample fastq file is added to the directory
-    sample_id: str = get_sample_internal_ids_from_sample_sheet(
-        sample_sheet_path=novaseqx_flow_cell_with_sample_sheet_no_fastq.get_sample_sheet_path_hk(),
-        flow_cell_sample_type=novaseqx_flow_cell_with_sample_sheet_no_fastq.sample_type,
-    )[0]
+    sample_id: str = novaseqx_flow_cell_with_sample_sheet_no_fastq.sample_sheet.get_sample_ids()[0]
     fastq_file_path = Path(
         novaseqx_flow_cell_with_sample_sheet_no_fastq.path,
         f"{sample_id}_S11_L1_R1_{FileExtensions.FASTQ}{FileExtensions.GZIP}",
     )
-    fastq_file_path.touch(exist_ok=True)
+    fastq_file_path.touch()
 
     # WHEN checking if the flow cell has fastq files for the samples
-    validate_flow_cell_has_fastq_files(flow_cell=novaseqx_flow_cell_with_sample_sheet_no_fastq)
+    validate_flow_cell_has_fastq_files(novaseqx_flow_cell_with_sample_sheet_no_fastq)
 
     # THEN no error is raised
 


### PR DESCRIPTION
## Description
This PR replaces a function which wrapped the `get_sample_ids` function on the sample sheet with a direct call to it.
This function
```python
def get_sample_internal_ids_from_sample_sheet(
    sample_sheet_path: Path, flow_cell_sample_type: Type[FlowCellSample]
) -> List[str]:
    """Return the sample internal ids for samples in the sample sheet."""
    sample_sheet = get_sample_sheet_from_file(
        infile=sample_sheet_path, flow_cell_sample_type=flow_cell_sample_type
    )
    return sample_sheet.get_sample_ids()
```
is always called in a context where we have a sample sheet object available. It is not necessary to reparse the entire sample sheet each time we want to retrieve the sample ids. We can just call `sample_sheet.get_sample_ids()` directly.

### Fixed
- Replace unnecessary function for retrieving sample ids from a sample sheet

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
