### PR TITLE
Fix warnings in tests

### DIFF
--- a/tests/store/api/conftest.py
+++ b/tests/store/api/conftest.py
@@ -478,9 +478,10 @@ def store_with_analyses_for_cases(
             completed_at=timestamp_now,
         )
         sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
-        analysis_store.relate_sample(
+        link = analysis_store.relate_sample(
             family=oldest_analysis.family, sample=sample, status=PhenotypeStatus.UNKNOWN
         )
+        analysis_store.session.add(link)
 
     return analysis_store
 
@@ -517,9 +518,10 @@ def store_with_analyses_for_cases_not_uploaded_fluffy(
             pipeline=Pipeline.FLUFFY,
         )
         sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
-        analysis_store.relate_sample(
+        link = analysis_store.relate_sample(
             family=oldest_analysis.family, sample=sample, status=PhenotypeStatus.UNKNOWN
         )
+        analysis_store.session.add(link)
     return analysis_store
 
 
@@ -556,9 +558,10 @@ def store_with_analyses_for_cases_not_uploaded_microsalt(
             pipeline=Pipeline.MICROSALT,
         )
         sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
-        analysis_store.relate_sample(
+        link = analysis_store.relate_sample(
             family=oldest_analysis.family, sample=sample, status=PhenotypeStatus.UNKNOWN
         )
+        analysis_store.session.add(link)
     return analysis_store
 
 
@@ -596,8 +599,9 @@ def store_with_analyses_for_cases_to_deliver(
             pipeline=Pipeline.MIP_DNA,
         )
         sample = helpers.add_sample(analysis_store, delivered_at=None)
-        analysis_store.relate_sample(
+        link = analysis_store.relate_sample(
             family=oldest_analysis.family, sample=sample, status=PhenotypeStatus.UNKNOWN
         )
+        analysis_store.session.add(link)
 
     return analysis_store

--- a/tests/store/api/status/test_analyses_to_clean.py
+++ b/tests/store/api/status/test_analyses_to_clean.py
@@ -18,7 +18,8 @@ def test_analysis_included(
         cleaned_at=None,
     )
     sample = helpers.add_sample(analysis_store, delivered_at=timestamp_yesterday)
-    analysis_store.relate_sample(family=analysis.family, sample=sample, status="unknown")
+    link = analysis_store.relate_sample(family=analysis.family, sample=sample, status="unknown")
+    analysis_store.session.add(link)
 
     # WHEN calling the analyses_to_clean
     analyses_to_clean = analysis_store.get_analyses_to_clean(before=timestamp_now)

--- a/tests/store/api/status/test_analyses_to_delivery_report.py
+++ b/tests/store/api/status/test_analyses_to_delivery_report.py
@@ -56,9 +56,10 @@ def test_outdated_analysis(analysis_store, helpers, timestamp_now, timestamp_yes
     sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
 
     # GIVEN a store sample case relation
-    analysis_store.relate_sample(
+    link = analysis_store.relate_sample(
         family=analysis.family, sample=sample, status=PhenotypeStatus.UNKNOWN
     )
+    analysis_store.session.add(link)
 
     # WHEN calling the analyses_to_delivery_report
     analyses = analysis_store.analyses_to_delivery_report(pipeline=pipeline).all()

--- a/tests/store/api/status/test_store_api_status_analysis.py
+++ b/tests/store/api/status/test_store_api_status_analysis.py
@@ -301,8 +301,9 @@ def test_one_of_two_sequenced_samples(
     not_sequenced_sample: Sample = helpers.add_sample(base_store, reads_updated_at=None)
 
     # GIVEN a database with a case with one of one sequenced samples and no analysis
-    base_store.relate_sample(test_case, sequenced_sample, PhenotypeStatus.UNKNOWN)
-    base_store.relate_sample(test_case, not_sequenced_sample, PhenotypeStatus.UNKNOWN)
+    link_1 = base_store.relate_sample(test_case, sequenced_sample, PhenotypeStatus.UNKNOWN)
+    link_2 = base_store.relate_sample(test_case, not_sequenced_sample, PhenotypeStatus.UNKNOWN)
+    base_store.session.add_all([link_1, link_2])
 
     # WHEN getting cases to analyse
     cases: list[Family] = base_store.cases_to_analyze(pipeline=Pipeline.MIP_DNA, threshold=True)

--- a/tests/store/api/status/test_store_api_status_cases.py
+++ b/tests/store/api/status/test_store_api_status_cases.py
@@ -598,11 +598,14 @@ def test_show_multiple_data_analysis(base_store: Store, helpers):
     data_analysis = Pipeline.BALSAMIC
     new_case = add_case(helpers, base_store, data_analysis=data_analysis)
     sample1 = helpers.add_sample(base_store)
-    base_store.relate_sample(new_case, sample1, "unknown")
+    link_1 = base_store.relate_sample(new_case, sample1, "unknown")
+    base_store.session.add(link_1)
     new_case2 = add_case(helpers, base_store, case_id="new_case2", data_analysis=data_analysis)
     sample2 = helpers.add_sample(base_store)
-    base_store.relate_sample(new_case, sample2, "unknown")
-    base_store.relate_sample(new_case2, sample2, "unknown")
+    link_2 = base_store.relate_sample(new_case, sample2, "unknown")
+    link_3 = base_store.relate_sample(new_case2, sample2, "unknown")
+    base_store.session.add_all([link_2, link_3])
+    base_store.session.commit()
 
     # WHEN getting active cases by data_analysis
     cases = base_store.cases(data_analysis=str(data_analysis)[:-1])
@@ -826,7 +829,8 @@ def test_only_prepared_cases(base_store: Store, helpers):
     base_store.session.add(link)
     neg_new_case = add_case(helpers, base_store, "neg_new_case")
     neg_sample = helpers.add_sample(base_store, name="neg_sample")
-    base_store.relate_sample(neg_new_case, neg_sample, "unknown")
+    link = base_store.relate_sample(neg_new_case, neg_sample, "unknown")
+    base_store.session.add(link)
 
     # WHEN getting active cases excluding prepared
     cases = base_store.cases(only_prepared=True)
@@ -847,7 +851,8 @@ def test_only_received_cases(base_store: Store, helpers):
     base_store.session.add(link)
     neg_new_case = add_case(helpers, base_store, "neg_new_case")
     neg_sample = helpers.add_sample(base_store, name="neg_sample")
-    base_store.relate_sample(neg_new_case, neg_sample, "unknown")
+    link = base_store.relate_sample(neg_new_case, neg_sample, "unknown")
+    base_store.session.add(link)
 
     # WHEN getting active cases excluding received
     cases = base_store.cases(only_received=True)
@@ -868,7 +873,8 @@ def test_only_sequenced_cases(base_store: Store, helpers):
     base_store.session.add(link)
     neg_new_case = add_case(helpers, base_store, "neg_new_case")
     neg_sample = helpers.add_sample(base_store, name="neg_sample")
-    base_store.relate_sample(neg_new_case, neg_sample, "unknown")
+    link = base_store.relate_sample(neg_new_case, neg_sample, "unknown")
+    base_store.session.add(link)
 
     # WHEN getting active cases excluding sequenced
     cases = base_store.cases(only_sequenced=True)
@@ -889,7 +895,8 @@ def test_only_delivered_cases(base_store: Store, helpers):
     base_store.session.add(link)
     neg_new_case = add_case(helpers, base_store, "neg_new_case")
     neg_sample = helpers.add_sample(base_store, name="neg_sample")
-    base_store.relate_sample(neg_new_case, neg_sample, "unknown")
+    link = base_store.relate_sample(neg_new_case, neg_sample, "unknown")
+    base_store.session.add(link)
 
     # WHEN getting active cases excluding delivered
     cases = base_store.cases(only_delivered=True)
@@ -907,7 +914,8 @@ def test_only_uploaded_cases(base_store: Store, helpers):
     helpers.add_analysis(base_store, uploaded_at=datetime.now())
     neg_new_case = add_case(helpers, base_store, "neg_new_case")
     neg_sample = helpers.add_sample(base_store, name="neg_sample")
-    base_store.relate_sample(neg_new_case, neg_sample, "unknown")
+    link = base_store.relate_sample(neg_new_case, neg_sample, "unknown")
+    base_store.session.add(link)
 
     # WHEN getting active cases excluding uploaded
     cases = base_store.cases(only_uploaded=True)
@@ -925,7 +933,8 @@ def test_only_delivery_reported_cases(base_store: Store, helpers):
     helpers.add_analysis(base_store, delivery_reported_at=datetime.now())
     neg_new_case = add_case(helpers, base_store, "neg_new_case")
     neg_sample = helpers.add_sample(base_store, name="neg_sample")
-    base_store.relate_sample(neg_new_case, neg_sample, "unknown")
+    link = base_store.relate_sample(neg_new_case, neg_sample, "unknown")
+    base_store.session.add(link)
 
     # WHEN getting active cases excluding delivery_reported
     cases = base_store.cases(only_delivery_reported=True)
@@ -948,7 +957,8 @@ def test_only_invoiced_cases(base_store: Store, helpers):
     base_store.session.add(link)
     neg_new_case = add_case(helpers, base_store, "neg_new_case")
     neg_sample = helpers.add_sample(base_store, name="neg_sample")
-    base_store.relate_sample(neg_new_case, neg_sample, "unknown")
+    link = base_store.relate_sample(neg_new_case, neg_sample, "unknown")
+    base_store.session.add(link)
 
     # WHEN getting active cases excluding invoiced
     cases = base_store.cases(only_invoiced=True)
@@ -966,7 +976,8 @@ def test_only_analysed_cases(base_store: Store, helpers):
     helpers.add_analysis(base_store, completed_at=datetime.now())
     neg_new_case = add_case(helpers, base_store, "neg_new_case")
     neg_sample = helpers.add_sample(base_store, name="neg_sample")
-    base_store.relate_sample(neg_new_case, neg_sample, "unknown")
+    link = base_store.relate_sample(neg_new_case, neg_sample, "unknown")
+    base_store.session.add(link)
 
     # WHEN getting active cases excluding not analysed
     cases = base_store.cases(only_analysed=True)

--- a/tests/store/api/test_base.py
+++ b/tests/store/api/test_base.py
@@ -28,9 +28,10 @@ def test_get_latest_analyses_for_cases_query(
         delivery_reported_at=None,
     )
     sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
-    analysis_store.relate_sample(
+    link = analysis_store.relate_sample(
         family=analysis_oldest.family, sample=sample, status=PhenotypeStatus.UNKNOWN
     )
+    analysis_store.session.add(link)
 
     # WHEN calling the analyses_to_delivery_report
     analyses: Query = analysis_store._get_latest_analyses_for_cases_query()

--- a/tests/store/filters/test_status_cases_filters.py
+++ b/tests/store/filters/test_status_cases_filters.py
@@ -45,7 +45,8 @@ def test_filter_cases_has_sequence(
     test_case = helpers.add_case(base_store)
 
     # GIVEN a database with a case with one sequenced samples for specified analysis
-    base_store.relate_sample(test_case, test_sample, PhenotypeStatus.UNKNOWN)
+    link = base_store.relate_sample(test_case, test_sample, PhenotypeStatus.UNKNOWN)
+    base_store.session.add(link)
 
     # GIVEN a cases Query
     cases: Query = base_store._get_outer_join_cases_with_analyses_query()
@@ -70,7 +71,8 @@ def test_filter_cases_has_sequence_when_external(base_store: Store, helpers: Sto
     test_case = helpers.add_case(base_store)
 
     # GIVEN a database with a case with one sequenced samples for specified analysis
-    base_store.relate_sample(test_case, test_sample, PhenotypeStatus.UNKNOWN)
+    link = base_store.relate_sample(test_case, test_sample, PhenotypeStatus.UNKNOWN)
+    base_store.session.add(link)
 
     # GIVEN a cases Query
     cases: Query = base_store._get_outer_join_cases_with_analyses_query()
@@ -95,7 +97,8 @@ def test_filter_cases_has_sequence_when_not_sequenced(base_store: Store, helpers
     test_case = helpers.add_case(base_store)
 
     # GIVEN a database with a case with one sequenced samples for specified analysis
-    base_store.relate_sample(test_case, test_sample, PhenotypeStatus.UNKNOWN)
+    link = base_store.relate_sample(test_case, test_sample, PhenotypeStatus.UNKNOWN)
+    base_store.session.add(link)
 
     # GIVEN a cases Query
     cases: Query = base_store._get_outer_join_cases_with_analyses_query()
@@ -122,7 +125,8 @@ def test_filter_cases_has_sequence_when_not_external_nor_sequenced(
     test_case = helpers.add_case(base_store)
 
     # GIVEN a database with a case with one sequenced samples for specified analysis
-    base_store.relate_sample(test_case, test_sample, PhenotypeStatus.UNKNOWN)
+    link = base_store.relate_sample(test_case, test_sample, PhenotypeStatus.UNKNOWN)
+    base_store.session.add(link)
 
     # GIVEN a cases Query
     cases: Query = base_store._get_outer_join_cases_with_analyses_query()
@@ -174,7 +178,8 @@ def test_filter_cases_with_pipeline_when_incorrect_pipline(
     test_case: Family = helpers.add_case(base_store, data_analysis=Pipeline.BALSAMIC)
 
     # GIVEN a database with a case with one sequenced samples for specified analysis
-    base_store.relate_sample(test_case, test_sample, PhenotypeStatus.UNKNOWN)
+    link = base_store.relate_sample(test_case, test_sample, PhenotypeStatus.UNKNOWN)
+    base_store.session.add(link)
 
     # GIVEN a cases Query
     cases: Query = base_store._get_outer_join_cases_with_analyses_query()
@@ -260,7 +265,8 @@ def test_filter_cases_with_loqusdb_supported_sequencing_method_empty(
 
     # GIVEN a MIP-DNA associated test case
     test_case_wts: Family = helpers.add_case(base_store, data_analysis=Pipeline.MIP_DNA)
-    base_store.relate_sample(test_case_wts, test_sample_wts, PhenotypeStatus.UNKNOWN)
+    link = base_store.relate_sample(test_case_wts, test_sample_wts, PhenotypeStatus.UNKNOWN)
+    base_store.session.add(link)
 
     # GIVEN a cases Query
     cases: Query = base_store._get_outer_join_cases_with_analyses_query()
@@ -294,7 +300,8 @@ def test_filter_cases_for_analysis(
     test_analysis.family.action: str = CaseActions.ANALYZE
 
     # GIVEN a database with a case with one sequenced samples for specified analysis
-    base_store.relate_sample(test_analysis.family, test_sample, PhenotypeStatus.UNKNOWN)
+    link = base_store.relate_sample(test_analysis.family, test_sample, PhenotypeStatus.UNKNOWN)
+    base_store.session.add(link)
 
     # GIVEN a cases Query
     cases: Query = base_store._get_outer_join_cases_with_analyses_query()
@@ -323,7 +330,8 @@ def test_filter_cases_for_analysis_when_sequenced_sample_and_no_analysis(
     test_case = helpers.add_case(base_store)
 
     # GIVEN a database with a case with one sequenced samples for specified analysis
-    base_store.relate_sample(test_case, test_sample, PhenotypeStatus.UNKNOWN)
+    link = base_store.relate_sample(test_case, test_sample, PhenotypeStatus.UNKNOWN)
+    base_store.session.add(link)
 
     # GIVEN a cases Query
     cases: Query = base_store._get_outer_join_cases_with_analyses_query()
@@ -358,7 +366,8 @@ def test_filter_cases_for_analysis_when_cases_with_no_action_and_new_sequence_da
     test_analysis.family.action: Union[None, str] = None
 
     # GIVEN a database with a case with one sequenced samples for specified analysis
-    base_store.relate_sample(test_analysis.family, test_sample, PhenotypeStatus.UNKNOWN)
+    link = base_store.relate_sample(test_analysis.family, test_sample, PhenotypeStatus.UNKNOWN)
+    base_store.session.add(link)
 
     # GIVEN an old analysis
     test_analysis.created_at = timestamp_yesterday
@@ -393,7 +402,8 @@ def test_filter_cases_for_analysis_when_cases_with_no_action_and_old_sequence_da
     test_analysis.family.action: Union[None, str] = None
 
     # GIVEN a database with a case with one sequenced samples for specified analysis
-    base_store.relate_sample(test_analysis.family, test_sample, PhenotypeStatus.UNKNOWN)
+    link = base_store.relate_sample(test_analysis.family, test_sample, PhenotypeStatus.UNKNOWN)
+    base_store.session.add(link)
 
     # GIVEN a cases Query
     cases: Query = base_store._get_outer_join_cases_with_analyses_query()
@@ -420,7 +430,8 @@ def test_filter_cases_with_scout_data_delivery(
     test_case = helpers.add_case(base_store, data_delivery=DataDelivery.FASTQ_ANALYSIS_SCOUT)
 
     # GIVEN a database with a case with one sequenced samples for specified analysis
-    base_store.relate_sample(test_case, test_sample, PhenotypeStatus.UNKNOWN)
+    link = base_store.relate_sample(test_case, test_sample, PhenotypeStatus.UNKNOWN)
+    base_store.session.add(link)
 
     # GIVEN a cases Query
     cases: Query = base_store._get_outer_join_cases_with_analyses_query()

--- a/tests/store/filters/test_status_samples_filters.py
+++ b/tests/store/filters/test_status_samples_filters.py
@@ -40,10 +40,11 @@ def test_get_samples_with_loqusdb_id(helpers, store, sample_store, sample_id, lo
     case = helpers.add_case(store)
     sample = helpers.add_sample(store, loqusdb_id=loqusdb_id)
     sample_not_uploaded = helpers.add_sample(store, internal_id=sample_id)
-    sample_store.relate_sample(family=case, sample=sample, status=PhenotypeStatus.UNKNOWN)
-    sample_store.relate_sample(
+    link_1 = sample_store.relate_sample(family=case, sample=sample, status=PhenotypeStatus.UNKNOWN)
+    link_2 = sample_store.relate_sample(
         family=case, sample=sample_not_uploaded, status=PhenotypeStatus.UNKNOWN
     )
+    sample_store.session.add_all([link_1, link_2])
 
     # GIVEN a sample query
     samples: Query = store._get_query(table=Sample)
@@ -63,8 +64,11 @@ def test_get_samples_without_loqusdb_id(helpers, store, sample_store, sample_id,
     case = helpers.add_case(store)
     sample = helpers.add_sample(store)
     sample_uploaded = helpers.add_sample(store, internal_id=sample_id, loqusdb_id=loqusdb_id)
-    sample_store.relate_sample(family=case, sample=sample, status=PhenotypeStatus.UNKNOWN)
-    sample_store.relate_sample(family=case, sample=sample_uploaded, status=PhenotypeStatus.UNKNOWN)
+    link_1 = sample_store.relate_sample(family=case, sample=sample, status=PhenotypeStatus.UNKNOWN)
+    link_2 = sample_store.relate_sample(
+        family=case, sample=sample_uploaded, status=PhenotypeStatus.UNKNOWN
+    )
+    sample_store.session.add_all([link_1, link_2])
 
     # GIVEN a sample query
     samples: Query = store._get_query(table=Sample)


### PR DESCRIPTION
## Description
A lot of warnings were generated in the tests due to the callers not adding the created link to the session.

### Fixed
- Add `FamilySample` object returned from `relate_sample` to session in caller contexts

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
