### PR TITLE
Fix session merge warnings

### DIFF
--- a/cg/meta/orders/microbial_submitter.py
+++ b/cg/meta/orders/microbial_submitter.py
@@ -6,7 +6,14 @@ from cg.meta.orders.lims import process_lims
 from cg.meta.orders.submitter import Submitter
 from cg.models.orders.order import OrderIn
 from cg.models.orders.samples import MicrobialSample
-from cg.store.models import ApplicationVersion, Customer, Family, Organism, Sample
+from cg.store.models import (
+    ApplicationVersion,
+    Customer,
+    Family,
+    FamilySample,
+    Organism,
+    Sample,
+)
 
 
 class MicrobialSubmitter(Submitter):
@@ -14,7 +21,6 @@ class MicrobialSubmitter(Submitter):
     def order_to_status(order: OrderIn) -> dict:
         """Convert order input for microbial samples."""
 
-        sample: MicrobialSample
         status_data = {
             "customer": order.customer,
             "order": order.name,
@@ -138,7 +144,10 @@ class MicrobialSubmitter(Submitter):
 
                 priority = new_sample.priority
                 sample_objs.append(new_sample)
-                self.status.relate_sample(family=case, sample=new_sample, status="unknown")
+                link: FamilySample = self.status.relate_sample(
+                    family=case, sample=new_sample, status="unknown"
+                )
+                self.status.session.add(link)
                 new_samples.append(new_sample)
 
             case.priority = priority

--- a/cg/meta/orders/pool_submitter.py
+++ b/cg/meta/orders/pool_submitter.py
@@ -8,7 +8,14 @@ from cg.meta.orders.submitter import Submitter
 from cg.models.orders.order import OrderIn
 from cg.models.orders.sample_base import SexEnum
 from cg.models.orders.samples import RmlSample
-from cg.store.models import ApplicationVersion, Customer, Family, Pool, Sample
+from cg.store.models import (
+    ApplicationVersion,
+    Customer,
+    Family,
+    FamilySample,
+    Pool,
+    Sample,
+)
 
 
 class PoolSubmitter(Submitter):
@@ -161,7 +168,10 @@ class PoolSubmitter(Submitter):
                     no_invoice=True,
                 )
                 new_samples.append(new_sample)
-                self.status.relate_sample(family=case, sample=new_sample, status="unknown")
+                link: FamilySample = self.status.relate_sample(
+                    family=case, sample=new_sample, status="unknown"
+                )
+                self.status.session.add(link)
             new_delivery = self.status.add_delivery(destination="caesar", pool=new_pool)
             self.status.session.add(new_delivery)
             new_pools.append(new_pool)

--- a/cg/store/api/add.py
+++ b/cg/store/api/add.py
@@ -270,7 +270,7 @@ class AddHandler(BaseHandler):
     ) -> Panel:
         """Build a new panel record."""
 
-        new_record: Panel = Panel(
+        new_record = Panel(
             name=name, abbrev=abbrev, current_version=version, date=date, gene_count=genes
         )
         new_record.customer = customer

--- a/cg/store/database.py
+++ b/cg/store/database.py
@@ -20,7 +20,7 @@ def initialize_database(db_uri: str) -> None:
     SESSION = scoped_session(session_factory)
 
 
-def get_session() -> scoped_session:
+def get_session() -> Session:
     """Get a SQLAlchemy session with a connection to status db."""
     if not SESSION:
         raise CgError("Database not initialised")

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -168,7 +168,7 @@ class ApplicationVersion(Model):
     updated_at = Column(types.DateTime, onupdate=dt.datetime.now)
     application_id = Column(ForeignKey(Application.id), nullable=False)
 
-    application = orm.relationship("Application", back_populates="versions", cascade_backrefs=False)
+    application = orm.relationship(Application, back_populates="versions", cascade_backrefs=False)
 
     def __str__(self) -> str:
         return f"{self.application.tag} ({self.version})"
@@ -277,7 +277,7 @@ class BedVersion(Model):
     updated_at = Column(types.DateTime, onupdate=dt.datetime.now)
     bed_id = Column(ForeignKey(Bed.id), nullable=False)
 
-    bed = orm.relationship("Bed", back_populates="versions", cascade_backrefs=False)
+    bed = orm.relationship(Bed, back_populates="versions", cascade_backrefs=False)
 
     def __str__(self) -> str:
         return f"{self.bed.name} ({self.version})"
@@ -321,6 +321,9 @@ class Customer(Model):
     primary_contact = orm.relationship("User", foreign_keys=[primary_contact_id])
 
     panels = orm.relationship("Panel", back_populates="customer", cascade_backrefs=False)
+    users = orm.relationship(
+        "User", secondary=customer_user, back_populates="customers", cascade_backrefs=False
+    )
 
     def __str__(self) -> str:
         return f"{self.internal_id} ({self.name})"
@@ -571,6 +574,7 @@ class Flowcell(Model):
         "SampleLaneSequencingMetrics",
         back_populates="flowcell",
         cascade="all, delete, delete-orphan",
+        cascade_backrefs=False,
     )
 
     def __str__(self):
@@ -706,7 +710,9 @@ class Sample(Model, PriorityMixin):
     flowcells = orm.relationship(
         Flowcell, secondary=flowcell_sample, back_populates="samples", cascade_backrefs=False
     )
-    sequencing_metrics = orm.relationship("SampleLaneSequencingMetrics", back_populates="sample")
+    sequencing_metrics = orm.relationship(
+        "SampleLaneSequencingMetrics", back_populates="sample", cascade_backrefs=False
+    )
     invoice = orm.relationship("Invoice", back_populates="samples", cascade_backrefs=False)
 
     def __str__(self) -> str:
@@ -828,7 +834,7 @@ class User(Model):
     order_portal_login = Column(types.Boolean, default=False)
 
     customers = orm.relationship(
-        "Customer", secondary=customer_user, backref="users", cascade_backrefs=False
+        Customer, secondary=customer_user, back_populates="users", cascade_backrefs=False
     )
 
     def to_dict(self) -> dict:

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -511,7 +511,7 @@ class FamilySample(Model):
     mother_id = Column(ForeignKey("sample.id"))
     father_id = Column(ForeignKey("sample.id"))
 
-    family = orm.relationship("Family", backref="links")
+    family = orm.relationship("Family", backref="links", cascade_backrefs=False)
     sample = orm.relationship("Sample", foreign_keys=[sample_id], backref="links")
     mother = orm.relationship("Sample", foreign_keys=[mother_id], backref="mother_links")
     father = orm.relationship("Sample", foreign_keys=[father_id], backref="father_links")

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -114,13 +114,14 @@ class Application(Model):
 
     created_at = Column(types.DateTime, default=dt.datetime.now)
     updated_at = Column(types.DateTime, onupdate=dt.datetime.now)
+
     versions = orm.relationship(
         "ApplicationVersion",
         order_by="ApplicationVersion.version",
-        backref="application",
+        back_populates="application",
         cascade_backrefs=False,
     )
-    pipeline_limitations = orm.relationship("ApplicationLimitations", backref="application")
+    pipeline_limitations = orm.relationship("ApplicationLimitations", back_populates="application")
 
     def __str__(self) -> str:
         return self.tag
@@ -167,6 +168,8 @@ class ApplicationVersion(Model):
     updated_at = Column(types.DateTime, onupdate=dt.datetime.now)
     application_id = Column(ForeignKey(Application.id), nullable=False)
 
+    application = orm.relationship("Application", back_populates="versions", cascade_backrefs=False)
+
     def __str__(self) -> str:
         return f"{self.application.tag} ({self.version})"
 
@@ -188,6 +191,8 @@ class ApplicationLimitations(Model):
     comment = Column(types.Text)
     created_at = Column(types.DateTime, default=dt.datetime.now)
     updated_at = Column(types.DateTime, onupdate=dt.datetime.now)
+
+    application = orm.relationship(Application, back_populates="pipeline_limitations")
 
     def __str__(self):
         return f"{self.application.tag} – {self.pipeline}"

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -308,6 +308,8 @@ class Customer(Model):
     primary_contact_id = Column(ForeignKey("user.id"))
     primary_contact = orm.relationship("User", foreign_keys=[primary_contact_id])
 
+    panels = orm.relationship("Panel", back_populates="customer", cascade_backrefs=False)
+
     def __str__(self) -> str:
         return f"{self.internal_id} ({self.name})"
 
@@ -592,7 +594,7 @@ class Panel(Model):
     abbrev = Column(types.String(32), unique=True)
     current_version = Column(types.Float, nullable=False)
     customer_id = Column(ForeignKey("customer.id", ondelete="CASCADE"), nullable=False)
-    customer = orm.relationship(Customer, backref="panels", cascade_backrefs=False)
+    customer = orm.relationship(Customer, back_populates="panels", cascade_backrefs=False)
     date = Column(types.DateTime, nullable=False)
     gene_count = Column(types.Integer)
     id = Column(types.Integer, primary_key=True)

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -823,7 +823,7 @@ class SampleLaneSequencingMetrics(Model):
     created_at = Column(types.DateTime)
 
     flowcell = orm.relationship(Flowcell, back_populates="sequencing_metrics")
-    sample = orm.relationship(Sample, back_populates="sequencing_metrics")
+    sample = orm.relationship(Sample, back_populates="sequencing_metrics", cascade_backrefs=False)
 
     __table_args__ = (
         UniqueConstraint(

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -365,7 +365,9 @@ class Family(Model, PriorityMixin):
     __table_args__ = (UniqueConstraint("customer_id", "name", name="_customer_name_uc"),)
 
     action = Column(types.Enum(*CASE_ACTIONS))
-    analyses = orm.relationship(Analysis, backref="family", order_by="-Analysis.completed_at")
+    analyses = orm.relationship(
+        Analysis, backref="family", order_by="-Analysis.completed_at", cascade_backrefs=False
+    )
     _cohorts = Column(types.Text)
     comment = Column(types.Text)
     created_at = Column(types.DateTime, default=dt.datetime.now)

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -387,6 +387,8 @@ class Family(Model, PriorityMixin):
     synopsis = Column(types.Text)
     tickets = Column(types.VARCHAR)
 
+    links = orm.relationship("FamilySample", back_populates="family", cascade_backrefs=False)
+
     @property
     def cohorts(self) -> list[str]:
         """Return a list of cohorts."""
@@ -515,10 +517,10 @@ class FamilySample(Model):
     mother_id = Column(ForeignKey("sample.id"))
     father_id = Column(ForeignKey("sample.id"))
 
-    family = orm.relationship("Family", backref="links", cascade_backrefs=False)
-    sample = orm.relationship("Sample", foreign_keys=[sample_id], backref="links")
-    mother = orm.relationship("Sample", foreign_keys=[mother_id], backref="mother_links")
-    father = orm.relationship("Sample", foreign_keys=[father_id], backref="father_links")
+    family = orm.relationship(Family, back_populates="links", cascade_backrefs=False)
+    sample = orm.relationship("Sample", foreign_keys=[sample_id], back_populates="links")
+    mother = orm.relationship("Sample", foreign_keys=[mother_id], back_populates="mother_links")
+    father = orm.relationship("Sample", foreign_keys=[father_id], back_populates="father_links")
 
     def to_dict(self, parents: bool = False, samples: bool = False, family: bool = False) -> dict:
         """Represent as dictionary"""
@@ -679,6 +681,15 @@ class Sample(Model, PriorityMixin):
     subject_id = Column(types.String(128))
 
     sequencing_metrics = orm.relationship("SampleLaneSequencingMetrics", back_populates="sample")
+    links = orm.relationship(
+        FamilySample, foreign_keys=[FamilySample.sample_id], back_populates="sample"
+    )
+    mother_links = orm.relationship(
+        FamilySample, foreign_keys=[FamilySample.mother_id], back_populates="mother"
+    )
+    father_links = orm.relationship(
+        FamilySample, foreign_keys=[FamilySample.father_id], back_populates="father"
+    )
 
     def __str__(self) -> str:
         return f"{self.internal_id} ({self.name})"

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -778,7 +778,7 @@ class Invoice(Model):
     record_type = Column(types.Text)
 
     samples = orm.relationship(Sample, backref="invoice", cascade_backrefs=False)
-    pools = orm.relationship(Pool, backref="invoice")
+    pools = orm.relationship(Pool, backref="invoice", cascade_backrefs=False)
 
     def __str__(self):
         return f"{self.customer_id} ({self.invoiced_at})"

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -773,7 +773,7 @@ class Invoice(Model):
     price = Column(types.Integer)
     record_type = Column(types.Text)
 
-    samples = orm.relationship(Sample, backref="invoice")
+    samples = orm.relationship(Sample, backref="invoice", cascade_backrefs=False)
     pools = orm.relationship(Pool, backref="invoice")
 
     def __str__(self):

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -243,7 +243,10 @@ class Bed(Model):
     updated_at = Column(types.DateTime, onupdate=dt.datetime.now)
 
     versions = orm.relationship(
-        "BedVersion", order_by="BedVersion.version", backref="bed", cascade_backrefs=False
+        "BedVersion",
+        order_by="BedVersion.version",
+        back_populates="bed",
+        cascade_backrefs=False,
     )
 
     def __str__(self) -> str:
@@ -271,6 +274,8 @@ class BedVersion(Model):
     created_at = Column(types.DateTime, default=dt.datetime.now)
     updated_at = Column(types.DateTime, onupdate=dt.datetime.now)
     bed_id = Column(ForeignKey(Bed.id), nullable=False)
+
+    bed = orm.relationship("Bed", back_populates="versions", cascade_backrefs=False)
 
     def __str__(self) -> str:
         return f"{self.bed.name} ({self.version})"

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -548,7 +548,9 @@ class Flowcell(Model):
     has_backup = Column(types.Boolean, nullable=False, default=False)
     updated_at = Column(types.DateTime, onupdate=dt.datetime.now)
 
-    samples = orm.relationship("Sample", secondary=flowcell_sample, backref="flowcells")
+    samples = orm.relationship(
+        "Sample", secondary=flowcell_sample, backref="flowcells", cascade_backrefs=False
+    )
     sequencing_metrics = orm.relationship(
         "SampleLaneSequencingMetrics",
         back_populates="flowcell",

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -237,7 +237,9 @@ class Bed(Model):
     created_at = Column(types.DateTime, default=dt.datetime.now)
     updated_at = Column(types.DateTime, onupdate=dt.datetime.now)
 
-    versions = orm.relationship("BedVersion", order_by="BedVersion.version", backref="bed")
+    versions = orm.relationship(
+        "BedVersion", order_by="BedVersion.version", backref="bed", cascade_backrefs=False
+    )
 
     def __str__(self) -> str:
         return self.name

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -644,6 +644,8 @@ class Pool(Model):
     received_at = Column(types.DateTime)
     ticket = Column(types.String(32))
 
+    invoice = orm.relationship("Invoice", back_populates="pools", cascade_backrefs=False)
+
     def to_dict(self):
         return to_dict(model_instance=self)
 
@@ -705,6 +707,7 @@ class Sample(Model, PriorityMixin):
         Flowcell, secondary=flowcell_sample, back_populates="samples", cascade_backrefs=False
     )
     sequencing_metrics = orm.relationship("SampleLaneSequencingMetrics", back_populates="sample")
+    invoice = orm.relationship("Invoice", back_populates="samples", cascade_backrefs=False)
 
     def __str__(self) -> str:
         return f"{self.internal_id} ({self.name})"
@@ -805,8 +808,8 @@ class Invoice(Model):
     price = Column(types.Integer)
     record_type = Column(types.Text)
 
-    samples = orm.relationship(Sample, backref="invoice", cascade_backrefs=False)
-    pools = orm.relationship(Pool, backref="invoice", cascade_backrefs=False)
+    samples = orm.relationship(Sample, back_populates="invoice", cascade_backrefs=False)
+    pools = orm.relationship(Pool, back_populates="invoice", cascade_backrefs=False)
 
     def __str__(self):
         return f"{self.customer_id} ({self.invoiced_at})"

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -115,7 +115,10 @@ class Application(Model):
     created_at = Column(types.DateTime, default=dt.datetime.now)
     updated_at = Column(types.DateTime, onupdate=dt.datetime.now)
     versions = orm.relationship(
-        "ApplicationVersion", order_by="ApplicationVersion.version", backref="application"
+        "ApplicationVersion",
+        order_by="ApplicationVersion.version",
+        backref="application",
+        cascade_backrefs=False,
     )
     pipeline_limitations = orm.relationship("ApplicationLimitations", backref="application")
 

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -792,7 +792,9 @@ class User(Model):
     is_admin = Column(types.Boolean, default=False)
     order_portal_login = Column(types.Boolean, default=False)
 
-    customers = orm.relationship("Customer", secondary=customer_user, backref="users")
+    customers = orm.relationship(
+        "Customer", secondary=customer_user, backref="users", cascade_backrefs=False
+    )
 
     def to_dict(self) -> dict:
         """Represent as dictionary."""

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -588,7 +588,7 @@ class Panel(Model):
     abbrev = Column(types.String(32), unique=True)
     current_version = Column(types.Float, nullable=False)
     customer_id = Column(ForeignKey("customer.id", ondelete="CASCADE"), nullable=False)
-    customer = orm.relationship(Customer, backref="panels")
+    customer = orm.relationship(Customer, backref="panels", cascade_backrefs=False)
     date = Column(types.DateTime, nullable=False)
     gene_count = Column(types.Integer)
     id = Column(types.Integer, primary_key=True)

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -646,7 +646,7 @@ class Sample(Model, PriorityMixin):
     customer_id = Column(ForeignKey("customer.id", ondelete="CASCADE"), nullable=False)
     customer = orm.relationship("Customer", foreign_keys=[customer_id])
     delivered_at = Column(types.DateTime)
-    deliveries = orm.relationship(Delivery, backref="sample")
+    deliveries = orm.relationship(Delivery, backref="sample", cascade_backrefs=False)
     downsampled_to = Column(types.BigInteger)
     from_sample = Column(types.String(128))
     id = Column(types.Integer, primary_key=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2546,7 +2546,8 @@ def store_with_users(store: Store, helpers: StoreHelpers) -> Store:
     ]
 
     for email, name, is_admin in user_details:
-        store.add_user(customer=customer, email=email, name=name, is_admin=is_admin)
+        user = store.add_user(customer=customer, email=email, name=name, is_admin=is_admin)
+        store.session.add(user)
 
     store.session.commit()
 

--- a/tests/store/api/add/test_store_add_application_version.py
+++ b/tests/store/api/add/test_store_add_application_version.py
@@ -27,9 +27,12 @@ def test_add_application_version(
     )
 
     # WHEN adding a new application version
-    store_with_an_application_with_and_without_attributes.add_application_version(
-        application=applications[0], version=version, valid_from=timestamp, prices=prices
+    version: ApplicationVersion = (
+        store_with_an_application_with_and_without_attributes.add_application_version(
+            application=applications[0], version=version, valid_from=timestamp, prices=prices
+        )
     )
+    store_with_an_application_with_and_without_attributes.session.add(version)
 
     # THEN the store has one application version
     assert (


### PR DESCRIPTION
This PR fixes all warnings related to objects automatically being merged into a session, part of https://github.com/Clinical-Genomics/cg/issues/2497. For example
```
RemovedIn20Warning: 
"File" object is being merged into a Session along the backref cascade path for relationship "Version.files"; 
in SQLAlchemy 2.0, this reverse cascade will not take place.  Set cascade_backrefs to False in
either the relationship() or backref() function for the 2.0 behavior; or to set globally for the whole 
Session, set the future=True flag 
(Background on this error at: https://sqlalche.me/e/14/s9r1)
(Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
    new_file.version = version
```

The warning says the following
```python
version = Version()
session.add(version)

file = File()
file.version = version  # <--- adds "file" to the session automatically, won't happen in 2.0
```
The warnings were generated by setting `export SQLALCHEMY_WARN_20=1`and running `pytest -W always`. Luckily, it seems like we did not rely on the automatic session add in that many spots.

The changes in this PR was made in the following way:
1. Generate warnings and store output in txt file `pytest -W always > out.txt`.
2. Pick an auto merge session warning.
3. Identify in which functions the warning originates.
4. Check each spot where the functions are called and verify that the object is explicitly added to the session.
5. Set `cascade_backrefs=False` on the relationship from which the warning originates to turn off the auto merge behaviour and silence it.
6. Re-run test suite and verify that the warning is gone and all tests are passing.

For some reason, `backref` was not behaving as expected. So I replaced all instances of it with `back_populates`. The difference between these is that `back_populates` needs to be explicitly defined on both models in the relationship (seems better to be explicit as well).

When we upgrade SQLAlchemy to 2.0, the `cascade_backrefs` option can be removed.
