### PR TITLE
Set reads_updated_at when reads are updated

### DIFF
--- a/cg/meta/demultiplex/status_db_storage_functions.py
+++ b/cg/meta/demultiplex/status_db_storage_functions.py
@@ -7,8 +7,10 @@ from cg.apps.sequencing_metrics_parser.api import (
     create_sample_lane_sequencing_metrics_for_flow_cell,
     create_undetermined_non_pooled_metrics,
 )
-from cg.meta.demultiplex.combine_sequencing_metrics import combine_mapped_metrics_with_undetermined
 from cg.constants import FlowCellStatus
+from cg.meta.demultiplex.combine_sequencing_metrics import (
+    combine_mapped_metrics_with_undetermined,
+)
 from cg.meta.demultiplex.utils import get_q30_threshold
 from cg.models.demultiplex.flow_cell import FlowCellDirectoryData
 from cg.store import Store
@@ -146,7 +148,6 @@ def update_sample_read_count(sample_id: str, q30_threshold: int, store: Store) -
             f"Updating sample {sample_id} with read count {sample_read_count} and setting sequenced at."
         )
         sample.reads = sample_read_count
-        if not sample.reads_updated_at:
-            sample.reads_updated_at = datetime.datetime.now()
+        sample.reads_updated_at = datetime.datetime.now()
     else:
         LOG.warning(f"Cannot find {sample_id} in status_db when adding read counts. Skipping.")

--- a/tests/meta/demultiplex/test_status_db_storage_functions.py
+++ b/tests/meta/demultiplex/test_status_db_storage_functions.py
@@ -1,5 +1,4 @@
 """Tests for the status_db_storage_functions module of the demultiplexing post post-processing module."""
-from datetime import datetime
 
 from mock import MagicMock
 
@@ -41,27 +40,25 @@ def test_add_single_sequencing_metrics_entry_to_statusdb(
     )
 
 
-def test_update_sample_read_count(demultiplex_context: CGConfig):
+def test_update_sample_read_count(demultiplex_context: CGConfig, timestamp_yesterday):
     # GIVEN a DemuxPostProcessing API
     demux_post_processing_api = DemuxPostProcessingAPI(demultiplex_context)
 
     # GIVEN a sample id and a q30 threshold
-    sample_internal_id = "sample_1"
-    q30_threshold = 0
+    sample_internal_id: str = "sample_1"
+    q30_threshold: int = 0
 
     # GIVEN a sample and a read count
     sample = MagicMock()
-    read_count = 100
-    sample.reads_updated_at = datetime.now()
+    read_count: int = 100
+    sample.reads_updated_at = timestamp_yesterday
 
     # GIVEN a mocked status_db
     status_db = MagicMock()
     status_db.get_sample_by_internal_id.return_value = sample
     status_db.get_number_of_reads_for_sample_passing_q30_threshold.return_value = read_count
     demux_post_processing_api.status_db = status_db
-    time_before_update: datetime = datetime.now()
 
-    assert sample.reads_updated_at < time_before_update
     # WHEN calling update_sample_read_count
     update_sample_read_count(
         sample_id=sample_internal_id, q30_threshold=q30_threshold, store=status_db
@@ -80,7 +77,7 @@ def test_update_sample_read_count(demultiplex_context: CGConfig):
     assert sample.reads == read_count
 
     # THEN the reads_updated_at has been updated with a new timestamp
-    assert sample.reads_updated_at > time_before_update
+    assert sample.reads_updated_at > timestamp_yesterday
 
 
 def test_metric_has_sample_in_statusdb(demultiplex_context: CGConfig):


### PR DESCRIPTION
## Description

With the name change of the column sample.sequenced_at to sample.reads_updated, the reads_updated_at value should also be set whenever the reads are updated, e.g. when a topup is done. This PR removes a check preventing this from happening.

### Fixed

- Set reads_updated_at even when a previous value is set.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b fix-reads-updated-at -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
