### PR TITLE
Fix missed session warnings

### DIFF
--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -533,9 +533,15 @@ class FamilySample(Model):
     father_id = Column(ForeignKey("sample.id"))
 
     family = orm.relationship(Family, back_populates="links", cascade_backrefs=False)
-    sample = orm.relationship("Sample", foreign_keys=[sample_id], back_populates="links")
-    mother = orm.relationship("Sample", foreign_keys=[mother_id], back_populates="mother_links")
-    father = orm.relationship("Sample", foreign_keys=[father_id], back_populates="father_links")
+    sample = orm.relationship(
+        "Sample", foreign_keys=[sample_id], back_populates="links", cascade_backrefs=False
+    )
+    mother = orm.relationship(
+        "Sample", foreign_keys=[mother_id], back_populates="mother_links", cascade_backrefs=False
+    )
+    father = orm.relationship(
+        "Sample", foreign_keys=[father_id], back_populates="father_links", cascade_backrefs=False
+    )
 
     def to_dict(self, parents: bool = False, samples: bool = False, family: bool = False) -> dict:
         """Represent as dictionary"""
@@ -699,13 +705,22 @@ class Sample(Model, PriorityMixin):
     subject_id = Column(types.String(128))
 
     links = orm.relationship(
-        FamilySample, foreign_keys=[FamilySample.sample_id], back_populates="sample"
+        FamilySample,
+        foreign_keys=[FamilySample.sample_id],
+        back_populates="sample",
+        cascade_backrefs=False,
     )
     mother_links = orm.relationship(
-        FamilySample, foreign_keys=[FamilySample.mother_id], back_populates="mother"
+        FamilySample,
+        foreign_keys=[FamilySample.mother_id],
+        back_populates="mother",
+        cascade_backrefs=False,
     )
     father_links = orm.relationship(
-        FamilySample, foreign_keys=[FamilySample.father_id], back_populates="father"
+        FamilySample,
+        foreign_keys=[FamilySample.father_id],
+        back_populates="father",
+        cascade_backrefs=False,
     )
     flowcells = orm.relationship(
         Flowcell, secondary=flowcell_sample, back_populates="samples", cascade_backrefs=False

--- a/tests/cli/upload/test_cli_upload_observations.py
+++ b/tests/cli/upload/test_cli_upload_observations.py
@@ -36,7 +36,8 @@ def test_observations(
     case: Family = helpers.add_case(store)
     case.customer.loqus_upload = True
     sample: Sample = helpers.add_sample(store, application_type=SequencingMethod.WES)
-    store.relate_sample(family=case, sample=sample, status=PhenotypeStatus.UNKNOWN)
+    link = store.relate_sample(family=case, sample=sample, status=PhenotypeStatus.UNKNOWN)
+    store.session.add(link)
 
     # WHEN trying to do a dry run upload to Loqusdb
     result = cli_runner.invoke(
@@ -96,7 +97,8 @@ def test_get_observations_api(base_context: CGConfig, helpers: StoreHelpers):
     # GIVEN a Loqusdb supported case
     case: Family = helpers.add_case(store, data_analysis=Pipeline.MIP_DNA)
     sample: Sample = helpers.add_sample(store, application_type=SequencingMethod.WES)
-    store.relate_sample(family=case, sample=sample, status=PhenotypeStatus.UNKNOWN)
+    link = store.relate_sample(family=case, sample=sample, status=PhenotypeStatus.UNKNOWN)
+    store.session.add(link)
 
     # WHEN retrieving the observation API
     observations_api: MipDNAObservationsAPI = get_observations_api(base_context, case)
@@ -113,7 +115,8 @@ def test_get_sequencing_method(base_context: CGConfig, helpers: StoreHelpers):
     # GIVEN a case object with a WGS sequencing method
     case: Family = helpers.add_case(store)
     sample: Sample = helpers.add_sample(store, application_type=SequencingMethod.WGS)
-    store.relate_sample(family=case, sample=sample, status=PhenotypeStatus.UNKNOWN)
+    link = store.relate_sample(family=case, sample=sample, status=PhenotypeStatus.UNKNOWN)
+    store.session.add(link)
 
     # WHEN getting the sequencing method
     sequencing_method: SequencingMethod = get_sequencing_method(case)
@@ -140,8 +143,9 @@ def test_get_sequencing_method_exception(
     sample_wes: Sample = helpers.add_sample(
         store, application_tag=external_wes_application_tag, application_type=SequencingMethod.WES
     )
-    store.relate_sample(family=case, sample=sample_wgs, status=PhenotypeStatus.UNKNOWN)
-    store.relate_sample(family=case, sample=sample_wes, status=PhenotypeStatus.UNKNOWN)
+    link_1 = store.relate_sample(family=case, sample=sample_wgs, status=PhenotypeStatus.UNKNOWN)
+    link_2 = store.relate_sample(family=case, sample=sample_wes, status=PhenotypeStatus.UNKNOWN)
+    store.session.add_all([link_1, link_2])
 
     # WHEN getting the sequencing method
     with pytest.raises(LoqusdbUploadCaseError):

--- a/tests/store/api/status/test_analyses_to_clean.py
+++ b/tests/store/api/status/test_analyses_to_clean.py
@@ -35,7 +35,8 @@ def test_analysis_excluded(analysis_store: Store, helpers, timestamp_now: dateti
         analysis_store, started_at=timestamp_now, uploaded_at=None, cleaned_at=None
     )
     sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
-    analysis_store.relate_sample(family=analysis.family, sample=sample, status="unknown")
+    link = analysis_store.relate_sample(family=analysis.family, sample=sample, status="unknown")
+    analysis_store.session.add(link)
 
     # WHEN calling the analyses_to_clean
     analyses_to_clean = analysis_store.get_analyses_to_clean()
@@ -59,7 +60,8 @@ def test_pipeline_included(
         cleaned_at=None,
     )
     sample = helpers.add_sample(analysis_store, delivered_at=timestamp_yesterday)
-    analysis_store.relate_sample(family=analysis.family, sample=sample, status="unknown")
+    link = analysis_store.relate_sample(family=analysis.family, sample=sample, status="unknown")
+    analysis_store.session.add(link)
 
     # WHEN calling the analyses_to_clean specifying the used pipeline
     analyses_to_clean = analysis_store.get_analyses_to_clean(
@@ -85,7 +87,8 @@ def test_pipeline_excluded(analysis_store: Store, helpers, timestamp_now: dateti
         cleaned_at=None,
     )
     sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
-    analysis_store.relate_sample(family=analysis.family, sample=sample, status="unknown")
+    link = analysis_store.relate_sample(family=analysis.family, sample=sample, status="unknown")
+    analysis_store.session.add(link)
 
     # WHEN calling the analyses_to_clean specifying another pipeline
     analyses_to_clean = analysis_store.get_analyses_to_clean(pipeline=wrong_pipeline)
@@ -107,7 +110,8 @@ def test_non_cleaned_included(
         cleaned_at=None,
     )
     sample = helpers.add_sample(analysis_store, delivered_at=timestamp_yesterday)
-    analysis_store.relate_sample(family=analysis.family, sample=sample, status="unknown")
+    link = analysis_store.relate_sample(family=analysis.family, sample=sample, status="unknown")
+    analysis_store.session.add(link)
 
     # WHEN calling the analyses_to_clean
     analyses_to_clean = analysis_store.get_analyses_to_clean(before=timestamp_now)
@@ -127,7 +131,8 @@ def test_cleaned_excluded(analysis_store: Store, helpers, timestamp_now: datetim
         cleaned_at=timestamp_now,
     )
     sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
-    analysis_store.relate_sample(family=analysis.family, sample=sample, status="unknown")
+    link = analysis_store.relate_sample(family=analysis.family, sample=sample, status="unknown")
+    analysis_store.session.add(link)
 
     # WHEN calling the analyses_to_clean
     analyses_to_clean = analysis_store.get_analyses_to_clean()

--- a/tests/store/api/status/test_analyses_to_delivery_report.py
+++ b/tests/store/api/status/test_analyses_to_delivery_report.py
@@ -20,9 +20,10 @@ def test_missing(analysis_store: Store, helpers, timestamp_now):
         data_delivery=DataDelivery.SCOUT,
     )
     sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
-    analysis_store.relate_sample(
+    link = analysis_store.relate_sample(
         family=analysis.family, sample=sample, status=PhenotypeStatus.UNKNOWN
     )
+    analysis_store.session.add(link)
     assert sample.delivered_at is not None
     assert analysis.delivery_report_created_at is None
 

--- a/tests/store/api/status/test_store_api_status.py
+++ b/tests/store/api/status/test_store_api_status.py
@@ -17,7 +17,8 @@ def test_case_in_uploaded_observations(helpers: StoreHelpers, sample_store: Stor
     analysis: Analysis = helpers.add_analysis(store=sample_store, pipeline=Pipeline.MIP_DNA)
     analysis.family.customer.loqus_upload = True
     sample: Sample = helpers.add_sample(sample_store, loqusdb_id=loqusdb_id)
-    sample_store.relate_sample(analysis.family, sample, PhenotypeStatus.UNKNOWN)
+    link = sample_store.relate_sample(analysis.family, sample, PhenotypeStatus.UNKNOWN)
+    sample_store.session.add(link)
     assert analysis.family.analyses
     for link in analysis.family.links:
         assert link.sample.loqusdb_id is not None
@@ -36,7 +37,8 @@ def test_case_not_in_uploaded_observations(helpers: StoreHelpers, sample_store: 
     analysis: Analysis = helpers.add_analysis(store=sample_store, pipeline=Pipeline.MIP_DNA)
     analysis.family.customer.loqus_upload = True
     sample: Sample = helpers.add_sample(sample_store)
-    sample_store.relate_sample(analysis.family, sample, PhenotypeStatus.UNKNOWN)
+    link = sample_store.relate_sample(analysis.family, sample, PhenotypeStatus.UNKNOWN)
+    sample_store.session.add(link)
     assert analysis.family.analyses
     for link in analysis.family.links:
         assert link.sample.loqusdb_id is None
@@ -55,7 +57,8 @@ def test_case_in_observations_to_upload(helpers: StoreHelpers, sample_store: Sto
     analysis: Analysis = helpers.add_analysis(store=sample_store, pipeline=Pipeline.MIP_DNA)
     analysis.family.customer.loqus_upload = True
     sample: Sample = helpers.add_sample(sample_store)
-    sample_store.relate_sample(analysis.family, sample, PhenotypeStatus.UNKNOWN)
+    link = sample_store.relate_sample(analysis.family, sample, PhenotypeStatus.UNKNOWN)
+    sample_store.session.add(link)
     assert analysis.family.analyses
     for link in analysis.family.links:
         assert link.sample.loqusdb_id is None
@@ -76,7 +79,8 @@ def test_case_not_in_observations_to_upload(
     analysis: Analysis = helpers.add_analysis(store=sample_store, pipeline=Pipeline.MIP_DNA)
     analysis.family.customer.loqus_upload = True
     sample: Sample = helpers.add_sample(sample_store, loqusdb_id=loqusdb_id)
-    sample_store.relate_sample(analysis.family, sample, PhenotypeStatus.UNKNOWN)
+    link = sample_store.relate_sample(analysis.family, sample, PhenotypeStatus.UNKNOWN)
+    sample_store.session.add(link)
     assert analysis.family.analyses
     for link in analysis.family.links:
         assert link.sample.loqusdb_id is not None
@@ -181,7 +185,7 @@ def test_set_case_action(analysis_store: Store, case_id):
     # Given a store with a case with action None
     action = analysis_store.get_case_by_internal_id(internal_id=case_id).action
 
-    assert action == None
+    assert action is None
 
     # When setting the case to "analyze"
     analysis_store.set_case_action(case_internal_id=case_id, action="analyze")

--- a/tests/store/api/status/test_store_api_status_analysis.py
+++ b/tests/store/api/status/test_store_api_status_analysis.py
@@ -29,7 +29,8 @@ def test_get_families_with_extended_models(
     test_analysis.family.action: str = CaseActions.ANALYZE
 
     # GIVEN a database with a case with one of one sequenced samples and completed analysis
-    base_store.relate_sample(test_analysis.family, test_sample, PhenotypeStatus.UNKNOWN)
+    link = base_store.relate_sample(test_analysis.family, test_sample, PhenotypeStatus.UNKNOWN)
+    base_store.session.add(link)
 
     # WHEN getting cases to analyse
     cases: list[Query] = list(base_store._get_outer_join_cases_with_analyses_query())
@@ -69,7 +70,8 @@ def test_get_cases_with_samples_query(
     )
 
     # GIVEN a database with a case with one of one sequenced samples and completed analysis
-    base_store.relate_sample(test_analysis.family, test_sample, PhenotypeStatus.UNKNOWN)
+    link = base_store.relate_sample(test_analysis.family, test_sample, PhenotypeStatus.UNKNOWN)
+    base_store.session.add(link)
 
     # WHEN getting the stored case with its associated samples
     cases: list[Query] = list(base_store._get_join_cases_with_samples_query())
@@ -114,7 +116,8 @@ def test_that_cases_can_have_many_samples(
     case_with_one: Family = helpers.add_case(base_store, "case_with_one_sample")
 
     # GIVEN a database with a case with one sample sequenced sample
-    base_store.relate_sample(case_with_one, test_sample, PhenotypeStatus.UNKNOWN)
+    link = base_store.relate_sample(case_with_one, test_sample, PhenotypeStatus.UNKNOWN)
+    base_store.session.add(link)
 
     # WHEN getting cases to analyse
     cases: list[Family] = base_store.cases_to_analyze(pipeline=Pipeline.MIP_DNA)
@@ -146,7 +149,8 @@ def test_external_sample_to_re_analyse(
     test_analysis.family.action: str = CaseActions.ANALYZE
 
     # GIVEN a database with a case with one not sequenced external sample
-    base_store.relate_sample(test_analysis.family, test_sample, PhenotypeStatus.UNKNOWN)
+    link = base_store.relate_sample(test_analysis.family, test_sample, PhenotypeStatus.UNKNOWN)
+    base_store.session.add(link)
 
     # WHEN getting cases to analyse
     cases: list[Family] = base_store.cases_to_analyze(pipeline=Pipeline.MIP_DNA)
@@ -168,7 +172,8 @@ def test_new_external_case_not_in_result(base_store: Store, helpers: StoreHelper
     test_case: Family = helpers.add_case(base_store, data_analysis=Pipeline.BALSAMIC)
 
     # GIVEN a database with a case with one externally sequenced samples for BALSAMIC analysis
-    base_store.relate_sample(test_case, test_sample, PhenotypeStatus.UNKNOWN)
+    link = base_store.relate_sample(test_case, test_sample, PhenotypeStatus.UNKNOWN)
+    base_store.session.add(link)
 
     # WHEN getting cases to analyse
     cases: list[Family] = base_store.cases_to_analyze(pipeline=Pipeline.BALSAMIC)
@@ -193,7 +198,8 @@ def test_case_to_re_analyse(base_store: Store, helpers: StoreHelpers, timestamp_
     test_analysis.family.action: str = CaseActions.ANALYZE
 
     # GIVEN a database with a case with one of one sequenced samples and completed analysis
-    base_store.relate_sample(test_analysis.family, test_sample, PhenotypeStatus.UNKNOWN)
+    link = base_store.relate_sample(test_analysis.family, test_sample, PhenotypeStatus.UNKNOWN)
+    base_store.session.add(link)
 
     # WHEN getting cases to analyse
     cases: list[Family] = base_store.cases_to_analyze(pipeline=Pipeline.MIP_DNA)
@@ -221,7 +227,8 @@ def test_all_samples_and_analysis_completed(
     test_analysis.family.action: Union[None, str] = None
 
     # GIVEN a database with a case with one of one sequenced samples and completed analysis
-    base_store.relate_sample(test_analysis.family, test_sample, PhenotypeStatus.UNKNOWN)
+    link = base_store.relate_sample(test_analysis.family, test_sample, PhenotypeStatus.UNKNOWN)
+    base_store.session.add(link)
 
     # WHEN getting cases to analyse
     cases: list[Family] = base_store.cases_to_analyze(pipeline=Pipeline.MIP_DNA)
@@ -242,7 +249,8 @@ def test_specified_analysis_in_result(
     test_case: Family = helpers.add_case(base_store, data_analysis=Pipeline.BALSAMIC)
 
     # GIVEN a database with a case with one sequenced samples for BALSAMIC analysis
-    base_store.relate_sample(test_case, test_sample, PhenotypeStatus.UNKNOWN)
+    link = base_store.relate_sample(test_case, test_sample, PhenotypeStatus.UNKNOWN)
+    base_store.session.add(link)
 
     # WHEN getting cases to analyse
     cases: list[Family] = base_store.cases_to_analyze(pipeline=Pipeline.BALSAMIC)
@@ -267,7 +275,8 @@ def test_exclude_other_pipeline_analysis_from_result(
     test_case = helpers.add_case(base_store, data_analysis=Pipeline.BALSAMIC)
 
     # GIVEN a database with a case with one sequenced samples for specified analysis
-    base_store.relate_sample(test_case, test_sample, PhenotypeStatus.UNKNOWN)
+    link = base_store.relate_sample(test_case, test_sample, PhenotypeStatus.UNKNOWN)
+    base_store.session.add(link)
 
     # WHEN getting cases to analyse for another pipeline
     cases: list[Family] = base_store.cases_to_analyze(pipeline=Pipeline.MIP_DNA)
@@ -315,7 +324,8 @@ def test_one_of_one_sequenced_samples(
     test_sample = helpers.add_sample(base_store, reads_updated_at=timestamp_now)
 
     # GIVEN a database with a case with a sequenced samples and no analysis
-    base_store.relate_sample(test_case, test_sample, PhenotypeStatus.UNKNOWN)
+    link = base_store.relate_sample(test_case, test_sample, PhenotypeStatus.UNKNOWN)
+    base_store.session.add(link)
     assert test_sample.reads_updated_at is not None
 
     # WHEN getting cases to analyse

--- a/tests/store/api/status/test_store_api_status_cases.py
+++ b/tests/store/api/status/test_store_api_status_cases.py
@@ -20,7 +20,8 @@ def test_delivered_at_affects_tat(base_store: Store, helpers):
         reads_updated_at=one_week_ago,
         delivered_at=one_week_ago,
     )
-    base_store.relate_sample(new_case, one_week_old_sample, "unknown")
+    link = base_store.relate_sample(new_case, one_week_old_sample, "unknown")
+    base_store.session.add(link)
 
     # WHEN getting active cases
     cases = base_store.cases()
@@ -45,7 +46,8 @@ def test_sequenced_at_affects_tat(base_store: Store, helpers):
         prepared_at=one_week_ago,
         reads_updated_at=one_week_ago,
     )
-    base_store.relate_sample(new_case, one_week_old_sample, "unknown")
+    link = base_store.relate_sample(new_case, one_week_old_sample, "unknown")
+    base_store.session.add(link)
 
     # WHEN getting active cases
     cases = base_store.cases()
@@ -68,7 +70,8 @@ def test_prepared_at_affects_tat(base_store: Store, helpers):
         received_at=one_week_ago,
         prepared_at=one_week_ago,
     )
-    base_store.relate_sample(new_case, one_week_old_sample, "unknown")
+    link = base_store.relate_sample(new_case, one_week_old_sample, "unknown")
+    base_store.session.add(link)
 
     # WHEN getting active cases
     cases = base_store.cases()
@@ -90,7 +93,8 @@ def test_received_at_affects_tat(base_store: Store, helpers):
         ordered_at=one_week_ago,
         received_at=one_week_ago,
     )
-    base_store.relate_sample(new_case, one_week_old_sample, "unknown")
+    link = base_store.relate_sample(new_case, one_week_old_sample, "unknown")
+    base_store.session.add(link)
 
     # WHEN getting active cases
     cases = base_store.cases()
@@ -109,9 +113,11 @@ def test_samples_flowcell(base_store: Store, helpers):
     new_case = add_case(helpers, base_store)
     sample_on_flowcell = helpers.add_sample(base_store)
     flowcell = helpers.add_flow_cell(base_store, samples=[sample_on_flowcell], status="ondisk")
-    base_store.relate_sample(new_case, sample_on_flowcell, "unknown")
+    link_1 = base_store.relate_sample(new_case, sample_on_flowcell, "unknown")
+    base_store.session.add(link_1)
     sample_not_on_flowcell = helpers.add_sample(base_store)
-    base_store.relate_sample(new_case, sample_not_on_flowcell, "unknown")
+    link_2 = base_store.relate_sample(new_case, sample_not_on_flowcell, "unknown")
+    base_store.session.add(link_2)
 
     # WHEN getting active cases
     cases = base_store.cases()
@@ -130,7 +136,8 @@ def test_sample_flowcell(base_store: Store, helpers):
     # GIVEN a database with a case with a sample that belongs to a flowcell with status ondisk
     new_case = add_case(helpers, base_store)
     sample = helpers.add_sample(base_store)
-    base_store.relate_sample(new_case, sample, "unknown")
+    link = base_store.relate_sample(new_case, sample, "unknown")
+    base_store.session.add(link)
     flowcell = helpers.add_flow_cell(base_store, samples=[sample], status="ondisk")
     assert flowcell.status
 
@@ -191,8 +198,9 @@ def test_received_at_is_newest_date(base_store: Store, helpers):
     yesteryear = datetime.now() - timedelta(days=365)
     newest_sample = helpers.add_sample(base_store, received_at=yesterday)
     oldest_sample = helpers.add_sample(base_store, received_at=yesteryear)
-    base_store.relate_sample(new_case, newest_sample, "unknown")
-    base_store.relate_sample(new_case, oldest_sample, "unknown")
+    link_1 = base_store.relate_sample(new_case, newest_sample, "unknown")
+    link_2 = base_store.relate_sample(new_case, oldest_sample, "unknown")
+    base_store.session.add_all([link_1, link_2])
 
     # WHEN getting active cases
     cases = base_store.cases()
@@ -212,8 +220,9 @@ def test_prepared_at_is_newest_date(base_store: Store, helpers):
     yesteryear = datetime.now() - timedelta(days=365)
     newest_sample = helpers.add_sample(base_store, prepared_at=yesterday)
     oldest_sample = helpers.add_sample(base_store, prepared_at=yesteryear)
-    base_store.relate_sample(new_case, newest_sample, "unknown")
-    base_store.relate_sample(new_case, oldest_sample, "unknown")
+    link_1 = base_store.relate_sample(new_case, newest_sample, "unknown")
+    link_2 = base_store.relate_sample(new_case, oldest_sample, "unknown")
+    base_store.session.add_all([link_1, link_2])
 
     # WHEN getting active cases
     cases = base_store.cases()
@@ -233,8 +242,9 @@ def test_sequenced_at_is_newest_date(base_store: Store, helpers):
     yesteryear = datetime.now() - timedelta(days=365)
     newest_sample = helpers.add_sample(base_store, reads_updated_at=yesterday)
     oldest_sample = helpers.add_sample(base_store, reads_updated_at=yesteryear)
-    base_store.relate_sample(new_case, newest_sample, "unknown")
-    base_store.relate_sample(new_case, oldest_sample, "unknown")
+    link_1 = base_store.relate_sample(new_case, newest_sample, "unknown")
+    link_2 = base_store.relate_sample(new_case, oldest_sample, "unknown")
+    base_store.session.add_all([link_1, link_2])
 
     # WHEN getting active cases
     cases = base_store.cases()
@@ -254,8 +264,9 @@ def test_delivered_at_is_newest_date(base_store: Store, helpers):
     yesteryear = datetime.now() - timedelta(days=365)
     newest_sample = helpers.add_sample(base_store, delivered_at=yesterday)
     oldest_sample = helpers.add_sample(base_store, delivered_at=yesteryear)
-    base_store.relate_sample(new_case, newest_sample, "unknown")
-    base_store.relate_sample(new_case, oldest_sample, "unknown")
+    link_1 = base_store.relate_sample(new_case, newest_sample, "unknown")
+    link_2 = base_store.relate_sample(new_case, oldest_sample, "unknown")
+    base_store.session.add_all([link_1, link_2])
 
     # WHEN getting active cases
     cases = base_store.cases()
@@ -281,8 +292,9 @@ def test_invoiced_at_is_newest_invoice_date(base_store: Store, helpers):
     invoice = base_store.add_invoice(helpers.ensure_customer(base_store))
     oldest_sample.invoice = invoice
     oldest_sample.invoice.invoiced_at = yesteryear
-    base_store.relate_sample(new_case, newest_sample, "unknown")
-    base_store.relate_sample(new_case, oldest_sample, "unknown")
+    link_1 = base_store.relate_sample(new_case, newest_sample, "unknown")
+    link_2 = base_store.relate_sample(new_case, oldest_sample, "unknown")
+    base_store.session.add_all([link_1, link_2])
 
     # WHEN getting active cases
     cases = base_store.cases()
@@ -301,7 +313,8 @@ def test_invoiced_at(base_store: Store, helpers):
     sample = helpers.add_sample(base_store)
     sample.invoice = base_store.add_invoice(helpers.ensure_customer(base_store))
     sample.invoice.invoiced_at = datetime.now()
-    base_store.relate_sample(new_case, sample, "unknown")
+    link = base_store.relate_sample(new_case, sample, "unknown")
+    base_store.session.add(link)
 
     # WHEN getting active cases
     cases = base_store.cases()
@@ -318,7 +331,8 @@ def test_delivered_at(base_store: Store, helpers):
     # GIVEN a database with a case and a delivered date
     new_case = add_case(helpers, base_store)
     sample = helpers.add_sample(base_store, delivered_at=datetime.now())
-    base_store.relate_sample(new_case, sample, "unknown")
+    link = base_store.relate_sample(new_case, sample, "unknown")
+    base_store.session.add(link)
 
     # WHEN getting active cases
     cases = base_store.cases()
@@ -335,7 +349,8 @@ def test_sequenced_at(base_store: Store, helpers):
     # GIVEN a database with a case and a sequenced date
     new_case = add_case(helpers, base_store)
     sample = helpers.add_sample(base_store, reads_updated_at=datetime.now())
-    base_store.relate_sample(new_case, sample, "unknown")
+    link = base_store.relate_sample(new_case, sample, "unknown")
+    base_store.session.add(link)
 
     # WHEN getting active cases
     cases = base_store.cases()
@@ -352,7 +367,8 @@ def test_prepared_at(base_store: Store, helpers):
     # GIVEN a database with a case and a prepared date
     new_case = add_case(helpers, base_store)
     sample = helpers.add_sample(base_store, prepared_at=datetime.now())
-    base_store.relate_sample(new_case, sample, "unknown")
+    link = base_store.relate_sample(new_case, sample, "unknown")
+    base_store.session.add(link)
 
     # WHEN getting active cases
     cases = base_store.cases()
@@ -369,7 +385,8 @@ def test_received_at(base_store: Store, helpers):
     # GIVEN a database with a case and a received date
     new_case = add_case(helpers, base_store)
     sample = helpers.add_sample(base_store, received_at=datetime.now())
-    base_store.relate_sample(new_case, sample, "unknown")
+    link = base_store.relate_sample(new_case, sample, "unknown")
+    base_store.session.add(link)
 
     # WHEN getting active cases
     cases = base_store.cases()
@@ -386,7 +403,8 @@ def test_no_invoice_true(base_store: Store, helpers):
     # GIVEN a database with a case and one no_invoice sample
     new_case = add_case(helpers, base_store)
     sample = helpers.add_sample(base_store, no_invoice=True)
-    base_store.relate_sample(new_case, sample, "unknown")
+    link = base_store.relate_sample(new_case, sample, "unknown")
+    base_store.session.add(link)
     assert sample.no_invoice
 
     # WHEN getting active cases
@@ -404,7 +422,8 @@ def test_one_no_invoice_false(base_store: Store, helpers):
     # GIVEN a database with a case and one sample to invoice
     new_case = add_case(helpers, base_store)
     sample = helpers.add_sample(base_store, no_invoice=False)
-    base_store.relate_sample(new_case, sample, "unknown")
+    link = base_store.relate_sample(new_case, sample, "unknown")
+    base_store.session.add(link)
     assert not sample.no_invoice
 
     # WHEN getting active cases
@@ -422,7 +441,8 @@ def test_one_external_sample(base_store: Store, helpers):
     # GIVEN a database with a case and one external sample
     new_case = add_case(helpers, base_store)
     sample = helpers.add_sample(base_store, is_external=True)
-    base_store.relate_sample(new_case, sample, "unknown")
+    link = base_store.relate_sample(new_case, sample, "unknown")
+    base_store.session.add(link)
     assert sample.application_version.application.is_external
 
     # WHEN getting active cases
@@ -445,7 +465,8 @@ def test_one_internal_sample(base_store: Store, helpers):
     # GIVEN a database with a case and one external sample
     new_case = add_case(helpers, base_store)
     sample = helpers.add_sample(base_store, is_external=False)
-    base_store.relate_sample(new_case, sample, "unknown")
+    link = base_store.relate_sample(new_case, sample, "unknown")
+    base_store.session.add(link)
     assert not sample.application_version.application.is_external
 
     # WHEN getting active cases
@@ -467,7 +488,8 @@ def test_include_case_by_sample_id(base_store: Store, helpers):
     # GIVEN a database with a sample with internal_id
     new_case = add_case(helpers, base_store)
     sample = helpers.add_sample(base_store)
-    base_store.relate_sample(new_case, sample, "unknown")
+    link = base_store.relate_sample(new_case, sample, "unknown")
+    base_store.session.add(link)
 
     # WHEN getting active cases by sample id
     cases = base_store.cases(sample_id=sample.internal_id)
@@ -484,7 +506,8 @@ def test_exclude_case_by_sample_id(base_store: Store, helpers):
     # GIVEN a database with a sample with internal_id
     new_case = add_case(helpers, base_store)
     sample = helpers.add_sample(base_store)
-    base_store.relate_sample(new_case, sample, "unknown")
+    link = base_store.relate_sample(new_case, sample, "unknown")
+    base_store.session.add(link)
 
     # WHEN getting active cases by non-existing sample id
     cases = base_store.cases(sample_id="dummy_id")
@@ -528,10 +551,7 @@ def test_include_case_by_case_uppercase_data_analysis(base_store: Store, helpers
 
     # GIVEN a database with a case with data analysis set
     data_analysis = Pipeline.BALSAMIC
-    assert str(data_analysis).upper() != str(data_analysis)
     new_case = add_case(helpers, base_store, data_analysis=data_analysis)
-    sample = helpers.add_sample(base_store)
-    base_store.relate_sample(new_case, sample, "unknown")
 
     # WHEN getting active cases by data_analysis
     cases = base_store.cases(data_analysis=new_case.data_analysis.upper())
@@ -546,9 +566,7 @@ def test_exclude_case_by_data_analysis(base_store: Store, helpers):
     """Test to that cases can be excluded by data_analysis"""
 
     # GIVEN a database with a case with data analysis set
-    new_case = add_case(helpers, base_store, data_analysis=Pipeline.BALSAMIC)
-    sample = helpers.add_sample(base_store)
-    base_store.relate_sample(new_case, sample, "unknown")
+    add_case(helpers, base_store, data_analysis=Pipeline.BALSAMIC)
 
     # WHEN getting active cases by data_analysis
     cases = base_store.cases(data_analysis="dummy_analysis")
@@ -563,8 +581,6 @@ def test_include_case_by_partial_data_analysis(base_store: Store, helpers):
     # GIVEN a database with a case with data analysis set
     data_analysis = Pipeline.BALSAMIC
     new_case = add_case(helpers, base_store, data_analysis=data_analysis)
-    sample = helpers.add_sample(base_store)
-    base_store.relate_sample(new_case, sample, "unknown")
 
     # WHEN getting active cases by partial data_analysis
     cases = base_store.cases(data_analysis=str(data_analysis)[:-1])
@@ -603,8 +619,6 @@ def test_show_data_analysis(base_store: Store, helpers):
     # GIVEN a database with a case with data analysis set
     data_analysis = Pipeline.BALSAMIC
     new_case = add_case(helpers, base_store, data_analysis=data_analysis)
-    sample = helpers.add_sample(base_store)
-    base_store.relate_sample(new_case, sample, "unknown")
 
     # WHEN getting active cases by data_analysis
     cases = base_store.cases(data_analysis=str(data_analysis))
@@ -621,8 +635,6 @@ def test_include_case_by_data_analysis(base_store: Store, helpers):
     # GIVEN a database with a case with data analysis set
     data_analysis = Pipeline.BALSAMIC
     new_case = add_case(helpers, base_store, data_analysis=data_analysis)
-    sample = helpers.add_sample(base_store)
-    base_store.relate_sample(new_case, sample, "unknown")
 
     # WHEN getting active cases by data_analysis
     cases = base_store.cases(data_analysis=new_case.data_analysis)
@@ -810,7 +822,8 @@ def test_only_prepared_cases(base_store: Store, helpers):
     # GIVEN a database with an prepared case
     new_case = add_case(helpers, base_store)
     sample = helpers.add_sample(base_store, prepared_at=datetime.now())
-    base_store.relate_sample(new_case, sample, "unknown")
+    link = base_store.relate_sample(new_case, sample, "unknown")
+    base_store.session.add(link)
     neg_new_case = add_case(helpers, base_store, "neg_new_case")
     neg_sample = helpers.add_sample(base_store, name="neg_sample")
     base_store.relate_sample(neg_new_case, neg_sample, "unknown")
@@ -830,7 +843,8 @@ def test_only_received_cases(base_store: Store, helpers):
     # GIVEN a database with an received case
     new_case = add_case(helpers, base_store)
     sample = helpers.add_sample(base_store, received_at=datetime.now())
-    base_store.relate_sample(new_case, sample, "unknown")
+    link = base_store.relate_sample(new_case, sample, "unknown")
+    base_store.session.add(link)
     neg_new_case = add_case(helpers, base_store, "neg_new_case")
     neg_sample = helpers.add_sample(base_store, name="neg_sample")
     base_store.relate_sample(neg_new_case, neg_sample, "unknown")
@@ -850,7 +864,8 @@ def test_only_sequenced_cases(base_store: Store, helpers):
     # GIVEN a database with an sequenced case
     new_case = add_case(helpers, base_store)
     sample = helpers.add_sample(base_store, reads_updated_at=datetime.now())
-    base_store.relate_sample(new_case, sample, "unknown")
+    link = base_store.relate_sample(new_case, sample, "unknown")
+    base_store.session.add(link)
     neg_new_case = add_case(helpers, base_store, "neg_new_case")
     neg_sample = helpers.add_sample(base_store, name="neg_sample")
     base_store.relate_sample(neg_new_case, neg_sample, "unknown")
@@ -870,7 +885,8 @@ def test_only_delivered_cases(base_store: Store, helpers):
     # GIVEN a database with an delivered case
     new_case = add_case(helpers, base_store)
     sample = helpers.add_sample(base_store, delivered_at=datetime.now())
-    base_store.relate_sample(new_case, sample, "unknown")
+    link = base_store.relate_sample(new_case, sample, "unknown")
+    base_store.session.add(link)
     neg_new_case = add_case(helpers, base_store, "neg_new_case")
     neg_sample = helpers.add_sample(base_store, name="neg_sample")
     base_store.relate_sample(neg_new_case, neg_sample, "unknown")
@@ -928,7 +944,8 @@ def test_only_invoiced_cases(base_store: Store, helpers):
     sample = helpers.add_sample(base_store)
     sample.invoice = base_store.add_invoice(helpers.ensure_customer(base_store))
     sample.invoice.invoiced_at = datetime.now()
-    base_store.relate_sample(new_case, sample, "unknown")
+    link = base_store.relate_sample(new_case, sample, "unknown")
+    base_store.session.add(link)
     neg_new_case = add_case(helpers, base_store, "neg_new_case")
     neg_sample = helpers.add_sample(base_store, name="neg_sample")
     base_store.relate_sample(neg_new_case, neg_sample, "unknown")
@@ -966,7 +983,8 @@ def test_exclude_prepared_cases(base_store: Store, helpers):
     # GIVEN a database with an prepared case
     new_case = add_case(helpers, base_store)
     sample = helpers.add_sample(base_store, prepared_at=datetime.now())
-    base_store.relate_sample(new_case, sample, "unknown")
+    link = base_store.relate_sample(new_case, sample, "unknown")
+    base_store.session.add(link)
 
     # WHEN getting active cases excluding prepared
     cases = base_store.cases(exclude_prepared=True)
@@ -981,7 +999,8 @@ def test_exclude_received_cases(base_store: Store, helpers):
     # GIVEN a database with an received case
     new_case = add_case(helpers, base_store)
     sample = helpers.add_sample(base_store, received_at=datetime.now())
-    base_store.relate_sample(new_case, sample, "unknown")
+    link = base_store.relate_sample(new_case, sample, "unknown")
+    base_store.session.add(link)
 
     # WHEN getting active cases excluding received
     cases = base_store.cases(exclude_received=True)
@@ -996,7 +1015,8 @@ def test_exclude_sequenced_cases(base_store: Store, helpers):
     # GIVEN a database with an sequenced case
     new_case = add_case(helpers, base_store)
     sample = helpers.add_sample(base_store, reads_updated_at=datetime.now())
-    base_store.relate_sample(new_case, sample, "unknown")
+    link = base_store.relate_sample(new_case, sample, "unknown")
+    base_store.session.add(link)
 
     # WHEN getting active cases excluding sequenced
     cases = base_store.cases(exclude_sequenced=True)
@@ -1011,7 +1031,8 @@ def test_exclude_delivered_cases(base_store: Store, helpers):
     # GIVEN a database with an delivered case
     new_case = add_case(helpers, base_store)
     sample = helpers.add_sample(base_store, delivered_at=datetime.now())
-    base_store.relate_sample(new_case, sample, "unknown")
+    link = base_store.relate_sample(new_case, sample, "unknown")
+    base_store.session.add(link)
 
     # WHEN getting active cases excluding delivered
     cases = base_store.cases(exclude_delivered=True)
@@ -1054,7 +1075,8 @@ def test_exclude_invoiced_cases(base_store: Store, helpers):
     sample = helpers.add_sample(base_store)
     sample.invoice = base_store.add_invoice(helpers.ensure_customer(base_store))
     sample.invoice.invoiced_at = datetime.now()
-    base_store.relate_sample(new_case, sample, "unknown")
+    link = base_store.relate_sample(new_case, sample, "unknown")
+    base_store.session.add(link)
 
     # WHEN getting active cases excluding invoiced
     cases = base_store.cases(exclude_invoiced=True)
@@ -1153,7 +1175,8 @@ def test_samples_bool_true(base_store: Store, helpers):
     assert sample.delivered_at
     sample.invoice = base_store.add_invoice(helpers.ensure_customer(base_store))
     sample.invoice.invoiced_at = datetime.now()
-    base_store.relate_sample(new_case, sample, "unknown")
+    link = base_store.relate_sample(new_case, sample, "unknown")
+    base_store.session.add(link)
 
     # WHEN getting active cases
     cases = base_store.cases()
@@ -1174,7 +1197,8 @@ def test_bool_false(base_store: Store, helpers):
     # GIVEN a database with a case
     new_case = add_case(helpers, base_store)
     sample = helpers.add_sample(base_store)
-    base_store.relate_sample(new_case, sample, "unknown")
+    link = base_store.relate_sample(new_case, sample, "unknown")
+    base_store.session.add(link)
 
     # WHEN getting active cases
     cases = base_store.cases()
@@ -1201,7 +1225,8 @@ def test_one_invoiced_sample(base_store: Store, helpers):
     sample.invoice = base_store.add_invoice(helpers.ensure_customer(base_store))
     sample.invoice.invoiced_at = datetime.now()
 
-    base_store.relate_sample(new_case, sample, "unknown")
+    link = base_store.relate_sample(new_case, sample, "unknown")
+    base_store.session.add(link)
     assert sample.invoice is not None
 
     # WHEN getting active cases
@@ -1252,7 +1277,8 @@ def test_samples_delivered(base_store: Store, helpers):
     # GIVEN a database with a sample that is delivered
     new_case = add_case(helpers, base_store)
     sample = helpers.add_sample(base_store, delivered_at=datetime.now())
-    base_store.relate_sample(new_case, sample, "unknown")
+    link = base_store.relate_sample(new_case, sample, "unknown")
+    base_store.session.add(link)
     assert sample.delivered_at is not None
 
     # WHEN getting active cases
@@ -1305,8 +1331,9 @@ def test_one_of_two_samples_received(base_store: Store, helpers):
     new_case = add_case(helpers, base_store)
     sample_received = helpers.add_sample(base_store, "sample_received", received_at=datetime.now())
     sample_not_received = helpers.add_sample(base_store, "sample_not_received", received_at=None)
-    base_store.relate_sample(new_case, sample_received, "unknown")
-    base_store.relate_sample(new_case, sample_not_received, "unknown")
+    link_1 = base_store.relate_sample(new_case, sample_received, "unknown")
+    link_2 = base_store.relate_sample(new_case, sample_not_received, "unknown")
+    base_store.session.add_all([link_1, link_2])
     assert sample_received.received_at is not None
     assert sample_not_received.received_at is None
 
@@ -1326,7 +1353,8 @@ def test_one_sequenced_sample(base_store: Store, helpers):
     # GIVEN a database with a case with a sequenced sample
     new_case = add_case(helpers, base_store)
     sample = helpers.add_sample(base_store, reads_updated_at=datetime.now())
-    base_store.relate_sample(new_case, sample, "unknown")
+    link = base_store.relate_sample(new_case, sample, "unknown")
+    base_store.session.add(link)
     assert sample.reads_updated_at is not None
 
     # WHEN getting active cases
@@ -1344,7 +1372,8 @@ def test_one_prepared_sample(base_store: Store, helpers):
     # GIVEN a database with a case
     new_case = add_case(helpers, base_store)
     sample = helpers.add_sample(base_store, prepared_at=datetime.now())
-    base_store.relate_sample(new_case, sample, "unknown")
+    link = base_store.relate_sample(new_case, sample, "unknown")
+    base_store.session.add(link)
     assert sample.prepared_at is not None
 
     # WHEN getting active cases
@@ -1362,7 +1391,8 @@ def test_one_received_sample(base_store: Store, helpers):
     # GIVEN a database with a case
     new_case = add_case(helpers, base_store)
     sample = helpers.add_sample(base_store, received_at=datetime.now())
-    base_store.relate_sample(new_case, sample, "unknown")
+    link = base_store.relate_sample(new_case, sample, "unknown")
+    base_store.session.add(link)
     assert sample.received_at is not None
 
     # WHEN getting active cases
@@ -1380,7 +1410,8 @@ def test_one_sample(base_store: Store, helpers):
     # GIVEN a database with a case
     new_case = add_case(helpers, base_store)
     sample = helpers.add_sample(base_store)
-    base_store.relate_sample(new_case, sample, "unknown")
+    link = base_store.relate_sample(new_case, sample, "unknown")
+    base_store.session.add(link)
     assert sample.received_at is None
     assert sample.prepared_at is None
     assert sample.delivered_at is None

--- a/tests/store/conftest.py
+++ b/tests/store/conftest.py
@@ -422,7 +422,8 @@ def store_with_analyses_for_cases(
             uploaded_to_vogue_at=timestamp_now,
         )
         sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
-        analysis_store.relate_sample(
+        link = analysis_store.relate_sample(
             family=oldest_analysis.family, sample=sample, status=PhenotypeStatus.UNKNOWN
         )
+        analysis_store.session.add(link)
     return analysis_store

--- a/tests/store/filters/test_status_cases_filters.py
+++ b/tests/store/filters/test_status_cases_filters.py
@@ -149,7 +149,8 @@ def test_filter_cases_with_pipeline_when_correct_pipline(
     test_case = helpers.add_case(base_store, data_analysis=Pipeline.BALSAMIC)
 
     # GIVEN a database with a case with one sequenced samples for specified analysis
-    base_store.relate_sample(test_case, test_sample, PhenotypeStatus.UNKNOWN)
+    link = base_store.relate_sample(test_case, test_sample, PhenotypeStatus.UNKNOWN)
+    base_store.session.add(link)
 
     # GIVEN a cases Query
     cases: Query = base_store._get_outer_join_cases_with_analyses_query()
@@ -202,8 +203,9 @@ def test_filter_cases_with_loqusdb_supported_pipeline(
     test_fluffy_case.customer.loqus_upload = True
 
     # GIVEN a database with a case with one sequenced samples for specified analysis
-    base_store.relate_sample(test_mip_case, test_sample, PhenotypeStatus.UNKNOWN)
-    base_store.relate_sample(test_fluffy_case, test_sample, PhenotypeStatus.UNKNOWN)
+    link_1 = base_store.relate_sample(test_mip_case, test_sample, PhenotypeStatus.UNKNOWN)
+    link_2 = base_store.relate_sample(test_fluffy_case, test_sample, PhenotypeStatus.UNKNOWN)
+    base_store.session.add_all([link_1, link_2])
 
     # GIVEN a cases Query
     cases: Query = base_store._get_outer_join_cases_with_analyses_query()
@@ -228,7 +230,8 @@ def test_filter_cases_with_loqusdb_supported_sequencing_method(
 
     # GIVEN a MIP-DNA associated test case
     test_case_wes: Family = helpers.add_case(base_store, data_analysis=Pipeline.MIP_DNA)
-    base_store.relate_sample(test_case_wes, test_sample_wes, PhenotypeStatus.UNKNOWN)
+    link = base_store.relate_sample(test_case_wes, test_sample_wes, PhenotypeStatus.UNKNOWN)
+    base_store.session.add(link)
 
     # GIVEN a cases Query
     cases: Query = base_store._get_outer_join_cases_with_analyses_query()
@@ -445,8 +448,9 @@ def test_filter_report_supported_data_delivery_cases(
     test_invalid_case = helpers.add_case(base_store, name="test", data_delivery=DataDelivery.FASTQ)
 
     # GIVEN a database with the test cases
-    base_store.relate_sample(test_case, test_sample, PhenotypeStatus.UNKNOWN)
-    base_store.relate_sample(test_invalid_case, test_sample, PhenotypeStatus.UNKNOWN)
+    link_1 = base_store.relate_sample(test_case, test_sample, PhenotypeStatus.UNKNOWN)
+    link_2 = base_store.relate_sample(test_invalid_case, test_sample, PhenotypeStatus.UNKNOWN)
+    base_store.session.add_all([link_1, link_2])
 
     # GIVEN a cases Query
     cases: Query = base_store._get_outer_join_cases_with_analyses_query()


### PR DESCRIPTION
## Description
Missed a couple of warnings all originating from the `relate_sample` function which returns a `FamilySample`. The returned object is explicitly added to the session everywhere in the code base, but not in the test suite 😅  Hence the big diff.

I think it would make more sense to add the object to the session in the store layer, but changing that would require a lot of refactoring (especially in the test suite since these assume the `AddHandler` only creates the objects mostly).

### Fixed
- Missed warnings related to the deprecated auto merging into sessions


### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
