### PR TITLE
Fix rnafusion analysis version

### DIFF
--- a/cg/meta/workflow/nf_analysis.py
+++ b/cg/meta/workflow/nf_analysis.py
@@ -64,6 +64,10 @@ class NfAnalysisAPI(AnalysisAPI):
         """Get workflow manager from Tower."""
         return WorkflowManager.Tower.value
 
+    def get_pipeline_version(self, case_id: str) -> str:
+        """Get pipeline version from config."""
+        return self.revision
+
     def get_case_path(self, case_id: str) -> Path:
         """Path to case working directory."""
         return Path(self.root_dir, case_id)

--- a/tests/cli/workflow/rnafusion/test_cli_rnafusion_store_housekeeper.py
+++ b/tests/cli/workflow/rnafusion/test_cli_rnafusion_store_housekeeper.py
@@ -126,6 +126,7 @@ def test_valid_case(
     mock_deliverable,
     caplog: LogCaptureFixture,
     rnafusion_case_id: str,
+    pipeline_version: str,
 ):
     caplog.set_level(logging.INFO)
     # GIVEN case-id
@@ -149,6 +150,14 @@ def test_valid_case(
     assert "Analysis successfully stored in StatusDB" in caplog.text
     assert rnafusion_context.status_db.get_case_by_internal_id(internal_id=case_id).analyses
     assert rnafusion_context.meta_apis["analysis_api"].housekeeper_api.bundle(case_id)
+
+    # THEN pipeline version should be correctly stored
+    assert (
+        rnafusion_context.status_db.get_case_by_internal_id(internal_id=case_id)
+        .analyses[0]
+        .pipeline_version
+        == pipeline_version
+    )
 
 
 def test_valid_case_already_added(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,10 +41,7 @@ from cg.meta.workflow.rnafusion import RnafusionAnalysisAPI
 from cg.meta.workflow.taxprofiler import TaxprofilerAnalysisAPI
 from cg.models import CompressionData
 from cg.models.cg_config import CGConfig, EncryptionDirectories
-from cg.models.demultiplex.run_parameters import (
-    RunParametersNovaSeq6000,
-    RunParametersNovaSeqX,
-)
+from cg.models.demultiplex.run_parameters import RunParametersNovaSeq6000, RunParametersNovaSeqX
 from cg.models.flow_cell.flow_cell import FlowCellDirectoryData
 from cg.models.rnafusion.rnafusion import RnafusionParameters
 from cg.models.taxprofiler.taxprofiler import TaxprofilerParameters
@@ -2626,6 +2623,12 @@ def strandedness() -> str:
 def strandedness_not_permitted() -> str:
     """Return a not permitted strandedness."""
     return "double_stranded"
+
+
+@pytest.fixture(scope="session")
+def pipeline_version() -> str:
+    """Return a pipeline version."""
+    return "2.2.0"
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Description

I had accidentally deleted a method that was required to fetch the correct version of the pipeline. It was restored and updated. 

Closes https://github.com/Clinical-Genomics/cg/issues/2620

### Fixed

- Fixed analysis version for stored analysis


### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b fix_version -a
    ```

### How to test

- [x] `cg workflow rnafusion store CASE`. Check that the version of the stored analysis corresponds to 2.3.4


### Expected test outcome

- [x] Take a screenshot and attach or copy/paste the output.
<img width="80" alt="image" src="https://github.com/Clinical-Genomics/cg/assets/29628428/7c789dbf-aff2-4280-bc3f-e850cac2ea53">

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
