### PR TITLE
Remove lambda expressions

### DIFF
--- a/cg/meta/upload/gisaid/models.py
+++ b/cg/meta/upload/gisaid/models.py
@@ -2,14 +2,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional
 
-from pydantic import (
-    BaseModel,
-    BeforeValidator,
-    FieldValidationInfo,
-    field_validator,
-    model_validator,
-)
-from typing_extensions import Annotated
+from pydantic import BaseModel, ConfigDict, model_validator
 
 from cg.meta.upload.gisaid.constants import AUTHORS
 
@@ -49,6 +42,7 @@ class UploadFiles(BaseModel):
 
 
 class GisaidSample(BaseModel):
+    model_config = ConfigDict(coerce_numbers_to_str=True)
     case_id: str
     cg_lims_id: str
     submitter: str
@@ -64,7 +58,7 @@ class GisaidSample(BaseModel):
     covv_location: Optional[str] = None
     covv_host: Optional[str] = "Human"
     covv_gender: Optional[str] = "unknown"
-    covv_patient_age: Annotated[Optional[str], BeforeValidator(lambda v: str(v))] = "unknown"
+    covv_patient_age: Optional[str] = "unknown"
     covv_patient_status: Optional[str] = "unknown"
     covv_seq_technology: Optional[str] = "Illumina NovaSeq"
     covv_orig_lab_addr: Optional[str] = None

--- a/cg/models/orders/sample_base.py
+++ b/cg/models/orders/sample_base.py
@@ -6,7 +6,7 @@ from typing_extensions import Annotated
 
 from cg.constants import DataDelivery, Pipeline
 from cg.models.orders.validators.sample_base_validators import snake_case
-from cg.store.models import Application, Customer, Case, Pool, Sample
+from cg.store.models import Application, Case, Customer, Pool, Sample
 
 
 class ControlEnum(StrEnum):
@@ -45,10 +45,10 @@ NAME_PATTERN = r"^[A-Za-z0-9-]*$"
 
 
 class OrderSample(BaseModel):
-    model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True)
-    age_at_sampling: Annotated[
-        Optional[str], BeforeValidator(lambda x: str(x) if x else None)
-    ] = None
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True, populate_by_name=True, coerce_numbers_to_str=True
+    )
+    age_at_sampling: Optional[str] = None
     application: constr(max_length=Application.tag.property.columns[0].type.length)
     capture_kit: Optional[str] = None
     collection_date: Optional[str] = None
@@ -123,6 +123,6 @@ class OrderSample(BaseModel):
     tumour: bool = False
     tumour_purity: Optional[int] = None
     verified_organism: Optional[bool] = None
-    volume: Annotated[Optional[str], BeforeValidator(lambda x: str(x))] = None
+    volume: Optional[str] = None
     well_position: Optional[str] = None
     well_position_rml: Optional[str] = None


### PR DESCRIPTION
## Description

Small PR which just removes any Pydantic validators used to coerce a number type to string, which were only necessary after migration but prior to v.2.4 and are now replaced with the "coerce_numbers_to_str=True" in the config_dict.

### Fixed

- Removed string coercion validators.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b remove-lambda-validators -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
