### PR TITLE
fix: rename sampleID in scout.yaml for balsamic

### DIFF
--- a/cg/meta/upload/scout/balsamic_config_builder.py
+++ b/cg/meta/upload/scout/balsamic_config_builder.py
@@ -57,15 +57,8 @@ class BalsamicConfigBuilder(ScoutConfigBuilder):
         self.add_common_sample_files(config_sample=config_sample, case_sample=case_sample)
         if BalsamicAnalysisAPI.get_sample_type(sample_obj=case_sample.sample) == SampleType.TUMOR:
             config_sample.phenotype = PhenotypeStatus.AFFECTED.value
-            config_sample.sample_id = SampleType.TUMOR.value.upper()
         else:
             config_sample.phenotype = PhenotypeStatus.UNAFFECTED.value
-            # If normal sample analysed as tumor, it will be treated as tumor in terms of ID for the Scout upload
-            config_sample.sample_id = (
-                SampleType.TUMOR.value.upper()
-                if config_sample.alignment_path and SampleType.TUMOR in config_sample.alignment_path
-                else SampleType.NORMAL.value.upper()
-            )
 
         config_sample.analysis_type = self.get_balsamic_analysis_type(sample=case_sample.sample)
 


### PR DESCRIPTION
## Description

For release 13 of BALSAMIC GENS will be introduced. In order to ensure that the links in Scout to GENS takes us to the uploaded sample in GENS (which uses the LIMS ID during upload), we need to rename the sample-id in the scout_load.yaml for balsamic, which currently renames the LIMD ID to TUMOR or NORMAL. 

See issue here: https://github.com/Clinical-Genomics/BALSAMIC/issues/1298

### Changed
- Removed 2 lines of code which renames LIMS-ID to TUMOR / NORMAL


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
