### PR TITLE
Update deprecated import

### DIFF
--- a/alembic/versions/089edc289291_add_table_customer_user.py
+++ b/alembic/versions/089edc289291_add_table_customer_user.py
@@ -9,7 +9,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import mysql
 
 # revision identifiers, used by Alembic.
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from alembic import op
 

--- a/alembic/versions/1dadcefd3bbf_feat_contacts_as_emails.py
+++ b/alembic/versions/1dadcefd3bbf_feat_contacts_as_emails.py
@@ -7,7 +7,7 @@ Create Date: 2021-04-19 17:43:37.671078
 """
 from sqlalchemy import Column, ForeignKey, String, orm, types
 from sqlalchemy.dialects import mysql
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from alembic import op
 

--- a/alembic/versions/20750539a335_add_ticket_to_families.py
+++ b/alembic/versions/20750539a335_add_ticket_to_families.py
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import mysql
 
 # revision identifiers, used by Alembic.
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from alembic import op
 

--- a/alembic/versions/2968d39ac35f_changes_in_delivery_options.py
+++ b/alembic/versions/2968d39ac35f_changes_in_delivery_options.py
@@ -10,7 +10,7 @@ from sqlalchemy import Column, orm, types
 from sqlalchemy.dialects import mysql
 
 # revision identifiers, used by Alembic.
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from alembic import op
 

--- a/alembic/versions/432379a1adfa_fix_sars_cov_2_data_analysis_to_database.py
+++ b/alembic/versions/432379a1adfa_fix_sars_cov_2_data_analysis_to_database.py
@@ -8,7 +8,7 @@ Create Date: 2021-03-16 12:05:13.275423
 import sqlalchemy as sa
 from sqlalchemy import Column, orm, types
 from sqlalchemy.dialects import mysql
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from alembic import op
 from cg.constants import DataDelivery, Pipeline

--- a/alembic/versions/7e344b9438bf_petname_avatar.py
+++ b/alembic/versions/7e344b9438bf_petname_avatar.py
@@ -8,7 +8,7 @@ Create Date: 2021-04-08 08:04:11.763421
 from datetime import datetime
 
 import sqlalchemy as sa
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from alembic import op
 

--- a/alembic/versions/9008aa5065b4_add_taxprofiler_analysis_option.py
+++ b/alembic/versions/9008aa5065b4_add_taxprofiler_analysis_option.py
@@ -7,7 +7,7 @@ Create Date: 2023-04-19 13:46:29.137152
 """
 import sqlalchemy as sa
 from sqlalchemy.dialects import mysql
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from alembic import op
 from cg.constants import Pipeline

--- a/alembic/versions/998be2e367cf_fix_mip_on_fastq_wgs_cases.py
+++ b/alembic/versions/998be2e367cf_fix_mip_on_fastq_wgs_cases.py
@@ -10,7 +10,7 @@ from typing import List
 
 import sqlalchemy as sa
 from sqlalchemy import orm
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from alembic import op
 from cg.constants import PREP_CATEGORIES, DataDelivery, Pipeline

--- a/alembic/versions/bf97b0121538_remove_avatars.py
+++ b/alembic/versions/bf97b0121538_remove_avatars.py
@@ -6,7 +6,7 @@ Create Date: 2022-02-25 16:13:16.666812
 
 """
 import sqlalchemy as sa
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from alembic import op
 

--- a/alembic/versions/ddc94088be4d_adds_customer_to_customer_group_link_.py
+++ b/alembic/versions/ddc94088be4d_adds_customer_to_customer_group_link_.py
@@ -10,7 +10,7 @@ from sqlalchemy import Column, orm, types
 
 # revision identifiers, used by Alembic.
 from sqlalchemy.dialects import mysql
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from alembic import op
 

--- a/alembic/versions/df1b3dd317d0_add_trusted_customer_field.py
+++ b/alembic/versions/df1b3dd317d0_add_trusted_customer_field.py
@@ -10,8 +10,7 @@ Create Date: 2023-04-12 11:13:37.585551
 import sqlalchemy as sa
 from sqlalchemy import Column, orm, types
 from sqlalchemy.engine import Connection
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, declarative_base
 
 from alembic import op
 

--- a/alembic/versions/e9df15a35de4_fix_tumour_not_to_maf.py
+++ b/alembic/versions/e9df15a35de4_fix_tumour_not_to_maf.py
@@ -10,7 +10,7 @@ from typing import List
 
 import sqlalchemy as sa
 from sqlalchemy import orm
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from alembic import op
 from cg.constants import PREP_CATEGORIES, DataDelivery, Pipeline

--- a/alembic/versions/ea5470295689_sequencing_stats.py
+++ b/alembic/versions/ea5470295689_sequencing_stats.py
@@ -7,7 +7,7 @@ Create Date: 2023-05-04 09:29:09.945895
 """
 import sqlalchemy as sa
 from sqlalchemy import Column, ForeignKey, orm, types
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from alembic import op
 

--- a/alembic/versions/ed0be7286cee_add_user_types.py
+++ b/alembic/versions/ed0be7286cee_add_user_types.py
@@ -7,7 +7,7 @@ Create Date: 2021-05-03 13:27:48.441597
 """
 from sqlalchemy import Column, ForeignKey, String, orm, types
 from sqlalchemy.dialects import mysql
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from alembic import op
 

--- a/alembic/versions/ef472ce31931_add_name_for_invoice_contact.py
+++ b/alembic/versions/ef472ce31931_add_name_for_invoice_contact.py
@@ -6,7 +6,7 @@ Create Date: 2021-05-03 09:21:58.047779
 
 """
 from sqlalchemy import Column, String, orm, types
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from alembic import op
 

--- a/alembic/versions/f2edbd530656_convert_priority_to_enum.py
+++ b/alembic/versions/f2edbd530656_convert_priority_to_enum.py
@@ -8,7 +8,7 @@ Create Date: 2021-12-16 12:39:57.439135
 import sqlalchemy as sa
 from sqlalchemy import Column, orm, types
 from sqlalchemy.dialects import mysql
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from alembic import op
 

--- a/alembic/versions/fab30255b84f_move_synopsis_to_case.py
+++ b/alembic/versions/fab30255b84f_move_synopsis_to_case.py
@@ -9,7 +9,7 @@ from typing import List
 
 import sqlalchemy as sa
 from sqlalchemy import orm
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from alembic import op
 

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -3,7 +3,7 @@ import re
 from typing import Dict, List, Optional, Set
 
 from sqlalchemy import Column, ForeignKey, Table, UniqueConstraint, orm, types
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 from sqlalchemy.orm.attributes import InstrumentedAttribute
 from sqlalchemy.util import deprecated
 


### PR DESCRIPTION
## Description
Replace sqlalchemy import deprecated in 1.4, fixes warning
```
MovedIn20Warning: 
The ``declarative_base()`` function is now available as sqlalchemy.orm.declarative_base().
(deprecated since: 1.4) (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
```
Part of https://github.com/Clinical-Genomics/cg/issues/2497.

### Fixed
- Deprecated sqlalchemy import of declarative_base

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
