### PR TITLE
Add string coercion for parent

### DIFF
--- a/cg/apps/scout/scout_export.py
+++ b/cg/apps/scout/scout_export.py
@@ -18,7 +18,9 @@ class Individual(BaseModel):
         Literal[PlinkGender.UNKNOWN, PlinkGender.MALE, PlinkGender.FEMALE, Gender.OTHER],
         BeforeValidator(set_gender_if_other),
     ]
-    father: Annotated[str, BeforeValidator(set_parent_if_missing)]
+    father: Annotated[
+        str, BeforeValidator(lambda x: str(x)), BeforeValidator(set_parent_if_missing)
+    ]
     mother: Annotated[str, BeforeValidator(set_parent_if_missing)]
     phenotype: PlinkPhenotypeStatus
     analysis_type: str = "wgs"

--- a/cg/apps/scout/scout_export.py
+++ b/cg/apps/scout/scout_export.py
@@ -21,7 +21,9 @@ class Individual(BaseModel):
     father: Annotated[
         str, BeforeValidator(lambda x: str(x)), BeforeValidator(set_parent_if_missing)
     ]
-    mother: Annotated[str, BeforeValidator(set_parent_if_missing)]
+    mother: Annotated[
+        str, BeforeValidator(lambda x: str(x)), BeforeValidator(set_parent_if_missing)
+    ]
     phenotype: PlinkPhenotypeStatus
     analysis_type: str = "wgs"
 

--- a/cg/apps/scout/validators.py
+++ b/cg/apps/scout/validators.py
@@ -4,7 +4,7 @@ from cg.constants.subject import Gender, PlinkGender, RelationshipStatus
 
 
 def set_parent_if_missing(parent: Optional[str]) -> str:
-    return str(RelationshipStatus.HAS_NO_PARENT) if parent is None else parent
+    return str(RelationshipStatus.HAS_NO_PARENT.value) if parent is None else parent
 
 
 def set_gender_if_other(gender: Optional[str]) -> str:

--- a/tests/apps/scout/test_scout_models.py
+++ b/tests/apps/scout/test_scout_models.py
@@ -30,7 +30,7 @@ def test_validate_case_father_none(none_case_raw: dict):
 
 
 def test_validate_case_father_int(none_case_raw: dict):
-    """Test to validate string coercion when the Father is set to 0"""
+    """Test to validate string coercion when the father is set to 0."""
 
     # GIVEN a case that has parent set to 0
     none_case_raw["individuals"][0][Pedigree.FATHER] = 0

--- a/tests/apps/scout/test_scout_models.py
+++ b/tests/apps/scout/test_scout_models.py
@@ -20,7 +20,30 @@ def test_validate_case_father_none(none_case_raw: dict):
     case_dict = case_obj.model_dump()
 
     # THEN assert father is set to string 0
-    assert case_dict["individuals"][0][Pedigree.FATHER] == str(RelationshipStatus.HAS_NO_PARENT)
+    assert case_dict["individuals"][0][Pedigree.FATHER] == str(
+        RelationshipStatus.HAS_NO_PARENT.value
+    )
+
+    # THEN assert that '_id' has been changed to 'id'
+    assert "_id" not in case_dict
+    assert "id" in case_dict
+
+
+def test_validate_case_father_int(none_case_raw: dict):
+    """Test to validate string coercion when the Father is set to 0"""
+
+    # GIVEN a case that has parent set to 0
+    none_case_raw["individuals"][0][Pedigree.FATHER] = 0
+
+    # WHEN validating the output with model
+    case_obj = ScoutExportCase.model_validate(none_case_raw)
+
+    case_dict = case_obj.model_dump()
+
+    # THEN assert father is set to string 0
+    assert case_dict["individuals"][0][Pedigree.FATHER] == str(
+        RelationshipStatus.HAS_NO_PARENT.value
+    )
 
     # THEN assert that '_id' has been changed to 'id'
     assert "_id" not in case_dict
@@ -39,10 +62,10 @@ def test_validate_case_parents_none(none_case_raw: dict):
 
     # THEN assert father and mother is set to string 0
     assert case_obj.model_dump()["individuals"][0][Pedigree.FATHER] == str(
-        RelationshipStatus.HAS_NO_PARENT
+        RelationshipStatus.HAS_NO_PARENT.value
     )
     assert case_obj.model_dump()["individuals"][0][Pedigree.MOTHER] == str(
-        RelationshipStatus.HAS_NO_PARENT
+        RelationshipStatus.HAS_NO_PARENT.value
     )
 
 
@@ -118,7 +141,7 @@ def test_set_parent_when_not_provided():
     validated_parent: str = set_parent_if_missing(parent=parent)
 
     # THEN the returned string should have been set to RelationshipStatus.HAS_NO_PARENT
-    assert validated_parent == str(RelationshipStatus.HAS_NO_PARENT)
+    assert validated_parent == str(RelationshipStatus.HAS_NO_PARENT.value)
 
 
 def test_set_gender_if_provided():


### PR DESCRIPTION
## Description

Addresses #2569 wherein an extra coercion to string is necessary.

### Fixed

- String coercion validator to Individuals.father and Individuals.mother.

### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b add-coercion-to-string-for-parent -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
