### PR TITLE
Upgrade to Python 3.11

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -9,10 +9,10 @@ jobs:
       - name: Check out git repository
         uses: actions/checkout@v3
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: "3.11"
 
       - name: Set up Black
         uses: psf/black@stable

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -13,10 +13,10 @@ jobs:
       - name: Check out git repository
         uses: actions/checkout@v3
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: "3.11"
 
       - name: Install build tools
         run: >-

--- a/.github/workflows/installations.yml
+++ b/.github/workflows/installations.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: ["3.11"]
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/tests_and_coverage.yml
+++ b/.github/workflows/tests_and_coverage.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: "3.11"
 
       - name: Cache dependencies
         uses: actions/cache@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/python:3.8-slim-bullseye
+FROM docker.io/library/python:3.11-slim-bullseye
 
 ENV GUNICORN_WORKERS=1
 ENV GUNICORN_THREADS=1

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ Jinja2
 lxml
 marshmallow>3               # due to code expects behaviour from >3
 markupsafe
-openpyxl==3.0.10
+openpyxl
 packaging
 pandas
 paramiko

--- a/tests/meta/workflow/test_balsamic.py
+++ b/tests/meta/workflow/test_balsamic.py
@@ -55,7 +55,10 @@ def test_get_verified_gender_unknown(caplog):
 
     # THEN gender must match the expected one
     assert retrieved_gender == Gender.FEMALE
-    assert f"The provided gender is unknown, setting {Gender.FEMALE} as the default" in caplog.text
+    assert (
+        f"The provided gender is unknown, setting {Gender.FEMALE.value} as the default"
+        in caplog.text
+    )
 
 
 def test_get_verified_pon():


### PR DESCRIPTION
## Description
This PR upgrades cg to Python 3.11. We are not affected by the [breaking changes](https://docs.python.org/3/whatsnew/3.11.html#removed). All of our packages support Python 3.11.

### Fixed
- Upgrade to Python 3.11

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
