### PR TITLE
Ensure connection is closed after CLI commands

### DIFF
--- a/cg/cli/base.py
+++ b/cg/cli/base.py
@@ -35,7 +35,7 @@ LEVELS = ["DEBUG", "INFO", "WARNING", "ERROR"]
 
 def teardown_session():
     """Ensure that the session is closed and all resources are released to the connection pool."""
-    registry: Optional[scoped_session] = get_scoped_session_registry()
+    registry: scoped_session | None = get_scoped_session_registry()
     if registry:
         registry.remove()
 


### PR DESCRIPTION
## Description
This PR adds a teardown function to the CLI which runs after each command has been processed, closing the database session and releasing any resources to the database. This might potentially resolve some of the issues we have experienced with alembic.

### Fixed
- Release db resources once CLI command has been processed


### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
