### PR TITLE
Missed is_flow_cell_check_applicable

### DIFF
--- a/cg/meta/workflow/analysis.py
+++ b/cg/meta/workflow/analysis.py
@@ -483,9 +483,10 @@ class AnalysisAPI(MetaAPI):
             self.status_db.request_flow_cells_for_case(case_id)
 
     def is_case_ready_for_analysis(self, case_id: str) -> bool:
-        if not self.status_db.are_all_flow_cells_on_disk(case_id):
-            LOG.warning(f"Case {case_id} is not ready - all flow cells not present on disk.")
-            return False
+        if self._is_flow_cell_check_applicable(case_id):
+            if not self.status_db.are_all_flow_cells_on_disk(case_id):
+                LOG.warning(f"Case {case_id} is not ready - all flow cells not present on disk.")
+                return False
         if self.prepare_fastq_api.is_spring_decompression_needed(
             case_id
         ) or self.prepare_fastq_api.is_spring_decompression_running(case_id):

--- a/cg/meta/workflow/analysis.py
+++ b/cg/meta/workflow/analysis.py
@@ -483,10 +483,11 @@ class AnalysisAPI(MetaAPI):
             self.status_db.request_flow_cells_for_case(case_id)
 
     def is_case_ready_for_analysis(self, case_id: str) -> bool:
-        if self._is_flow_cell_check_applicable(case_id):
-            if not self.status_db.are_all_flow_cells_on_disk(case_id):
-                LOG.warning(f"Case {case_id} is not ready - all flow cells not present on disk.")
-                return False
+        if self._is_flow_cell_check_applicable(
+            case_id
+        ) and not self.status_db.are_all_flow_cells_on_disk(case_id):
+            LOG.warning(f"Case {case_id} is not ready - all flow cells not present on disk.")
+            return False
         if self.prepare_fastq_api.is_spring_decompression_needed(
             case_id
         ) or self.prepare_fastq_api.is_spring_decompression_running(case_id):

--- a/cg/meta/workflow/analysis.py
+++ b/cg/meta/workflow/analysis.py
@@ -474,9 +474,9 @@ class AnalysisAPI(MetaAPI):
     def ensure_flow_cells_on_disk(self, case_id: str) -> None:
         """Check if flow cells are on disk for given case. If not, request flow cells."""
         if not self._is_flow_cell_check_applicable(case_id):
-            LOG.warning(
+            LOG.info(
                 "Flow cell check is not applicable - "
-                "ensure that the case is neither down sampled nor external."
+                "the case is either down sampled or external."
             )
             return
         if not self.status_db.are_all_flow_cells_on_disk(case_id=case_id):

--- a/tests/meta/workflow/test_analysis.py
+++ b/tests/meta/workflow/test_analysis.py
@@ -1,7 +1,6 @@
 """Test for analysis"""
 
 from datetime import datetime
-from typing import List
 
 import mock
 import pytest
@@ -142,11 +141,12 @@ def test_ensure_flow_cells_on_disk_check_not_applicable(
         "_is_flow_cell_check_applicable",
         return_value=False,
     ):
+        caplog.set_level("INFO")
         mip_analysis_api.ensure_flow_cells_on_disk(case.internal_id)
 
     # THEN a warning should be logged
     assert (
-        "Flow cell check is not applicable - ensure that the case is neither down sampled nor external."
+        "Flow cell check is not applicable - the case is either down sampled or external."
         in caplog.text
     )
 


### PR DESCRIPTION
## Description

When merging #2378, we missed adding a "_is_flow_cell_check_applicable" to the last check in the prepare_fastq_files flow. This blocks downsampled cases to have their analyses started.

### Fixed

- Check if flow cell check is applicable before checking if they are on disk.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b fix-downsampled-analysis-start -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
