### PR TITLE
fix(relax clean flow cell criteria)

### DIFF
--- a/cg/meta/clean/clean_flow_cells.py
+++ b/cg/meta/clean/clean_flow_cells.py
@@ -76,9 +76,11 @@ class CleanFlowCellAPI:
                 self.is_flow_cell_in_statusdb(),
                 self.is_flow_cell_backed_up(),
                 self.has_sequencing_metrics_in_statusdb(),
-                self.has_fastq_files_for_samples_in_housekeeper(),
-                self.has_spring_meta_data_files_for_samples_in_housekeeper(),
-                self.has_spring_files_for_samples_in_housekeeper(),
+                self.has_fastq_files_for_samples_in_housekeeper()
+                or (
+                    self.has_spring_meta_data_files_for_samples_in_housekeeper()
+                    and self.has_spring_files_for_samples_in_housekeeper()
+                ),
                 self.has_sample_sheet_in_housekeeper(),
             ]
         )

--- a/tests/meta/clean/test_clean_flow_cells_api.py
+++ b/tests/meta/clean/test_clean_flow_cells_api.py
@@ -191,7 +191,7 @@ def test_can_flow_cell_be_deleted_no_spring_with_fastq(
                 flow_cell_clean_api_can_be_removed.can_flow_cell_directory_be_deleted()
             )
 
-            # THEN the check whether the flow cell can be deleted returns True
+    # THEN the check whether the flow cell can be deleted returns True
     assert can_be_deleted
 
 
@@ -214,7 +214,7 @@ def test_can_flow_cell_be_deleted_spring_no_fastq(
                 flow_cell_clean_api_can_be_removed.can_flow_cell_directory_be_deleted()
             )
 
-            # THEN the check whether the flow cell can be deleted returns True
+    # THEN the check whether the flow cell can be deleted returns True
     assert can_be_deleted
 
 
@@ -241,7 +241,7 @@ def test_can_flow_cell_be_deleted_no_spring_no_fastq(
                     flow_cell_clean_api_can_be_removed.can_flow_cell_directory_be_deleted()
                 )
 
-                # THEN the check whether the flow cell can be deleted returns True
+    # THEN the check whether the flow cell can be deleted returns True
     assert not can_be_deleted
 
 

--- a/tests/meta/clean/test_clean_flow_cells_api.py
+++ b/tests/meta/clean/test_clean_flow_cells_api.py
@@ -172,6 +172,79 @@ def test_can_flow_cell_be_deleted(flow_cell_clean_api_can_be_removed: CleanFlowC
     assert can_be_deleted
 
 
+def test_can_flow_cell_be_deleted_no_spring_with_fastq(
+    flow_cell_clean_api_can_be_removed: CleanFlowCellAPI,
+):
+    """Test that a flow cell can be deleted when it has fastq files but no spring files."""
+    # GIVEN a flow cell that can be deleted
+
+    with mock.patch(
+        "cg.meta.clean.clean_flow_cells.CleanFlowCellAPI.is_directory_older_than_21_days",
+        return_value=True,
+    ):
+        with mock.patch(
+            "cg.meta.clean.clean_flow_cells.CleanFlowCellAPI.has_spring_meta_data_files_for_samples_in_housekeeper",
+            return_value=False,
+        ):
+            # WHEN checking that the flow cell can be deleted
+            can_be_deleted: bool = (
+                flow_cell_clean_api_can_be_removed.can_flow_cell_directory_be_deleted()
+            )
+
+            # THEN the check whether the flow cell can be deleted returns True
+    assert can_be_deleted
+
+
+def test_can_flow_cell_be_deleted_spring_no_fastq(
+    flow_cell_clean_api_can_be_removed: CleanFlowCellAPI,
+):
+    """Test that a flow cell can be deleted when it has spring files but no fastq files."""
+    # GIVEN a flow cell that can be deleted
+
+    with mock.patch(
+        "cg.meta.clean.clean_flow_cells.CleanFlowCellAPI.is_directory_older_than_21_days",
+        return_value=True,
+    ):
+        with mock.patch(
+            "cg.meta.clean.clean_flow_cells.CleanFlowCellAPI.has_fastq_files_for_samples_in_housekeeper",
+            return_value=False,
+        ):
+            # WHEN checking that the flow cell can be deleted
+            can_be_deleted: bool = (
+                flow_cell_clean_api_can_be_removed.can_flow_cell_directory_be_deleted()
+            )
+
+            # THEN the check whether the flow cell can be deleted returns True
+    assert can_be_deleted
+
+
+def test_can_flow_cell_be_deleted_no_spring_no_fastq(
+    flow_cell_clean_api_can_be_removed: CleanFlowCellAPI,
+):
+    """Test that a flow cell can not be deleted when it has no spring files and no fastq files."""
+    # GIVEN a flow cell that can be deleted
+
+    with mock.patch(
+        "cg.meta.clean.clean_flow_cells.CleanFlowCellAPI.is_directory_older_than_21_days",
+        return_value=True,
+    ):
+        with mock.patch(
+            "cg.meta.clean.clean_flow_cells.CleanFlowCellAPI.has_fastq_files_for_samples_in_housekeeper",
+            return_value=False,
+        ):
+            with mock.patch(
+                "cg.meta.clean.clean_flow_cells.CleanFlowCellAPI.has_spring_meta_data_files_for_samples_in_housekeeper",
+                return_value=False,
+            ):
+                # WHEN checking that the flow cell can be deleted
+                can_be_deleted: bool = (
+                    flow_cell_clean_api_can_be_removed.can_flow_cell_directory_be_deleted()
+                )
+
+                # THEN the check whether the flow cell can be deleted returns True
+    assert not can_be_deleted
+
+
 def test_delete_flow_cell_directory(flow_cell_clean_api_can_be_removed: CleanFlowCellAPI):
     """Test that a flow cell directory is removed."""
     # GIVEN a flow cell that can be removed


### PR DESCRIPTION
## Description

Relaxes the clean flow cell criteria to either require fastq files OR spring and spring meta data files in housekeeper.



### Added

-

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
