### PR TITLE
Delete old flow cell before adding re-demultiplexed flow cell

### DIFF
--- a/cg/meta/demultiplex/delete_demultiplex_api.py
+++ b/cg/meta/demultiplex/delete_demultiplex_api.py
@@ -52,7 +52,7 @@ class DeleteDemuxAPI:
 
     @property
     def status_db_presence(self) -> bool:
-        """Update about the presence of given flow cell in status_db"""
+        """Update about the presence of given flow cell in status_db."""
         return bool(self.status_db.get_flow_cell_by_name(flow_cell_name=self.flow_cell_name))
 
     @staticmethod


### PR DESCRIPTION
## Description
Part of the tasks in #2541. 
In #2144 the automatic deletion of a flow cell from Housekeeper and StatusDB was removed, having to explicitly delete a flow cell before re-demultiplexing. This PR re-incorporates the removed deletion but not in the demultiplex command but in the post-processing, more specifically in the `finish_flow_cell` command.

### Added

- Instantiation of the `DeleteDemuxAPI` and call to its command `delete_flow_cell` inside the command `finish_flow_cell`.

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
