### PR TITLE
Lock genologics package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,5 +41,5 @@ typing_extensions
 urllib3
 
 # apps
-genologics
+genologics==0.3.18
 housekeeper>=4.6,<5.0


### PR DESCRIPTION
## Description
The new major release of the genologics package breaks placing orders (at least sars cov). Locking it for now.
See https://github.com/Clinical-Genomics/cg/issues/2572.

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


