### PR TITLE
Catch sample sheet missing exception

### DIFF
--- a/cg/cli/demultiplex/sample_sheet.py
+++ b/cg/cli/demultiplex/sample_sheet.py
@@ -150,9 +150,14 @@ def create_all_sheets(context: CGConfig, dry_run: bool):
         except FlowCellError:
             continue
         flow_cell_id: str = flow_cell.id
-        sample_sheet_path: Optional[Path] = get_sample_sheet_path(
-            flow_cell_id=flow_cell_id, hk_api=hk_api
-        )
+
+        try:
+            sample_sheet_path: Optional[Path] = get_sample_sheet_path(
+                flow_cell_id=flow_cell_id, hk_api=hk_api
+            )
+        except HousekeeperFileMissingError:
+            sample_sheet_path = None
+
         if flow_cell.sample_sheet_exists():
             LOG.debug("Sample sheet already exists in flow cell directory")
             if not dry_run:


### PR DESCRIPTION
## Description
This PR patches the sample sheet generation, catching an exception which previously caused the sample sheet generation to fail. Missed in a previous PR.

### Fixed
- Sampel sheet generation

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
