### PR TITLE
Patch errors

### DIFF
--- a/cg/apps/housekeeper/hk.py
+++ b/cg/apps/housekeeper/hk.py
@@ -110,6 +110,7 @@ class HousekeeperAPI:
         )
 
         new_file.version: Version = version_obj
+        self._store.session.add(new_file)
         return new_file
 
     def files(


### PR DESCRIPTION
## Description
This PR patches an issue in the `hk` module in cg which became apparent after merging https://github.com/Clinical-Genomics/housekeeper/pull/161. 

I missed one spot in the `hk` module where we relied on an implicit add, which in turned caused a bunch of tests to fail when housekeeper was updated to the most recent release.

### Fixed
- Patch due to missing add in the `hk` module


### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
