### PR TITLE
Update order report templates to reads_updated_at

### DIFF
--- a/cg/meta/report/templates/balsamic_report.html
+++ b/cg/meta/report/templates/balsamic_report.html
@@ -125,7 +125,7 @@
                    </td>
                 {% endif %}
                   <td>{{ sample.methods.sequencing }}</td>
-                  <td>{{ sample.timestamps.sequenced_at }}</td>
+                  <td>{{ sample.timestamps.reads_updated_at }}</td>
                   <td>{{ case.data_analysis.pipeline }}</td>
                 </tr>
               {% endfor %}

--- a/cg/meta/report/templates/mip-dna_report.html
+++ b/cg/meta/report/templates/mip-dna_report.html
@@ -126,7 +126,7 @@
                   <td>{{ sample.timestamps.prepared_at }}</td>
                   <td>{{ sample.metadata.bait_set }}</td>
                   <td>{{ sample.methods.sequencing }}</td>
-                  <td>{{ sample.timestamps.sequenced_at }}</td>
+                  <td>{{ sample.timestamps.reads_updated_at }}</td>
                   <td>{{ case.data_analysis.pipeline }}</td>
                 </tr>
               {% endfor %}

--- a/cg/meta/report/templates/rnafusion_report.html
+++ b/cg/meta/report/templates/rnafusion_report.html
@@ -114,7 +114,7 @@
                   <td>{{ sample.methods.library_prep }}</td>
                   <td>{{ sample.timestamps.prepared_at }}</td>
                   <td>{{ sample.methods.sequencing }}</td>
-                  <td>{{ sample.timestamps.sequenced_at }}</td>
+                  <td>{{ sample.timestamps.reads_updated_at }}</td>
                   <td>{{ case.data_analysis.pipeline }}</td>
                 </tr>
               {% endfor %}


### PR DESCRIPTION
## Description

Addresses issue #2520 where it was highlighted that in #2414, templates were not updated accordingly.

### Fixed

- Templates now references sample.reads_updated_at


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b update-report-templates -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
