### PR TITLE
Rename family sample

### DIFF
--- a/cg/apps/downsample/downsample.py
+++ b/cg/apps/downsample/downsample.py
@@ -8,7 +8,7 @@ from cg.meta.meta import MetaAPI
 from cg.meta.workflow.downsample.downsample import DownsampleWorkflow
 from cg.models.cg_config import CGConfig
 from cg.models.downsample.downsample_data import DownsampleData
-from cg.store.models import Case, FamilySample, Sample
+from cg.store.models import Case, CaseSample, Sample
 from cg.utils.calculations import multiply_by_million
 
 LOG = logging.getLogger(__name__)
@@ -80,7 +80,7 @@ class DownsampleAPI(MetaAPI):
         self, downsample_data: DownsampleData, sample: Sample, case: Case
     ) -> None:
         """Create a link between sample and case in statusDB."""
-        sample_case_link: FamilySample = self.status_db.relate_sample(
+        sample_case_link: CaseSample = self.status_db.relate_sample(
             family=case,
             sample=sample,
             status=downsample_data.get_sample_status(),

--- a/cg/apps/downsample/downsample.py
+++ b/cg/apps/downsample/downsample.py
@@ -81,7 +81,7 @@ class DownsampleAPI(MetaAPI):
     ) -> None:
         """Create a link between sample and case in statusDB."""
         sample_case_link: CaseSample = self.status_db.relate_sample(
-            family=case,
+            case=case,
             sample=sample,
             status=downsample_data.get_sample_status(),
         )

--- a/cg/cli/add.py
+++ b/cg/cli/add.py
@@ -321,7 +321,7 @@ def link_sample_to_case(
             raise click.Abort
 
     new_record: CaseSample = status_db.relate_sample(
-        family=case_obj, sample=sample, status=status, mother=mother, father=father
+        case=case_obj, sample=sample, status=status, mother=mother, father=father
     )
     status_db.session.add(new_record)
     status_db.session.commit()

--- a/cg/cli/add.py
+++ b/cg/cli/add.py
@@ -14,7 +14,7 @@ from cg.store.models import (
     Collaboration,
     Customer,
     Case,
-    FamilySample,
+    CaseSample,
     Panel,
     Sample,
     User,
@@ -320,7 +320,7 @@ def link_sample_to_case(
             LOG.error("%s: father not found", father_id)
             raise click.Abort
 
-    new_record: FamilySample = status_db.relate_sample(
+    new_record: CaseSample = status_db.relate_sample(
         family=case_obj, sample=sample, status=status, mother=mother, father=father
     )
     status_db.session.add(new_record)

--- a/cg/meta/deliver.py
+++ b/cg/meta/deliver.py
@@ -13,7 +13,7 @@ from cg.constants import delivery as constants
 from cg.constants.constants import DataDelivery
 from cg.exc import MissingFilesError
 from cg.store import Store
-from cg.store.models import Case, FamilySample, Sample
+from cg.store.models import Case, CaseSample, Sample
 
 LOG = logging.getLogger(__name__)
 
@@ -77,7 +77,7 @@ class DeliverAPI:
                 LOG.info(f"Could not find any version for {case_id}")
             elif not self.skip_missing_bundle:
                 raise SyntaxError(f"Could not find any version for {case_id}")
-        links: list[FamilySample] = self.store.get_case_samples_by_case_id(case_internal_id=case_id)
+        links: list[CaseSample] = self.store.get_case_samples_by_case_id(case_internal_id=case_id)
         if not links:
             LOG.warning(f"Could not find any samples linked to case {case_id}")
             return
@@ -98,7 +98,7 @@ class DeliverAPI:
         if not self.sample_tags:
             return
 
-        link: FamilySample
+        link: CaseSample
         for link in links:
             if link.sample.sequencing_qc or self.deliver_failed_samples:
                 sample_id: str = link.sample.internal_id

--- a/cg/meta/orders/case_submitter.py
+++ b/cg/meta/orders/case_submitter.py
@@ -311,7 +311,7 @@ class CaseSubmitter(Submitter):
 
     def _create_link(self, case_obj, family_samples, father_obj, mother_obj, sample):
         link_obj = self.status.relate_sample(
-            family=case_obj,
+            case=case_obj,
             sample=family_samples[sample["name"]],
             status=sample["status"],
             mother=mother_obj,

--- a/cg/meta/orders/case_submitter.py
+++ b/cg/meta/orders/case_submitter.py
@@ -9,7 +9,7 @@ from cg.meta.orders.lims import process_lims
 from cg.meta.orders.submitter import Submitter
 from cg.models.orders.order import OrderIn
 from cg.models.orders.samples import Of1508Sample, OrderInSample
-from cg.store.models import ApplicationVersion, Customer, Case, FamilySample, Sample
+from cg.store.models import ApplicationVersion, Customer, Case, CaseSample, Sample
 
 LOG = logging.getLogger(__name__)
 
@@ -265,12 +265,12 @@ class CaseSubmitter(Submitter):
                 sample_mother: Sample = case_samples.get(sample.get(Pedigree.MOTHER))
                 sample_father: Sample = case_samples.get(sample.get(Pedigree.FATHER))
                 with self.status.session.no_autoflush:
-                    case_sample: FamilySample = self.status.get_case_sample_link(
+                    case_sample: CaseSample = self.status.get_case_sample_link(
                         case_internal_id=status_db_case.internal_id,
                         sample_internal_id=sample["internal_id"],
                     )
                 if not case_sample:
-                    case_sample: FamilySample = self._create_link(
+                    case_sample: CaseSample = self._create_link(
                         case_obj=status_db_case,
                         family_samples=case_samples,
                         father_obj=sample_father,

--- a/cg/meta/orders/fastq_submitter.py
+++ b/cg/meta/orders/fastq_submitter.py
@@ -69,7 +69,7 @@ class FastqSubmitter(Submitter):
             customer_internal_id=CustomerNames.CG_INTERNAL_CUSTOMER
         )
         relationship: CaseSample = self.status.relate_sample(
-            family=case, sample=sample_obj, status=StatusEnum.unknown
+            case=case, sample=sample_obj, status=StatusEnum.unknown
         )
         self.status.session.add_all([case, relationship])
 
@@ -126,7 +126,7 @@ class FastqSubmitter(Submitter):
                     self.create_maf_case(sample_obj=new_sample)
                 case.customer = customer
                 new_relationship = self.status.relate_sample(
-                    family=case, sample=new_sample, status=StatusEnum.unknown
+                    case=case, sample=new_sample, status=StatusEnum.unknown
                 )
                 new_delivery = self.status.add_delivery(destination="caesar", sample=new_sample)
                 self.status.session.add_all([case, new_relationship, new_delivery])

--- a/cg/meta/orders/fastq_submitter.py
+++ b/cg/meta/orders/fastq_submitter.py
@@ -9,7 +9,7 @@ from cg.meta.orders.lims import process_lims
 from cg.meta.orders.submitter import Submitter
 from cg.models.orders.order import OrderIn
 from cg.models.orders.sample_base import StatusEnum
-from cg.store.models import ApplicationVersion, Customer, Case, FamilySample, Sample
+from cg.store.models import ApplicationVersion, Customer, Case, CaseSample, Sample
 
 
 class FastqSubmitter(Submitter):
@@ -68,7 +68,7 @@ class FastqSubmitter(Submitter):
         case.customer = self.status.get_customer_by_internal_id(
             customer_internal_id=CustomerNames.CG_INTERNAL_CUSTOMER
         )
-        relationship: FamilySample = self.status.relate_sample(
+        relationship: CaseSample = self.status.relate_sample(
             family=case, sample=sample_obj, status=StatusEnum.unknown
         )
         self.status.session.add_all([case, relationship])

--- a/cg/meta/orders/metagenome_submitter.py
+++ b/cg/meta/orders/metagenome_submitter.py
@@ -8,7 +8,7 @@ from cg.meta.orders.submitter import Submitter
 from cg.models.orders.order import OrderIn
 from cg.models.orders.sample_base import StatusEnum
 from cg.models.orders.samples import MetagenomeSample
-from cg.store.models import ApplicationVersion, Customer, Case, FamilySample, Sample
+from cg.store.models import ApplicationVersion, Customer, Case, CaseSample, Sample
 
 
 class MetagenomeSubmitter(Submitter):
@@ -128,7 +128,7 @@ class MetagenomeSubmitter(Submitter):
                     self.status.session.add(case)
                     self.status.session.commit()
 
-                new_relationship: FamilySample = self.status.relate_sample(
+                new_relationship: CaseSample = self.status.relate_sample(
                     family=case, sample=new_sample, status=StatusEnum.unknown
                 )
                 self.status.session.add(new_relationship)

--- a/cg/meta/orders/metagenome_submitter.py
+++ b/cg/meta/orders/metagenome_submitter.py
@@ -129,7 +129,7 @@ class MetagenomeSubmitter(Submitter):
                     self.status.session.commit()
 
                 new_relationship: CaseSample = self.status.relate_sample(
-                    family=case, sample=new_sample, status=StatusEnum.unknown
+                    case=case, sample=new_sample, status=StatusEnum.unknown
                 )
                 self.status.session.add(new_relationship)
 

--- a/cg/meta/orders/microbial_submitter.py
+++ b/cg/meta/orders/microbial_submitter.py
@@ -145,7 +145,7 @@ class MicrobialSubmitter(Submitter):
                 priority = new_sample.priority
                 sample_objs.append(new_sample)
                 link: CaseSample = self.status.relate_sample(
-                    family=case, sample=new_sample, status="unknown"
+                    case=case, sample=new_sample, status="unknown"
                 )
                 self.status.session.add(link)
                 new_samples.append(new_sample)

--- a/cg/meta/orders/microbial_submitter.py
+++ b/cg/meta/orders/microbial_submitter.py
@@ -10,7 +10,7 @@ from cg.store.models import (
     ApplicationVersion,
     Customer,
     Case,
-    FamilySample,
+    CaseSample,
     Organism,
     Sample,
 )
@@ -144,7 +144,7 @@ class MicrobialSubmitter(Submitter):
 
                 priority = new_sample.priority
                 sample_objs.append(new_sample)
-                link: FamilySample = self.status.relate_sample(
+                link: CaseSample = self.status.relate_sample(
                     family=case, sample=new_sample, status="unknown"
                 )
                 self.status.session.add(link)

--- a/cg/meta/orders/pool_submitter.py
+++ b/cg/meta/orders/pool_submitter.py
@@ -169,7 +169,7 @@ class PoolSubmitter(Submitter):
                 )
                 new_samples.append(new_sample)
                 link: CaseSample = self.status.relate_sample(
-                    family=case, sample=new_sample, status="unknown"
+                    case=case, sample=new_sample, status="unknown"
                 )
                 self.status.session.add(link)
             new_delivery = self.status.add_delivery(destination="caesar", pool=new_pool)

--- a/cg/meta/orders/pool_submitter.py
+++ b/cg/meta/orders/pool_submitter.py
@@ -12,7 +12,7 @@ from cg.store.models import (
     ApplicationVersion,
     Customer,
     Case,
-    FamilySample,
+    CaseSample,
     Pool,
     Sample,
 )
@@ -168,7 +168,7 @@ class PoolSubmitter(Submitter):
                     no_invoice=True,
                 )
                 new_samples.append(new_sample)
-                link: FamilySample = self.status.relate_sample(
+                link: CaseSample = self.status.relate_sample(
                     family=case, sample=new_sample, status="unknown"
                 )
                 self.status.session.add(link)

--- a/cg/meta/report/report_api.py
+++ b/cg/meta/report/report_api.py
@@ -33,7 +33,7 @@ from cg.store.models import (
     Application,
     ApplicationLimitations,
     Case,
-    FamilySample,
+    CaseSample,
     Sample,
 )
 
@@ -228,7 +228,7 @@ class ReportAPI(MetaAPI):
     def get_samples_data(self, case: Case, analysis_metadata: AnalysisModel) -> list[SampleModel]:
         """Extracts all the samples associated to a specific case and their attributes."""
         samples = list()
-        case_samples: list[FamilySample] = self.status_db.get_case_samples_by_case_id(
+        case_samples: list[CaseSample] = self.status_db.get_case_samples_by_case_id(
             case_internal_id=case.internal_id
         )
         for case_sample in case_samples:

--- a/cg/meta/upload/scout/balsamic_config_builder.py
+++ b/cg/meta/upload/scout/balsamic_config_builder.py
@@ -10,7 +10,7 @@ from cg.meta.upload.scout.hk_tags import CaseTags, SampleTags
 from cg.meta.upload.scout.scout_config_builder import ScoutConfigBuilder
 from cg.meta.workflow.balsamic import BalsamicAnalysisAPI
 from cg.models.scout.scout_load_config import BalsamicLoadConfig, ScoutCancerIndividual
-from cg.store.models import Analysis, FamilySample, Sample
+from cg.store.models import Analysis, CaseSample, Sample
 
 LOG = logging.getLogger(__name__)
 
@@ -50,7 +50,7 @@ class BalsamicConfigBuilder(ScoutConfigBuilder):
             hk_tags=self.sample_tags.vcf2cytosure, sample_id=sample_id
         )
 
-    def build_config_sample(self, case_sample: FamilySample) -> ScoutCancerIndividual:
+    def build_config_sample(self, case_sample: CaseSample) -> ScoutCancerIndividual:
         """Build a sample with balsamic specific information."""
         config_sample = ScoutCancerIndividual()
         self.add_common_sample_info(config_sample=config_sample, case_sample=case_sample)
@@ -91,7 +91,7 @@ class BalsamicConfigBuilder(ScoutConfigBuilder):
         self.include_case_files()
 
         LOG.info("Building samples")
-        db_sample: FamilySample
+        db_sample: CaseSample
 
         for db_sample in self.analysis_obj.case.links:
             self.load_config.samples.append(self.build_config_sample(case_sample=db_sample))

--- a/cg/meta/upload/scout/mip_config_builder.py
+++ b/cg/meta/upload/scout/mip_config_builder.py
@@ -18,7 +18,7 @@ from cg.models.scout.scout_load_config import (
     ScoutLoadConfig,
     ScoutMipIndividual,
 )
-from cg.store.models import Analysis, Case, FamilySample
+from cg.store.models import Analysis, Case, CaseSample
 
 LOG = logging.getLogger(__name__)
 
@@ -67,7 +67,7 @@ class MipConfigBuilder(ScoutConfigBuilder):
         self.include_case_files()
 
         LOG.info("Building samples")
-        db_sample: FamilySample
+        db_sample: CaseSample
         for db_sample in self.analysis_obj.case.links:
             self.load_config.samples.append(self.build_config_sample(case_sample=db_sample))
         self.include_pedigree_picture()
@@ -82,7 +82,7 @@ class MipConfigBuilder(ScoutConfigBuilder):
         else:
             LOG.info("family of 1 sample - skip pedigree graph")
 
-    def build_config_sample(self, case_sample: FamilySample) -> ScoutMipIndividual:
+    def build_config_sample(self, case_sample: CaseSample) -> ScoutMipIndividual:
         """Build a sample with mip specific information"""
 
         config_sample = ScoutMipIndividual()

--- a/cg/meta/upload/scout/rnafusion_config_builder.py
+++ b/cg/meta/upload/scout/rnafusion_config_builder.py
@@ -12,7 +12,7 @@ from cg.constants.scout_upload import (
 from cg.meta.upload.scout.hk_tags import CaseTags, SampleTags
 from cg.meta.upload.scout.scout_config_builder import ScoutConfigBuilder
 from cg.models.scout.scout_load_config import RnafusionLoadConfig, ScoutCancerIndividual
-from cg.store.models import Analysis, FamilySample
+from cg.store.models import Analysis, CaseSample
 
 LOG = logging.getLogger(__name__)
 
@@ -36,7 +36,7 @@ class RnafusionConfigBuilder(ScoutConfigBuilder):
         self.include_case_files()
 
         LOG.info("Building samples")
-        db_sample: FamilySample
+        db_sample: CaseSample
 
         for db_sample in self.analysis_obj.case.links:
             self.load_config.samples.append(self.build_config_sample(case_sample=db_sample))
@@ -56,7 +56,7 @@ class RnafusionConfigBuilder(ScoutConfigBuilder):
             self.get_file_from_hk(getattr(self.case_tags, scout_key)),
         )
 
-    def build_config_sample(self, case_sample: FamilySample) -> ScoutCancerIndividual:
+    def build_config_sample(self, case_sample: CaseSample) -> ScoutCancerIndividual:
         """Build a sample with rnafusion specific information."""
         config_sample = ScoutCancerIndividual()
 

--- a/cg/meta/upload/scout/scout_config_builder.py
+++ b/cg/meta/upload/scout/scout_config_builder.py
@@ -9,7 +9,7 @@ from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.apps.lims import LimsAPI
 from cg.meta.upload.scout.hk_tags import CaseTags, SampleTags
 from cg.models.scout.scout_load_config import ScoutIndividual, ScoutLoadConfig
-from cg.store.models import Analysis, FamilySample, Sample
+from cg.store.models import Analysis, CaseSample, Sample
 
 LOG = logging.getLogger(__name__)
 
@@ -40,7 +40,7 @@ class ScoutConfigBuilder:
         self.include_phenotype_terms()
 
     def add_common_sample_info(
-        self, config_sample: ScoutIndividual, case_sample: FamilySample
+        self, config_sample: ScoutIndividual, case_sample: CaseSample
     ) -> None:
         """Add the information to a sample that is common for different analysis types"""
         sample_id: str = case_sample.sample.internal_id
@@ -64,7 +64,7 @@ class ScoutConfigBuilder:
     def add_common_sample_files(
         self,
         config_sample: ScoutIndividual,
-        case_sample: FamilySample,
+        case_sample: CaseSample,
     ) -> None:
         """Add common sample files for different analysis types."""
         sample_id: str = case_sample.sample.internal_id
@@ -72,7 +72,7 @@ class ScoutConfigBuilder:
         self.include_sample_alignment_file(config_sample=config_sample)
         self.include_sample_files(config_sample=config_sample)
 
-    def build_config_sample(self, case_sample: FamilySample) -> ScoutIndividual:
+    def build_config_sample(self, case_sample: CaseSample) -> ScoutIndividual:
         """Build a sample for the scout load config"""
         raise NotImplementedError
 
@@ -91,7 +91,7 @@ class ScoutConfigBuilder:
     def include_phenotype_terms(self) -> None:
         LOG.info("Adding phenotype terms to scout load config")
         phenotype_terms: set[str] = set()
-        link_obj: FamilySample
+        link_obj: CaseSample
         for link_obj in self.analysis_obj.case.links:
             sample_obj: Sample = link_obj.sample
             for phenotype_term in sample_obj.phenotype_terms:
@@ -107,7 +107,7 @@ class ScoutConfigBuilder:
     def include_phenotype_groups(self) -> None:
         LOG.info("Adding phenotype groups to scout load config")
         phenotype_groups: set[str] = set()
-        link_obj: FamilySample
+        link_obj: CaseSample
         for link_obj in self.analysis_obj.case.links:
             sample_obj: Sample = link_obj.sample
             for phenotype_group in sample_obj.phenotype_groups:

--- a/cg/meta/workflow/analysis.py
+++ b/cg/meta/workflow/analysis.py
@@ -18,7 +18,7 @@ from cg.meta.meta import MetaAPI
 from cg.meta.workflow.fastq import FastqHandler
 from cg.models.analysis import AnalysisModel
 from cg.models.cg_config import CGConfig
-from cg.store.models import Analysis, BedVersion, Case, FamilySample, Sample
+from cg.store.models import Analysis, BedVersion, Case, CaseSample, Sample
 
 LOG = logging.getLogger(__name__)
 
@@ -379,7 +379,7 @@ class AnalysisAPI(MetaAPI):
             self.decompression_running(case_id=case_id)
             return
         case_obj: Case = self.status_db.get_case_by_internal_id(internal_id=case_id)
-        link: FamilySample
+        link: CaseSample
         any_decompression_started = False
         for link in case_obj.links:
             sample_id: str = link.sample.internal_id

--- a/cg/meta/workflow/balsamic.py
+++ b/cg/meta/workflow/balsamic.py
@@ -25,7 +25,7 @@ from cg.models.balsamic.metrics import (
     BalsamicWGSQCMetrics,
 )
 from cg.models.cg_config import CGConfig
-from cg.store.models import Case, FamilySample, Sample
+from cg.store.models import Case, CaseSample, Sample
 from cg.utils import Process
 from cg.utils.utils import build_command_from_dict, get_string_from_list_by_pattern
 
@@ -154,7 +154,7 @@ class BalsamicAnalysisAPI(AnalysisAPI):
                 case_obj=case_obj, sample_obj=link.sample, concatenate=True
             )
 
-    def get_concatenated_fastq_path(self, link_object: FamilySample) -> Path:
+    def get_concatenated_fastq_path(self, link_object: CaseSample) -> Path:
         """Returns path to the concatenated FASTQ file of a sample"""
         file_collection: list[dict] = self.gather_file_metadata_for_sample(link_object.sample)
         fastq_data = file_collection[0]
@@ -538,7 +538,7 @@ class BalsamicAnalysisAPI(AnalysisAPI):
             return application_types.pop().lower()
 
     def resolve_target_bed(
-        self, panel_bed: Optional[str], link_object: FamilySample
+        self, panel_bed: Optional[str], link_object: CaseSample
     ) -> Optional[str]:
         if panel_bed:
             return panel_bed

--- a/cg/meta/workflow/mip.py
+++ b/cg/meta/workflow/mip.py
@@ -23,7 +23,7 @@ from cg.models.mip.mip_analysis import MipAnalysis
 from cg.models.mip.mip_config import MipBaseConfig
 from cg.models.mip.mip_metrics_deliverables import MIPMetricsDeliverables
 from cg.models.mip.mip_sample_info import MipBaseSampleInfo
-from cg.store.models import BedVersion, Case, FamilySample, Sample
+from cg.store.models import BedVersion, Case, CaseSample, Sample
 
 CLI_OPTIONS = {
     "config": {"option": "--config_file"},
@@ -127,7 +127,7 @@ class MipAnalysisAPI(AnalysisAPI):
         LOG.info("Config file saved to %s", pedigree_config_path)
 
     @staticmethod
-    def get_sample_data(link_obj: FamilySample) -> dict[str, Union[str, int]]:
+    def get_sample_data(link_obj: CaseSample) -> dict[str, Union[str, int]]:
         """Return sample specific data."""
         return {
             "sample_id": link_obj.sample.internal_id,
@@ -335,7 +335,7 @@ class MipAnalysisAPI(AnalysisAPI):
     def get_trailblazer_config_path(self, case_id: str) -> Path:
         return Path(self.get_case_path(case_id=case_id), "analysis", "slurm_job_ids.yaml")
 
-    def config_sample(self, link_obj: FamilySample, panel_bed: str) -> dict:
+    def config_sample(self, link_obj: CaseSample, panel_bed: str) -> dict:
         raise NotImplementedError
 
     def get_pipeline_version(self, case_id: str) -> str:

--- a/cg/meta/workflow/mip_dna.py
+++ b/cg/meta/workflow/mip_dna.py
@@ -6,7 +6,7 @@ from cg.constants.gene_panel import GENOME_BUILD_37
 from cg.constants.pedigree import Pedigree
 from cg.meta.workflow.mip import MipAnalysisAPI
 from cg.models.cg_config import CGConfig
-from cg.store.models import Case, FamilySample
+from cg.store.models import Case, CaseSample
 from cg.utils import Process
 
 
@@ -50,7 +50,7 @@ class MipDNAAnalysisAPI(MipAnalysisAPI):
         return self._process
 
     def config_sample(
-        self, link_obj: FamilySample, panel_bed: Optional[str]
+        self, link_obj: CaseSample, panel_bed: Optional[str]
     ) -> dict[str, Union[str, int, None]]:
         """Return config sample data."""
         sample_data: dict[str, Union[str, int]] = self.get_sample_data(link_obj=link_obj)

--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -40,7 +40,7 @@ def view_family_sample_link(unused1, unused2, model, unused3):
 
     return Markup(
         "<a href='%s'>%s</a>"
-        % (url_for("familysample.index_view", search=model.internal_id), model.internal_id)
+        % (url_for("casesample.index_view", search=model.internal_id), model.internal_id)
     )
 
 
@@ -563,7 +563,7 @@ class DeliveryView(BaseView):
     edit_modal = True
 
 
-class FamilySampleView(BaseView):
+class CaseSampleView(BaseView):
     """Admin view for Model.caseSample"""
 
     column_default_sort = ("created_at", True)

--- a/cg/server/app.py
+++ b/cg/server/app.py
@@ -20,7 +20,7 @@ from cg.store.models import (
     Customer,
     Delivery,
     Case,
-    FamilySample,
+    CaseSample,
     Flowcell,
     Invoice,
     Organism,
@@ -122,7 +122,7 @@ def _register_admin_views():
 
     # Business data views
     ext.admin.add_view(admin.CaseView(Case, ext.db.session))
-    ext.admin.add_view(admin.FamilySampleView(FamilySample, ext.db.session))
+    ext.admin.add_view(admin.FamilySampleView(CaseSample, ext.db.session))
     ext.admin.add_view(admin.SampleView(Sample, ext.db.session))
     ext.admin.add_view(admin.PoolView(Pool, ext.db.session))
     ext.admin.add_view(admin.FlowcellView(Flowcell, ext.db.session))

--- a/cg/server/app.py
+++ b/cg/server/app.py
@@ -122,7 +122,7 @@ def _register_admin_views():
 
     # Business data views
     ext.admin.add_view(admin.CaseView(Case, ext.db.session))
-    ext.admin.add_view(admin.FamilySampleView(CaseSample, ext.db.session))
+    ext.admin.add_view(admin.CaseSampleView(CaseSample, ext.db.session))
     ext.admin.add_view(admin.SampleView(Sample, ext.db.session))
     ext.admin.add_view(admin.PoolView(Pool, ext.db.session))
     ext.admin.add_view(admin.FlowcellView(Flowcell, ext.db.session))

--- a/cg/store/api/add.py
+++ b/cg/store/api/add.py
@@ -226,7 +226,7 @@ class AddHandler(BaseHandler):
 
     def relate_sample(
         self,
-        family: Case,
+        case: Case,
         sample: Sample,
         status: str,
         mother: Sample = None,
@@ -235,7 +235,7 @@ class AddHandler(BaseHandler):
         """Relate a sample record to a family record."""
 
         new_record: CaseSample = CaseSample(status=status)
-        new_record.case = family
+        new_record.case = case
         new_record.sample = sample
         new_record.mother = mother
         new_record.father = father

--- a/cg/store/api/add.py
+++ b/cg/store/api/add.py
@@ -17,7 +17,7 @@ from cg.store.models import (
     Customer,
     Delivery,
     Case,
-    FamilySample,
+    CaseSample,
     Flowcell,
     Invoice,
     Organism,
@@ -231,10 +231,10 @@ class AddHandler(BaseHandler):
         status: str,
         mother: Sample = None,
         father: Sample = None,
-    ) -> FamilySample:
+    ) -> CaseSample:
         """Relate a sample record to a family record."""
 
-        new_record: FamilySample = FamilySample(status=status)
+        new_record: CaseSample = CaseSample(status=status)
         new_record.case = family
         new_record.sample = sample
         new_record.mother = mother

--- a/cg/store/api/base.py
+++ b/cg/store/api/base.py
@@ -48,10 +48,7 @@ class BaseHandler:
     def _get_join_cases_with_samples_query(self) -> Query:
         """Return a join query for all cases in the database with samples."""
         return (
-            self._get_query(table=Case)
-            .join(Case.links)
-            .join(CaseSample.sample)
-            .join(Case.customer)
+            self._get_query(table=Case).join(Case.links).join(CaseSample.sample).join(Case.customer)
         )
 
     def _get_join_analysis_case_query(self) -> Query:

--- a/cg/store/api/base.py
+++ b/cg/store/api/base.py
@@ -15,7 +15,7 @@ from cg.store.models import (
     ApplicationVersion,
     Customer,
     Case,
-    FamilySample,
+    CaseSample,
     Flowcell,
 )
 from cg.store.models import Model as ModelBase
@@ -40,7 +40,7 @@ class BaseHandler:
             self._get_query(table=Case)
             .outerjoin(Analysis)
             .join(Case.links)
-            .join(FamilySample.sample)
+            .join(CaseSample.sample)
             .join(ApplicationVersion)
             .join(Application)
         )
@@ -50,7 +50,7 @@ class BaseHandler:
         return (
             self._get_query(table=Case)
             .join(Case.links)
-            .join(FamilySample.sample)
+            .join(CaseSample.sample)
             .join(Case.customer)
         )
 
@@ -60,11 +60,11 @@ class BaseHandler:
 
     def _get_join_case_sample_query(self) -> Query:
         """Return join case sample query."""
-        return self._get_query(table=FamilySample).join(FamilySample.case).join(FamilySample.sample)
+        return self._get_query(table=CaseSample).join(CaseSample.case).join(CaseSample.sample)
 
     def _get_join_case_and_sample_query(self) -> Query:
         """Return join case sample query."""
-        return self._get_query(table=Case).join(Case.links).join(FamilySample.sample)
+        return self._get_query(table=Case).join(Case.links).join(CaseSample.sample)
 
     def _get_join_sample_and_customer_query(self) -> Query:
         """Return join sample and customer query."""
@@ -76,7 +76,7 @@ class BaseHandler:
 
     def _get_join_sample_family_query(self) -> Query:
         """Return a join sample case relationship query."""
-        return self._get_query(table=Sample).join(Case.links).join(FamilySample.sample)
+        return self._get_query(table=Sample).join(Case.links).join(CaseSample.sample)
 
     def _get_join_sample_application_version_query(self) -> Query:
         """Return join sample to application version query."""
@@ -88,7 +88,7 @@ class BaseHandler:
 
     def _get_join_analysis_sample_family_query(self) -> Query:
         """Return join analysis to sample to case query."""
-        return self._get_query(table=Analysis).join(Case).join(Case.links).join(FamilySample.sample)
+        return self._get_query(table=Analysis).join(Case).join(Case.links).join(CaseSample.sample)
 
     def _get_subquery_with_latest_case_analysis_date(self) -> Query:
         """Return a subquery with the case internal id and the date of its latest analysis."""
@@ -173,14 +173,14 @@ class BaseHandler:
 
         # sample filters
         if sample_id:
-            cases_query = cases_query.join(Case.links).join(FamilySample.sample)
+            cases_query = cases_query.join(Case.links).join(CaseSample.sample)
             cases_query = apply_sample_filter(
                 samples=cases_query,
                 filter_functions=[SampleFilter.FILTER_BY_INTERNAL_ID_PATTERN],
                 internal_id_pattern=sample_id,
             )
         else:
-            cases_query = cases_query.outerjoin(Case.links).outerjoin(FamilySample.sample)
+            cases_query = cases_query.outerjoin(Case.links).outerjoin(CaseSample.sample)
 
         # other joins
         cases_query = (

--- a/cg/store/api/find_business_data.py
+++ b/cg/store/api/find_business_data.py
@@ -29,7 +29,7 @@ from cg.store.models import (
     ApplicationLimitations,
     Customer,
     Case,
-    FamilySample,
+    CaseSample,
     Flowcell,
     Invoice,
     Pool,
@@ -231,7 +231,7 @@ class FindBusinessDataHandler(BaseHandler):
         """Return all cases."""
         return self._get_query(table=Case).all()
 
-    def get_case_samples_by_case_id(self, case_internal_id: str) -> list[FamilySample]:
+    def get_case_samples_by_case_id(self, case_internal_id: str) -> list[CaseSample]:
         """Return the case-sample links associated with a case."""
         return apply_case_sample_filter(
             filter_functions=[CaseSampleFilter.GET_SAMPLES_IN_CASE_BY_INTERNAL_ID],
@@ -528,7 +528,7 @@ class FindBusinessDataHandler(BaseHandler):
         ).all()
         return pools + samples
 
-    def get_case_sample_link(self, case_internal_id: str, sample_internal_id: str) -> FamilySample:
+    def get_case_sample_link(self, case_internal_id: str, sample_internal_id: str) -> CaseSample:
         """Return a case-sample link between a family and a sample."""
         filter_functions: list[CaseSampleFilter] = [
             CaseSampleFilter.GET_SAMPLES_IN_CASE_BY_INTERNAL_ID,

--- a/cg/store/filters/status_flow_cell_filters.py
+++ b/cg/store/filters/status_flow_cell_filters.py
@@ -3,12 +3,12 @@ from typing import Callable, Optional
 
 from sqlalchemy.orm import Query
 
-from cg.store.models import Case, FamilySample, Flowcell
+from cg.store.models import Case, CaseSample, Flowcell
 
 
 def filter_flow_cells_by_case(case: Case, flow_cells: Query, **kwargs) -> Query:
     """Return flow cells by case id."""
-    return flow_cells.filter(FamilySample.case == case)
+    return flow_cells.filter(CaseSample.case == case)
 
 
 def filter_flow_cell_by_name(flow_cells: Query, flow_cell_name: str, **kwargs) -> Query:

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -400,7 +400,7 @@ class Case(Model, PriorityMixin):
     tickets = Column(types.VARCHAR(128))
 
     analyses = orm.relationship(Analysis, back_populates="case", order_by="-Analysis.completed_at")
-    links = orm.relationship("FamilySample", back_populates="case")
+    links = orm.relationship("CaseSample", back_populates="case")
 
     @property
     def cohorts(self) -> list[str]:
@@ -515,7 +515,7 @@ class Case(Model, PriorityMixin):
         return data
 
 
-class FamilySample(Model):
+class CaseSample(Model):
     __tablename__ = "family_sample"
     __table_args__ = (UniqueConstraint("family_id", "sample_id", name="_family_sample_uc"),)
 
@@ -694,13 +694,13 @@ class Sample(Model, PriorityMixin):
     subject_id = Column(types.String(128))
 
     links = orm.relationship(
-        FamilySample, foreign_keys=[FamilySample.sample_id], back_populates="sample"
+        CaseSample, foreign_keys=[CaseSample.sample_id], back_populates="sample"
     )
     mother_links = orm.relationship(
-        FamilySample, foreign_keys=[FamilySample.mother_id], back_populates="mother"
+        CaseSample, foreign_keys=[CaseSample.mother_id], back_populates="mother"
     )
     father_links = orm.relationship(
-        FamilySample, foreign_keys=[FamilySample.father_id], back_populates="father"
+        CaseSample, foreign_keys=[CaseSample.father_id], back_populates="father"
     )
     flowcells = orm.relationship(Flowcell, secondary=flowcell_sample, back_populates="samples")
     sequencing_metrics = orm.relationship("SampleLaneSequencingMetrics", back_populates="sample")

--- a/tests/cli/add/test_cli_add_relationship.py
+++ b/tests/cli/add/test_cli_add_relationship.py
@@ -5,7 +5,7 @@ from click.testing import CliRunner
 from cg.cli.add import add
 from cg.models.cg_config import CGConfig
 from cg.store import Store
-from cg.store.models import FamilySample
+from cg.store.models import CaseSample
 from tests.store_helpers import StoreHelpers
 
 
@@ -26,7 +26,7 @@ def test_add_relationship_required(cli_runner: CliRunner, base_context: CGConfig
 
     # THEN it should be added
     assert result.exit_code == 0
-    family_sample_query = disk_store._get_query(table=FamilySample)
+    family_sample_query = disk_store._get_query(table=CaseSample)
 
     assert family_sample_query.count() == 1
     assert family_sample_query.first().case.internal_id == case_id
@@ -56,7 +56,7 @@ def test_add_relationship_bad_sample(cli_runner: CliRunner, base_context: CGConf
 
     # THEN it should complain on missing sample instead of adding a relationship
     assert result.exit_code == 1
-    assert disk_store._get_query(table=FamilySample).count() == 0
+    assert disk_store._get_query(table=CaseSample).count() == 0
 
 
 def test_add_relationship_bad_family(cli_runner: CliRunner, base_context: CGConfig, helpers):
@@ -83,7 +83,7 @@ def test_add_relationship_bad_family(cli_runner: CliRunner, base_context: CGConf
 
     # THEN it should complain in missing case instead of adding a relationship
     assert result.exit_code == 1
-    assert disk_store._get_query(table=FamilySample).count() == 0
+    assert disk_store._get_query(table=CaseSample).count() == 0
 
 
 def test_add_relationship_bad_status(cli_runner: CliRunner, base_context: CGConfig, helpers):
@@ -112,7 +112,7 @@ def test_add_relationship_bad_status(cli_runner: CliRunner, base_context: CGConf
 
     # THEN it should complain on bad status instead of adding a relationship
     assert result.exit_code == 2
-    assert disk_store._get_query(table=FamilySample).count() == 0
+    assert disk_store._get_query(table=CaseSample).count() == 0
 
 
 def test_add_relationship_mother(
@@ -146,7 +146,7 @@ def test_add_relationship_mother(
 
     # THEN it should be added
     assert result.exit_code == 0
-    family_sample_query = disk_store._get_query(table=FamilySample)
+    family_sample_query = disk_store._get_query(table=CaseSample)
     assert family_sample_query.count() == 1
     assert family_sample_query.first().mother.internal_id == mother_id
 
@@ -181,7 +181,7 @@ def test_add_relationship_bad_mother(
 
     # THEN it should not be added
     assert result.exit_code == 1
-    assert disk_store._get_query(table=FamilySample).count() == 0
+    assert disk_store._get_query(table=CaseSample).count() == 0
 
 
 def test_add_relationship_father(
@@ -218,7 +218,7 @@ def test_add_relationship_father(
 
     # THEN it should be added
     assert result.exit_code == 0
-    family_sample_query = disk_store._get_query(table=FamilySample)
+    family_sample_query = disk_store._get_query(table=CaseSample)
     assert family_sample_query.count() == 1
     assert family_sample_query.first().father.internal_id == father_id
 
@@ -255,4 +255,4 @@ def test_add_relationship_bad_father(
 
     # THEN it should not be added
     assert result.exit_code == 1
-    assert disk_store._get_query(table=FamilySample).count() == 0
+    assert disk_store._get_query(table=CaseSample).count() == 0

--- a/tests/cli/delete/test_cli_delete_case.py
+++ b/tests/cli/delete/test_cli_delete_case.py
@@ -6,7 +6,7 @@ from click.testing import CliRunner
 from cg.cli.delete.case import delete_case as delete_case_command
 from cg.models.cg_config import CGConfig
 from cg.store import Store
-from cg.store.models import Case, FamilySample, Sample
+from cg.store.models import Case, CaseSample, Sample
 from tests.store_helpers import StoreHelpers
 
 SUCCESS = 0
@@ -88,7 +88,7 @@ def test_delete_case_with_dry_run(
     helpers.add_relationship(store=base_store, case=case_obj, sample=sample)
 
     case_query = base_store._get_query(table=Case)
-    family_sample_query = base_store._get_query(table=FamilySample)
+    family_sample_query = base_store._get_query(table=CaseSample)
     sample_query = base_store._get_query(table=Sample)
 
     assert case_query.count() == 1
@@ -141,7 +141,7 @@ def test_delete_case_with_links(cli_runner: CliRunner, base_context: CGConfig, h
     helpers.add_relationship(store=base_store, case=case_obj, sample=sample)
 
     case_query = base_store._get_query(table=Case)
-    family_sample_query = base_store._get_query(table=FamilySample)
+    family_sample_query = base_store._get_query(table=CaseSample)
     sample_query = base_store._get_query(table=Sample)
 
     assert case_query.count() > 0
@@ -172,7 +172,7 @@ def test_delete_case_with_links_to_other_case(
     helpers.add_relationship(store=base_store, case=case_obj2, sample=sample)
 
     case_query = base_store._get_query(table=Case)
-    family_sample_query = base_store._get_query(table=FamilySample)
+    family_sample_query = base_store._get_query(table=CaseSample)
     sample_query = base_store._get_query(table=Sample)
 
     assert case_query.count() == 2
@@ -206,7 +206,7 @@ def test_delete_case_with_father_links(
         store=base_store, case=case_obj2, sample=sample_child, father=sample_father
     )
     case_query = base_store._get_query(table=Case)
-    family_sample_query = base_store._get_query(table=FamilySample)
+    family_sample_query = base_store._get_query(table=CaseSample)
     sample_query = base_store._get_query(table=Sample)
 
     assert case_query.count() == 2
@@ -239,7 +239,7 @@ def test_delete_mother_case(cli_runner: CliRunner, base_context: CGConfig, helpe
     )
 
     case_query = base_store._get_query(table=Case)
-    family_sample_query = base_store._get_query(table=FamilySample)
+    family_sample_query = base_store._get_query(table=CaseSample)
     sample_query = base_store._get_query(table=Sample)
 
     assert case_query.count() == 2
@@ -271,7 +271,7 @@ def test_delete_child_case(cli_runner: CliRunner, base_context: CGConfig, helper
     )
 
     case_query = base_store._get_query(table=Case)
-    family_sample_query = base_store._get_query(table=FamilySample)
+    family_sample_query = base_store._get_query(table=CaseSample)
     sample_query = base_store._get_query(table=Sample)
 
     assert case_query.count() == 2
@@ -307,7 +307,7 @@ def test_delete_trio_case(cli_runner: CliRunner, base_context: CGConfig, helpers
         father=sample_father,
     )
     case_query = base_store._get_query(table=Case)
-    family_sample_query = base_store._get_query(table=FamilySample)
+    family_sample_query = base_store._get_query(table=CaseSample)
     sample_query = base_store._get_query(table=Sample)
 
     assert case_query.count() == 1

--- a/tests/cli/upload/test_cli_upload_observations.py
+++ b/tests/cli/upload/test_cli_upload_observations.py
@@ -36,7 +36,7 @@ def test_observations(
     case: Case = helpers.add_case(store)
     case.customer.loqus_upload = True
     sample: Sample = helpers.add_sample(store, application_type=SequencingMethod.WES)
-    link = store.relate_sample(family=case, sample=sample, status=PhenotypeStatus.UNKNOWN)
+    link = store.relate_sample(case=case, sample=sample, status=PhenotypeStatus.UNKNOWN)
     store.session.add(link)
 
     # WHEN trying to do a dry run upload to Loqusdb
@@ -97,7 +97,7 @@ def test_get_observations_api(base_context: CGConfig, helpers: StoreHelpers):
     # GIVEN a Loqusdb supported case
     case: Case = helpers.add_case(store, data_analysis=Pipeline.MIP_DNA)
     sample: Sample = helpers.add_sample(store, application_type=SequencingMethod.WES)
-    link = store.relate_sample(family=case, sample=sample, status=PhenotypeStatus.UNKNOWN)
+    link = store.relate_sample(case=case, sample=sample, status=PhenotypeStatus.UNKNOWN)
     store.session.add(link)
 
     # WHEN retrieving the observation API
@@ -115,7 +115,7 @@ def test_get_sequencing_method(base_context: CGConfig, helpers: StoreHelpers):
     # GIVEN a case object with a WGS sequencing method
     case: Case = helpers.add_case(store)
     sample: Sample = helpers.add_sample(store, application_type=SequencingMethod.WGS)
-    link = store.relate_sample(family=case, sample=sample, status=PhenotypeStatus.UNKNOWN)
+    link = store.relate_sample(case=case, sample=sample, status=PhenotypeStatus.UNKNOWN)
     store.session.add(link)
 
     # WHEN getting the sequencing method
@@ -144,10 +144,10 @@ def test_get_sequencing_method_exception(
         store, application_tag=external_wes_application_tag, application_type=SequencingMethod.WES
     )
     link_1: CaseSample = store.relate_sample(
-        family=case, sample=sample_wgs, status=PhenotypeStatus.UNKNOWN
+        case=case, sample=sample_wgs, status=PhenotypeStatus.UNKNOWN
     )
     link_2: CaseSample = store.relate_sample(
-        family=case, sample=sample_wes, status=PhenotypeStatus.UNKNOWN
+        case=case, sample=sample_wes, status=PhenotypeStatus.UNKNOWN
     )
     store.session.add_all([link_1, link_2])
 

--- a/tests/cli/upload/test_cli_upload_observations.py
+++ b/tests/cli/upload/test_cli_upload_observations.py
@@ -21,7 +21,7 @@ from cg.exc import CaseNotFoundError, LoqusdbUploadCaseError
 from cg.meta.observations.mip_dna_observations_api import MipDNAObservationsAPI
 from cg.models.cg_config import CGConfig
 from cg.store import Store
-from cg.store.models import Case, FamilySample, Sample
+from cg.store.models import Case, CaseSample, Sample
 from tests.store_helpers import StoreHelpers
 
 
@@ -143,10 +143,10 @@ def test_get_sequencing_method_exception(
     sample_wes: Sample = helpers.add_sample(
         store, application_tag=external_wes_application_tag, application_type=SequencingMethod.WES
     )
-    link_1: FamilySample = store.relate_sample(
+    link_1: CaseSample = store.relate_sample(
         family=case, sample=sample_wgs, status=PhenotypeStatus.UNKNOWN
     )
-    link_2: FamilySample = store.relate_sample(
+    link_2: CaseSample = store.relate_sample(
         family=case, sample=sample_wes, status=PhenotypeStatus.UNKNOWN
     )
     store.session.add_all([link_1, link_2])

--- a/tests/meta/deliver/test_delivery_api.py
+++ b/tests/meta/deliver/test_delivery_api.py
@@ -10,7 +10,7 @@ from cg.constants.delivery import INBOX_NAME
 from cg.constants.housekeeper_tags import AlignmentFileTag
 from cg.meta.deliver import DeliverAPI
 from cg.store import Store
-from cg.store.models import Case, FamilySample, Sample
+from cg.store.models import Case, CaseSample, Sample
 from tests.cli.deliver.conftest import fastq_delivery_bundle, mip_delivery_bundle
 from tests.store.conftest import case_obj
 from tests.store_helpers import StoreHelpers
@@ -49,7 +49,7 @@ def test_get_case_analysis_files(populated_deliver_api: DeliverAPI, case_id: str
     assert version
 
     # GIVEN that a case object exists in the database
-    link_objs: list[FamilySample] = deliver_api.store.get_case_samples_by_case_id(
+    link_objs: list[CaseSample] = deliver_api.store.get_case_samples_by_case_id(
         case_internal_id=case_id
     )
     samples: list[Sample] = [link.sample for link in link_objs]
@@ -99,7 +99,7 @@ def test_get_case_files_from_version(
     assert len(version.files) == 2
 
     # GIVEN the sample ids of the samples
-    link_objs: list[FamilySample] = analysis_store.get_case_samples_by_case_id(case_id)
+    link_objs: list[CaseSample] = analysis_store.get_case_samples_by_case_id(case_id)
     samples: list[Sample] = [link.sample for link in link_objs]
     sample_ids: set[str] = {sample.internal_id for sample in samples}
 

--- a/tests/meta/report/test_report_api.py
+++ b/tests/meta/report/test_report_api.py
@@ -14,7 +14,7 @@ from cg.models.mip.mip_analysis import MipAnalysis
 from cg.models.report.report import CaseModel, CustomerModel, DataAnalysisModel, ReportModel
 from cg.models.report.sample import ApplicationModel, MethodsModel, SampleModel, TimestampModel
 from cg.store import Store
-from cg.store.models import Analysis, Case, FamilySample
+from cg.store.models import Analysis, Case, CaseSample
 from tests.meta.report.helper import recursive_assert
 from tests.store_helpers import StoreHelpers
 
@@ -236,7 +236,7 @@ def test_get_samples_data(
     report_api_mip_dna: MipDNAReportAPI,
     mip_analysis_api: MipDNAAnalysisAPI,
     case_mip_dna: Case,
-    case_samples_data: list[FamilySample],
+    case_samples_data: list[CaseSample],
     lims_samples: list[dict],
 ):
     """Validates the retrieved sample data."""
@@ -245,7 +245,7 @@ def test_get_samples_data(
 
     # GIVEN an expected output
     expected_lims_data: dict = lims_samples[0]
-    expected_sample_data: FamilySample = case_samples_data[0]
+    expected_sample_data: CaseSample = case_samples_data[0]
 
     # GIVEN a mip analysis mock metadata
     mip_metadata: MipAnalysis = mip_analysis_api.get_latest_metadata(case_mip_dna.internal_id)
@@ -269,7 +269,7 @@ def test_get_samples_data(
 
 def test_get_lims_sample(
     report_api_mip_dna: MipDNAReportAPI,
-    case_samples_data: list[FamilySample],
+    case_samples_data: list[CaseSample],
     lims_samples: list[dict],
 ):
     """Tests lims data extraction."""
@@ -288,7 +288,7 @@ def test_get_lims_sample(
 
 def test_get_sample_application_data(
     report_api_mip_dna: MipDNAReportAPI,
-    case_samples_data: list[FamilySample],
+    case_samples_data: list[CaseSample],
     lims_samples: list[dict],
 ):
     """Tests sample application data extraction."""
@@ -331,7 +331,7 @@ def test_get_unique_applications(
 
 
 def test_get_sample_methods_data(
-    report_api_mip_dna: MipDNAReportAPI, case_samples_data: list[FamilySample]
+    report_api_mip_dna: MipDNAReportAPI, case_samples_data: list[CaseSample]
 ):
     """Tests sample methods retrieval from lims."""
 
@@ -431,7 +431,7 @@ def test_get_case_analysis_data_pipeline_not_supported(
 
 def test_get_sample_timestamp_data(
     report_api_mip_dna: MipDNAReportAPI,
-    case_samples_data: list[FamilySample],
+    case_samples_data: list[CaseSample],
     timestamp_yesterday: datetime,
 ):
     """Checks that the sample timestamp information is correctly retrieved from StatusDB."""

--- a/tests/store/api/conftest.py
+++ b/tests/store/api/conftest.py
@@ -9,7 +9,7 @@ from cg.constants.priority import PriorityTerms
 from cg.constants.subject import PhenotypeStatus
 from cg.meta.orders.pool_submitter import PoolSubmitter
 from cg.store import Store
-from cg.store.models import FamilySample
+from cg.store.models import CaseSample
 from tests.meta.demultiplex.conftest import populated_flow_cell_store
 from tests.store_helpers import StoreHelpers
 
@@ -479,7 +479,7 @@ def store_with_analyses_for_cases(
             completed_at=timestamp_now,
         )
         sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
-        link: FamilySample = analysis_store.relate_sample(
+        link: CaseSample = analysis_store.relate_sample(
             family=oldest_analysis.case, sample=sample, status=PhenotypeStatus.UNKNOWN
         )
         analysis_store.session.add(link)
@@ -519,7 +519,7 @@ def store_with_analyses_for_cases_not_uploaded_fluffy(
             pipeline=Pipeline.FLUFFY,
         )
         sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
-        link: FamilySample = analysis_store.relate_sample(
+        link: CaseSample = analysis_store.relate_sample(
             family=oldest_analysis.case, sample=sample, status=PhenotypeStatus.UNKNOWN
         )
         analysis_store.session.add(link)
@@ -559,7 +559,7 @@ def store_with_analyses_for_cases_not_uploaded_microsalt(
             pipeline=Pipeline.MICROSALT,
         )
         sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
-        link: FamilySample = analysis_store.relate_sample(
+        link: CaseSample = analysis_store.relate_sample(
             family=oldest_analysis.case, sample=sample, status=PhenotypeStatus.UNKNOWN
         )
         analysis_store.session.add(link)
@@ -600,7 +600,7 @@ def store_with_analyses_for_cases_to_deliver(
             pipeline=Pipeline.MIP_DNA,
         )
         sample = helpers.add_sample(analysis_store, delivered_at=None)
-        link: FamilySample = analysis_store.relate_sample(
+        link: CaseSample = analysis_store.relate_sample(
             family=oldest_analysis.case, sample=sample, status=PhenotypeStatus.UNKNOWN
         )
         analysis_store.session.add(link)

--- a/tests/store/api/conftest.py
+++ b/tests/store/api/conftest.py
@@ -480,7 +480,7 @@ def store_with_analyses_for_cases(
         )
         sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
         link: CaseSample = analysis_store.relate_sample(
-            family=oldest_analysis.case, sample=sample, status=PhenotypeStatus.UNKNOWN
+            case=oldest_analysis.case, sample=sample, status=PhenotypeStatus.UNKNOWN
         )
         analysis_store.session.add(link)
 
@@ -520,7 +520,7 @@ def store_with_analyses_for_cases_not_uploaded_fluffy(
         )
         sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
         link: CaseSample = analysis_store.relate_sample(
-            family=oldest_analysis.case, sample=sample, status=PhenotypeStatus.UNKNOWN
+            case=oldest_analysis.case, sample=sample, status=PhenotypeStatus.UNKNOWN
         )
         analysis_store.session.add(link)
     return analysis_store
@@ -560,7 +560,7 @@ def store_with_analyses_for_cases_not_uploaded_microsalt(
         )
         sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
         link: CaseSample = analysis_store.relate_sample(
-            family=oldest_analysis.case, sample=sample, status=PhenotypeStatus.UNKNOWN
+            case=oldest_analysis.case, sample=sample, status=PhenotypeStatus.UNKNOWN
         )
         analysis_store.session.add(link)
     return analysis_store
@@ -601,7 +601,7 @@ def store_with_analyses_for_cases_to_deliver(
         )
         sample = helpers.add_sample(analysis_store, delivered_at=None)
         link: CaseSample = analysis_store.relate_sample(
-            family=oldest_analysis.case, sample=sample, status=PhenotypeStatus.UNKNOWN
+            case=oldest_analysis.case, sample=sample, status=PhenotypeStatus.UNKNOWN
         )
         analysis_store.session.add(link)
 

--- a/tests/store/api/delete/test_store_api_delete.py
+++ b/tests/store/api/delete/test_store_api_delete.py
@@ -1,5 +1,5 @@
 from cg.store import Store
-from cg.store.models import Case, FamilySample, Flowcell, Sample
+from cg.store.models import Case, CaseSample, Flowcell, Sample
 
 
 def test_delete_flow_cell(bcl2fastq_flow_cell_id: str, populated_flow_cell_store: Store):
@@ -47,14 +47,14 @@ def test_store_api_delete_relationships_between_sample_and_cases(
     store_with_multiple_cases_and_samples.delete_relationships_sample(sample=sample_in_single_case)
 
     # THEN it should no longer be associated with any cases, but other relationships should remain
-    results: list[FamilySample] = (
-        store_with_multiple_cases_and_samples._get_query(table=FamilySample)
-        .filter(FamilySample.sample_id == sample_in_single_case.id)
+    results: list[CaseSample] = (
+        store_with_multiple_cases_and_samples._get_query(table=CaseSample)
+        .filter(CaseSample.sample_id == sample_in_single_case.id)
         .all()
     )
-    existing_relationships: list[FamilySample] = (
-        store_with_multiple_cases_and_samples._get_query(table=FamilySample)
-        .filter(FamilySample.sample_id == sample_in_multiple_cases.id)
+    existing_relationships: list[CaseSample] = (
+        store_with_multiple_cases_and_samples._get_query(table=CaseSample)
+        .filter(CaseSample.sample_id == sample_in_multiple_cases.id)
         .all()
     )
 
@@ -71,12 +71,12 @@ def test_store_api_delete_all_empty_cases(
 
     # GIVEN a database containing a case without samples and a case with samples
     case_without_samples: list[
-        FamilySample
+        CaseSample
     ] = store_with_multiple_cases_and_samples.get_case_samples_by_case_id(
         case_internal_id=case_id_without_samples
     )
     case_with_samples: list[
-        FamilySample
+        CaseSample
     ] = store_with_multiple_cases_and_samples.get_case_samples_by_case_id(
         case_internal_id=case_id_with_multiple_samples
     )
@@ -90,11 +90,11 @@ def test_store_api_delete_all_empty_cases(
     )
 
     # THEN no entry should be found for the empty case, but the one with samples should remain.
-    result: list[FamilySample] = store_with_multiple_cases_and_samples.get_case_samples_by_case_id(
+    result: list[CaseSample] = store_with_multiple_cases_and_samples.get_case_samples_by_case_id(
         case_internal_id=case_id_without_samples
     )
     case_with_samples: list[
-        FamilySample
+        CaseSample
     ] = store_with_multiple_cases_and_samples.get_case_samples_by_case_id(
         case_internal_id=case_id_with_multiple_samples
     )

--- a/tests/store/api/find/test_find_business_data.py
+++ b/tests/store/api/find/test_find_business_data.py
@@ -17,7 +17,7 @@ from cg.store.models import (
     ApplicationVersion,
     Customer,
     Case,
-    FamilySample,
+    CaseSample,
     Flowcell,
     Invoice,
     Pool,
@@ -438,18 +438,18 @@ def test_get_case_samples_by_case_id(
     store_with_analyses_for_cases: Store,
     case_id: str,
 ):
-    """Test that getting case-samples by case id returns a list of FamilySamples."""
+    """Test that getting case-samples by case id returns a list of CaseSamples."""
     # GIVEN a store with case-samples and a case id
 
     # WHEN fetching the case-samples matching the case id
-    case_samples: list[FamilySample] = store_with_analyses_for_cases.get_case_samples_by_case_id(
+    case_samples: list[CaseSample] = store_with_analyses_for_cases.get_case_samples_by_case_id(
         case_internal_id=case_id
     )
 
     # THEN a list of case-samples should be returned
     assert case_samples
     assert isinstance(case_samples, list)
-    assert isinstance(case_samples[0], FamilySample)
+    assert isinstance(case_samples[0], CaseSample)
 
 
 def test_get_case_sample_link(
@@ -457,17 +457,18 @@ def test_get_case_sample_link(
     case_id: str,
     sample_id: str,
 ):
-    """Test that the returned element is a FamilySample with the correct case and sample internal ids."""
+    """Test that the returned element is a CaseSample with the correct case and sample internal ids."""
     # GIVEN a store with case-samples and valid case and sample internal ids
 
     # WHEN fetching a case-sample with case and sample internal ids
-    case_sample: FamilySample = store_with_analyses_for_cases.get_case_sample_link(
+    case_sample: CaseSample = store_with_analyses_for_cases.get_case_sample_link(
         case_internal_id=case_id,
         sample_internal_id=sample_id,
     )
 
-    # THEN the returned element is a FamilySample object
-    assert isinstance(case_sample, FamilySample)
+    # THEN the returned element is a CaseSample
+    assert isinstance(case_sample, CaseSample)
+
     # THEN the returned family sample has the correct case and sample internal ids
     assert case_sample.case.internal_id == case_id
     assert case_sample.sample.internal_id == sample_id

--- a/tests/store/api/status/test_analyses_to_clean.py
+++ b/tests/store/api/status/test_analyses_to_clean.py
@@ -20,7 +20,7 @@ def test_analysis_included(
     )
     sample = helpers.add_sample(analysis_store, delivered_at=timestamp_yesterday)
     link: CaseSample = analysis_store.relate_sample(
-        family=analysis.case, sample=sample, status="unknown"
+        case=analysis.case, sample=sample, status="unknown"
     )
     analysis_store.session.add(link)
 
@@ -40,7 +40,7 @@ def test_analysis_excluded(analysis_store: Store, helpers, timestamp_now: dateti
     )
     sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
     link: CaseSample = analysis_store.relate_sample(
-        family=analysis.case, sample=sample, status="unknown"
+        case=analysis.case, sample=sample, status="unknown"
     )
     analysis_store.session.add(link)
 
@@ -67,7 +67,7 @@ def test_pipeline_included(
     )
     sample = helpers.add_sample(analysis_store, delivered_at=timestamp_yesterday)
     link: CaseSample = analysis_store.relate_sample(
-        family=analysis.case, sample=sample, status="unknown"
+        case=analysis.case, sample=sample, status="unknown"
     )
     analysis_store.session.add(link)
 
@@ -96,7 +96,7 @@ def test_pipeline_excluded(analysis_store: Store, helpers, timestamp_now: dateti
     )
     sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
     link: CaseSample = analysis_store.relate_sample(
-        family=analysis.case, sample=sample, status="unknown"
+        case=analysis.case, sample=sample, status="unknown"
     )
     analysis_store.session.add(link)
 
@@ -121,7 +121,7 @@ def test_non_cleaned_included(
     )
     sample = helpers.add_sample(analysis_store, delivered_at=timestamp_yesterday)
     link: CaseSample = analysis_store.relate_sample(
-        family=analysis.case, sample=sample, status="unknown"
+        case=analysis.case, sample=sample, status="unknown"
     )
     analysis_store.session.add(link)
 
@@ -144,7 +144,7 @@ def test_cleaned_excluded(analysis_store: Store, helpers, timestamp_now: datetim
     )
     sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
     link: CaseSample = analysis_store.relate_sample(
-        family=analysis.case, sample=sample, status="unknown"
+        case=analysis.case, sample=sample, status="unknown"
     )
     analysis_store.session.add(link)
 

--- a/tests/store/api/status/test_analyses_to_clean.py
+++ b/tests/store/api/status/test_analyses_to_clean.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 from cg.constants import Pipeline
 from cg.store import Store
-from cg.store.models import FamilySample
+from cg.store.models import CaseSample
 
 
 def test_analysis_included(
@@ -19,7 +19,7 @@ def test_analysis_included(
         cleaned_at=None,
     )
     sample = helpers.add_sample(analysis_store, delivered_at=timestamp_yesterday)
-    link: FamilySample = analysis_store.relate_sample(
+    link: CaseSample = analysis_store.relate_sample(
         family=analysis.case, sample=sample, status="unknown"
     )
     analysis_store.session.add(link)
@@ -39,7 +39,7 @@ def test_analysis_excluded(analysis_store: Store, helpers, timestamp_now: dateti
         analysis_store, started_at=timestamp_now, uploaded_at=None, cleaned_at=None
     )
     sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
-    link: FamilySample = analysis_store.relate_sample(
+    link: CaseSample = analysis_store.relate_sample(
         family=analysis.case, sample=sample, status="unknown"
     )
     analysis_store.session.add(link)
@@ -66,7 +66,7 @@ def test_pipeline_included(
         cleaned_at=None,
     )
     sample = helpers.add_sample(analysis_store, delivered_at=timestamp_yesterday)
-    link: FamilySample = analysis_store.relate_sample(
+    link: CaseSample = analysis_store.relate_sample(
         family=analysis.case, sample=sample, status="unknown"
     )
     analysis_store.session.add(link)
@@ -95,7 +95,7 @@ def test_pipeline_excluded(analysis_store: Store, helpers, timestamp_now: dateti
         cleaned_at=None,
     )
     sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
-    link: FamilySample = analysis_store.relate_sample(
+    link: CaseSample = analysis_store.relate_sample(
         family=analysis.case, sample=sample, status="unknown"
     )
     analysis_store.session.add(link)
@@ -120,7 +120,7 @@ def test_non_cleaned_included(
         cleaned_at=None,
     )
     sample = helpers.add_sample(analysis_store, delivered_at=timestamp_yesterday)
-    link: FamilySample = analysis_store.relate_sample(
+    link: CaseSample = analysis_store.relate_sample(
         family=analysis.case, sample=sample, status="unknown"
     )
     analysis_store.session.add(link)
@@ -143,7 +143,7 @@ def test_cleaned_excluded(analysis_store: Store, helpers, timestamp_now: datetim
         cleaned_at=timestamp_now,
     )
     sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
-    link: FamilySample = analysis_store.relate_sample(
+    link: CaseSample = analysis_store.relate_sample(
         family=analysis.case, sample=sample, status="unknown"
     )
     analysis_store.session.add(link)

--- a/tests/store/api/status/test_analyses_to_delivery_report.py
+++ b/tests/store/api/status/test_analyses_to_delivery_report.py
@@ -3,7 +3,7 @@
 from cg.constants import DataDelivery, Pipeline
 from cg.constants.subject import PhenotypeStatus
 from cg.store import Store
-from cg.store.models import FamilySample
+from cg.store.models import CaseSample
 from cg.utils.date import get_date
 
 
@@ -21,7 +21,7 @@ def test_missing(analysis_store: Store, helpers, timestamp_now):
         data_delivery=DataDelivery.SCOUT,
     )
     sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
-    link: FamilySample = analysis_store.relate_sample(
+    link: CaseSample = analysis_store.relate_sample(
         family=analysis.case, sample=sample, status=PhenotypeStatus.UNKNOWN
     )
     analysis_store.session.add(link)
@@ -57,7 +57,7 @@ def test_outdated_analysis(analysis_store, helpers, timestamp_now, timestamp_yes
     sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
 
     # GIVEN a store sample case relation
-    link: FamilySample = analysis_store.relate_sample(
+    link: CaseSample = analysis_store.relate_sample(
         family=analysis.case, sample=sample, status=PhenotypeStatus.UNKNOWN
     )
     analysis_store.session.add(link)

--- a/tests/store/api/status/test_analyses_to_delivery_report.py
+++ b/tests/store/api/status/test_analyses_to_delivery_report.py
@@ -5,9 +5,10 @@ from cg.constants.subject import PhenotypeStatus
 from cg.store import Store
 from cg.store.models import CaseSample
 from cg.utils.date import get_date
+from tests.store_helpers import StoreHelpers
 
 
-def test_missing(analysis_store: Store, helpers, timestamp_now):
+def test_missing(analysis_store: Store, helpers: StoreHelpers, timestamp_now):
     """Tests that analyses that are completed, but lacks delivery report are returned."""
 
     # GIVEN an analysis that is delivered but has no delivery report
@@ -22,7 +23,7 @@ def test_missing(analysis_store: Store, helpers, timestamp_now):
     )
     sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
     link: CaseSample = analysis_store.relate_sample(
-        family=analysis.case, sample=sample, status=PhenotypeStatus.UNKNOWN
+        case=analysis.case, sample=sample, status=PhenotypeStatus.UNKNOWN
     )
     analysis_store.session.add(link)
     assert sample.delivered_at is not None
@@ -35,7 +36,9 @@ def test_missing(analysis_store: Store, helpers, timestamp_now):
     assert analysis in analyses
 
 
-def test_outdated_analysis(analysis_store, helpers, timestamp_now, timestamp_yesterday):
+def test_outdated_analysis(
+    analysis_store: Store, helpers: StoreHelpers, timestamp_now, timestamp_yesterday
+):
     """Tests that analyses that are older then when Hasta became production (2017-09-26) are not included in the cases to generate a delivery report for"""
 
     # GIVEN an analysis that is older than Hasta
@@ -58,7 +61,7 @@ def test_outdated_analysis(analysis_store, helpers, timestamp_now, timestamp_yes
 
     # GIVEN a store sample case relation
     link: CaseSample = analysis_store.relate_sample(
-        family=analysis.case, sample=sample, status=PhenotypeStatus.UNKNOWN
+        case=analysis.case, sample=sample, status=PhenotypeStatus.UNKNOWN
     )
     analysis_store.session.add(link)
 
@@ -69,7 +72,9 @@ def test_outdated_analysis(analysis_store, helpers, timestamp_now, timestamp_yes
     assert len(analyses) == 0
 
 
-def test_analyses_to_upload_delivery_reports(analysis_store, helpers, timestamp_now):
+def test_analyses_to_upload_delivery_reports(
+    analysis_store: Store, helpers: StoreHelpers, timestamp_now
+):
     """Tests extraction of analyses ready for delivery report upload"""
 
     # GIVEN an analysis that has a delivery report generated

--- a/tests/store/api/status/test_store_api_status_analysis.py
+++ b/tests/store/api/status/test_store_api_status_analysis.py
@@ -8,7 +8,7 @@ from cg.constants import Pipeline
 from cg.constants.constants import CaseActions
 from cg.constants.subject import PhenotypeStatus
 from cg.store import Store
-from cg.store.models import Analysis, Case, FamilySample, Sample
+from cg.store.models import Analysis, Case, CaseSample, Sample
 from tests.store_helpers import StoreHelpers
 
 
@@ -301,10 +301,10 @@ def test_one_of_two_sequenced_samples(
     not_sequenced_sample: Sample = helpers.add_sample(base_store, last_sequenced_at=None)
 
     # GIVEN a database with a case with one of one sequenced samples and no analysis
-    link_1: FamilySample = base_store.relate_sample(
+    link_1: CaseSample = base_store.relate_sample(
         test_case, sequenced_sample, PhenotypeStatus.UNKNOWN
     )
-    link_2: FamilySample = base_store.relate_sample(
+    link_2: CaseSample = base_store.relate_sample(
         test_case, not_sequenced_sample, PhenotypeStatus.UNKNOWN
     )
     base_store.session.add_all([link_1, link_2])

--- a/tests/store/api/status/test_store_api_status_cases.py
+++ b/tests/store/api/status/test_store_api_status_cases.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 
 from cg.constants import CASE_ACTIONS, DataDelivery, Pipeline, Priority
 from cg.store import Store
-from cg.store.models import Analysis, Case, FamilySample
+from cg.store.models import Analysis, Case, CaseSample
 
 
 def test_delivered_at_affects_tat(base_store: Store, helpers):
@@ -113,10 +113,10 @@ def test_samples_flowcell(base_store: Store, helpers):
     new_case = add_case(helpers, base_store)
     sample_on_flowcell = helpers.add_sample(base_store)
     flowcell = helpers.add_flow_cell(base_store, samples=[sample_on_flowcell], status="ondisk")
-    link_1: FamilySample = base_store.relate_sample(new_case, sample_on_flowcell, "unknown")
+    link_1: CaseSample = base_store.relate_sample(new_case, sample_on_flowcell, "unknown")
     base_store.session.add(link_1)
     sample_not_on_flowcell = helpers.add_sample(base_store)
-    link_2: FamilySample = base_store.relate_sample(new_case, sample_not_on_flowcell, "unknown")
+    link_2: CaseSample = base_store.relate_sample(new_case, sample_not_on_flowcell, "unknown")
     base_store.session.add(link_2)
 
     # WHEN getting active cases
@@ -198,8 +198,8 @@ def test_received_at_is_newest_date(base_store: Store, helpers):
     yesteryear = datetime.now() - timedelta(days=365)
     newest_sample = helpers.add_sample(base_store, received_at=yesterday)
     oldest_sample = helpers.add_sample(base_store, received_at=yesteryear)
-    link_1: FamilySample = base_store.relate_sample(new_case, newest_sample, "unknown")
-    link_2: FamilySample = base_store.relate_sample(new_case, oldest_sample, "unknown")
+    link_1: CaseSample = base_store.relate_sample(new_case, newest_sample, "unknown")
+    link_2: CaseSample = base_store.relate_sample(new_case, oldest_sample, "unknown")
     base_store.session.add_all([link_1, link_2])
 
     # WHEN getting active cases
@@ -220,8 +220,8 @@ def test_prepared_at_is_newest_date(base_store: Store, helpers):
     yesteryear = datetime.now() - timedelta(days=365)
     newest_sample = helpers.add_sample(base_store, prepared_at=yesterday)
     oldest_sample = helpers.add_sample(base_store, prepared_at=yesteryear)
-    link_1: FamilySample = base_store.relate_sample(new_case, newest_sample, "unknown")
-    link_2: FamilySample = base_store.relate_sample(new_case, oldest_sample, "unknown")
+    link_1: CaseSample = base_store.relate_sample(new_case, newest_sample, "unknown")
+    link_2: CaseSample = base_store.relate_sample(new_case, oldest_sample, "unknown")
     base_store.session.add_all([link_1, link_2])
 
     # WHEN getting active cases
@@ -242,8 +242,8 @@ def test_sequenced_at_is_newest_date(base_store: Store, helpers):
     yesteryear = datetime.now() - timedelta(days=365)
     newest_sample = helpers.add_sample(base_store, last_sequenced_at=yesterday)
     oldest_sample = helpers.add_sample(base_store, last_sequenced_at=yesteryear)
-    link_1: FamilySample = base_store.relate_sample(new_case, newest_sample, "unknown")
-    link_2: FamilySample = base_store.relate_sample(new_case, oldest_sample, "unknown")
+    link_1: CaseSample = base_store.relate_sample(new_case, newest_sample, "unknown")
+    link_2: CaseSample = base_store.relate_sample(new_case, oldest_sample, "unknown")
     base_store.session.add_all([link_1, link_2])
 
     # WHEN getting active cases
@@ -264,8 +264,8 @@ def test_delivered_at_is_newest_date(base_store: Store, helpers):
     yesteryear = datetime.now() - timedelta(days=365)
     newest_sample = helpers.add_sample(base_store, delivered_at=yesterday)
     oldest_sample = helpers.add_sample(base_store, delivered_at=yesteryear)
-    link_1: FamilySample = base_store.relate_sample(new_case, newest_sample, "unknown")
-    link_2: FamilySample = base_store.relate_sample(new_case, oldest_sample, "unknown")
+    link_1: CaseSample = base_store.relate_sample(new_case, newest_sample, "unknown")
+    link_2: CaseSample = base_store.relate_sample(new_case, oldest_sample, "unknown")
     base_store.session.add_all([link_1, link_2])
 
     # WHEN getting active cases
@@ -292,8 +292,8 @@ def test_invoiced_at_is_newest_invoice_date(base_store: Store, helpers):
     invoice = base_store.add_invoice(helpers.ensure_customer(base_store))
     oldest_sample.invoice = invoice
     oldest_sample.invoice.invoiced_at = yesteryear
-    link_1: FamilySample = base_store.relate_sample(new_case, newest_sample, "unknown")
-    link_2: FamilySample = base_store.relate_sample(new_case, oldest_sample, "unknown")
+    link_1: CaseSample = base_store.relate_sample(new_case, newest_sample, "unknown")
+    link_2: CaseSample = base_store.relate_sample(new_case, oldest_sample, "unknown")
     base_store.session.add_all([link_1, link_2])
 
     # WHEN getting active cases
@@ -598,12 +598,12 @@ def test_show_multiple_data_analysis(base_store: Store, helpers):
     data_analysis = Pipeline.BALSAMIC
     new_case = add_case(helpers, base_store, data_analysis=data_analysis)
     sample1 = helpers.add_sample(base_store)
-    link_1: FamilySample = base_store.relate_sample(new_case, sample1, "unknown")
+    link_1: CaseSample = base_store.relate_sample(new_case, sample1, "unknown")
     base_store.session.add(link_1)
     new_case2 = add_case(helpers, base_store, case_id="new_case2", data_analysis=data_analysis)
     sample2 = helpers.add_sample(base_store)
-    link_2: FamilySample = base_store.relate_sample(new_case, sample2, "unknown")
-    link_3: FamilySample = base_store.relate_sample(new_case2, sample2, "unknown")
+    link_2: CaseSample = base_store.relate_sample(new_case, sample2, "unknown")
+    link_3: CaseSample = base_store.relate_sample(new_case2, sample2, "unknown")
     base_store.session.add_all([link_2, link_3])
     base_store.session.commit()
 
@@ -1342,8 +1342,8 @@ def test_one_of_two_samples_received(base_store: Store, helpers):
     new_case = add_case(helpers, base_store)
     sample_received = helpers.add_sample(base_store, "sample_received", received_at=datetime.now())
     sample_not_received = helpers.add_sample(base_store, "sample_not_received", received_at=None)
-    link_1: FamilySample = base_store.relate_sample(new_case, sample_received, "unknown")
-    link_2: FamilySample = base_store.relate_sample(new_case, sample_not_received, "unknown")
+    link_1: CaseSample = base_store.relate_sample(new_case, sample_received, "unknown")
+    link_2: CaseSample = base_store.relate_sample(new_case, sample_not_received, "unknown")
     base_store.session.add_all([link_1, link_2])
     assert sample_received.received_at is not None
     assert sample_not_received.received_at is None

--- a/tests/store/api/test_base.py
+++ b/tests/store/api/test_base.py
@@ -2,7 +2,7 @@
 from sqlalchemy.orm import Query
 
 from cg.constants.subject import PhenotypeStatus
-from cg.store.models import FamilySample
+from cg.store.models import CaseSample
 
 
 def test_get_latest_analyses_for_cases_query(
@@ -29,7 +29,7 @@ def test_get_latest_analyses_for_cases_query(
         delivery_reported_at=None,
     )
     sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
-    link: FamilySample = analysis_store.relate_sample(
+    link: CaseSample = analysis_store.relate_sample(
         family=analysis_oldest.case, sample=sample, status=PhenotypeStatus.UNKNOWN
     )
     analysis_store.session.add(link)

--- a/tests/store/api/test_base.py
+++ b/tests/store/api/test_base.py
@@ -2,11 +2,12 @@
 from sqlalchemy.orm import Query
 
 from cg.constants.subject import PhenotypeStatus
+from cg.store.api.core import Store
 from cg.store.models import CaseSample
 
 
 def test_get_latest_analyses_for_cases_query(
-    analysis_store, helpers, timestamp_now, timestamp_yesterday
+    analysis_store: Store, helpers, timestamp_now, timestamp_yesterday
 ):
     """Tests that analyses that are not latest are not returned."""
 
@@ -30,7 +31,7 @@ def test_get_latest_analyses_for_cases_query(
     )
     sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
     link: CaseSample = analysis_store.relate_sample(
-        family=analysis_oldest.case, sample=sample, status=PhenotypeStatus.UNKNOWN
+        case=analysis_oldest.case, sample=sample, status=PhenotypeStatus.UNKNOWN
     )
     analysis_store.session.add(link)
 

--- a/tests/store/conftest.py
+++ b/tests/store/conftest.py
@@ -446,7 +446,7 @@ def store_with_analyses_for_cases(
         )
         sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
         link: CaseSample = analysis_store.relate_sample(
-            family=oldest_analysis.case, sample=sample, status=PhenotypeStatus.UNKNOWN
+            case=oldest_analysis.case, sample=sample, status=PhenotypeStatus.UNKNOWN
         )
         analysis_store.session.add(link)
     return analysis_store

--- a/tests/store/conftest.py
+++ b/tests/store/conftest.py
@@ -8,7 +8,7 @@ import pytest
 from cg.constants import Pipeline
 from cg.constants.subject import Gender, PhenotypeStatus
 from cg.store import Store
-from cg.store.models import Analysis, Application, Customer, Case, FamilySample, Organism, Sample
+from cg.store.models import Analysis, Application, Customer, Case, CaseSample, Organism, Sample
 from tests.store_helpers import StoreHelpers
 
 
@@ -445,7 +445,7 @@ def store_with_analyses_for_cases(
             uploaded_to_vogue_at=timestamp_now,
         )
         sample = helpers.add_sample(analysis_store, delivered_at=timestamp_now)
-        link: FamilySample = analysis_store.relate_sample(
+        link: CaseSample = analysis_store.relate_sample(
             family=oldest_analysis.case, sample=sample, status=PhenotypeStatus.UNKNOWN
         )
         analysis_store.session.add(link)

--- a/tests/store/filters/test_status_cases_filters.py
+++ b/tests/store/filters/test_status_cases_filters.py
@@ -29,7 +29,7 @@ from cg.store.filters.status_case_filters import (
     filter_report_supported_data_delivery_cases,
     filter_running_cases,
 )
-from cg.store.models import Analysis, Case, FamilySample, Sample
+from cg.store.models import Analysis, Case, CaseSample, Sample
 from tests.store_helpers import StoreHelpers
 
 
@@ -208,10 +208,10 @@ def test_filter_cases_with_loqusdb_supported_pipeline(
     test_fluffy_case.customer.loqus_upload = True
 
     # GIVEN a database with a case with one sequenced samples for specified analysis
-    link_1: FamilySample = base_store.relate_sample(
+    link_1: CaseSample = base_store.relate_sample(
         test_mip_case, test_sample, PhenotypeStatus.UNKNOWN
     )
-    link_2: FamilySample = base_store.relate_sample(
+    link_2: CaseSample = base_store.relate_sample(
         test_fluffy_case, test_sample, PhenotypeStatus.UNKNOWN
     )
     base_store.session.add_all([link_1, link_2])
@@ -463,8 +463,8 @@ def test_filter_report_supported_data_delivery_cases(
     test_invalid_case = helpers.add_case(base_store, name="test", data_delivery=DataDelivery.FASTQ)
 
     # GIVEN a database with the test cases
-    link_1: FamilySample = base_store.relate_sample(test_case, test_sample, PhenotypeStatus.UNKNOWN)
-    link_2: FamilySample = base_store.relate_sample(
+    link_1: CaseSample = base_store.relate_sample(test_case, test_sample, PhenotypeStatus.UNKNOWN)
+    link_2: CaseSample = base_store.relate_sample(
         test_invalid_case, test_sample, PhenotypeStatus.UNKNOWN
     )
     base_store.session.add_all([link_1, link_2])

--- a/tests/store/filters/test_status_samples_filters.py
+++ b/tests/store/filters/test_status_samples_filters.py
@@ -29,7 +29,7 @@ from cg.store.filters.status_sample_filters import (
     filter_samples_without_invoice_id,
     filter_samples_without_loqusdb_id,
 )
-from cg.store.models import FamilySample, Sample
+from cg.store.models import CaseSample, Sample
 from tests.store.conftest import StoreConstants
 
 
@@ -40,10 +40,10 @@ def test_get_samples_with_loqusdb_id(helpers, store, sample_store, sample_id, lo
     case = helpers.add_case(store)
     sample = helpers.add_sample(store, loqusdb_id=loqusdb_id)
     sample_not_uploaded = helpers.add_sample(store, internal_id=sample_id)
-    link_1: FamilySample = sample_store.relate_sample(
+    link_1: CaseSample = sample_store.relate_sample(
         family=case, sample=sample, status=PhenotypeStatus.UNKNOWN
     )
-    link_2: FamilySample = sample_store.relate_sample(
+    link_2: CaseSample = sample_store.relate_sample(
         family=case, sample=sample_not_uploaded, status=PhenotypeStatus.UNKNOWN
     )
     sample_store.session.add_all([link_1, link_2])
@@ -66,10 +66,10 @@ def test_get_samples_without_loqusdb_id(helpers, store, sample_store, sample_id,
     case = helpers.add_case(store)
     sample = helpers.add_sample(store)
     sample_uploaded = helpers.add_sample(store, internal_id=sample_id, loqusdb_id=loqusdb_id)
-    link_1: FamilySample = sample_store.relate_sample(
+    link_1: CaseSample = sample_store.relate_sample(
         family=case, sample=sample, status=PhenotypeStatus.UNKNOWN
     )
-    link_2: FamilySample = sample_store.relate_sample(
+    link_2: CaseSample = sample_store.relate_sample(
         family=case, sample=sample_uploaded, status=PhenotypeStatus.UNKNOWN
     )
     sample_store.session.add_all([link_1, link_2])

--- a/tests/store_helpers.py
+++ b/tests/store_helpers.py
@@ -656,7 +656,7 @@ class StoreHelpers:
     ) -> CaseSample:
         """Utility function to link a sample to a case."""
         link = store.relate_sample(
-            sample=sample, family=case, status=status, father=father, mother=mother
+            sample=sample, case=case, status=status, father=father, mother=mother
         )
         store.session.add(link)
         store.session.commit()
@@ -724,7 +724,7 @@ class StoreHelpers:
 
         for sample in samples:
             link = base_store.relate_sample(
-                family=case, sample=sample, status=PhenotypeStatus.UNKNOWN
+                case=case, sample=sample, status=PhenotypeStatus.UNKNOWN
             )
             base_store.session.add(link)
             base_store.session.commit()

--- a/tests/store_helpers.py
+++ b/tests/store_helpers.py
@@ -22,7 +22,7 @@ from cg.store.models import (
     Collaboration,
     Customer,
     Case,
-    FamilySample,
+    CaseSample,
     Flowcell,
     Invoice,
     Organism,
@@ -653,7 +653,7 @@ class StoreHelpers:
         status: str = PhenotypeStatus.UNKNOWN,
         father: Sample = None,
         mother: Sample = None,
-    ) -> FamilySample:
+    ) -> CaseSample:
         """Utility function to link a sample to a case."""
         link = store.relate_sample(
             sample=sample, family=case, status=status, father=father, mother=mother


### PR DESCRIPTION
## Description
This PR renames the FamilySample ~table~ model to CaseSample and any references to it.

### Fixed
- Rename FamilySample
- Bonus: rename family parameter on relate_sample


### How to test

- [x] Do ensure all the views work as expected

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


