### PR TITLE
fix(sars-cov2 excel order) Properly parse the primer field

### DIFF
--- a/cg/models/orders/excel_sample.py
+++ b/cg/models/orders/excel_sample.py
@@ -1,5 +1,8 @@
 from typing import List, Optional
 
+from pydantic import AfterValidator, BeforeValidator, Field
+from typing_extensions import Annotated
+
 from cg.models.orders.sample_base import OrderSample
 from cg.models.orders.validators.excel_sample_validators import (
     convert_sex,
@@ -8,13 +11,11 @@ from cg.models.orders.validators.excel_sample_validators import (
     convert_to_priority,
     numeric_value,
     parse_panels,
+    replace_spaces_with_underscores,
     validate_data_analysis,
     validate_parent,
     validate_source,
-    replace_spaces_with_underscores,
 )
-from pydantic import AfterValidator, BeforeValidator, Field
-from typing_extensions import Annotated
 
 
 class ExcelSample(OrderSample):
@@ -65,7 +66,7 @@ class ExcelSample(OrderSample):
     pool: str = Field(None, alias="UDF/pool name")
     post_formalin_fixation_time: str = Field(None, alias="UDF/Post Formalin Fixation Time")
     pre_processing_method: str = Field(None, alias="UDF/Pre Processing Method")
-    primer: str = Field(None, alias="UDF/Primer")
+    primer: str = Field(None, alias="UDF/primer")
     priority: Annotated[
         str,
         AfterValidator(convert_to_lower),

--- a/cg/models/orders/sample_base.py
+++ b/cg/models/orders/sample_base.py
@@ -1,11 +1,12 @@
 from enum import Enum
 from typing import List, Optional
 
+from pydantic import BaseModel, BeforeValidator, ConfigDict, constr
+from typing_extensions import Annotated
+
 from cg.constants import DataDelivery, Pipeline
 from cg.models.orders.validators.sample_base_validators import snake_case
 from cg.store.models import Application, Customer, Family, Pool, Sample
-from pydantic import BaseModel, BeforeValidator, ConfigDict, constr
-from typing_extensions import Annotated
 
 
 class ControlEnum(str, Enum):
@@ -101,6 +102,7 @@ class OrderSample(BaseModel):
     post_formalin_fixation_time: Optional[int] = None
     pre_processing_method: Optional[str] = None
     priority: Annotated[PriorityEnum, BeforeValidator(snake_case)] = PriorityEnum.standard
+    primer: Optional[str] = None
     quantity: Optional[int] = None
     reagent_label: Optional[str] = None
     reference_genome: Optional[


### PR DESCRIPTION
## Description
Customers reported that the Primer field was not properly parsed when they uploaded orderforms.

This PR changes the primer alias from UDF/Primer to UDF/primer to match the header in the excel sheet

### Fixed

- Changed primer alias from UDF/Primer to UDF/primer

### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
