### PR TITLE
Rename family in db

### DIFF
--- a/alembic/versions/2023_11_08_b105b426af99_rename_family_in_db.py
+++ b/alembic/versions/2023_11_08_b105b426af99_rename_family_in_db.py
@@ -16,13 +16,13 @@ depends_on = None
 
 
 def upgrade():
+    # Drop foreign key constraints that reference the unique constraint to be dropped
+    op.drop_constraint("analysis_ibfk_1", "analysis", type_="foreignkey")
+    op.drop_constraint("family_sample_ibfk_1", "family_sample", type_="foreignkey")
+
     # Rename tables
     op.rename_table("family", "case")
     op.rename_table("family_sample", "case_sample")
-
-    # Drop foreign key constraints that reference the unique constraint to be dropped
-    op.drop_constraint("analysis_ibfk_1", "analysis", type_="foreignkey")
-    op.drop_constraint("case_sample_ibfk_1", "case_sample", type_="foreignkey")
 
     # Rename foreign keys
     op.alter_column("analysis", "family_id", new_column_name="case_id", existing_type=sa.Integer())

--- a/alembic/versions/2023_11_08_b105b426af99_rename_family_in_db.py
+++ b/alembic/versions/2023_11_08_b105b426af99_rename_family_in_db.py
@@ -64,4 +64,4 @@ def downgrade():
 
     # Recreate foreign key constraints referencing the original unique constraint
     op.create_foreign_key("analysis_ibfk_1", "analysis", "family", ["family_id"], ["id"])
-    op.create_foreign_key("case_sample_ibfk_1", "family_sample", "family", ["family_id"], ["id"])
+    op.create_foreign_key("family_sample_ibfk_1", "family_sample", "family", ["family_id"], ["id"])

--- a/alembic/versions/2023_11_08_b105b426af99_rename_family_in_db.py
+++ b/alembic/versions/2023_11_08_b105b426af99_rename_family_in_db.py
@@ -42,24 +42,26 @@ def upgrade():
 
 
 def downgrade():
-    # Rename tables
+    # Drop foreign key constraints before renaming them back
+    op.drop_constraint("analysis_ibfk_1", "analysis", type_="foreignkey")
+    op.drop_constraint("case_sample_ibfk_1", "case_sample", type_="foreignkey")
+
+    # Drop the unique constraint
+    op.drop_constraint("_case_sample_uc", "case_sample", type_="unique")
+
+    # Rename foreign keys back to original before renaming tables
+    op.alter_column("analysis", "case_id", new_column_name="family_id", existing_type=sa.Integer())
+    op.alter_column(
+        "case_sample", "case_id", new_column_name="family_id", existing_type=sa.Integer()
+    )
+
+    # Rename tables back to original
     op.rename_table("case", "family")
     op.rename_table("case_sample", "family_sample")
-
-    # Drop foreign key constraints before renaming them back
-    op.drop_constraint('analysis_ibfk_1', 'analysis', type_='foreignkey')
-    op.drop_constraint('case_sample_ibfk_1', 'case_sample', type_='foreignkey')
-
-    # Rename foreign keys
-    op.alter_column("analysis", "case_id", new_column_name="family_id", existing_type=sa.Integer())
-    op.alter_column("case_sample", "case_id", new_column_name="family_id", existing_type=sa.Integer())
-
-    # Drop the new unique constraint
-    op.drop_constraint("_case_sample_uc", "family_sample", type_="unique")
 
     # Recreate the original unique constraint
     op.create_unique_constraint("_family_sample_uc", "family_sample", ["family_id", "sample_id"])
 
     # Recreate foreign key constraints referencing the original unique constraint
-    op.create_foreign_key('analysis_ibfk_1', 'analysis', 'family', ['family_id'], ['id'])
-    op.create_foreign_key('case_sample_ibfk_1', 'family_sample', 'family', ['family_id'], ['id'])
+    op.create_foreign_key("analysis_ibfk_1", "analysis", "family", ["family_id"], ["id"])
+    op.create_foreign_key("case_sample_ibfk_1", "family_sample", "family", ["family_id"], ["id"])

--- a/alembic/versions/2023_11_08_b105b426af99_rename_family_in_db.py
+++ b/alembic/versions/2023_11_08_b105b426af99_rename_family_in_db.py
@@ -1,0 +1,43 @@
+"""Rename family in db
+
+Revision ID: b105b426af99
+Revises: 70e641d723b3
+Create Date: 2023-11-08 15:13:25.197537
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "b105b426af99"
+down_revision = "70e641d723b3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Rename tables
+    op.rename_table("family", "case")
+    op.rename_table("family_sample", "case_sample")
+
+    # Rename foreign keys
+    op.alter_column("analysis", "family_id", new_column_name="case_id", type=sa.Integer())
+    op.alter_column("case_sample", "family_id", new_column_name="case_id", type=sa.Integer())
+
+    # Rename unique constraint
+    op.drop_constraint("_family_sample_uc", "case_sample", type_="unique")
+    op.create_unique_constraint("_case_sample_uc", "case_sample", ["case_id", "sample_id"])
+
+
+def downgrade():
+    # Rename tables
+    op.rename_table("case", "family")
+    op.rename_table("case_sample", "family_sample")
+
+    # Rename foreign keys
+    op.alter_column("analysis", "case_id", new_column_name="family_id", type=sa.Integer())
+    op.alter_column("family_sample", "case_id", new_column_name="family_id", type=sa.Integer())
+
+    # Rename unique constraint
+    op.drop_constraint("_case_sample_uc", "family_sample", type_="unique")
+    op.create_unique_constraint("_family_sample_uc", "family_sample", ["family_id", "sample_id"])

--- a/cg/cli/workflow/fastq/base.py
+++ b/cg/cli/workflow/fastq/base.py
@@ -33,7 +33,7 @@ def store_fastq_analysis(context: click.Context, case_id: str, dry_run: bool = F
         completed_at=dt.datetime.now(),
         primary=True,
         started_at=dt.datetime.now(),
-        family_id=case_obj.id,
+        case_id=case_obj.id,
     )
     if dry_run:
         return

--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -33,8 +33,8 @@ def view_priority(unused1, unused2, model, unused3):
     return Markup("%s" % model.priority.name) if model else ""
 
 
-def view_family_sample_link(unused1, unused2, model, unused3):
-    """column formatter to open the family-sample view"""
+def view_case_sample_link(unused1, unused2, model, unused3):
+    """column formatter to open the case-sample view"""
 
     del unused1, unused2, unused3
 
@@ -258,7 +258,7 @@ class CaseView(BaseView):
         "tickets",
     ]
     column_formatters = {
-        "internal_id": view_family_sample_link,
+        "internal_id": view_case_sample_link,
         "priority": view_priority,
     }
     column_searchable_list = [
@@ -279,7 +279,7 @@ class CaseView(BaseView):
     }
 
     @staticmethod
-    def view_family_link(unused1, unused2, model, unused3):
+    def view_case_link(unused1, unused2, model, unused3):
         """column formatter to open this view"""
         del unused1, unused2, unused3
         markup = ""
@@ -310,9 +310,9 @@ class CaseView(BaseView):
     def set_action_for_cases(self, action: Union[CaseActions, None], case_entry_ids: list[str]):
         try:
             for entry_id in case_entry_ids:
-                family = db.get_case_by_entry_id(entry_id=entry_id)
-                if family:
-                    family.action = action
+                case = db.get_case_by_entry_id(entry_id=entry_id)
+                if case:
+                    case.action = action
 
             db.session.commit()
 
@@ -328,7 +328,7 @@ class CaseView(BaseView):
             if not self.handle_view_exception(ex):
                 raise
 
-            flash(gettext(f"Failed to set family action. {str(ex)}"))
+            flash(gettext(f"Failed to set case action. {str(ex)}"))
 
 
 class FlowcellView(BaseView):
@@ -392,7 +392,7 @@ class AnalysisView(BaseView):
     column_default_sort = ("created_at", True)
     column_editable_list = ["is_primary"]
     column_filters = ["pipeline", "pipeline_version", "is_primary"]
-    column_formatters = {"case": CaseView.view_family_link}
+    column_formatters = {"case": CaseView.view_case_link}
     column_searchable_list = [
         "case.internal_id",
         "case.name",
@@ -448,7 +448,7 @@ class SampleView(BaseView):
     column_filters = ["customer.internal_id", "priority", "sex", "application_version.application"]
     column_formatters = {
         "is_external": is_external_application,
-        "internal_id": view_family_sample_link,
+        "internal_id": view_case_sample_link,
         "invoice": InvoiceView.view_invoice_link,
         "priority": view_priority,
     }
@@ -570,7 +570,7 @@ class CaseSampleView(BaseView):
     column_editable_list = ["status"]
     column_filters = ["status"]
     column_formatters = {
-        "case": CaseView.view_family_link,
+        "case": CaseView.view_case_link,
         "sample": SampleView.view_sample_link,
     }
     column_searchable_list = ["case.internal_id", "case.name", "sample.internal_id"]

--- a/cg/store/api/base.py
+++ b/cg/store/api/base.py
@@ -104,7 +104,7 @@ class BaseHandler:
         return analyses.join(
             case_and_date_subquery,
             and_(
-                Analysis.case_id == case_and_date_subquery.c.family_id,
+                Analysis.case_id == case_and_date_subquery.c.case_id,
                 Analysis.started_at == case_and_date_subquery.c.started_at,
             ),
         )

--- a/cg/store/api/base.py
+++ b/cg/store/api/base.py
@@ -92,7 +92,7 @@ class BaseHandler:
         case_and_date: Query = (
             self._get_join_analysis_case_query()
             .group_by(Case.id)
-            .with_entities(Analysis.family_id, func.max(Analysis.started_at).label("started_at"))
+            .with_entities(Analysis.case_id, func.max(Analysis.started_at).label("started_at"))
             .subquery()
         )
         return case_and_date
@@ -104,7 +104,7 @@ class BaseHandler:
         return analyses.join(
             case_and_date_subquery,
             and_(
-                Analysis.family_id == case_and_date_subquery.c.family_id,
+                Analysis.case_id == case_and_date_subquery.c.family_id,
                 Analysis.started_at == case_and_date_subquery.c.started_at,
             ),
         )

--- a/cg/store/api/find_business_data.py
+++ b/cg/store/api/find_business_data.py
@@ -59,7 +59,7 @@ class FindBusinessDataHandler(BaseHandler):
         active_actions = ["analyze", "running"]
 
         for family_sample in sample.links:
-            case: Case = self.get_case_by_entry_id(entry_id=family_sample.family_id)
+            case: Case = self.get_case_by_entry_id(entry_id=family_sample.case_id)
             if case.action in active_actions:
                 return True
 

--- a/cg/store/filters/status_analysis_filters.py
+++ b/cg/store/filters/status_analysis_filters.py
@@ -67,7 +67,7 @@ def order_analyses_by_uploaded_at_asc(analyses: Query, **kwargs) -> Query:
 
 def filter_analyses_by_case_entry_id(analyses: Query, case_entry_id: int, **kwargs) -> Query:
     """Return a query of analysis filtered by case entry id."""
-    return analyses.filter(Analysis.family_id == case_entry_id)
+    return analyses.filter(Analysis.case_id == case_entry_id)
 
 
 def filter_analyses_started_before(analyses: Query, started_at_date: datetime, **kwargs) -> Query:

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -216,7 +216,7 @@ class Analysis(Model):
     is_primary = Column(types.Boolean, default=False)
 
     created_at = Column(types.DateTime, default=dt.datetime.now, nullable=False)
-    family_id = Column(ForeignKey("family.id", ondelete="CASCADE"), nullable=False)
+    case_id = Column(ForeignKey("case.id", ondelete="CASCADE"), nullable=False)
     uploaded_to_vogue_at = Column(types.DateTime, nullable=True)
 
     case = orm.relationship("Case", back_populates="analyses")
@@ -377,7 +377,7 @@ class Delivery(Model):
 
 
 class Case(Model, PriorityMixin):
-    __tablename__ = "family"
+    __tablename__ = "case"
     __table_args__ = (UniqueConstraint("customer_id", "name", name="_customer_name_uc"),)
 
     action = Column(types.Enum(*CASE_ACTIONS))
@@ -516,11 +516,11 @@ class Case(Model, PriorityMixin):
 
 
 class CaseSample(Model):
-    __tablename__ = "family_sample"
-    __table_args__ = (UniqueConstraint("family_id", "sample_id", name="_family_sample_uc"),)
+    __tablename__ = "case_sample"
+    __table_args__ = (UniqueConstraint("case_id", "sample_id", name="_case_sample_uc"),)
 
     id = Column(types.Integer, primary_key=True)
-    family_id = Column(ForeignKey("family.id", ondelete="CASCADE"), nullable=False)
+    case_id = Column(ForeignKey("case.id", ondelete="CASCADE"), nullable=False)
     sample_id = Column(ForeignKey("sample.id", ondelete="CASCADE"), nullable=False)
     status = Column(types.Enum(*STATUS_OPTIONS), default="unknown", nullable=False)
 

--- a/tests/cli/workflow/fastq/test_fastq_base.py
+++ b/tests/cli/workflow/fastq/test_fastq_base.py
@@ -23,7 +23,7 @@ def test_store_fastq_analysis(caplog, another_case_id: str, cli_runner, fastq_co
     assert (
         len(
             fastq_context.status_db._get_query(table=Analysis)
-            .filter(Analysis.family_id == case_obj.id)
+            .filter(Analysis.case_id == case_obj.id)
             .all()
         )
         > 0

--- a/tests/store_helpers.py
+++ b/tests/store_helpers.py
@@ -292,9 +292,7 @@ class StoreHelpers:
         if not case:
             case = StoreHelpers.add_case(store, data_analysis=pipeline, data_delivery=data_delivery)
 
-        analysis = store.add_analysis(
-            pipeline=pipeline, version=pipeline_version, case_id=case.id
-        )
+        analysis = store.add_analysis(pipeline=pipeline, version=pipeline_version, case_id=case.id)
 
         analysis.started_at = started_at or datetime.now()
         if completed_at:

--- a/tests/store_helpers.py
+++ b/tests/store_helpers.py
@@ -293,7 +293,7 @@ class StoreHelpers:
             case = StoreHelpers.add_case(store, data_analysis=pipeline, data_delivery=data_delivery)
 
         analysis = store.add_analysis(
-            pipeline=pipeline, version=pipeline_version, family_id=case.id
+            pipeline=pipeline, version=pipeline_version, case_id=case.id
         )
 
         analysis.started_at = started_at or datetime.now()


### PR DESCRIPTION
## Description
This PR renames the actual database table names, foreign keys and constraints to use case instead of family. Pretty high risk PR since the schema changes are not contained in a transaction.

Let me know if you think it should be split into smaller PR:s isolating each schema change.

### Fixed
- Rename family to case in database schemas

### How to test

- [x] Apply upgrade and downgrade in stage
- [x] Ensure views work

```
(cg-env) ➜  cg git:(rename-family-in-db) ✗ alembic --config ../alembic-stage.ini upgrade head          
INFO  [alembic.runtime.migration] Context impl MySQLImpl.
INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 70e641d723b3 -> b105b426af99, Rename family in db
(cg-env) ➜  cg git:(rename-family-in-db) ✗ alembic --config ../alembic-stage.ini downgrade 70e641d723b3
INFO  [alembic.runtime.migration] Context impl MySQLImpl.
INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
INFO  [alembic.runtime.migration] Running downgrade b105b426af99 -> 70e641d723b3, Rename family in db
```

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

