### PR TITLE
Lock broken lib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ Flask-CORS
 Flask-Dance
 Flask
 flask_wtf
+wtforms==3.0.0
 google-auth
 gunicorn
 requests[security]


### PR DESCRIPTION
## Description
After a recent release of wtforms, the edit functionality in our views are broken. See https://github.com/flask-admin/flask-admin/issues/2391.

### Fixed
- Add and lock broken sub dependency `wtforms`

### How to test
Open a view and validate that the edit functionality works.

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
