### PR TITLE
Extract database module

### DIFF
--- a/cg/cli/base.py
+++ b/cg/cli/base.py
@@ -2,7 +2,7 @@
 import logging
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 import click
 import coloredlogs
@@ -25,7 +25,7 @@ from cg.cli.workflow.base import workflow as workflow_cmd
 from cg.constants.constants import FileFormat
 from cg.io.controller import ReadFile
 from cg.models.cg_config import CGConfig
-from cg.store import Store
+from cg.store.database import create_all_tables, drop_all_tables, get_tables
 
 LOG = logging.getLogger(__name__)
 LEVELS = ["DEBUG", "INFO", "WARNING", "ERROR"]
@@ -68,19 +68,18 @@ def base(
 @click.pass_obj
 def init(context: CGConfig, reset: bool, force: bool):
     """Setup the database."""
-    status_db: Store = context.status_db
-    existing_tables = status_db.engine.table_names()
+    existing_tables: List[str] = get_tables()
     if force or reset:
         if existing_tables and not force:
             message = f"Delete existing tables? [{', '.join(existing_tables)}]"
             click.confirm(click.style(message, fg="yellow"), abort=True)
-        status_db.drop_all()
+        drop_all_tables()
     elif existing_tables:
         LOG.error("Database already exists, use '--reset'")
         raise click.Abort
 
-    status_db.create_all()
-    LOG.info("Success! New tables: %s", ", ".join(status_db.engine.table_names()))
+    create_all_tables()
+    LOG.info(f"Success! New tables: {', '.join(get_tables())}")
 
 
 base.add_command(add_cmd)

--- a/cg/models/cg_config.py
+++ b/cg/models/cg_config.py
@@ -20,6 +20,7 @@ from cg.apps.tb import TrailblazerAPI
 from cg.constants.observations import LoqusdbInstance
 from cg.constants.priority import SlurmQos
 from cg.store import Store
+from cg.store.database import initialize_database
 
 LOG = logging.getLogger(__name__)
 
@@ -422,7 +423,8 @@ class CGConfig(BaseModel):
         status_db = self.__dict__.get("status_db_")
         if status_db is None:
             LOG.debug("Instantiating status db")
-            status_db = Store(uri=self.database)
+            initialize_database(self.database)
+            status_db = Store()
             self.status_db_ = status_db
         return status_db
 

--- a/cg/server/app.py
+++ b/cg/server/app.py
@@ -1,10 +1,14 @@
+from typing import Optional
+
 import coloredlogs
 import requests
 from flask import Flask, redirect, session, url_for
 from flask_admin.base import AdminIndexView
 from flask_dance.consumer import oauth_authorized
 from flask_dance.contrib.google import google, make_google_blueprint
+from sqlalchemy.orm import scoped_session
 
+from cg.store.database import get_scoped_session_registry
 from cg.store.models import (
     Analysis,
     Application,
@@ -132,4 +136,10 @@ def _register_teardowns(app: Flask):
 
     @app.teardown_appcontext
     def remove_database_session(exception=None):
-        ext.db.session.remove()
+        """
+        Remove the database session to ensure database resources are
+        released when a request has been processed.
+        """
+        scoped_session_registry: Optional[scoped_session] = get_scoped_session_registry()
+        if scoped_session_registry:
+            scoped_session_registry.remove()

--- a/cg/server/ext.py
+++ b/cg/server/ext.py
@@ -1,6 +1,6 @@
 from decimal import Decimal
-
 from json import JSONEncoder
+
 from flask_admin import Admin
 from flask_cors import CORS
 from flask_wtf.csrf import CSRFProtect
@@ -8,6 +8,7 @@ from flask_wtf.csrf import CSRFProtect
 from cg.apps.lims import LimsAPI
 from cg.apps.osticket import OsTicket
 from cg.store.api.core import Store
+from cg.store.database import initialize_database
 
 
 class FlaskLims(LimsAPI):
@@ -33,7 +34,8 @@ class FlaskStore(Store):
 
     def init_app(self, app):
         uri = app.config["SQLALCHEMY_DATABASE_URI"]
-        super(FlaskStore, self).__init__(uri)
+        initialize_database(uri)
+        super(FlaskStore, self).__init__()
 
 
 class CustomJSONEncoder(JSONEncoder):

--- a/cg/store/api/core.py
+++ b/cg/store/api/core.py
@@ -2,7 +2,7 @@ import logging
 
 from cg.store.api.delete import DeleteDataHandler
 from cg.store.api.find_business_data import FindBusinessDataHandler
-from cg.store.database import get_session
+from cg.store.database import get_scoped_session_registry
 
 from .add import AddHandler
 from .find_basic_data import FindBasicDataHandler
@@ -29,5 +29,9 @@ class CoreHandler(
 
 class Store(CoreHandler):
     def __init__(self):
-        self.session = get_session()
+        self._session = get_scoped_session_registry()
         super().__init__(self.session)
+
+    @property
+    def session(self):
+        return self._session()

--- a/cg/store/api/core.py
+++ b/cg/store/api/core.py
@@ -1,11 +1,8 @@
 import logging
 
-from sqlalchemy import create_engine
-from sqlalchemy.orm import scoped_session, sessionmaker
-
 from cg.store.api.delete import DeleteDataHandler
 from cg.store.api.find_business_data import FindBusinessDataHandler
-from cg.store.models import Model
+from cg.store.database import get_session
 
 from .add import AddHandler
 from .find_basic_data import FindBasicDataHandler
@@ -24,25 +21,13 @@ class CoreHandler(
     """Aggregating class for the store api handlers."""
 
     def __init__(self, session):
-        DeleteDataHandler(session=session)
-        FindBasicDataHandler(session=session)
-        FindBusinessDataHandler(session=session)
-        StatusHandler(session=session)
+        DeleteDataHandler(session)
+        FindBasicDataHandler(session)
+        FindBusinessDataHandler(session)
+        StatusHandler(session)
 
 
 class Store(CoreHandler):
-    uri: str = ""
-
-    def __init__(self, uri):
-        self.uri = uri
-        self.engine = create_engine(uri, pool_pre_ping=True)
-        self.session = scoped_session(sessionmaker(bind=self.engine))
-        super().__init__(session=self.session)
-
-    def create_all(self):
-        """Create all tables in the database."""
-        Model.metadata.create_all(bind=self.session.get_bind())
-
-    def drop_all(self):
-        """Drop all tables in the database."""
-        Model.metadata.drop_all(bind=self.session.get_bind())
+    def __init__(self):
+        self.session = get_session()
+        super().__init__(self.session)

--- a/cg/store/api/core.py
+++ b/cg/store/api/core.py
@@ -2,7 +2,7 @@ import logging
 
 from cg.store.api.delete import DeleteDataHandler
 from cg.store.api.find_business_data import FindBusinessDataHandler
-from cg.store.database import get_scoped_session_registry
+from cg.store.database import get_session
 
 from .add import AddHandler
 from .find_basic_data import FindBasicDataHandler
@@ -29,9 +29,4 @@ class CoreHandler(
 
 class Store(CoreHandler):
     def __init__(self):
-        self._session = get_scoped_session_registry()
-        super().__init__(self.session)
-
-    @property
-    def session(self):
-        return self._session()
+        self.session = get_session()

--- a/cg/store/database.py
+++ b/cg/store/database.py
@@ -1,0 +1,61 @@
+from typing import List, Optional
+
+from sqlalchemy import create_engine, inspect
+from sqlalchemy.engine.base import Engine
+from sqlalchemy.engine.reflection import Inspector
+from sqlalchemy.orm import Session, scoped_session, sessionmaker
+
+from cg.exc import CgError
+from cg.store.models import Model
+
+SESSION: Optional[scoped_session] = None
+ENGINE: Optional[Engine] = None
+
+
+def initialize_database(db_uri: str) -> None:
+    """Initialize the SQLAlchemy engine and session for status db."""
+    global SESSION, ENGINE
+    ENGINE = create_engine(db_uri, pool_pre_ping=True)
+    session_factory = sessionmaker(ENGINE)
+    SESSION = scoped_session(session_factory)
+
+
+def get_session() -> Session:
+    """
+    Get a SQLAlchemy session with a connection to status db.
+    The session is retrieved from the scoped session registry and is thread local.
+    """
+    if not SESSION:
+        raise CgError("Database not initialised")
+    return SESSION()
+
+
+def get_scoped_session_registry() -> Optional[scoped_session]:
+    """Get the scoped session registry for status db."""
+    return SESSION
+
+
+def get_engine() -> Engine:
+    """Get the SQLAlchemy engine with a connection to status db."""
+    if not ENGINE:
+        raise CgError("Database not initialised")
+    return ENGINE
+
+
+def create_all_tables() -> None:
+    """Create all tables in status db."""
+    session: Session = get_session()
+    Model.metadata.create_all(bind=session.get_bind())
+
+
+def drop_all_tables() -> None:
+    """Drop all tables in status db."""
+    session: Session = get_session()
+    Model.metadata.drop_all(bind=session.get_bind())
+
+
+def get_tables() -> List[str]:
+    """Get a list of all tables in status db."""
+    engine: Engine = get_engine()
+    inspector: Inspector = inspect(engine)
+    return inspector.get_table_names()

--- a/cg/store/database.py
+++ b/cg/store/database.py
@@ -20,7 +20,7 @@ def initialize_database(db_uri: str) -> None:
     SESSION = scoped_session(session_factory)
 
 
-def get_session():
+def get_session() -> scoped_session:
     """Get a SQLAlchemy session with a connection to status db."""
     if not SESSION:
         raise CgError("Database not initialised")

--- a/cg/store/database.py
+++ b/cg/store/database.py
@@ -8,31 +8,28 @@ from sqlalchemy.orm import Session, scoped_session, sessionmaker
 from cg.exc import CgError
 from cg.store.models import Model
 
-SESSION_REGISTRY: Optional[scoped_session] = None
+SESSION: Optional[scoped_session] = None
 ENGINE: Optional[Engine] = None
 
 
 def initialize_database(db_uri: str) -> None:
     """Initialize the SQLAlchemy engine and session for status db."""
-    global SESSION_REGISTRY, ENGINE
+    global SESSION, ENGINE
     ENGINE = create_engine(db_uri, pool_pre_ping=True)
     session_factory = sessionmaker(ENGINE)
-    SESSION_REGISTRY = scoped_session(session_factory)
+    SESSION = scoped_session(session_factory)
 
 
-def get_session() -> Session:
-    """
-    Get a SQLAlchemy session with a connection to status db.
-    The session is retrieved from the scoped session registry and is thread local.
-    """
-    if not SESSION_REGISTRY:
+def get_session():
+    """Get a SQLAlchemy session with a connection to status db."""
+    if not SESSION:
         raise CgError("Database not initialised")
-    return SESSION_REGISTRY
+    return SESSION
 
 
 def get_scoped_session_registry() -> Optional[scoped_session]:
     """Get the scoped session registry for status db."""
-    return SESSION_REGISTRY
+    return SESSION
 
 
 def get_engine() -> Engine:

--- a/cg/store/database.py
+++ b/cg/store/database.py
@@ -8,16 +8,16 @@ from sqlalchemy.orm import Session, scoped_session, sessionmaker
 from cg.exc import CgError
 from cg.store.models import Model
 
-SESSION: Optional[scoped_session] = None
+SESSION_REGISTRY: Optional[scoped_session] = None
 ENGINE: Optional[Engine] = None
 
 
 def initialize_database(db_uri: str) -> None:
     """Initialize the SQLAlchemy engine and session for status db."""
-    global SESSION, ENGINE
+    global SESSION_REGISTRY, ENGINE
     ENGINE = create_engine(db_uri, pool_pre_ping=True)
     session_factory = sessionmaker(ENGINE)
-    SESSION = scoped_session(session_factory)
+    SESSION_REGISTRY = scoped_session(session_factory)
 
 
 def get_session() -> Session:
@@ -25,14 +25,14 @@ def get_session() -> Session:
     Get a SQLAlchemy session with a connection to status db.
     The session is retrieved from the scoped session registry and is thread local.
     """
-    if not SESSION:
+    if not SESSION_REGISTRY:
         raise CgError("Database not initialised")
-    return SESSION()
+    return SESSION_REGISTRY()
 
 
 def get_scoped_session_registry() -> Optional[scoped_session]:
     """Get the scoped session registry for status db."""
-    return SESSION
+    return SESSION_REGISTRY
 
 
 def get_engine() -> Engine:

--- a/cg/store/database.py
+++ b/cg/store/database.py
@@ -27,7 +27,7 @@ def get_session() -> Session:
     """
     if not SESSION_REGISTRY:
         raise CgError("Database not initialised")
-    return SESSION_REGISTRY()
+    return SESSION_REGISTRY
 
 
 def get_scoped_session_registry() -> Optional[scoped_session]:

--- a/tests/cli/test_base.py
+++ b/tests/cli/test_base.py
@@ -7,6 +7,7 @@ import cg
 from cg.cli.base import base, init
 from cg.models.cg_config import CGConfig
 from cg.store import Store
+from cg.store.database import get_tables, initialize_database
 
 
 def test_cli_version(cli_runner: CliRunner):
@@ -39,7 +40,8 @@ def test_cli_init(cli_runner: CliRunner, base_context: CGConfig, caplog, tmp_pat
     database = Path(tmp_path, "test_db.sqlite3")
     database_path = Path(database)
     database_uri = f"sqlite:///{database}"
-    base_context.status_db_ = Store(uri=database_uri)
+    initialize_database(database_uri)
+    base_context.status_db_ = Store()
 
     assert database_path.exists() is False
 
@@ -49,7 +51,7 @@ def test_cli_init(cli_runner: CliRunner, base_context: CGConfig, caplog, tmp_pat
     # THEN it should setup the database with some tables
     assert result.exit_code == 0
     assert database_path.exists()
-    assert len(Store(uri=database_uri).engine.table_names()) > 0
+    assert len(get_tables()) > 0
 
     # GIVEN the database already exists
     # WHEN calling the init function

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,10 +24,10 @@ from cg.apps.hermes.hermes_api import HermesApi
 from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.apps.lims.api import LimsAPI
 from cg.constants import FileExtensions, Pipeline, SequencingFileTag
-from cg.constants.constants import CaseActions, FileFormat, FlowCellStatus, Strandedness
+from cg.constants.constants import CaseActions, FileFormat, Strandedness
 from cg.constants.demultiplexing import BclConverter, DemultiplexingDirsAndFiles
 from cg.constants.priority import SlurmQos
-from cg.constants.sequencing import Sequencers, SequencingPlatform
+from cg.constants.sequencing import SequencingPlatform
 from cg.constants.subject import Gender
 from cg.io.controller import ReadFile, WriteFile
 from cg.io.json import read_json, write_json
@@ -46,6 +46,7 @@ from cg.models.flow_cell.flow_cell import FlowCellDirectoryData
 from cg.models.rnafusion.rnafusion import RnafusionParameters
 from cg.models.taxprofiler.taxprofiler import TaxprofilerParameters
 from cg.store import Store
+from cg.store.database import create_all_tables, drop_all_tables, initialize_database
 from cg.store.models import Bed, BedVersion, Customer, Family, Organism, Sample
 from cg.utils import Process
 from tests.mocks.crunchy import MockCrunchyAPI
@@ -1764,10 +1765,11 @@ def wgs_application_tag() -> str:
 @pytest.fixture(name="store")
 def store() -> Store:
     """Return a CG store."""
-    _store = Store(uri="sqlite:///")
-    _store.create_all()
+    initialize_database("sqlite:///")
+    _store = Store()
+    create_all_tables()
     yield _store
-    _store.drop_all()
+    drop_all_tables()
 
 
 @pytest.fixture(name="apptag_rna")


### PR DESCRIPTION
## Description
This PR resolves an issue with the previous refactoring. For some reason, the way we instantiated and passed around the sessions caused them to end up in an invalid state. This PR is almost identical, with the exception of using the `scoped_session` factory ([docs](https://docs.sqlalchemy.org/en/20/orm/contextual.html#implicit-method-access)) instead of explicitly instantiating the sessions ourselves.

In the end, we will likely not keep the session as an attribute on the store object and handlers since it is confusing. We are using the `scoped_session` pattern, which means we have a single global session per thread and request. The session can be retrieved directly where it is used.

### Test
Stress tested in stage

### Fixed
- session handling

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions