### PR TITLE
Fix enums

### DIFF
--- a/cg/constants/archiving.py
+++ b/cg/constants/archiving.py
@@ -1,4 +1,4 @@
-from cg.utils.enums import StrEnum
+from enum import StrEnum
 
 
 class ArchiveLocations(StrEnum):

--- a/cg/constants/constants.py
+++ b/cg/constants/constants.py
@@ -3,7 +3,7 @@
 import click
 
 from cg.utils.date import get_date
-from cg.utils.enums import StrEnum
+from enum import StrEnum
 
 VALID_DATA_IN_PRODUCTION = get_date("2017-09-27")
 

--- a/cg/constants/demultiplexing.py
+++ b/cg/constants/demultiplexing.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import click
 
 from cg.constants.sequencing import Sequencers
-from cg.utils.enums import Enum, StrEnum
+from enum import Enum, StrEnum
 
 
 class BclConverter(StrEnum):

--- a/cg/constants/encryption.py
+++ b/cg/constants/encryption.py
@@ -1,10 +1,10 @@
 """Constants specific for encryption"""
-from enum import Enum
+from enum import StrEnum
 
 from cg.utils.enums import ListEnum
 
 
-class CipherAlgorithm(str, Enum):
+class CipherAlgorithm(StrEnum):
     TRIPLE_DES: str = "3DES"
     AES: str = "AES"
     AES192: str = "AES192"
@@ -18,7 +18,7 @@ class CipherAlgorithm(str, Enum):
     TWOFISH: str = "TWOFISH"
 
 
-class EncryptionUserID(str, Enum):
+class EncryptionUserID(StrEnum):
     HASTA_USER_ID: str = '"Clinical Genomics"'
 
 

--- a/cg/constants/gene_panel.py
+++ b/cg/constants/gene_panel.py
@@ -1,7 +1,7 @@
 """Gene panel specific constants."""
 
 
-from cg.utils.enums import StrEnum
+from enum import StrEnum
 
 GENOME_BUILD_37 = "37"
 GENOME_BUILD_38 = "GRCh38"

--- a/cg/constants/housekeeper_tags.py
+++ b/cg/constants/housekeeper_tags.py
@@ -2,7 +2,7 @@
 
 
 from cg.constants.constants import Pipeline
-from cg.utils.enums import StrEnum
+from enum import StrEnum
 
 
 class AlignmentFileTag(StrEnum):

--- a/cg/constants/invoice.py
+++ b/cg/constants/invoice.py
@@ -1,4 +1,4 @@
-from cg.utils.enums import StrEnum
+from enum import StrEnum
 
 
 class CustomerNames(StrEnum):

--- a/cg/constants/lims.py
+++ b/cg/constants/lims.py
@@ -1,6 +1,6 @@
 # LIMS constants
 
-from cg.utils.enums import StrEnum
+from enum import StrEnum
 
 YES_NO_LIMS_BOOLEANS = ["require_qc_ok", "tumour", "verified_organism"]
 

--- a/cg/constants/nf_analysis.py
+++ b/cg/constants/nf_analysis.py
@@ -1,5 +1,5 @@
 """Nf-tower related constants."""
-from cg.utils.enums import StrEnum
+from enum import StrEnum
 
 
 class NfTowerStatus(StrEnum):

--- a/cg/constants/observations.py
+++ b/cg/constants/observations.py
@@ -3,7 +3,7 @@ from enum import Enum
 
 from cg.constants.constants import Pipeline
 from cg.constants.sequencing import SequencingMethod
-from cg.utils.enums import StrEnum
+from enum import StrEnum
 
 LOQUSDB_ID = "_id"
 LOQUSDB_SUPPORTED_PIPELINES = [Pipeline.MIP_DNA, Pipeline.BALSAMIC]

--- a/cg/constants/orderforms.py
+++ b/cg/constants/orderforms.py
@@ -1,6 +1,6 @@
 from cg.constants import ANALYSIS_SOURCES, METAGENOME_SOURCES
 from cg.models.orders.order import OrderType
-from cg.utils.enums import StrEnum
+from enum import StrEnum
 
 SEX_MAP = {"male": "M", "female": "F", "unknown": "unknown"}
 REV_SEX_MAP = {value: key for key, value in SEX_MAP.items()}

--- a/cg/constants/pdc.py
+++ b/cg/constants/pdc.py
@@ -1,5 +1,6 @@
 """PDC related constants"""
-from cg.utils.enums import IntEnum, ListEnum
+from enum import IntEnum
+from cg.utils.enums import ListEnum
 
 
 class DSMCParameters(ListEnum):

--- a/cg/constants/pedigree.py
+++ b/cg/constants/pedigree.py
@@ -1,7 +1,7 @@
-from enum import Enum
+from enum import StrEnum
 
 
-class Pedigree(str, Enum):
+class Pedigree(StrEnum):
     FATHER = "father"
     MOTHER = "mother"
     CHILD = "child"

--- a/cg/constants/priority.py
+++ b/cg/constants/priority.py
@@ -1,7 +1,7 @@
 """Priority specific constants"""
 from enum import IntEnum
 
-from cg.utils.enums import StrEnum
+from enum import StrEnum
 
 
 class SlurmQos(StrEnum):

--- a/cg/constants/scout_upload.py
+++ b/cg/constants/scout_upload.py
@@ -1,4 +1,4 @@
-from cg.utils.enums import StrEnum
+from enum import StrEnum
 
 
 class GenomeBuild(StrEnum):

--- a/cg/constants/sequencing.py
+++ b/cg/constants/sequencing.py
@@ -1,5 +1,5 @@
 """Constants related to sequencing."""
-from cg.utils.enums import StrEnum
+from enum import StrEnum
 
 
 class Sequencers(StrEnum):

--- a/cg/constants/subject.py
+++ b/cg/constants/subject.py
@@ -6,7 +6,7 @@ class Gender(StrEnum):
     MALE = "male"
     UNKNOWN = "unknown"
     OTHER = "other"
-    MISSING = None
+    MISSING = ""
 
     def __repr__(self):
         return self.value
@@ -16,7 +16,7 @@ class PhenotypeStatus(StrEnum):
     UNKNOWN = "unknown"
     UNAFFECTED = "unaffected"
     AFFECTED = "affected"
-    MISSING = None
+    MISSING = ""
 
     def __repr__(self):
         return self.value

--- a/cg/constants/subject.py
+++ b/cg/constants/subject.py
@@ -1,7 +1,7 @@
-from enum import Enum, IntEnum
+from enum import StrEnum, IntEnum
 
 
-class Gender(str, Enum):
+class Gender(StrEnum):
     FEMALE = "female"
     MALE = "male"
     UNKNOWN = "unknown"
@@ -12,7 +12,7 @@ class Gender(str, Enum):
         return self.value
 
 
-class PhenotypeStatus(str, Enum):
+class PhenotypeStatus(StrEnum):
     UNKNOWN = "unknown"
     UNAFFECTED = "unaffected"
     AFFECTED = "affected"
@@ -28,11 +28,11 @@ class PlinkPhenotypeStatus(IntEnum):
     AFFECTED = 2
 
 
-class PlinkGender(str, Enum):
+class PlinkGender(StrEnum):
     UNKNOWN = 0
     MALE = 1
     FEMALE = 2
 
 
-class RelationshipStatus(str, Enum):
+class RelationshipStatus(StrEnum):
     HAS_NO_PARENT = 0

--- a/cg/constants/subject.py
+++ b/cg/constants/subject.py
@@ -1,4 +1,4 @@
-from enum import StrEnum, IntEnum
+from enum import Enum, StrEnum, IntEnum
 
 
 class Gender(StrEnum):
@@ -28,11 +28,16 @@ class PlinkPhenotypeStatus(IntEnum):
     AFFECTED = 2
 
 
-class PlinkGender(IntEnum):
+class PlinkGender(str, Enum):
     UNKNOWN = 0
     MALE = 1
     FEMALE = 2
 
+    def __str__(self) -> str:
+        return str.__str__(self.value)
 
-class RelationshipStatus(IntEnum):
+class RelationshipStatus(str, Enum):
     HAS_NO_PARENT = 0
+
+    def __str__(self) -> str:
+        return str.__str__(self.value)

--- a/cg/constants/subject.py
+++ b/cg/constants/subject.py
@@ -28,11 +28,11 @@ class PlinkPhenotypeStatus(IntEnum):
     AFFECTED = 2
 
 
-class PlinkGender(StrEnum):
+class PlinkGender(IntEnum):
     UNKNOWN = 0
     MALE = 1
     FEMALE = 2
 
 
-class RelationshipStatus(StrEnum):
+class RelationshipStatus(IntEnum):
     HAS_NO_PARENT = 0

--- a/cg/constants/subject.py
+++ b/cg/constants/subject.py
@@ -36,6 +36,7 @@ class PlinkGender(str, Enum):
     def __str__(self) -> str:
         return str.__str__(self.value)
 
+
 class RelationshipStatus(str, Enum):
     HAS_NO_PARENT = 0
 

--- a/cg/constants/tb.py
+++ b/cg/constants/tb.py
@@ -1,4 +1,4 @@
-from enum import Enum
+from enum import StrEnum
 
 
 class AnalysisStatus:
@@ -12,7 +12,7 @@ class AnalysisStatus:
     QC: str = "qc"
 
 
-class AnalysisTypes(str, Enum):
+class AnalysisTypes(StrEnum):
     WGS: str = "wgs"
     WES: str = "wes"
     TGS: str = "tgs"

--- a/cg/meta/archive/ddn_dataflow.py
+++ b/cg/meta/archive/ddn_dataflow.py
@@ -1,6 +1,6 @@
 """Module for archiving and retrieving folders via DDN Dataflow."""
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from pathlib import Path
 from typing import Optional
 from urllib.parse import urljoin
@@ -28,7 +28,7 @@ DESTINATION_ATTRIBUTE: str = "destination"
 SOURCE_ATTRIBUTE: str = "source"
 
 
-class DataflowEndpoints(str, Enum):
+class DataflowEndpoints(StrEnum):
     """Enum containing all DDN dataflow endpoints used."""
 
     ARCHIVE_FILES = "files/archive"

--- a/cg/models/orders/constants.py
+++ b/cg/models/orders/constants.py
@@ -1,5 +1,5 @@
 from cg.constants.constants import Pipeline
-from cg.utils.enums import StrEnum
+from enum import StrEnum
 
 
 class OrderType(StrEnum):

--- a/cg/models/orders/sample_base.py
+++ b/cg/models/orders/sample_base.py
@@ -1,4 +1,4 @@
-from enum import Enum
+from enum import StrEnum
 from typing import Optional
 
 from pydantic import BaseModel, BeforeValidator, ConfigDict, constr
@@ -9,19 +9,19 @@ from cg.models.orders.validators.sample_base_validators import snake_case
 from cg.store.models import Application, Customer, Family, Pool, Sample
 
 
-class ControlEnum(str, Enum):
+class ControlEnum(StrEnum):
     not_control = ""
     positive = "positive"
     negative = "negative"
 
 
-class SexEnum(str, Enum):
+class SexEnum(StrEnum):
     male = "male"
     female = "female"
     unknown = "unknown"
 
 
-class PriorityEnum(str, Enum):
+class PriorityEnum(StrEnum):
     research = "research"
     standard = "standard"
     priority = "priority"
@@ -29,13 +29,13 @@ class PriorityEnum(str, Enum):
     clinical_trials = "clinical_trials"
 
 
-class ContainerEnum(str, Enum):
+class ContainerEnum(StrEnum):
     no_container = "No container"
     plate = "96 well plate"
     tube = "Tube"
 
 
-class StatusEnum(str, Enum):
+class StatusEnum(StrEnum):
     affected = "affected"
     unaffected = "unaffected"
     unknown = "unknown"

--- a/cg/utils/enums.py
+++ b/cg/utils/enums.py
@@ -1,5 +1,6 @@
 """Enum classes has string or list values that behaves like defined """
 from enum import Enum
 
+
 class ListEnum(list, Enum):
     pass

--- a/cg/utils/enums.py
+++ b/cg/utils/enums.py
@@ -1,16 +1,5 @@
 """Enum classes has string or list values that behaves like defined """
 from enum import Enum
 
-
-class StrEnum(str, Enum):
-    def __str__(self) -> str:
-        return str.__str__(self)
-
-
 class ListEnum(list, Enum):
     pass
-
-
-class IntEnum(int, Enum):
-    def __int__(self) -> int:
-        return int.__int__(self)


### PR DESCRIPTION
## Description
This PR patches a breaking change in Python 3.11 related to enum mixins, see https://github.com/python/cpython/issues/100458. Closes https://github.com/Clinical-Genomics/cg/issues/2618.

I think this bug explains both the weird values seen in the ticketing service.

To resolve the issue, all instances of
```python
from cg.utils.enums import StrEnum
from cg.utils.enums import IntEnum
```
were replaced with
```python
from enum import StrEnum
from enum import IntEnum
```

It might be the case that some database tables need to be patched 🥲 

### Fixed
- Broken enums


### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
