### PR TITLE
Rename family relationships

### DIFF
--- a/cg/cli/clean.py
+++ b/cg/cli/clean.py
@@ -210,7 +210,7 @@ def hk_bundle_files(
     size_cleaned: int = 0
     for analysis in analyses:
         LOG.info(f"Cleaning analysis {analysis}")
-        bundle_name: str = analysis.family.internal_id
+        bundle_name: str = analysis.case.internal_id
         hk_bundle_version: Optional[Version] = housekeeper_api.version(
             bundle=bundle_name, date=analysis.started_at
         )
@@ -230,7 +230,7 @@ def hk_bundle_files(
             f"date {analysis.started_at}"
         )
         version_files: list[File] = housekeeper_api.get_files(
-            bundle=analysis.family.internal_id, tags=tags, version=hk_bundle_version.id
+            bundle=analysis.case.internal_id, tags=tags, version=hk_bundle_version.id
         ).all()
         for version_file in version_files:
             file_path: Path = Path(version_file.full_path)

--- a/cg/cli/delete/case.py
+++ b/cg/cli/delete/case.py
@@ -117,7 +117,7 @@ def _log_sample_process_information(sample: Sample):
 
 def _log_sample_links(sample: Sample):
     for sample_link in sample.links:
-        LOG.info(f"Sample is linked to: {sample_link.family.internal_id}")
+        LOG.info(f"Sample is linked to: {sample_link.case.internal_id}")
     for sample_link in sample.mother_links:
         LOG.info(f"Sample is linked as mother to: {sample_link.mother.internal_id}")
     for sample_link in sample.father_links:

--- a/cg/cli/delete/cases.py
+++ b/cg/cli/delete/cases.py
@@ -23,7 +23,7 @@ def _get_cases(identifiers: click.Tuple([str, str]), store: Store) -> [Case]:
     _cases = set()
     for sample in samples_by_id:
         for link in sample.links:
-            _cases.add(link.family)
+            _cases.add(link.case)
 
     return _cases
 

--- a/cg/cli/get.py
+++ b/cg/cli/get.py
@@ -62,7 +62,7 @@ def get_sample(context: click.Context, cases: bool, hide_flow_cell: bool, sample
         click.echo(tabulate([row], headers=SAMPLE_HEADERS, tablefmt="psql"))
         if cases:
             case_ids: list[str] = [
-                link_obj.family.internal_id for link_obj in existing_sample.links
+                link_obj.case.internal_id for link_obj in existing_sample.links
             ]
             context.invoke(get_case, case_ids=case_ids, samples=False)
         if not hide_flow_cell:

--- a/cg/cli/get.py
+++ b/cg/cli/get.py
@@ -61,9 +61,7 @@ def get_sample(context: click.Context, cases: bool, hide_flow_cell: bool, sample
         ]
         click.echo(tabulate([row], headers=SAMPLE_HEADERS, tablefmt="psql"))
         if cases:
-            case_ids: list[str] = [
-                link_obj.case.internal_id for link_obj in existing_sample.links
-            ]
+            case_ids: list[str] = [link_obj.case.internal_id for link_obj in existing_sample.links]
             context.invoke(get_case, case_ids=case_ids, samples=False)
         if not hide_flow_cell:
             for sample_flow_cell in existing_sample.flowcells:

--- a/cg/cli/set/cases.py
+++ b/cg/cli/set/cases.py
@@ -26,7 +26,7 @@ def _get_cases(identifiers: click.Tuple([str, str]), store: Store) -> list[Case]
     cases: set[Case] = set()
     for sample in samples_by_id:
         for link in sample.links:
-            cases.add(link.family)
+            cases.add(link.case)
 
     return list(cases)
 

--- a/cg/cli/upload/base.py
+++ b/cg/cli/upload/base.py
@@ -102,14 +102,14 @@ def upload_all_completed_analyses(context: click.Context, pipeline: Pipeline = N
 
     exit_code = 0
     for analysis_obj in status_db.get_analyses_to_upload(pipeline=pipeline):
-        if analysis_obj.family.analyses[0].uploaded_at is not None:
+        if analysis_obj.case.analyses[0].uploaded_at is not None:
             LOG.warning(
-                f"Skipping upload for case {analysis_obj.family.internal_id}. "
-                f"It has been already uploaded at {analysis_obj.family.analyses[0].uploaded_at}."
+                f"Skipping upload for case {analysis_obj.case.internal_id}. "
+                f"It has been already uploaded at {analysis_obj.case.analyses[0].uploaded_at}."
             )
             continue
 
-        case_id = analysis_obj.family.internal_id
+        case_id = analysis_obj.case.internal_id
         LOG.info("Uploading analysis for case: %s", case_id)
         try:
             context.invoke(upload, case_id=case_id)

--- a/cg/cli/upload/clinical_delivery.py
+++ b/cg/cli/upload/clinical_delivery.py
@@ -87,25 +87,25 @@ def auto_fastq(context: click.Context, dry_run: bool):
     status_db: Store = context.obj.status_db
     trailblazer_api: TrailblazerAPI = context.obj.trailblazer_api
     for analysis_obj in status_db.get_analyses_to_upload(pipeline=Pipeline.FASTQ):
-        if analysis_obj.family.analyses[0].uploaded_at:
+        if analysis_obj.case.analyses[0].uploaded_at:
             LOG.debug(
-                f"Newer analysis already uploaded for {analysis_obj.family.internal_id}, skipping"
+                f"Newer analysis already uploaded for {analysis_obj.case.internal_id}, skipping"
             )
             continue
         if analysis_obj.upload_started_at:
             if trailblazer_api.is_latest_analysis_completed(
-                case_id=analysis_obj.family.internal_id
+                case_id=analysis_obj.case.internal_id
             ):
                 LOG.info(
-                    f"The upload for {analysis_obj.family.internal_id} is completed, setting uploaded at to {dt.datetime.now()}"
+                    f"The upload for {analysis_obj.case.internal_id} is completed, setting uploaded at to {dt.datetime.now()}"
                 )
                 analysis_obj.uploaded_at = dt.datetime.now()
             else:
                 LOG.debug(
-                    f"Upload to clinical-delivery for {analysis_obj.family.internal_id} has already started, skipping"
+                    f"Upload to clinical-delivery for {analysis_obj.case.internal_id} has already started, skipping"
                 )
             continue
-        case: Case = analysis_obj.family
+        case: Case = analysis_obj.case
         LOG.info(f"Uploading family: {case.internal_id}")
         analysis_obj.upload_started_at = dt.datetime.now()
         try:

--- a/cg/cli/upload/clinical_delivery.py
+++ b/cg/cli/upload/clinical_delivery.py
@@ -93,9 +93,7 @@ def auto_fastq(context: click.Context, dry_run: bool):
             )
             continue
         if analysis_obj.upload_started_at:
-            if trailblazer_api.is_latest_analysis_completed(
-                case_id=analysis_obj.case.internal_id
-            ):
+            if trailblazer_api.is_latest_analysis_completed(case_id=analysis_obj.case.internal_id):
                 LOG.info(
                     f"The upload for {analysis_obj.case.internal_id} is completed, setting uploaded at to {dt.datetime.now()}"
                 )

--- a/cg/cli/upload/nipt/base.py
+++ b/cg/cli/upload/nipt/base.py
@@ -74,7 +74,7 @@ def nipt_upload_all(context: click.Context, dry_run: bool):
         return
 
     for analysis in analyses:
-        internal_id = analysis.family.internal_id
+        internal_id = analysis.case.internal_id
 
         if nipt_upload_api.flowcell_passed_qc_value(
             case_id=internal_id, q30_threshold=Q30_THRESHOLD

--- a/cg/cli/upload/nipt/ftp.py
+++ b/cg/cli/upload/nipt/ftp.py
@@ -65,5 +65,5 @@ def nipt_upload_all(context: click.Context, dry_run: bool):
         return
 
     for analysis in analyses:
-        case_id = analysis.family.internal_id
+        case_id = analysis.case.internal_id
         context.invoke(nipt_upload_case, case_id=case_id, dry_run=dry_run)

--- a/cg/cli/workflow/commands.py
+++ b/cg/cli/workflow/commands.py
@@ -198,7 +198,7 @@ def past_run_dirs(
     LOG.info(f"Cleaning {len(possible_cleanups)} analyses created before {before}")
 
     for analysis in possible_cleanups:
-        case_id = analysis.family.internal_id
+        case_id = analysis.case.internal_id
         try:
             LOG.info("Cleaning %s output for %s", analysis_api.pipeline, case_id)
             context.invoke(clean_run_dir, yes=yes, case_id=case_id, dry_run=dry_run)

--- a/cg/meta/clean/api.py
+++ b/cg/meta/clean/api.py
@@ -30,7 +30,7 @@ class CleanAPI:
         for analysis in self.status_db.get_analyses_for_pipeline_started_at_before(
             pipeline=pipeline, started_at_before=before
         ):
-            bundle_name = analysis.family.internal_id
+            bundle_name = analysis.case.internal_id
 
             hk_bundle_version: Optional[Version] = self.housekeeper_api.version(
                 bundle=bundle_name, date=analysis.started_at

--- a/cg/meta/observations/observations_api.py
+++ b/cg/meta/observations/observations_api.py
@@ -51,9 +51,7 @@ class ObservationsAPI:
         """Fetch input files from a case to upload to Loqusdb."""
         analysis: Analysis = case.analyses[0]
         analysis_date: datetime = analysis.started_at or analysis.completed_at
-        hk_version: Version = self.housekeeper_api.version(
-            analysis.case.internal_id, analysis_date
-        )
+        hk_version: Version = self.housekeeper_api.version(analysis.case.internal_id, analysis_date)
         return self.extract_observations_files_from_hk(hk_version)
 
     def get_loqusdb_api(self, loqusdb_instance: LoqusdbInstance) -> LoqusdbAPI:

--- a/cg/meta/observations/observations_api.py
+++ b/cg/meta/observations/observations_api.py
@@ -52,7 +52,7 @@ class ObservationsAPI:
         analysis: Analysis = case.analyses[0]
         analysis_date: datetime = analysis.started_at or analysis.completed_at
         hk_version: Version = self.housekeeper_api.version(
-            analysis.family.internal_id, analysis_date
+            analysis.case.internal_id, analysis_date
         )
         return self.extract_observations_files_from_hk(hk_version)
 

--- a/cg/meta/report/report_api.py
+++ b/cg/meta/report/report_api.py
@@ -115,7 +115,7 @@ class ReportAPI(MetaAPI):
             :MAX_ITEMS_TO_RETRIEVE
         ]
         for analysis_obj in analyses:
-            case: Case = analysis_obj.family
+            case: Case = analysis_obj.case
             last_version: Version = self.housekeeper_api.last_version(bundle=case.internal_id)
             hk_file: File = self.housekeeper_api.get_files(
                 bundle=case.internal_id, version=last_version.id if last_version else None
@@ -134,7 +134,7 @@ class ReportAPI(MetaAPI):
         analyses: Query = self.status_db.analyses_to_upload_delivery_reports(pipeline=pipeline)[
             :MAX_ITEMS_TO_RETRIEVE
         ]
-        return [analysis_obj.family for analysis_obj in analyses]
+        return [analysis_obj.case for analysis_obj in analyses]
 
     def update_delivery_report_date(self, case: Case, analysis_date: datetime) -> None:
         """Updates the date when delivery report was created."""
@@ -201,7 +201,7 @@ class ReportAPI(MetaAPI):
         """
         version = None
         if analysis:
-            version = len(analysis.family.analyses) - analysis.family.analyses.index(analysis)
+            version = len(analysis.case.analyses) - analysis.case.analyses.index(analysis)
         return version
 
     def get_case_data(

--- a/cg/meta/upload/coverage.py
+++ b/cg/meta/upload/coverage.py
@@ -19,9 +19,9 @@ class UploadCoverageApi:
 
     def data(self, analysis_obj: Analysis) -> dict:
         """Get data for uploading coverage."""
-        family_id = analysis_obj.family.internal_id
-        data = {"family": family_id, "family_name": analysis_obj.family.name, "samples": []}
-        for link_obj in analysis_obj.family.links:
+        family_id = analysis_obj.case.internal_id
+        data = {"family": family_id, "family_name": analysis_obj.case.name, "samples": []}
+        for link_obj in analysis_obj.case.links:
             analysis_date = analysis_obj.started_at or analysis_obj.completed_at
             hk_version = self.hk_api.version(family_id, analysis_date)
             hk_coverage = self.hk_api.files(

--- a/cg/meta/upload/fohm/fohm.py
+++ b/cg/meta/upload/fohm/fohm.py
@@ -171,7 +171,7 @@ class FOHMUploadAPI:
         """Hardlink samples rawdata files to fohm delivery folder."""
         for sample_id in self.aggregation_dataframe["internal_id"]:
             sample: Sample = self.status_db.get_sample_by_internal_id(internal_id=sample_id)
-            bundle_name = sample.links[0].family.internal_id
+            bundle_name = sample.links[0].case.internal_id
             version_obj: Version = self.housekeeper_api.last_version(bundle=bundle_name)
             files = self.housekeeper_api.files(version=version_obj.id, tags=[sample_id]).all()
             for file in files:

--- a/cg/meta/upload/gt.py
+++ b/cg/meta/upload/gt.py
@@ -40,16 +40,16 @@ class UploadGenotypesAPI(object):
         }
 
         """
-        case_id = analysis_obj.family.internal_id
+        case_id = analysis_obj.case.internal_id
         LOG.info("Fetching upload genotype data for %s", case_id)
         hk_version = self.hk.last_version(case_id)
         hk_bcf = self.get_bcf_file(hk_version)
         data = {"bcf": hk_bcf.full_path}
         if analysis_obj.pipeline in [Pipeline.BALSAMIC, Pipeline.BALSAMIC_UMI]:
-            data["samples_sex"] = self._get_samples_sex_balsamic(case_obj=analysis_obj.family)
+            data["samples_sex"] = self._get_samples_sex_balsamic(case_obj=analysis_obj.case)
         elif analysis_obj.pipeline == Pipeline.MIP_DNA:
             data["samples_sex"] = self._get_samples_sex_mip(
-                case_obj=analysis_obj.family, hk_version=hk_version
+                case_obj=analysis_obj.case, hk_version=hk_version
             )
         else:
             raise ValueError(f"Pipeline {analysis_obj.pipeline} does not support Genotype upload")

--- a/cg/meta/upload/scout/balsamic_config_builder.py
+++ b/cg/meta/upload/scout/balsamic_config_builder.py
@@ -93,5 +93,5 @@ class BalsamicConfigBuilder(ScoutConfigBuilder):
         LOG.info("Building samples")
         db_sample: FamilySample
 
-        for db_sample in self.analysis_obj.family.links:
+        for db_sample in self.analysis_obj.case.links:
             self.load_config.samples.append(self.build_config_sample(case_sample=db_sample))

--- a/cg/meta/upload/scout/mip_config_builder.py
+++ b/cg/meta/upload/scout/mip_config_builder.py
@@ -48,7 +48,7 @@ class MipConfigBuilder(ScoutConfigBuilder):
 
         self.add_common_info_to_load_config()
         mip_analysis_data: MipAnalysis = self.mip_analysis_api.get_latest_metadata(
-            self.analysis_obj.family.internal_id
+            self.analysis_obj.case.internal_id
         )
         self.load_config.human_genome_build = (
             "38" if "38" in mip_analysis_data.genome_build else "37"
@@ -59,7 +59,7 @@ class MipConfigBuilder(ScoutConfigBuilder):
 
         self.load_config.gene_panels = (
             self.mip_analysis_api.convert_panels(
-                self.analysis_obj.family.customer.internal_id, self.analysis_obj.family.panels
+                self.analysis_obj.case.customer.internal_id, self.analysis_obj.case.panels
             )
             or None
         )
@@ -68,14 +68,14 @@ class MipConfigBuilder(ScoutConfigBuilder):
 
         LOG.info("Building samples")
         db_sample: FamilySample
-        for db_sample in self.analysis_obj.family.links:
+        for db_sample in self.analysis_obj.case.links:
             self.load_config.samples.append(self.build_config_sample(case_sample=db_sample))
         self.include_pedigree_picture()
 
     def include_pedigree_picture(self) -> None:
         if self.is_multi_sample_case(self.load_config):
             if self.is_family_case(self.load_config):
-                svg_path: Path = self.run_madeline(self.analysis_obj.family)
+                svg_path: Path = self.run_madeline(self.analysis_obj.case)
                 self.load_config.madeline = str(svg_path)
             else:
                 LOG.info("family of unconnected samples - skip pedigree graph")

--- a/cg/meta/upload/scout/rnafusion_config_builder.py
+++ b/cg/meta/upload/scout/rnafusion_config_builder.py
@@ -38,7 +38,7 @@ class RnafusionConfigBuilder(ScoutConfigBuilder):
         LOG.info("Building samples")
         db_sample: FamilySample
 
-        for db_sample in self.analysis_obj.family.links:
+        for db_sample in self.analysis_obj.case.links:
             self.load_config.samples.append(self.build_config_sample(case_sample=db_sample))
 
     def include_case_files(self) -> None:

--- a/cg/meta/upload/scout/scout_config_builder.py
+++ b/cg/meta/upload/scout/scout_config_builder.py
@@ -30,11 +30,11 @@ class ScoutConfigBuilder:
     def add_common_info_to_load_config(self) -> None:
         """Add the mandatory common information to a scout load config object"""
         self.load_config.analysis_date = self.analysis_obj.completed_at
-        self.load_config.default_gene_panels = self.analysis_obj.family.panels
-        self.load_config.family = self.analysis_obj.family.internal_id
-        self.load_config.family_name = self.analysis_obj.family.name
-        self.load_config.owner = self.analysis_obj.family.customer.internal_id
-        self.load_config.synopsis = self.analysis_obj.family.synopsis
+        self.load_config.default_gene_panels = self.analysis_obj.case.panels
+        self.load_config.family = self.analysis_obj.case.internal_id
+        self.load_config.family_name = self.analysis_obj.case.name
+        self.load_config.owner = self.analysis_obj.case.customer.internal_id
+        self.load_config.synopsis = self.analysis_obj.case.synopsis
         self.include_cohorts()
         self.include_phenotype_groups()
         self.include_phenotype_terms()
@@ -92,7 +92,7 @@ class ScoutConfigBuilder:
         LOG.info("Adding phenotype terms to scout load config")
         phenotype_terms: set[str] = set()
         link_obj: FamilySample
-        for link_obj in self.analysis_obj.family.links:
+        for link_obj in self.analysis_obj.case.links:
             sample_obj: Sample = link_obj.sample
             for phenotype_term in sample_obj.phenotype_terms:
                 LOG.debug(
@@ -108,7 +108,7 @@ class ScoutConfigBuilder:
         LOG.info("Adding phenotype groups to scout load config")
         phenotype_groups: set[str] = set()
         link_obj: FamilySample
-        for link_obj in self.analysis_obj.family.links:
+        for link_obj in self.analysis_obj.case.links:
             sample_obj: Sample = link_obj.sample
             for phenotype_group in sample_obj.phenotype_groups:
                 LOG.debug(
@@ -122,7 +122,7 @@ class ScoutConfigBuilder:
 
     def include_cohorts(self) -> None:
         LOG.info("Including cohorts to scout load config")
-        cohorts: list[str] = self.analysis_obj.family.cohorts
+        cohorts: list[str] = self.analysis_obj.case.cohorts
         if cohorts:
             LOG.debug("Adding cohorts %s", ", ".join(cohorts))
             self.load_config.cohorts = cohorts

--- a/cg/meta/upload/scout/uploadscoutapi.py
+++ b/cg/meta/upload/scout/uploadscoutapi.py
@@ -64,7 +64,7 @@ class UploadScoutAPI:
 
         # Fetch last version from housekeeper
         # This should be safe since analyses are only added if data is analysed
-        hk_version_obj: Version = self.housekeeper.last_version(analysis_obj.family.internal_id)
+        hk_version_obj: Version = self.housekeeper.last_version(analysis_obj.case.internal_id)
         LOG.debug("Found housekeeper version %s", hk_version_obj.id)
 
         load_config: ScoutLoadConfig
@@ -427,7 +427,7 @@ class UploadScoutAPI:
     ) -> list[str]:
         """Maps a list of uploaded DNA cases linked to DNA sample."""
         potential_cases_related_to_dna_sample: list[Case] = [
-            dna_sample_family_relation.family for dna_sample_family_relation in dna_sample.links
+            dna_sample_family_relation.case for dna_sample_family_relation in dna_sample.links
         ]
         return self.filter_cases_related_to_dna_sample(
             list_of_dna_cases=potential_cases_related_to_dna_sample, collaborators=collaborators

--- a/cg/meta/upload/scout/uploadscoutapi.py
+++ b/cg/meta/upload/scout/uploadscoutapi.py
@@ -426,9 +426,7 @@ class UploadScoutAPI:
         self, dna_sample: Sample, collaborators: set[Customer]
     ) -> list[str]:
         """Maps a list of uploaded DNA cases linked to DNA sample."""
-        potential_cases_related_to_dna_sample: list[Case] = [
-            dna_sample_family_relation.case for dna_sample_family_relation in dna_sample.links
-        ]
+        potential_cases_related_to_dna_sample: list[Case] = [link.case for link in dna_sample.links]
         return self.filter_cases_related_to_dna_sample(
             list_of_dna_cases=potential_cases_related_to_dna_sample, collaborators=collaborators
         )

--- a/cg/meta/upload/upload_api.py
+++ b/cg/meta/upload/upload_api.py
@@ -48,7 +48,7 @@ class UploadAPI(MetaAPI):
 
         self.status_db.session.commit()
         self.trailblazer_api.set_analysis_uploaded(
-            case_id=analysis.family.internal_id, uploaded_at=analysis.uploaded_at
+            case_id=analysis.case.internal_id, uploaded_at=analysis.uploaded_at
         )
 
     @staticmethod

--- a/cg/meta/workflow/analysis.py
+++ b/cg/meta/workflow/analysis.py
@@ -173,7 +173,7 @@ class AnalysisAPI(MetaAPI):
             completed_at=dt.datetime.now(),
             primary=(len(case_obj.analyses) == 0),
         )
-        new_analysis.family = case_obj
+        new_analysis.case = case_obj
         if dry_run:
             LOG.info("Dry-run: StatusDB changes will not be commited")
             return

--- a/cg/meta/workflow/balsamic.py
+++ b/cg/meta/workflow/balsamic.py
@@ -168,7 +168,7 @@ class BalsamicAnalysisAPI(AnalysisAPI):
         concatenated_fastq_name: str = self.fastq_handler.get_concatenated_name(linked_fastq_name)
         return Path(
             self.root_dir,
-            link_object.family.internal_id,
+            link_object.case.internal_id,
             "fastq",
             concatenated_fastq_name,
         )
@@ -544,7 +544,7 @@ class BalsamicAnalysisAPI(AnalysisAPI):
             return panel_bed
         if self.get_application_type(link_object.sample) not in self.__BALSAMIC_BED_APPLICATIONS:
             return None
-        return self.get_target_bed_from_lims(link_object.family.internal_id)
+        return self.get_target_bed_from_lims(link_object.case.internal_id)
 
     def get_pipeline_version(self, case_id: str) -> str:
         LOG.debug("Fetch pipeline version")

--- a/cg/meta/workflow/microsalt.py
+++ b/cg/meta/workflow/microsalt.py
@@ -271,7 +271,7 @@ class MicrosaltAnalysisAPI(AnalysisAPI):
         if not sample:
             LOG.error("No sample found with id: %s", unique_id)
             raise click.Abort
-        case_id = sample.links[0].family.internal_id
+        case_id = sample.links[0].case.internal_id
         sample_id = sample.internal_id
         return case_id, sample_id
 

--- a/cg/meta/workflow/mip_dna.py
+++ b/cg/meta/workflow/mip_dna.py
@@ -58,7 +58,7 @@ class MipDNAAnalysisAPI(MipAnalysisAPI):
             sample_data["capture_kit"]: str = panel_bed or DEFAULT_CAPTURE_KIT
         else:
             sample_data["capture_kit"]: Optional[str] = panel_bed or self.get_target_bed_from_lims(
-                case_id=link_obj.family.internal_id
+                case_id=link_obj.case.internal_id
             )
         if link_obj.mother:
             sample_data[Pedigree.MOTHER.value]: str = link_obj.mother.internal_id

--- a/cg/meta/workflow/mutant.py
+++ b/cg/meta/workflow/mutant.py
@@ -96,11 +96,11 @@ class MutantAnalysisAPI(AnalysisAPI):
     def get_sample_parameters(self, sample_obj: Sample) -> MutantSampleConfig:
         return MutantSampleConfig(
             CG_ID_sample=sample_obj.internal_id,
-            case_ID=sample_obj.links[0].family.internal_id,
+            case_ID=sample_obj.links[0].case.internal_id,
             Customer_ID_sample=sample_obj.name,
             customer_id=sample_obj.customer.internal_id,
             sequencing_qc_pass=sample_obj.sequencing_qc,
-            CG_ID_project=sample_obj.links[0].family.name,
+            CG_ID_project=sample_obj.links[0].case.name,
             Customer_ID_project=sample_obj.original_ticket,
             application_tag=sample_obj.application_version.application.tag,
             method_libprep=str(self.lims_api.get_prep_method(lims_id=sample_obj.internal_id)),

--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -392,10 +392,10 @@ class AnalysisView(BaseView):
     column_default_sort = ("created_at", True)
     column_editable_list = ["is_primary"]
     column_filters = ["pipeline", "pipeline_version", "is_primary"]
-    column_formatters = {"family": CaseView.view_family_link}
+    column_formatters = {"case": CaseView.view_family_link}
     column_searchable_list = [
-        "family.internal_id",
-        "family.name",
+        "case.internal_id",
+        "case.name",
     ]
     form_extra_fields = {"pipeline": SelectEnumField(enum_class=Pipeline)}
 
@@ -570,10 +570,10 @@ class FamilySampleView(BaseView):
     column_editable_list = ["status"]
     column_filters = ["status"]
     column_formatters = {
-        "family": CaseView.view_family_link,
+        "case": CaseView.view_family_link,
         "sample": SampleView.view_sample_link,
     }
-    column_searchable_list = ["family.internal_id", "family.name", "sample.internal_id"]
+    column_searchable_list = ["case.internal_id", "case.name", "sample.internal_id"]
     create_modal = True
     edit_modal = True
 

--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -283,10 +283,10 @@ class CaseView(BaseView):
         """column formatter to open this view"""
         del unused1, unused2, unused3
         markup = ""
-        if model.family:
+        if model.case:
             markup += Markup(
                 " <a href='%s'>%s</a>"
-                % (url_for("case.index_view", search=model.family.internal_id), model.family)
+                % (url_for("case.index_view", search=model.case.internal_id), model.case)
             )
 
         return markup
@@ -504,7 +504,7 @@ class SampleView(BaseView):
             sample: Sample = db.get_sample_by_entry_id(entry_id=int(entry_id))
 
             sample_case_ids: list[str] = [
-                case_sample.family.internal_id for case_sample in sample.links
+                case_sample.case.internal_id for case_sample in sample.links
             ]
             all_associated_case_ids.update(sample_case_ids)
 
@@ -564,7 +564,7 @@ class DeliveryView(BaseView):
 
 
 class FamilySampleView(BaseView):
-    """Admin view for Model.FamilySample"""
+    """Admin view for Model.caseSample"""
 
     column_default_sort = ("created_at", True)
     column_editable_list = ["status"]

--- a/cg/store/api/add.py
+++ b/cg/store/api/add.py
@@ -235,7 +235,7 @@ class AddHandler(BaseHandler):
         """Relate a sample record to a family record."""
 
         new_record: FamilySample = FamilySample(status=status)
-        new_record.family = family
+        new_record.case = family
         new_record.sample = sample
         new_record.mother = mother
         new_record.father = father

--- a/cg/store/api/base.py
+++ b/cg/store/api/base.py
@@ -60,9 +60,7 @@ class BaseHandler:
 
     def _get_join_case_sample_query(self) -> Query:
         """Return join case sample query."""
-        return (
-            self._get_query(table=FamilySample).join(FamilySample.case).join(FamilySample.sample)
-        )
+        return self._get_query(table=FamilySample).join(FamilySample.case).join(FamilySample.sample)
 
     def _get_join_case_and_sample_query(self) -> Query:
         """Return join case sample query."""

--- a/cg/store/api/base.py
+++ b/cg/store/api/base.py
@@ -56,12 +56,12 @@ class BaseHandler:
 
     def _get_join_analysis_case_query(self) -> Query:
         """Return join analysis case query."""
-        return self._get_query(table=Analysis).join(Analysis.family)
+        return self._get_query(table=Analysis).join(Analysis.case)
 
     def _get_join_case_sample_query(self) -> Query:
         """Return join case sample query."""
         return (
-            self._get_query(table=FamilySample).join(FamilySample.family).join(FamilySample.sample)
+            self._get_query(table=FamilySample).join(FamilySample.case).join(FamilySample.sample)
         )
 
     def _get_join_case_and_sample_query(self) -> Query:

--- a/cg/store/filters/status_flow_cell_filters.py
+++ b/cg/store/filters/status_flow_cell_filters.py
@@ -8,7 +8,7 @@ from cg.store.models import Case, FamilySample, Flowcell
 
 def filter_flow_cells_by_case(case: Case, flow_cells: Query, **kwargs) -> Query:
     """Return flow cells by case id."""
-    return flow_cells.filter(FamilySample.family == case)
+    return flow_cells.filter(FamilySample.case == case)
 
 
 def filter_flow_cell_by_name(flow_cells: Query, flow_cell_name: str, **kwargs) -> Query:

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -219,16 +219,16 @@ class Analysis(Model):
     family_id = Column(ForeignKey("family.id", ondelete="CASCADE"), nullable=False)
     uploaded_to_vogue_at = Column(types.DateTime, nullable=True)
 
-    family = orm.relationship("Case", back_populates="analyses")
+    case = orm.relationship("Case", back_populates="analyses")
 
     def __str__(self):
-        return f"{self.family.internal_id} | {self.completed_at.date()}"
+        return f"{self.case.internal_id} | {self.completed_at.date()}"
 
     def to_dict(self, family: bool = True):
         """Represent as dictionary"""
         data = to_dict(model_instance=self)
         if family:
-            data["family"] = self.family.to_dict()
+            data["family"] = self.case.to_dict()
         return data
 
 
@@ -399,10 +399,8 @@ class Case(Model, PriorityMixin):
     synopsis = Column(types.Text)
     tickets = Column(types.VARCHAR(128))
 
-    analyses = orm.relationship(
-        Analysis, back_populates="family", order_by="-Analysis.completed_at"
-    )
-    links = orm.relationship("FamilySample", back_populates="family")
+    analyses = orm.relationship(Analysis, back_populates="case", order_by="-Analysis.completed_at")
+    links = orm.relationship("FamilySample", back_populates="case")
 
     @property
     def cohorts(self) -> list[str]:
@@ -532,7 +530,7 @@ class FamilySample(Model):
     mother_id = Column(ForeignKey("sample.id"))
     father_id = Column(ForeignKey("sample.id"))
 
-    family = orm.relationship(Case, back_populates="links")
+    case = orm.relationship(Case, back_populates="links")
     sample = orm.relationship("Sample", foreign_keys=[sample_id], back_populates="links")
     mother = orm.relationship("Sample", foreign_keys=[mother_id], back_populates="mother_links")
     father = orm.relationship("Sample", foreign_keys=[father_id], back_populates="father_links")
@@ -548,11 +546,11 @@ class FamilySample(Model):
             data["mother"] = self.mother.to_dict() if self.mother else None
             data["father"] = self.father.to_dict() if self.father else None
         if family:
-            data["family"] = self.family.to_dict()
+            data["family"] = self.case.to_dict()
         return data
 
     def __str__(self) -> str:
-        return f"{self.family.internal_id} | {self.sample.internal_id}"
+        return f"{self.case.internal_id} | {self.sample.internal_id}"
 
 
 class Flowcell(Model):

--- a/tests/cli/add/test_cli_add_relationship.py
+++ b/tests/cli/add/test_cli_add_relationship.py
@@ -29,7 +29,7 @@ def test_add_relationship_required(cli_runner: CliRunner, base_context: CGConfig
     family_sample_query = disk_store._get_query(table=FamilySample)
 
     assert family_sample_query.count() == 1
-    assert family_sample_query.first().family.internal_id == case_id
+    assert family_sample_query.first().case.internal_id == case_id
     assert family_sample_query.first().sample.internal_id == sample_id
 
 

--- a/tests/cli/clean/test_hk_case_bundle_files.py
+++ b/tests/cli/clean/test_hk_case_bundle_files.py
@@ -77,7 +77,7 @@ def test_clean_hk_case_files_single_analysis(
     analysis: Analysis = helpers.add_analysis(
         store=store, started_at=date_days_ago, completed_at=date_days_ago, pipeline=pipeline
     )
-    bundle_name: str = analysis.family.internal_id
+    bundle_name: str = analysis.case.internal_id
 
     # GIVEN a housekeeper api with some files
     hk_bundle_data["name"] = bundle_name
@@ -116,7 +116,7 @@ def test_clean_hk_case_files_analysis_with_protected_tag(
     analysis: Analysis = helpers.add_analysis(
         store=store, started_at=date_days_ago, completed_at=date_days_ago, pipeline=pipeline
     )
-    bundle_name: str = analysis.family.internal_id
+    bundle_name: str = analysis.case.internal_id
 
     # GIVEN a housekeeper api with some file with protected tags
     protected_tags = WORKFLOW_PROTECTED_TAGS[pipeline][0]

--- a/tests/cli/delete/test_cli_delete_case.py
+++ b/tests/cli/delete/test_cli_delete_case.py
@@ -1,3 +1,4 @@
+
 """This script tests the cli methods to set families to status-db"""
 import logging
 
@@ -65,7 +66,7 @@ def test_delete_case_with_analysis(
     # GIVEN a database with a case with an analysis
     base_store: Store = base_context.status_db
     analysis_obj = helpers.add_analysis(base_store)
-    case_id = analysis_obj.family.internal_id
+    case_id = analysis_obj.case.internal_id
 
     # WHEN deleting a case
 

--- a/tests/cli/delete/test_cli_delete_case.py
+++ b/tests/cli/delete/test_cli_delete_case.py
@@ -1,4 +1,3 @@
-
 """This script tests the cli methods to set families to status-db"""
 import logging
 

--- a/tests/cli/get/test_cli_get_analysis.py
+++ b/tests/cli/get/test_cli_get_analysis.py
@@ -28,7 +28,7 @@ def test_get_analysis_required(
     """Test to get a analysis using only the required argument"""
     # GIVEN a database with an analysis
     analysis: Analysis = helpers.add_analysis(disk_store, pipeline_version="9.3")
-    internal_id = analysis.family.internal_id
+    internal_id = analysis.case.internal_id
     assert disk_store._get_query(table=Analysis).count() == 1
 
     # WHEN getting a analysis

--- a/tests/cli/get/test_cli_get_sample.py
+++ b/tests/cli/get/test_cli_get_sample.py
@@ -155,7 +155,7 @@ def test_get_sample_no_cases_with_case(
     # THEN all related cases should be listed in the output
     assert result.exit_code == EXIT_SUCCESS
     for family_sample in disk_store._get_query(table=Sample).first().links:
-        assert family_sample.family.internal_id not in result.output
+        assert family_sample.case.internal_id not in result.output
 
 
 def test_get_sample_cases_without_case(
@@ -188,7 +188,7 @@ def test_get_sample_cases_with_case(
     # THEN all related families should be listed in the output
     assert result.exit_code == EXIT_SUCCESS
     for link in disk_store._get_query(table=Sample).first().links:
-        assert link.family.internal_id in result.output
+        assert link.case.internal_id in result.output
 
 
 def test_hide_sample_flowcells_without_flowcell(

--- a/tests/cli/upload/conftest.py
+++ b/tests/cli/upload/conftest.py
@@ -81,7 +81,7 @@ def upload_genotypes_hk_api(
 ) -> HousekeeperAPI:
     """Add and include files from upload genotypes hk bundle"""
     helpers.ensure_hk_bundle(real_housekeeper_api, upload_genotypes_hk_bundle)
-    hk_version = real_housekeeper_api.last_version(analysis_obj.family.internal_id)
+    hk_version = real_housekeeper_api.last_version(analysis_obj.case.internal_id)
     real_housekeeper_api.include(hk_version)
     return real_housekeeper_api
 
@@ -166,7 +166,7 @@ def upload_report_hk_api(
     """Add and include files from upload reports hk bundle"""
 
     helpers.ensure_hk_bundle(real_housekeeper_api, upload_report_hk_bundle)
-    hk_version = real_housekeeper_api.last_version(analysis_obj.family.internal_id)
+    hk_version = real_housekeeper_api.last_version(analysis_obj.case.internal_id)
     real_housekeeper_api.include(hk_version)
     return real_housekeeper_api
 

--- a/tests/cli/upload/test_cli_upload_fastq.py
+++ b/tests/cli/upload/test_cli_upload_fastq.py
@@ -13,7 +13,7 @@ def test_auto_fastq_not_started(
     caplog.set_level(logging.INFO)
     # GIVEN a case to be delivered
     analysis_obj.pipeline = Pipeline.FASTQ
-    analysis_obj.family.data_delivery = DataDelivery.FASTQ
+    analysis_obj.case.data_delivery = DataDelivery.FASTQ
     base_context.status_db.session.commit()
     base_context.status_db.session.close()
     # WHEN the upload command is invoked with dry run

--- a/tests/cli/upload/test_cli_upload_nipt.py
+++ b/tests/cli/upload/test_cli_upload_nipt.py
@@ -31,7 +31,7 @@ def test_nipt_statina_upload_case(
     caplog.set_level(logging.DEBUG)
 
     analysis_obj: Analysis = helpers.add_analysis(store=upload_context.status_db)
-    case_id = analysis_obj.family.internal_id
+    case_id = analysis_obj.case.internal_id
     assert not analysis_obj.upload_started_at
     assert not analysis_obj.uploaded_at
 
@@ -71,7 +71,7 @@ def test_nipt_statina_upload_case_dry_run(
     caplog.set_level(logging.DEBUG)
 
     analysis_obj: Analysis = helpers.add_analysis(store=upload_context.status_db)
-    case_id = analysis_obj.family.internal_id
+    case_id = analysis_obj.case.internal_id
     assert not analysis_obj.upload_started_at
     assert not analysis_obj.uploaded_at
 
@@ -174,7 +174,7 @@ def test_nipt_statina_upload_auto_analysis_without_case(
         completed_at=datetime.datetime.now(),
         pipeline=Pipeline.FLUFFY,
     )
-    analysis_obj.family = None
+    analysis_obj.case = None
     mocker.patch.object(NiptUploadAPI, "get_all_upload_analyses", return_value=[analysis_obj])
     # WHEN uploading all NIPT cases
     result = cli_runner.invoke(cli=nipt_upload_all, args=[], obj=upload_context)
@@ -232,7 +232,7 @@ def test_nipt_statina_upload_force_failed_case(
     caplog.set_level(logging.DEBUG)
 
     analysis_obj: Analysis = helpers.add_analysis(store=upload_context.status_db)
-    case_id = analysis_obj.family.internal_id
+    case_id = analysis_obj.case.internal_id
 
     # WHEN uploading of a specified NIPT case AND the qc fails but it forced to upload
     mocker.patch.object(NiptUploadAPI, "get_statina_files", return_value=MockStatinaUploadFiles())

--- a/tests/cli/upload/test_cli_upload_nipt_ftp.py
+++ b/tests/cli/upload/test_cli_upload_nipt_ftp.py
@@ -92,7 +92,7 @@ def test_nipt_upload_case_not_changing_uploaded_at(
     caplog.set_level(logging.DEBUG)
 
     analysis_obj = helpers.add_analysis(store=upload_context.status_db)
-    case_id = analysis_obj.family.internal_id
+    case_id = analysis_obj.case.internal_id
     assert not analysis_obj.upload_started_at
     assert not analysis_obj.uploaded_at
 

--- a/tests/meta/orders/test_meta_orders_status.py
+++ b/tests/meta/orders/test_meta_orders_status.py
@@ -268,11 +268,11 @@ def test_store_samples(orders_api, base_store, fastq_status_data, ticket_id: str
     first_sample = new_samples[0]
     assert len(first_sample.links) == 2
     family_link = first_sample.links[0]
-    assert family_link.family in base_store.get_cases()
+    assert family_link.case in base_store.get_cases()
     for sample in new_samples:
         assert len(sample.deliveries) == 1
-    assert family_link.family.data_analysis
-    assert family_link.family.data_delivery in [DataDelivery.FASTQ, DataDelivery.NO_DELIVERY]
+    assert family_link.case.data_analysis
+    assert family_link.case.data_delivery in [DataDelivery.FASTQ, DataDelivery.NO_DELIVERY]
 
 
 def test_store_samples_sex_stored(orders_api, base_store, fastq_status_data, ticket_id: str):
@@ -316,7 +316,7 @@ def test_store_fastq_samples_non_tumour_wgs_to_mip(orders_api, base_store, fastq
     )
 
     # THEN the analysis for the case should be MAF
-    assert new_samples[0].links[0].family.data_analysis == Pipeline.MIP_DNA
+    assert new_samples[0].links[0].case.data_analysis == Pipeline.MIP_DNA
 
 
 def test_store_fastq_samples_tumour_wgs_to_fastq(
@@ -342,7 +342,7 @@ def test_store_fastq_samples_tumour_wgs_to_fastq(
     )
 
     # THEN the analysis for the case should be FASTQ
-    assert new_samples[0].links[0].family.data_analysis == Pipeline.FASTQ
+    assert new_samples[0].links[0].case.data_analysis == Pipeline.FASTQ
 
 
 def test_store_fastq_samples_non_wgs_as_fastq(
@@ -374,7 +374,7 @@ def test_store_fastq_samples_non_wgs_as_fastq(
     )
 
     # THEN the analysis for the case should be fastq (none)
-    assert new_samples[0].links[0].family.data_analysis == Pipeline.FASTQ
+    assert new_samples[0].links[0].case.data_analysis == Pipeline.FASTQ
 
 
 def test_store_samples_bad_apptag(orders_api, base_store, fastq_status_data, ticket_id: str):

--- a/tests/meta/report/test_report_api.py
+++ b/tests/meta/report/test_report_api.py
@@ -195,7 +195,7 @@ def test_get_report_version_version(
     # GIVEN a specific set of analyses
     last_analysis: Analysis = helpers.add_analysis(store, completed_at=datetime.now())
     first_analysis: Analysis = helpers.add_analysis(
-        store, last_analysis.family, completed_at=timestamp_yesterday
+        store, last_analysis.case, completed_at=timestamp_yesterday
     )
 
     # WHEN retrieving the version

--- a/tests/meta/upload/scout/conftest.py
+++ b/tests/meta/upload/scout/conftest.py
@@ -529,11 +529,11 @@ def mip_dna_analysis(
 def balsamic_analysis_obj(analysis_obj: Analysis) -> Analysis:
     """Return a Balsamic analysis object."""
     analysis_obj.pipeline = Pipeline.BALSAMIC
-    for link_object in analysis_obj.family.links:
+    for link_object in analysis_obj.case.links:
         link_object.sample.application_version.application.prep_category = (
             PrepCategory.WHOLE_EXOME_SEQUENCING
         )
-        link_object.family.data_analysis = Pipeline.BALSAMIC
+        link_object.case.data_analysis = Pipeline.BALSAMIC
     return analysis_obj
 
 
@@ -541,11 +541,11 @@ def balsamic_analysis_obj(analysis_obj: Analysis) -> Analysis:
 def balsamic_umi_analysis_obj(analysis_obj: Analysis) -> Analysis:
     """Return a Balsamic UMI analysis object."""
     analysis_obj.pipeline = Pipeline.BALSAMIC_UMI
-    for link_object in analysis_obj.family.links:
+    for link_object in analysis_obj.case.links:
         link_object.sample.application_version.application.prep_category = (
             PrepCategory.WHOLE_EXOME_SEQUENCING
         )
-        link_object.family.data_analysis = Pipeline.BALSAMIC_UMI
+        link_object.case.data_analysis = Pipeline.BALSAMIC_UMI
 
     return analysis_obj
 
@@ -554,12 +554,12 @@ def balsamic_umi_analysis_obj(analysis_obj: Analysis) -> Analysis:
 def rnafusion_analysis_obj(analysis_obj: Analysis) -> Analysis:
     """Return a RNAfusion analysis object."""
     analysis_obj.pipeline = Pipeline.RNAFUSION
-    for link_object in analysis_obj.family.links:
+    for link_object in analysis_obj.case.links:
         link_object.sample.application_version.application.prep_category = (
             PrepCategory.WHOLE_TRANSCRIPTOME_SEQUENCING
         )
-        link_object.family.data_analysis = Pipeline.RNAFUSION
-        link_object.family.panels = None
+        link_object.case.data_analysis = Pipeline.RNAFUSION
+        link_object.case.panels = None
     return analysis_obj
 
 

--- a/tests/meta/upload/test_meta_upload_coverage.py
+++ b/tests/meta/upload/test_meta_upload_coverage.py
@@ -14,6 +14,7 @@ class MockAnalysis:
 
     def __init__(self, case_obj: Case, started_at: datetime):
         self.case_obj = case_obj
+        self.case = case_obj
         self.started_at = started_at
 
     @property

--- a/tests/mocks/store_model.py
+++ b/tests/mocks/store_model.py
@@ -28,4 +28,4 @@ class Analysis(Analysis):
     def __init__(self):
         self.id = 1
         self.completed_at = datetime.datetime.now()
-        self.family: Case = Case()
+        self.case: Case = Case()

--- a/tests/store/api/conftest.py
+++ b/tests/store/api/conftest.py
@@ -480,7 +480,7 @@ def store_with_analyses_for_cases(
         )
         sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
         link: FamilySample = analysis_store.relate_sample(
-            family=oldest_analysis.family, sample=sample, status=PhenotypeStatus.UNKNOWN
+            family=oldest_analysis.case, sample=sample, status=PhenotypeStatus.UNKNOWN
         )
         analysis_store.session.add(link)
 
@@ -520,7 +520,7 @@ def store_with_analyses_for_cases_not_uploaded_fluffy(
         )
         sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
         link: FamilySample = analysis_store.relate_sample(
-            family=oldest_analysis.family, sample=sample, status=PhenotypeStatus.UNKNOWN
+            family=oldest_analysis.case, sample=sample, status=PhenotypeStatus.UNKNOWN
         )
         analysis_store.session.add(link)
     return analysis_store
@@ -560,7 +560,7 @@ def store_with_analyses_for_cases_not_uploaded_microsalt(
         )
         sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
         link: FamilySample = analysis_store.relate_sample(
-            family=oldest_analysis.family, sample=sample, status=PhenotypeStatus.UNKNOWN
+            family=oldest_analysis.case, sample=sample, status=PhenotypeStatus.UNKNOWN
         )
         analysis_store.session.add(link)
     return analysis_store
@@ -601,7 +601,7 @@ def store_with_analyses_for_cases_to_deliver(
         )
         sample = helpers.add_sample(analysis_store, delivered_at=None)
         link: FamilySample = analysis_store.relate_sample(
-            family=oldest_analysis.family, sample=sample, status=PhenotypeStatus.UNKNOWN
+            family=oldest_analysis.case, sample=sample, status=PhenotypeStatus.UNKNOWN
         )
         analysis_store.session.add(link)
 

--- a/tests/store/api/find/test_find_business_data.py
+++ b/tests/store/api/find/test_find_business_data.py
@@ -38,7 +38,7 @@ def test_get_analysis_by_case_entry_id_and_started_at(
 
     # WHEN getting analysis via case_id and start date
     db_analysis = sample_store.get_analysis_by_case_entry_id_and_started_at(
-        case_entry_id=analysis.family.id, started_at_date=analysis.started_at
+        case_entry_id=analysis.case.id, started_at_date=analysis.started_at
     )
 
     # THEN the analysis should have been retrieved
@@ -469,7 +469,7 @@ def test_get_case_sample_link(
     # THEN the returned element is a FamilySample object
     assert isinstance(case_sample, FamilySample)
     # THEN the returned family sample has the correct case and sample internal ids
-    assert case_sample.family.internal_id == case_id
+    assert case_sample.case.internal_id == case_id
     assert case_sample.sample.internal_id == sample_id
 
 

--- a/tests/store/api/find/test_find_business_data_analysis.py
+++ b/tests/store/api/find/test_find_business_data_analysis.py
@@ -63,7 +63,7 @@ def test_get_analyses_to_deliver_for_pipeline(
 
     # THEN only the newest analysis should be returned
     for analysis in analyses:
-        assert analysis.family.internal_id in ["test_case_1", "yellowhog"]
+        assert analysis.case.internal_id in ["test_case_1", "yellowhog"]
         assert analysis.uploaded_at is None
         assert analysis.pipeline == pipeline
 

--- a/tests/store/api/status/test_analyses_to_clean.py
+++ b/tests/store/api/status/test_analyses_to_clean.py
@@ -20,7 +20,7 @@ def test_analysis_included(
     )
     sample = helpers.add_sample(analysis_store, delivered_at=timestamp_yesterday)
     link: FamilySample = analysis_store.relate_sample(
-        family=analysis.family, sample=sample, status="unknown"
+        family=analysis.case, sample=sample, status="unknown"
     )
     analysis_store.session.add(link)
 
@@ -40,7 +40,7 @@ def test_analysis_excluded(analysis_store: Store, helpers, timestamp_now: dateti
     )
     sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
     link: FamilySample = analysis_store.relate_sample(
-        family=analysis.family, sample=sample, status="unknown"
+        family=analysis.case, sample=sample, status="unknown"
     )
     analysis_store.session.add(link)
 
@@ -67,7 +67,7 @@ def test_pipeline_included(
     )
     sample = helpers.add_sample(analysis_store, delivered_at=timestamp_yesterday)
     link: FamilySample = analysis_store.relate_sample(
-        family=analysis.family, sample=sample, status="unknown"
+        family=analysis.case, sample=sample, status="unknown"
     )
     analysis_store.session.add(link)
 
@@ -96,7 +96,7 @@ def test_pipeline_excluded(analysis_store: Store, helpers, timestamp_now: dateti
     )
     sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
     link: FamilySample = analysis_store.relate_sample(
-        family=analysis.family, sample=sample, status="unknown"
+        family=analysis.case, sample=sample, status="unknown"
     )
     analysis_store.session.add(link)
 
@@ -121,7 +121,7 @@ def test_non_cleaned_included(
     )
     sample = helpers.add_sample(analysis_store, delivered_at=timestamp_yesterday)
     link: FamilySample = analysis_store.relate_sample(
-        family=analysis.family, sample=sample, status="unknown"
+        family=analysis.case, sample=sample, status="unknown"
     )
     analysis_store.session.add(link)
 
@@ -144,7 +144,7 @@ def test_cleaned_excluded(analysis_store: Store, helpers, timestamp_now: datetim
     )
     sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
     link: FamilySample = analysis_store.relate_sample(
-        family=analysis.family, sample=sample, status="unknown"
+        family=analysis.case, sample=sample, status="unknown"
     )
     analysis_store.session.add(link)
 

--- a/tests/store/api/status/test_analyses_to_delivery_report.py
+++ b/tests/store/api/status/test_analyses_to_delivery_report.py
@@ -22,7 +22,7 @@ def test_missing(analysis_store: Store, helpers, timestamp_now):
     )
     sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
     link: FamilySample = analysis_store.relate_sample(
-        family=analysis.family, sample=sample, status=PhenotypeStatus.UNKNOWN
+        family=analysis.case, sample=sample, status=PhenotypeStatus.UNKNOWN
     )
     analysis_store.session.add(link)
     assert sample.delivered_at is not None
@@ -58,7 +58,7 @@ def test_outdated_analysis(analysis_store, helpers, timestamp_now, timestamp_yes
 
     # GIVEN a store sample case relation
     link: FamilySample = analysis_store.relate_sample(
-        family=analysis.family, sample=sample, status=PhenotypeStatus.UNKNOWN
+        family=analysis.case, sample=sample, status=PhenotypeStatus.UNKNOWN
     )
     analysis_store.session.add(link)
 

--- a/tests/store/api/status/test_store_api_status.py
+++ b/tests/store/api/status/test_store_api_status.py
@@ -15,19 +15,19 @@ def test_case_in_uploaded_observations(helpers: StoreHelpers, sample_store: Stor
 
     # GIVEN a case with observations that has been uploaded to Loqusdb
     analysis: Analysis = helpers.add_analysis(store=sample_store, pipeline=Pipeline.MIP_DNA)
-    analysis.family.customer.loqus_upload = True
+    analysis.case.customer.loqus_upload = True
     sample: Sample = helpers.add_sample(sample_store, loqusdb_id=loqusdb_id)
-    link = sample_store.relate_sample(analysis.family, sample, PhenotypeStatus.UNKNOWN)
+    link = sample_store.relate_sample(analysis.case, sample, PhenotypeStatus.UNKNOWN)
     sample_store.session.add(link)
-    assert analysis.family.analyses
-    for link in analysis.family.links:
+    assert analysis.case.analyses
+    for link in analysis.case.links:
         assert link.sample.loqusdb_id is not None
 
     # WHEN getting observations to upload
     uploaded_observations: Query = sample_store.observations_uploaded()
 
     # THEN the case should be in the returned query
-    assert analysis.family in uploaded_observations
+    assert analysis.case in uploaded_observations
 
 
 def test_case_not_in_uploaded_observations(helpers: StoreHelpers, sample_store: Store):
@@ -35,19 +35,19 @@ def test_case_not_in_uploaded_observations(helpers: StoreHelpers, sample_store: 
 
     # GIVEN a case with observations that has not been uploaded to loqusdb
     analysis: Analysis = helpers.add_analysis(store=sample_store, pipeline=Pipeline.MIP_DNA)
-    analysis.family.customer.loqus_upload = True
+    analysis.case.customer.loqus_upload = True
     sample: Sample = helpers.add_sample(sample_store)
-    link = sample_store.relate_sample(analysis.family, sample, PhenotypeStatus.UNKNOWN)
+    link = sample_store.relate_sample(analysis.case, sample, PhenotypeStatus.UNKNOWN)
     sample_store.session.add(link)
-    assert analysis.family.analyses
-    for link in analysis.family.links:
+    assert analysis.case.analyses
+    for link in analysis.case.links:
         assert link.sample.loqusdb_id is None
 
     # WHEN getting observations to upload
     uploaded_observations: Query = sample_store.observations_uploaded()
 
     # THEN the case should not be in the returned query
-    assert analysis.family not in uploaded_observations
+    assert analysis.case not in uploaded_observations
 
 
 def test_case_in_observations_to_upload(helpers: StoreHelpers, sample_store: Store):
@@ -55,19 +55,19 @@ def test_case_in_observations_to_upload(helpers: StoreHelpers, sample_store: Sto
 
     # GIVEN a case with completed analysis and samples w/o loqusdb_id
     analysis: Analysis = helpers.add_analysis(store=sample_store, pipeline=Pipeline.MIP_DNA)
-    analysis.family.customer.loqus_upload = True
+    analysis.case.customer.loqus_upload = True
     sample: Sample = helpers.add_sample(sample_store)
-    link = sample_store.relate_sample(analysis.family, sample, PhenotypeStatus.UNKNOWN)
+    link = sample_store.relate_sample(analysis.case, sample, PhenotypeStatus.UNKNOWN)
     sample_store.session.add(link)
-    assert analysis.family.analyses
-    for link in analysis.family.links:
+    assert analysis.case.analyses
+    for link in analysis.case.links:
         assert link.sample.loqusdb_id is None
 
     # WHEN getting observations to upload
     observations_to_upload: Query = sample_store.observations_to_upload()
 
     # THEN the case should be in the returned query
-    assert analysis.family in observations_to_upload
+    assert analysis.case in observations_to_upload
 
 
 def test_case_not_in_observations_to_upload(
@@ -77,19 +77,19 @@ def test_case_not_in_observations_to_upload(
 
     # GIVEN a case with completed analysis and samples with a Loqusdb ID
     analysis: Analysis = helpers.add_analysis(store=sample_store, pipeline=Pipeline.MIP_DNA)
-    analysis.family.customer.loqus_upload = True
+    analysis.case.customer.loqus_upload = True
     sample: Sample = helpers.add_sample(sample_store, loqusdb_id=loqusdb_id)
-    link = sample_store.relate_sample(analysis.family, sample, PhenotypeStatus.UNKNOWN)
+    link = sample_store.relate_sample(analysis.case, sample, PhenotypeStatus.UNKNOWN)
     sample_store.session.add(link)
-    assert analysis.family.analyses
-    for link in analysis.family.links:
+    assert analysis.case.analyses
+    for link in analysis.case.links:
         assert link.sample.loqusdb_id is not None
 
     # WHEN getting observations to upload
     observations_to_upload: Query = sample_store.observations_to_upload()
 
     # THEN the case should not be in the returned query
-    assert analysis.family not in observations_to_upload
+    assert analysis.case not in observations_to_upload
 
 
 def test_analyses_to_upload_when_not_completed_at(helpers, sample_store):

--- a/tests/store/api/status/test_store_api_status_analysis.py
+++ b/tests/store/api/status/test_store_api_status_analysis.py
@@ -26,10 +26,10 @@ def test_get_families_with_extended_models(
     )
 
     # Given an action set to analyze
-    test_analysis.family.action: str = CaseActions.ANALYZE
+    test_analysis.case.action: str = CaseActions.ANALYZE
 
     # GIVEN a database with a case with one of one sequenced samples and completed analysis
-    link = base_store.relate_sample(test_analysis.family, test_sample, PhenotypeStatus.UNKNOWN)
+    link = base_store.relate_sample(test_analysis.case, test_sample, PhenotypeStatus.UNKNOWN)
     base_store.session.add(link)
 
     # WHEN getting cases to analyse
@@ -70,7 +70,7 @@ def test_get_cases_with_samples_query(
     )
 
     # GIVEN a database with a case with one of one sequenced samples and completed analysis
-    link = base_store.relate_sample(test_analysis.family, test_sample, PhenotypeStatus.UNKNOWN)
+    link = base_store.relate_sample(test_analysis.case, test_sample, PhenotypeStatus.UNKNOWN)
     base_store.session.add(link)
 
     # WHEN getting the stored case with its associated samples
@@ -146,10 +146,10 @@ def test_external_sample_to_re_analyse(
     assert test_analysis.completed_at
 
     # Given an action set to analyze
-    test_analysis.family.action: str = CaseActions.ANALYZE
+    test_analysis.case.action: str = CaseActions.ANALYZE
 
     # GIVEN a database with a case with one not sequenced external sample
-    link = base_store.relate_sample(test_analysis.family, test_sample, PhenotypeStatus.UNKNOWN)
+    link = base_store.relate_sample(test_analysis.case, test_sample, PhenotypeStatus.UNKNOWN)
     base_store.session.add(link)
 
     # WHEN getting cases to analyse
@@ -159,7 +159,7 @@ def test_external_sample_to_re_analyse(
     assert cases
 
     # THEN test case should be among the cases returned for analysis
-    assert test_analysis.family in cases
+    assert test_analysis.case in cases
 
 
 def test_new_external_case_not_in_result(base_store: Store, helpers: StoreHelpers):
@@ -195,10 +195,10 @@ def test_case_to_re_analyse(base_store: Store, helpers: StoreHelpers, timestamp_
     )
 
     # Given an action set to analyze
-    test_analysis.family.action: str = CaseActions.ANALYZE
+    test_analysis.case.action: str = CaseActions.ANALYZE
 
     # GIVEN a database with a case with one of one sequenced samples and completed analysis
-    link = base_store.relate_sample(test_analysis.family, test_sample, PhenotypeStatus.UNKNOWN)
+    link = base_store.relate_sample(test_analysis.case, test_sample, PhenotypeStatus.UNKNOWN)
     base_store.session.add(link)
 
     # WHEN getting cases to analyse
@@ -208,7 +208,7 @@ def test_case_to_re_analyse(base_store: Store, helpers: StoreHelpers, timestamp_
     assert cases
 
     # THEN test case should be among the cases returned for analysis
-    assert test_analysis.family in cases
+    assert test_analysis.case in cases
 
 
 def test_all_samples_and_analysis_completed(
@@ -224,10 +224,10 @@ def test_all_samples_and_analysis_completed(
     test_analysis: Analysis = helpers.add_analysis(base_store, completed_at=timestamp_now)
 
     # Given a completed analysis
-    test_analysis.family.action: Union[None, str] = None
+    test_analysis.case.action: Union[None, str] = None
 
     # GIVEN a database with a case with one of one sequenced samples and completed analysis
-    link = base_store.relate_sample(test_analysis.family, test_sample, PhenotypeStatus.UNKNOWN)
+    link = base_store.relate_sample(test_analysis.case, test_sample, PhenotypeStatus.UNKNOWN)
     base_store.session.add(link)
 
     # WHEN getting cases to analyse
@@ -363,7 +363,7 @@ def test_get_analyses_for_case_and_pipeline_before(
     # THEN assert that the analyses before the given date are returned
     for analysis in analyses:
         assert analysis.started_at < timestamp_now
-        assert analysis.family.internal_id == case_id
+        assert analysis.case.internal_id == case_id
         assert analysis.pipeline == pipeline
 
 
@@ -387,7 +387,7 @@ def test_get_analyses_for_case_before(
     # THEN assert that the analyses before the given date are returned
     for analysis in analyses:
         assert analysis.started_at < timestamp_now
-        assert analysis.family.internal_id == case_id
+        assert analysis.case.internal_id == case_id
 
 
 def test_get_analyses_for_pipeline_before(

--- a/tests/store/api/status/test_store_api_status_cases.py
+++ b/tests/store/api/status/test_store_api_status_cases.py
@@ -159,7 +159,7 @@ def test_case_action(base_store: Store, helpers):
     analysis = helpers.add_analysis(
         base_store, completed_at=datetime.now(), uploaded_at=datetime.now()
     )
-    analysis.family.action = "analyze"
+    analysis.case.action = "analyze"
 
     # WHEN getting active cases
     cases = base_store.cases()
@@ -167,7 +167,7 @@ def test_case_action(base_store: Store, helpers):
     # THEN cases should contain info on analysis (case) action
     assert cases
     for case in cases:
-        assert case.get("case_action") == analysis.family.action
+        assert case.get("case_action") == analysis.case.action
 
 
 def test_analysis_dates_for_rerun(base_store: Store, helpers):
@@ -177,7 +177,7 @@ def test_analysis_dates_for_rerun(base_store: Store, helpers):
     analysis = helpers.add_analysis(
         base_store, completed_at=datetime.now(), uploaded_at=datetime.now()
     )
-    analysis.family.action = "analyze"
+    analysis.case.action = "analyze"
 
     # WHEN getting active cases
     cases = base_store.cases()

--- a/tests/store/api/test_base.py
+++ b/tests/store/api/test_base.py
@@ -30,7 +30,7 @@ def test_get_latest_analyses_for_cases_query(
     )
     sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
     link: FamilySample = analysis_store.relate_sample(
-        family=analysis_oldest.family, sample=sample, status=PhenotypeStatus.UNKNOWN
+        family=analysis_oldest.case, sample=sample, status=PhenotypeStatus.UNKNOWN
     )
     analysis_store.session.add(link)
 

--- a/tests/store/conftest.py
+++ b/tests/store/conftest.py
@@ -446,7 +446,7 @@ def store_with_analyses_for_cases(
         )
         sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
         link: FamilySample = analysis_store.relate_sample(
-            family=oldest_analysis.family, sample=sample, status=PhenotypeStatus.UNKNOWN
+            family=oldest_analysis.case, sample=sample, status=PhenotypeStatus.UNKNOWN
         )
         analysis_store.session.add(link)
     return analysis_store

--- a/tests/store/filters/test_status_analyses_filters.py
+++ b/tests/store/filters/test_status_analyses_filters.py
@@ -249,7 +249,7 @@ def test_filter_analysis_by_case(base_store: Store, helpers: StoreHelpers, case:
     # THEN only the analysis belonging to the case should be retrieved
     assert analysis not in analyses
     assert analysis_other_case in analyses
-    assert analysis_other_case.family == case
+    assert analysis_other_case.case == case
 
 
 def test_filter_analysis_started_before(
@@ -262,7 +262,7 @@ def test_filter_analysis_started_before(
         store=base_store, started_at=timestamp_now - timedelta(days=1)
     )
     analysis: Analysis = helpers.add_analysis(
-        store=base_store, started_at=timestamp_now, case=analysis_old.family
+        store=base_store, started_at=timestamp_now, case=analysis_old.case
     )
 
     # WHEN filtering the analyses by started_at
@@ -286,7 +286,7 @@ def test_filter_analysis_not_cleaned(
     # GIVEN a set of mock analyses
     analysis_cleaned: Analysis = helpers.add_analysis(store=base_store, cleaned_at=timestamp_now)
     analysis: Analysis = helpers.add_analysis(
-        store=base_store, cleaned_at=None, case=analysis_cleaned.family
+        store=base_store, cleaned_at=None, case=analysis_cleaned.case
     )
 
     # WHEN filtering the analyses by cleaned_at
@@ -312,7 +312,7 @@ def test_filter_analyses_by_started_at(
     analysis_started_old: Analysis = helpers.add_analysis(
         store=base_store,
         started_at=timestamp_yesterday,
-        case=analysis_started_now.family,
+        case=analysis_started_now.case,
     )
 
     # WHEN filtering the analyses by started_at

--- a/tests/store/filters/test_status_case_sample_filters.py
+++ b/tests/store/filters/test_status_case_sample_filters.py
@@ -24,7 +24,7 @@ def test_get_samples_in_case_by_internal_id_valid_id(
     assert 0 < filtered_query.count() < case_sample_query.count()
     # THEN the case_samples in the filtered query have the correct case internal id
     for case_sample in filtered_query.all():
-        assert case_sample.family.internal_id == case_id
+        assert case_sample.case.internal_id == case_id
 
 
 def test_get_samples_in_case_by_internal_id_nonexistent_id(

--- a/tests/store/filters/test_status_cases_filters.py
+++ b/tests/store/filters/test_status_cases_filters.py
@@ -301,10 +301,10 @@ def test_filter_cases_for_analysis(
     )
 
     # Given an action set to analyze
-    test_analysis.family.action: str = CaseActions.ANALYZE
+    test_analysis.case.action: str = CaseActions.ANALYZE
 
     # GIVEN a database with a case with one sequenced samples for specified analysis
-    link = base_store.relate_sample(test_analysis.family, test_sample, PhenotypeStatus.UNKNOWN)
+    link = base_store.relate_sample(test_analysis.case, test_sample, PhenotypeStatus.UNKNOWN)
     base_store.session.add(link)
 
     # GIVEN a cases Query
@@ -367,10 +367,10 @@ def test_filter_cases_for_analysis_when_cases_with_no_action_and_new_sequence_da
     test_analysis: Analysis = helpers.add_analysis(base_store, pipeline=Pipeline.MIP_DNA)
 
     # Given an action set to None
-    test_analysis.family.action: Union[None, str] = None
+    test_analysis.case.action: Union[None, str] = None
 
     # GIVEN a database with a case with one sequenced samples for specified analysis
-    link = base_store.relate_sample(test_analysis.family, test_sample, PhenotypeStatus.UNKNOWN)
+    link = base_store.relate_sample(test_analysis.case, test_sample, PhenotypeStatus.UNKNOWN)
     base_store.session.add(link)
 
     # GIVEN an old analysis
@@ -403,10 +403,10 @@ def test_filter_cases_for_analysis_when_cases_with_no_action_and_old_sequence_da
     test_analysis: Analysis = helpers.add_analysis(base_store, pipeline=Pipeline.MIP_DNA)
 
     # Given an action set to None
-    test_analysis.family.action: Union[None, str] = None
+    test_analysis.case.action: Union[None, str] = None
 
     # GIVEN a database with a case with one sequenced samples for specified analysis
-    link = base_store.relate_sample(test_analysis.family, test_sample, PhenotypeStatus.UNKNOWN)
+    link = base_store.relate_sample(test_analysis.case, test_sample, PhenotypeStatus.UNKNOWN)
     base_store.session.add(link)
 
     # GIVEN a cases Query

--- a/tests/store_helpers.py
+++ b/tests/store_helpers.py
@@ -315,7 +315,7 @@ class StoreHelpers:
             analysis.uploaded_to_vogue_at = uploaded_to_vogue_at
 
         analysis.limitations = "A limitation"
-        analysis.family = case
+        analysis.case = case
         store.session.add(analysis)
         store.session.commit()
         return analysis

--- a/tests/utils/test_dispatcher.py
+++ b/tests/utils/test_dispatcher.py
@@ -199,6 +199,6 @@ def test_dispatcher_on_other_functions(
     # THEN the dispatcher should return the correct analyses
     for analysis in analyses:
         assert analysis
-        assert analysis.family.internal_id == case_internal_id
+        assert analysis.case.internal_id == case_internal_id
         assert analysis.pipeline == pipeline
         assert analysis.started_at < timestamp_now


### PR DESCRIPTION
## Description
This PR renames all SQLAlchemy relationships named `family` to `case`. It is not necessary to reflect these changes with a revision since the relationships are defined in the Python code.

The changes were made by renaming the fields in the `models.py` file - so probably easier to understand the changes if you start with that file.

### Fixed
- Rename all model relationships called family to case

### How to test
- [x] Do ensure that the views work as expected

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

