### PR TITLE
Fix database model error

### DIFF
--- a/alembic/versions/2023_10_30_b6f00cc615cf_sync_db.py
+++ b/alembic/versions/2023_10_30_b6f00cc615cf_sync_db.py
@@ -18,9 +18,6 @@ depends_on = None
 
 def upgrade():
     op.alter_column(
-        "application", "min_sequencing_depth", existing_type=mysql.INTEGER(), nullable=False
-    )
-    op.alter_column(
         "family",
         "action",
         existing_type=mysql.ENUM("analyze", "running", "hold"),
@@ -92,7 +89,4 @@ def downgrade():
         existing_type=sa.Enum("analyze", "hold", "running"),
         type_=mysql.ENUM("analyze", "running", "hold"),
         existing_nullable=True,
-    )
-    op.alter_column(
-        "application", "min_sequencing_depth", existing_type=mysql.INTEGER(), nullable=True
     )

--- a/alembic/versions/2023_10_30_b6f00cc615cf_sync_db.py
+++ b/alembic/versions/2023_10_30_b6f00cc615cf_sync_db.py
@@ -25,27 +25,6 @@ def upgrade():
         existing_nullable=True,
     )
     op.alter_column(
-        "family",
-        "data_delivery",
-        existing_type=mysql.VARCHAR(length=64),
-        type_=sa.Enum(
-            "analysis",
-            "analysis-scout",
-            "fastq",
-            "fastq-scout",
-            "fastq_qc",
-            "fastq-analysis",
-            "fastq_qc-analysis",
-            "fastq-analysis-scout",
-            "nipt-viewer",
-            "no-delivery",
-            "scout",
-            "statina",
-            name="datadelivery",
-        ),
-        existing_nullable=True,
-    )
-    op.alter_column(
         "flowcell",
         "status",
         existing_type=mysql.ENUM("ondisk", "processing", "removed", "requested", "retrieved"),
@@ -60,27 +39,6 @@ def downgrade():
         "status",
         existing_type=sa.Enum("ondisk", "removed", "requested", "processing", "retrieved"),
         type_=mysql.ENUM("ondisk", "processing", "removed", "requested", "retrieved"),
-        existing_nullable=True,
-    )
-    op.alter_column(
-        "family",
-        "data_delivery",
-        existing_type=sa.Enum(
-            "analysis",
-            "analysis-scout",
-            "fastq",
-            "fastq-scout",
-            "fastq_qc",
-            "fastq-analysis",
-            "fastq_qc-analysis",
-            "fastq-analysis-scout",
-            "nipt-viewer",
-            "no-delivery",
-            "scout",
-            "statina",
-            name="datadelivery",
-        ),
-        type_=mysql.VARCHAR(length=64),
         existing_nullable=True,
     )
     op.alter_column(

--- a/alembic/versions/2023_10_30_b6f00cc615cf_sync_db.py
+++ b/alembic/versions/2023_10_30_b6f00cc615cf_sync_db.py
@@ -1,0 +1,113 @@
+"""Sync db
+
+Revision ID: b6f00cc615cf
+Revises: 392e49db40fc
+Create Date: 2023-10-30 14:57:48.992414
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+# revision identifiers, used by Alembic.
+revision = "b6f00cc615cf"
+down_revision = "392e49db40fc"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        "application", "min_sequencing_depth", existing_type=mysql.INTEGER(), nullable=False
+    )
+    op.drop_constraint(
+        "application_limitations_ibfk_1", "application_limitations", type_="foreignkey"
+    )
+    op.create_foreign_key(
+        None, "application_limitations", "application", ["application_id"], ["id"]
+    )
+    op.alter_column(
+        "family",
+        "action",
+        existing_type=mysql.ENUM("analyze", "running", "hold"),
+        type_=sa.Enum("analyze", "hold", "running"),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "family",
+        "data_delivery",
+        existing_type=mysql.VARCHAR(length=64),
+        type_=sa.Enum(
+            "analysis",
+            "analysis-scout",
+            "fastq",
+            "fastq-scout",
+            "fastq_qc",
+            "fastq-analysis",
+            "fastq_qc-analysis",
+            "fastq-analysis-scout",
+            "nipt-viewer",
+            "no-delivery",
+            "scout",
+            "statina",
+            name="datadelivery",
+        ),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "flowcell",
+        "status",
+        existing_type=mysql.ENUM("ondisk", "processing", "removed", "requested", "retrieved"),
+        type_=sa.Enum("ondisk", "removed", "requested", "processing", "retrieved"),
+        existing_nullable=True,
+    )
+
+
+def downgrade():
+    op.alter_column(
+        "flowcell",
+        "status",
+        existing_type=sa.Enum("ondisk", "removed", "requested", "processing", "retrieved"),
+        type_=mysql.ENUM("ondisk", "processing", "removed", "requested", "retrieved"),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "family",
+        "data_delivery",
+        existing_type=sa.Enum(
+            "analysis",
+            "analysis-scout",
+            "fastq",
+            "fastq-scout",
+            "fastq_qc",
+            "fastq-analysis",
+            "fastq_qc-analysis",
+            "fastq-analysis-scout",
+            "nipt-viewer",
+            "no-delivery",
+            "scout",
+            "statina",
+            name="datadelivery",
+        ),
+        type_=mysql.VARCHAR(length=64),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "family",
+        "action",
+        existing_type=sa.Enum("analyze", "hold", "running"),
+        type_=mysql.ENUM("analyze", "running", "hold"),
+        existing_nullable=True,
+    )
+    op.drop_constraint(None, "application_limitations", type_="foreignkey")
+    op.create_foreign_key(
+        "application_limitations_ibfk_1",
+        "application_limitations",
+        "application",
+        ["application_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.alter_column(
+        "application", "min_sequencing_depth", existing_type=mysql.INTEGER(), nullable=True
+    )

--- a/alembic/versions/2023_10_30_b6f00cc615cf_sync_db.py
+++ b/alembic/versions/2023_10_30_b6f00cc615cf_sync_db.py
@@ -20,12 +20,6 @@ def upgrade():
     op.alter_column(
         "application", "min_sequencing_depth", existing_type=mysql.INTEGER(), nullable=False
     )
-    op.drop_constraint(
-        "application_limitations_ibfk_1", "application_limitations", type_="foreignkey"
-    )
-    op.create_foreign_key(
-        None, "application_limitations", "application", ["application_id"], ["id"]
-    )
     op.alter_column(
         "family",
         "action",
@@ -98,15 +92,6 @@ def downgrade():
         existing_type=sa.Enum("analyze", "hold", "running"),
         type_=mysql.ENUM("analyze", "running", "hold"),
         existing_nullable=True,
-    )
-    op.drop_constraint(None, "application_limitations", type_="foreignkey")
-    op.create_foreign_key(
-        "application_limitations_ibfk_1",
-        "application_limitations",
-        "application",
-        ["application_id"],
-        ["id"],
-        ondelete="CASCADE",
     )
     op.alter_column(
         "application", "min_sequencing_depth", existing_type=mysql.INTEGER(), nullable=True

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -387,9 +387,7 @@ class Family(Model, PriorityMixin):
     customer_id = Column(ForeignKey("customer.id", ondelete="CASCADE"), nullable=False)
     customer = orm.relationship(Customer, foreign_keys=[customer_id])
     data_analysis = Column(types.Enum(*list(Pipeline)))
-    data_delivery = Column(
-        types.Enum(DataDelivery, values_callable=lambda obj: [e.value for e in obj])
-    )
+    data_delivery = Column(types.Enum(*list(DataDelivery)))
     id = Column(types.Integer, primary_key=True)
     internal_id = Column(types.String(32), unique=True, nullable=False)
     name = Column(types.String(128), nullable=False)

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -387,7 +387,9 @@ class Family(Model, PriorityMixin):
     customer_id = Column(ForeignKey("customer.id", ondelete="CASCADE"), nullable=False)
     customer = orm.relationship(Customer, foreign_keys=[customer_id])
     data_analysis = Column(types.Enum(*list(Pipeline)))
-    data_delivery = Column(types.Enum(*list(DataDelivery)))
+    data_delivery = Column(
+        types.Enum(DataDelivery, values_callable=lambda obj: [e.value for e in obj])
+    )
     id = Column(types.Integer, primary_key=True)
     internal_id = Column(types.String(32), unique=True, nullable=False)
     name = Column(types.String(128), nullable=False)
@@ -396,7 +398,7 @@ class Family(Model, PriorityMixin):
 
     priority = Column(types.Enum(Priority), default=Priority.standard, nullable=False)
     synopsis = Column(types.Text)
-    tickets = Column(types.VARCHAR)
+    tickets = Column(types.VARCHAR(128))
 
     analyses = orm.relationship(
         Analysis, back_populates="family", order_by="-Analysis.completed_at"


### PR DESCRIPTION
## Description
When generating a revision, an error popped up
```
Alembic: sqlalchemy.exc.CompileError: VARCHAR requires a length on dialect mysql (Family.tickets)
```
This PR adds a length limit to the `Family.tickets` field which resolves this error.


Some changes detected when auto generating the revision are fixed in this PR as well. The enum fields are sensitive to ordering, which has changed for `family.action`, `family.data_delivery` and `flowcell.status`. Some of them have chaged from varchar to enum as well.

```
INFO  [alembic.runtime.migration] Context impl MySQLImpl.
INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
INFO  [alembic.autogenerate.compare] Detected NOT NULL on column 'application.min_sequencing_depth'
INFO  [alembic.autogenerate.compare] Detected type change from ENUM('analyze', 'running', 'hold') to Enum('analyze', 'hold', 'running') on 'family.action'
INFO  [alembic.autogenerate.compare] Detected type change from VARCHAR(length=64) to Enum('analysis', 'analysis-scout', 'fastq', 'fastq-scout', 'fastq_qc', 'fastq-analysis', 'fastq_qc-analysis', 'fastq-analysis-scout', 'nipt-viewer', 'no-delivery', 'scout', 'statina', name='datadelivery') on 'family.data_delivery'
INFO  [alembic.autogenerate.compare] Detected type change from ENUM('ondisk', 'processing', 'removed', 'requested', 'retrieved') to Enum('ondisk', 'removed', 'requested', 'processing', 'retrieved') on 'flowcell.status'
  Generating /Users/sebastianallard/repos/cg/alembic/versions/2023_10_30_b6f00cc615cf_sync_db.py ...  done
```


### Fixed
- Fix column error in Family model
- Sync models with schema


### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Apply migrations to stage database.
- [ ] Verify it is working by retrieving some data.
- [ ] Merge and apply to prod
