### PR TITLE
Fix deprecation warnings

### DIFF
--- a/cg/apps/crunchy/files.py
+++ b/cg/apps/crunchy/files.py
@@ -89,7 +89,7 @@ def get_spring_archive_files(crunchy_metadata: CrunchyMetadata) -> Dict[str, Cru
 def write_metadata_content(spring_metadata: CrunchyMetadata, spring_metadata_path: Path) -> None:
     """Update the file on disk."""
     content: dict = ReadStream.get_content_from_stream(
-        file_format=FileFormat.JSON, stream=spring_metadata.model_dump_json(exclude_none=True)
+        file_format=FileFormat.JSON, stream=spring_metadata.json(exclude_none=True)
     )
     WriteFile.write_file_from_content(
         content=content["files"], file_format=FileFormat.JSON, file_path=spring_metadata_path

--- a/cg/apps/crunchy/files.py
+++ b/cg/apps/crunchy/files.py
@@ -89,7 +89,7 @@ def get_spring_archive_files(crunchy_metadata: CrunchyMetadata) -> Dict[str, Cru
 def write_metadata_content(spring_metadata: CrunchyMetadata, spring_metadata_path: Path) -> None:
     """Update the file on disk."""
     content: dict = ReadStream.get_content_from_stream(
-        file_format=FileFormat.JSON, stream=spring_metadata.json(exclude_none=True)
+        file_format=FileFormat.JSON, stream=spring_metadata.model_dump_json(exclude_none=True)
     )
     WriteFile.write_file_from_content(
         content=content["files"], file_format=FileFormat.JSON, file_path=spring_metadata_path

--- a/cg/apps/demultiplex/demultiplex_api.py
+++ b/cg/apps/demultiplex/demultiplex_api.py
@@ -69,7 +69,7 @@ class DemultiplexingAPI:
             demux_dir=demux_dir.as_posix(),
             demux_started=flow_cell.demultiplexing_started_path.as_posix(),
         )
-        return DEMULTIPLEX_ERROR.format(**error_parameters.dict())
+        return DEMULTIPLEX_ERROR.format(**error_parameters.model_dump())
 
     @staticmethod
     def get_sbatch_command(
@@ -94,7 +94,7 @@ class DemultiplexingAPI:
             demux_completed_file=demux_completed.as_posix(),
             environment=environment,
         )
-        return DEMULTIPLEX_COMMAND[flow_cell.bcl_converter].format(**command_parameters.dict())
+        return DEMULTIPLEX_COMMAND[flow_cell.bcl_converter].format(**command_parameters.model_dump())
 
     @staticmethod
     def demultiplex_sbatch_path(flow_cell: FlowCellDirectoryData) -> Path:

--- a/cg/apps/demultiplex/demultiplex_api.py
+++ b/cg/apps/demultiplex/demultiplex_api.py
@@ -94,7 +94,9 @@ class DemultiplexingAPI:
             demux_completed_file=demux_completed.as_posix(),
             environment=environment,
         )
-        return DEMULTIPLEX_COMMAND[flow_cell.bcl_converter].format(**command_parameters.model_dump())
+        return DEMULTIPLEX_COMMAND[flow_cell.bcl_converter].format(
+            **command_parameters.model_dump()
+        )
 
     @staticmethod
     def demultiplex_sbatch_path(flow_cell: FlowCellDirectoryData) -> Path:

--- a/cg/apps/demultiplex/sample_sheet/models.py
+++ b/cg/apps/demultiplex/sample_sheet/models.py
@@ -2,7 +2,7 @@ import logging
 from collections import defaultdict
 from typing import List, Tuple
 
-from pydantic import BaseModel, ConfigDict, Extra, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from cg.apps.demultiplex.sample_sheet.validators import SampleId
 from cg.constants.constants import GenomeVersion
@@ -21,7 +21,7 @@ class FlowCellSample(BaseModel):
     sample_id: SampleId
     index: str
     index2: str = ""
-    model_config = ConfigDict(populate_by_name=True, extra=Extra.ignore)
+    model_config = ConfigDict(populate_by_name=True, extra='ignore')
 
 
 class FlowCellSampleBcl2Fastq(FlowCellSample):

--- a/cg/apps/demultiplex/sample_sheet/models.py
+++ b/cg/apps/demultiplex/sample_sheet/models.py
@@ -21,7 +21,7 @@ class FlowCellSample(BaseModel):
     sample_id: SampleId
     index: str
     index2: str = ""
-    model_config = ConfigDict(populate_by_name=True, extra='ignore')
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
 
 
 class FlowCellSampleBcl2Fastq(FlowCellSample):

--- a/cg/apps/hermes/hermes_api.py
+++ b/cg/apps/hermes/hermes_api.py
@@ -58,7 +58,7 @@ class HermesApi:
         """Convert a deliverables object to a housekeeper object"""
         bundle_info = {
             "name": bundle_name,
-            "files": [file_info.dict() for file_info in deliverables.files],
+            "files": [file_info.model_dump() for file_info in deliverables.files],
         }
         if created:
             bundle_info["created"] = created

--- a/cg/apps/scout/scout_export.py
+++ b/cg/apps/scout/scout_export.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Optional
 from cg.apps.scout.validators import set_gender_if_other, set_parent_if_missing
 from cg.constants.gene_panel import GENOME_BUILD_37
 from cg.constants.subject import Gender, PlinkGender, PlinkPhenotypeStatus
-from pydantic import BaseModel, BeforeValidator, Field, Strict
+from pydantic import BaseModel, BeforeValidator, Field
 from typing_extensions import Annotated, Literal
 
 

--- a/cg/apps/slurm/slurm_api.py
+++ b/cg/apps/slurm/slurm_api.py
@@ -46,11 +46,11 @@ class SlurmAPI:
 
     @staticmethod
     def generate_sbatch_header(sbatch_parameters: Sbatch) -> str:
-        return SBATCH_HEADER_TEMPLATE.format(**sbatch_parameters.dict())
+        return SBATCH_HEADER_TEMPLATE.format(**sbatch_parameters.model_dump())
 
     @staticmethod
     def generate_dragen_sbatch_header(sbatch_parameters: Sbatch) -> str:
-        return DRAGEN_SBATCH_HEADER_TEMPLATE.format(**sbatch_parameters.dict())
+        return DRAGEN_SBATCH_HEADER_TEMPLATE.format(**sbatch_parameters.model_dump())
 
     @staticmethod
     def generate_sbatch_body(commands: str, error_function: Optional[str] = None) -> str:

--- a/cg/meta/upload/gisaid/gisaid.py
+++ b/cg/meta/upload/gisaid/gisaid.py
@@ -154,7 +154,7 @@ class GisaidAPI:
     def create_gisaid_csv(self, gisaid_samples: List[GisaidSample], case_id: str) -> None:
         """Create csv file for gisaid upload"""
         samples_df = pd.DataFrame(
-            data=[gisaid_sample.dict() for gisaid_sample in gisaid_samples],
+            data=[gisaid_sample.model_dump() for gisaid_sample in gisaid_samples],
             columns=HEADERS,
         )
 

--- a/cg/meta/upload/mutacc.py
+++ b/cg/meta/upload/mutacc.py
@@ -42,9 +42,9 @@ class UploadToMutaccAPI:
 
         if all([self._has_bam(case), self._has_causatives(case)]):
             causatives = self.scout.get_causative_variants(case_id=case.id)
-            mutacc_case = remap(case.dict(), SCOUT_TO_MUTACC_CASE)
+            mutacc_case = remap(case.model_dump(), SCOUT_TO_MUTACC_CASE)
             mutacc_variants = [
-                remap(variant.dict(), SCOUT_TO_MUTACC_VARIANTS) for variant in causatives
+                remap(variant.model_dump(), SCOUT_TO_MUTACC_VARIANTS) for variant in causatives
             ]
             return {"case": mutacc_case, "causatives": mutacc_variants}
         return {}

--- a/cg/meta/upload/scout/uploadscoutapi.py
+++ b/cg/meta/upload/scout/uploadscoutapi.py
@@ -85,7 +85,7 @@ class UploadScoutAPI:
 
         LOG.info(f"Save Scout load config to {file_path.as_posix()}.")
         WriteFile.write_file_from_content(
-            content=upload_config.dict(exclude_none=True),
+            content=upload_config.model_dump(exclude_none=True),
             file_format=FileFormat.YAML,
             file_path=file_path,
         )

--- a/cg/meta/workflow/analysis.py
+++ b/cg/meta/workflow/analysis.py
@@ -211,7 +211,7 @@ class AnalysisAPI(MetaAPI):
             pipeline=str(self.pipeline),
             analysis_type=self.get_bundle_deliverables_type(case_id),
             created=self.get_bundle_created_date(case_id),
-        ).dict()
+        ).model_dump()
 
     def get_bundle_created_date(self, case_id: str) -> dt.datetime:
         return self.get_date_from_file_path(self.get_deliverables_file_path(case_id=case_id))

--- a/cg/meta/workflow/mutant.py
+++ b/cg/meta/workflow/mutant.py
@@ -129,7 +129,7 @@ class MutantAnalysisAPI(AnalysisAPI):
         case_obj = self.status_db.get_case_by_internal_id(internal_id=case_id)
         samples: List[Sample] = [link.sample for link in case_obj.links]
         case_config_list = [
-            self.get_sample_parameters(sample_obj=sample_obj).dict() for sample_obj in samples
+            self.get_sample_parameters(sample_obj).model_dump() for sample_obj in samples
         ]
         config_path = self.get_case_config_path(case_id=case_id)
         if dry_run:

--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -489,7 +489,7 @@ def parse_orderform():
         error_message = error.message if hasattr(error, "message") else str(error)
         http_error_response = http.HTTPStatus.INTERNAL_SERVER_ERROR
     else:
-        return jsonify(**parsed_order.dict())
+        return jsonify(**parsed_order.model_dump())
 
     if error_message:
         return abort(make_response(jsonify(message=error_message), http_error_response))

--- a/tests/apps/sequencing_metrics_parser/parsers/test_bclconvert.py
+++ b/tests/apps/sequencing_metrics_parser/parsers/test_bclconvert.py
@@ -49,7 +49,7 @@ def test_parse_bcl_convert_quality_metrics(
     assert isinstance(quality_metrics_model, BclConvertQualityMetrics)
 
     # ASSERT that the parsed quality metrics has the correct values
-    for attr_name, attr_value in quality_metrics_model.dict().items():
+    for attr_name, attr_value in quality_metrics_model.model_dump().items():
         assert getattr(bcl_convert_quality_metric_model_with_data, attr_name) == attr_value
 
 
@@ -67,7 +67,7 @@ def test_parse_bcl_convert_demux_metrics(
     assert isinstance(demux_metrics_model, BclConvertDemuxMetrics)
 
     # ASSERT that the parsed demux metrics has the correct values
-    for attr_name, attr_value in demux_metrics_model.dict().items():
+    for attr_name, attr_value in demux_metrics_model.model_dump().items():
         assert getattr(bcl_convert_demux_metric_model_with_data, attr_name) == attr_value
 
 

--- a/tests/apps/slurm/conftest.py
+++ b/tests/apps/slurm/conftest.py
@@ -19,7 +19,7 @@ def sbatch_parameters(email_adress: str, slurm_account: str) -> Sbatch:
         "hours": 2,
         "commands": "genmod",
     }
-    return Sbatch.parse_obj(config)
+    return Sbatch.model_validate(config)
 
 
 @pytest.fixture

--- a/tests/meta/archive/conftest.py
+++ b/tests/meta/archive/conftest.py
@@ -148,7 +148,7 @@ def miria_file_retrieve(local_directory: Path, remote_path: Path) -> MiriaObject
 def transfer_payload(miria_file_archive: MiriaObject) -> TransferPayload:
     """Return a TransferPayload object containing two identical MiriaObject object."""
     return TransferPayload(
-        files_to_transfer=[miria_file_archive, miria_file_archive.copy(deep=True)]
+        files_to_transfer=[miria_file_archive, miria_file_archive.model_copy(deep=True)]
     )
 
 

--- a/tests/meta/upload/scout/test_generate_load_config.py
+++ b/tests/meta/upload/scout/test_generate_load_config.py
@@ -106,7 +106,7 @@ def test_generate_config_adds_meta_result_key(
     )
 
     # THEN the config should contain the rank model version used
-    assert result_data.dict()[result_key]
+    assert result_data.model_dump()[result_key]
 
 
 def test_generate_config_adds_sample_paths(


### PR DESCRIPTION
## Description
This PR fixes all Pydantic deprecation warnings for models already migrated to v2 but still using methods from v1.

Replace calls to
- `parse_obj` with `model_validate`
- `dict` with `model_dump`
- `Extra.ignore` with `'ignore'`

### Fixed
- Pydantic deprecation warnings

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
