### PR TITLE
Patch view

### DIFF
--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -392,7 +392,7 @@ class AnalysisView(BaseView):
     column_default_sort = ("created_at", True)
     column_editable_list = ["is_primary"]
     column_filters = ["pipeline", "pipeline_version", "is_primary"]
-    column_formatters = {"family": CaseView.view_family_link}
+    column_formatters = {"case": CaseView.view_family_link}
     column_searchable_list = [
         "family.internal_id",
         "family.name",
@@ -570,7 +570,7 @@ class FamilySampleView(BaseView):
     column_editable_list = ["status"]
     column_filters = ["status"]
     column_formatters = {
-        "family": CaseView.view_family_link,
+        "case": CaseView.view_family_link,
         "sample": SampleView.view_sample_link,
     }
     column_searchable_list = ["family.internal_id", "family.name", "sample.internal_id"]

--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -286,7 +286,7 @@ class FamilyView(BaseView):
         if model.family:
             markup += Markup(
                 " <a href='%s'>%s</a>"
-                % (url_for("family.index_view", search=model.family.internal_id), model.family)
+                % (url_for("case.index_view", search=model.family.internal_id), model.family)
             )
 
         return markup

--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -243,7 +243,7 @@ class CollaborationView(BaseView):
     column_searchable_list = ["internal_id", "name"]
 
 
-class CaseView(BaseView):
+class FamilyView(BaseView):
     """Admin view for Model.Case"""
 
     column_default_sort = ("created_at", True)
@@ -286,7 +286,7 @@ class CaseView(BaseView):
         if model.family:
             markup += Markup(
                 " <a href='%s'>%s</a>"
-                % (url_for("case.index_view", search=model.family.internal_id), model.family)
+                % (url_for("family.index_view", search=model.family.internal_id), model.family)
             )
 
         return markup
@@ -392,7 +392,7 @@ class AnalysisView(BaseView):
     column_default_sort = ("created_at", True)
     column_editable_list = ["is_primary"]
     column_filters = ["pipeline", "pipeline_version", "is_primary"]
-    column_formatters = {"case": CaseView.view_family_link}
+    column_formatters = {"family": FamilyView.view_family_link}
     column_searchable_list = [
         "family.internal_id",
         "family.name",
@@ -570,7 +570,7 @@ class FamilySampleView(BaseView):
     column_editable_list = ["status"]
     column_filters = ["status"]
     column_formatters = {
-        "case": CaseView.view_family_link,
+        "family": FamilyView.view_family_link,
         "sample": SampleView.view_sample_link,
     }
     column_searchable_list = ["family.internal_id", "family.name", "sample.internal_id"]

--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -243,7 +243,7 @@ class CollaborationView(BaseView):
     column_searchable_list = ["internal_id", "name"]
 
 
-class FamilyView(BaseView):
+class CaseView(BaseView):
     """Admin view for Model.Case"""
 
     column_default_sort = ("created_at", True)
@@ -392,7 +392,7 @@ class AnalysisView(BaseView):
     column_default_sort = ("created_at", True)
     column_editable_list = ["is_primary"]
     column_filters = ["pipeline", "pipeline_version", "is_primary"]
-    column_formatters = {"family": FamilyView.view_family_link}
+    column_formatters = {"family": CaseView.view_family_link}
     column_searchable_list = [
         "family.internal_id",
         "family.name",
@@ -570,7 +570,7 @@ class FamilySampleView(BaseView):
     column_editable_list = ["status"]
     column_filters = ["status"]
     column_formatters = {
-        "family": FamilyView.view_family_link,
+        "family": CaseView.view_family_link,
         "sample": SampleView.view_sample_link,
     }
     column_searchable_list = ["family.internal_id", "family.name", "sample.internal_id"]

--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -286,7 +286,7 @@ class CaseView(BaseView):
         if model.family:
             markup += Markup(
                 " <a href='%s'>%s</a>"
-                % (url_for("family.index_view", search=model.family.internal_id), model.family)
+                % (url_for("case.index_view", search=model.family.internal_id), model.family)
             )
 
         return markup

--- a/cg/server/app.py
+++ b/cg/server/app.py
@@ -121,7 +121,7 @@ def _register_admin_views():
     )
 
     # Business data views
-    ext.admin.add_view(admin.CaseView(Case, ext.db.session))
+    ext.admin.add_view(admin.FamilyView(Case, ext.db.session))
     ext.admin.add_view(admin.FamilySampleView(FamilySample, ext.db.session))
     ext.admin.add_view(admin.SampleView(Sample, ext.db.session))
     ext.admin.add_view(admin.PoolView(Pool, ext.db.session))

--- a/cg/server/app.py
+++ b/cg/server/app.py
@@ -121,7 +121,7 @@ def _register_admin_views():
     )
 
     # Business data views
-    ext.admin.add_view(admin.FamilyView(Case, ext.db.session))
+    ext.admin.add_view(admin.CaseView(Case, ext.db.session))
     ext.admin.add_view(admin.FamilySampleView(FamilySample, ext.db.session))
     ext.admin.add_view(admin.SampleView(Sample, ext.db.session))
     ext.admin.add_view(admin.PoolView(Pool, ext.db.session))


### PR DESCRIPTION
## Description
Missed to rename a parameter in the view layer which caused the `Analysis` and `FamilySample` views to break.

### Fixed
- Broken analysis and case views

### Test
Deploy to cg-vm and verify that the analysis and family sample views work and correctly link to the case.

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

