### PR TITLE
fix(move error handling clean flow cells)

### DIFF
--- a/cg/meta/clean/clean_flow_cells.py
+++ b/cg/meta/clean/clean_flow_cells.py
@@ -20,15 +20,16 @@ LOG = logging.getLogger(__name__)
 
 class CleanFlowCellAPI:
     """
-            Handles the cleaning of flow cells in the flow cells and demultiplexed runs directories.
+    Handles the cleaning of flow cells in the flow cells and demultiplexed runs directories.
     Requirements for cleaning:
             Flow cell is older than 21 days
             Flow cell is backed up
             Flow cell is in StatusDB
             Flow cell has sequencing metrics in StatusDB
-            Flow cell has fastq files in Housekeeper
-            Flow cell has SPRING files in Housekeeper
-            Flow cell has SPRING metadata in Housekeeper
+            Flow cell has fastq files in Housekeeper or
+                Flow cell has SPRING files in Housekeeper
+                and
+                Flow cell has SPRING metadata in Housekeeper
             Flow cell has a sample sheet in Housekeeper
     """
 
@@ -76,11 +77,7 @@ class CleanFlowCellAPI:
                 self.is_flow_cell_in_statusdb(),
                 self.is_flow_cell_backed_up(),
                 self.has_sequencing_metrics_in_statusdb(),
-                self.has_fastq_files_for_samples_in_housekeeper()
-                or (
-                    self.has_spring_meta_data_files_for_samples_in_housekeeper()
-                    and self.has_spring_files_for_samples_in_housekeeper()
-                ),
+                self.has_sample_fastq_or_spring_files_in_housekeeper(),
                 self.has_sample_sheet_in_housekeeper(),
             ]
         )
@@ -122,6 +119,18 @@ class CleanFlowCellAPI:
             self.get_files_for_samples_on_flow_cell_with_tag(tag=SequencingFileTag.SPRING_METADATA)
         )
 
+    def has_sample_fastq_or_spring_files_in_housekeeper(self) -> bool:
+        """Check if a flow cell has fastq or spring files in housekeeper."""
+        if not self.has_fastq_files_for_samples_in_housekeeper() and not (
+            self.has_spring_files_for_samples_in_housekeeper()
+            and self.has_spring_meta_data_files_for_samples_in_housekeeper()
+        ):
+            raise HousekeeperFileMissingError(
+                f"Flow cell {self.flow_cell.id} is missing fastq and spring files for some samples. "
+                f"Info can be found in debug mode."
+            )
+        return True
+
     def get_flow_cell_from_status_db(self) -> Optional[Flowcell]:
         """
         Get the flow cell entry from StatusDB.
@@ -148,7 +157,7 @@ class CleanFlowCellAPI:
             )
         return metrics
 
-    def get_files_for_samples_on_flow_cell_with_tag(self, tag: str) -> Optional[list[File]]:
+    def get_files_for_samples_on_flow_cell_with_tag(self, tag: str) -> list[File] | None:
         """
         Return the files with the specified tag for all samples on a Flow cell.
         """
@@ -162,7 +171,8 @@ class CleanFlowCellAPI:
                 ).all()
             )
             if not files:
-                raise HousekeeperFileMissingError(
+                LOG.debug(
                     f"No files with tag {tag} found for sample {bundle_name} on flow cell {self.flow_cell.id}"
                 )
+                return None
         return files

--- a/cg/meta/clean/clean_flow_cells.py
+++ b/cg/meta/clean/clean_flow_cells.py
@@ -120,7 +120,11 @@ class CleanFlowCellAPI:
         )
 
     def has_sample_fastq_or_spring_files_in_housekeeper(self) -> bool:
-        """Check if a flow cell has fastq or spring files in housekeeper."""
+        """
+        Check if a flow cell has fastq or spring files in housekeeper.
+        Raises:
+            HousekeeperFileMissingError
+        """
         if not self.has_fastq_files_for_samples_in_housekeeper() and not (
             self.has_spring_files_for_samples_in_housekeeper()
             and self.has_spring_meta_data_files_for_samples_in_housekeeper()

--- a/tests/meta/clean/test_clean_flow_cells_api.py
+++ b/tests/meta/clean/test_clean_flow_cells_api.py
@@ -310,7 +310,7 @@ def test_flow_cell_has_not_fastq_files_in_housekeeper(
 
     # WHEN checking whether a sample on a flow cell has fastq files
 
-    # THEN nothing the flow cell has no fastq files in housekeeper.
+    # THEN the flow cell has no fastq files in housekeeper.
     assert not flow_cell_clean_api_can_not_be_removed.has_fastq_files_for_samples_in_housekeeper()
     assert SequencingFileTag.FASTQ in caplog.text
 

--- a/tests/meta/clean/test_clean_flow_cells_api.py
+++ b/tests/meta/clean/test_clean_flow_cells_api.py
@@ -237,12 +237,10 @@ def test_can_flow_cell_be_deleted_no_spring_no_fastq(
                 return_value=False,
             ):
                 # WHEN checking that the flow cell can be deleted
-                can_be_deleted: bool = (
-                    flow_cell_clean_api_can_be_removed.can_flow_cell_directory_be_deleted()
-                )
 
-    # THEN the check whether the flow cell can be deleted returns True
-    assert not can_be_deleted
+                # THEN a HousekeeperFileMissingError is raised
+                with pytest.raises(HousekeeperFileMissingError):
+                    flow_cell_clean_api_can_be_removed.can_flow_cell_directory_be_deleted()
 
 
 def test_delete_flow_cell_directory(flow_cell_clean_api_can_be_removed: CleanFlowCellAPI):

--- a/tests/meta/clean/test_clean_flow_cells_api.py
+++ b/tests/meta/clean/test_clean_flow_cells_api.py
@@ -310,10 +310,9 @@ def test_flow_cell_has_not_fastq_files_in_housekeeper(
 
     # WHEN checking whether a sample on a flow cell has fastq files
 
-    # THEN a HousekeeperFileMissingError is raised
-    with pytest.raises(HousekeeperFileMissingError):
-        flow_cell_clean_api_can_not_be_removed.has_fastq_files_for_samples_in_housekeeper()
-        assert SequencingFileTag.SPRING in caplog.text
+    # THEN nothing the flow cell has no fastq files in housekeeper.
+    assert not flow_cell_clean_api_can_not_be_removed.has_fastq_files_for_samples_in_housekeeper()
+    assert SequencingFileTag.FASTQ in caplog.text
 
 
 def test_flow_cell_has_not_spring_files_in_housekeeper(
@@ -330,10 +329,9 @@ def test_flow_cell_has_not_spring_files_in_housekeeper(
 
     # WHEN checking whether a sample on a flow cell has spring files
 
-    # THEN a HousekeeperFileMissingError is raised
-    with pytest.raises(HousekeeperFileMissingError):
-        flow_cell_clean_api_can_not_be_removed.has_spring_files_for_samples_in_housekeeper()
-        assert SequencingFileTag.SPRING in caplog.text
+    # THEN the flow cell has no spring files for samples in housekeeper
+    assert not flow_cell_clean_api_can_not_be_removed.has_spring_files_for_samples_in_housekeeper()
+    assert SequencingFileTag.SPRING in caplog.text
 
 
 def test_flow_cell_has_not_spring_meta_data_files_in_housekeeper(
@@ -350,7 +348,25 @@ def test_flow_cell_has_not_spring_meta_data_files_in_housekeeper(
 
     # WHEN checking whether a sample on a flow cell has spring files
 
+    # THEN the flow cell has no spring metadata files in housekeeper
+
+    assert (
+        not flow_cell_clean_api_can_not_be_removed.has_spring_meta_data_files_for_samples_in_housekeeper()
+    )
+    assert SequencingFileTag.SPRING_METADATA in caplog.text
+
+
+def test_has_no_sample_files_in_housekeeper(
+    flow_cell_clean_api_can_not_be_removed: CleanFlowCellAPI,
+    store_with_flow_cell_not_to_clean: Store,
+    housekeeper_api_with_flow_cell_not_to_clean: HousekeeperAPI,
+):
+    # GIVEN a flow cell that has entries in StatusDB but does not have any files in Housekeeper for its samples
+    flow_cell_clean_api_can_not_be_removed.status_db = store_with_flow_cell_not_to_clean
+    flow_cell_clean_api_can_not_be_removed.hk_api = housekeeper_api_with_flow_cell_not_to_clean
+
+    # WHEN checking whether a sample on a flow cell has files in housekeeper
+
     # THEN a HousekeeperFileMissingError is raised
     with pytest.raises(HousekeeperFileMissingError):
-        flow_cell_clean_api_can_not_be_removed.has_spring_meta_data_files_for_samples_in_housekeeper()
-        assert SequencingFileTag.SPRING_METADATA in caplog.text
+        flow_cell_clean_api_can_not_be_removed.has_sample_fastq_or_spring_files_in_housekeeper()


### PR DESCRIPTION
## Description

The CleanFlowCellAPI would raise an error and exit when no fastq files where found even if a sample would have spring files in housekeeper.
This was unintened with the relaxation of criteria.

To fix this:

A new function was added to the CleanFlowCellAPI
`has_sample_fastq_or_spring_files_in_housekeeper`

This function checks if all samples have either fastq files OR spring files and spring meta data files. If any sample does not have one or the other a `HousekeeperFileMissingError`  is raised that will be propagated to the user.

Moved `HousekeeperFilesMissingError` into `has_sample_fastq_or_spring_files_in_housekeeper`
was previously in `get_files_for_samples_on_flow_cell_with_tag`



### Added

-

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
