### PR TITLE
Fix validator decorators in CGDeliverables

### DIFF
--- a/cg/apps/hermes/models.py
+++ b/cg/apps/hermes/models.py
@@ -3,8 +3,9 @@ import logging
 from pathlib import Path
 from typing import List, Optional
 
-from cg.exc import CgDataError
 from pydantic import BaseModel, field_validator
+
+from cg.exc import CgDataError
 
 LOG = logging.getLogger(__name__)
 
@@ -24,8 +25,8 @@ class CGDeliverables(BaseModel):
     bundle_id: str
     files: List[CGTag]
 
-    @classmethod
     @field_validator("files")
+    @classmethod
     def remove_missing_files(cls, files: List[CGTag]) -> List[CGTag]:
         """Validates that the files in a suggested CGDeliverables object are correct.
         I.e. if a file doesn't exist an error is raised if the file was mandatory,


### PR DESCRIPTION
## Description

Addresses issue #2500, wherein it was discovered that a field validator was not triggering correctly. This is due to decorators being specified in the wrong order which this PR addresses. 

As a side note, the only reason for not following the "Annotated" pattern that we usually adhere to is that we get circular imports when importing "CGTag" to a validators.py class. In a future PR we might consider some refactoring.

### Fixed

- Field validator decorator before class method decorator in remove_missing_files.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b 2500-fix-remove-missing-files -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
