### PR TITLE
Upgrade to Python 3.10

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -9,10 +9,10 @@ jobs:
       - name: Check out git repository
         uses: actions/checkout@v3
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.10
 
       - name: Set up Black
         uses: psf/black@stable

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: '3.10'
 
       - name: Set up Black
         uses: psf/black@stable

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: '3.10'
 
       - name: Install build tools
         run: >-

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -13,10 +13,10 @@ jobs:
       - name: Check out git repository
         uses: actions/checkout@v3
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.10
 
       - name: Install build tools
         run: >-

--- a/.github/workflows/installations.yml
+++ b/.github/workflows/installations.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10]
+        python-version: ['3.10']
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/installations.yml
+++ b/.github/workflows/installations.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.10]
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/tests_and_coverage.yml
+++ b/.github/workflows/tests_and_coverage.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: '3.10'
 
       - name: Cache dependencies
         uses: actions/cache@v3

--- a/.github/workflows/tests_and_coverage.yml
+++ b/.github/workflows/tests_and_coverage.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.10
 
       - name: Cache dependencies
         uses: actions/cache@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/python:3.8-slim-bullseye
+FROM docker.io/library/python:3.10-slim-bullseye
 
 ENV GUNICORN_WORKERS=1
 ENV GUNICORN_THREADS=1

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     tests_require=parse_requirements("requirements-dev.txt"),
     classifiers=[
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: Implementation :: CPython",
     ],
 )


### PR DESCRIPTION
## Description
This PR upgrades cg to Python 3.10, see [breaking changes](https://docs.python.org/3/whatsnew/3.10.html#porting-to-python-3-10). 

Blocked by https://github.com/Clinical-Genomics/cg/pull/2499 and https://github.com/Clinical-Genomics/cg/pull/2565 (some of the versions of the packages we currently use do not officially support 3.10).




### Fixed
- Upgrade to Python 3.10

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
