### PR TITLE
Fix missed join

### DIFF
--- a/cg/store/api/base.py
+++ b/cg/store/api/base.py
@@ -41,12 +41,10 @@ class BaseHandler:
         return (
             self._get_query(table=Family)
             .outerjoin(Analysis)
-            .join(
-                Family.links,
-                FamilySample.sample,
-                ApplicationVersion,
-                Application,
-            )
+            .outerjoin(Family.links)
+            .outerjoin(FamilySample.sample)
+            .outerjoin(ApplicationVersion)
+            .outerjoin(Application)
         )
 
     def _get_join_cases_with_samples_query(self) -> Query:


### PR DESCRIPTION
## Description
Missed a deprecated join. This PR fixes the warning
```
RemovedIn20Warning: 
Passing a chain of multiple join conditions to Query.join() is deprecated and will be removed in SQLAlchemy 2.0. 
Please use individual join() calls per relationship.
(Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
    .join(
```

### Fixed
- Deprecated join

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
