### PR TITLE
Fix join

### DIFF
--- a/cg/store/api/base.py
+++ b/cg/store/api/base.py
@@ -41,10 +41,10 @@ class BaseHandler:
         return (
             self._get_query(table=Family)
             .outerjoin(Analysis)
-            .outerjoin(Family.links)
-            .outerjoin(FamilySample.sample)
-            .outerjoin(ApplicationVersion)
-            .outerjoin(Application)
+            .join(Family.links)
+            .join(FamilySample.sample)
+            .join(ApplicationVersion)
+            .join(Application)
         )
 
     def _get_join_cases_with_samples_query(self) -> Query:


### PR DESCRIPTION
## Description
Messed up the previous PR, should have been a `join` and not `outerjoin`.

### Fixed
- Wrong join

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions