### PR TITLE
Count dsmc processes 

### DIFF
--- a/cg/meta/backup/pdc.py
+++ b/cg/meta/backup/pdc.py
@@ -41,8 +41,8 @@ class PdcAPI:
         is_dsmc_running: bool = False
         try:
             for process in psutil.process_iter():
+                LOG.debug(process.name())
                 if "dsmc" in process.name():
-                    LOG.debug(process.name())
                     is_dsmc_running = True
         except Exception as error:
             LOG.debug(f"{error}")

--- a/cg/meta/backup/pdc.py
+++ b/cg/meta/backup/pdc.py
@@ -23,6 +23,7 @@ LOG = logging.getLogger(__name__)
 
 SERVER = "hasta"
 NO_FILE_FOUND_ANSWER = "ANS1092W"
+MAX_NR_OF_DSMC_PROCESSES: int = 3
 
 
 class PdcAPI:
@@ -39,17 +40,16 @@ class PdcAPI:
             Exception: for all non-exit exceptions.
         """
         is_dsmc_running: bool = False
-        dsmc_count: int = 0
+        dsmc_process_count: int = 0
         try:
             for process in psutil.process_iter():
                 LOG.debug(process.name())
                 if "dsmc" == process.name():
-                    dsmc_count += 1
+                    dsmc_process_count += 1
         except Exception as error:
             LOG.debug(f"{error}")
-        if dsmc_count >= 3:
+        if dsmc_process_count >= MAX_NR_OF_DSMC_PROCESSES:
             is_dsmc_running = True
-        if is_dsmc_running:
             LOG.debug("Too many Dsmc processes are already running")
         return is_dsmc_running
 
@@ -97,7 +97,7 @@ class PdcAPI:
             FlowCellEncryptionError if encryption is not complete.
         """
         if self.validate_is_dsmc_running():
-            raise DsmcAlreadyRunningError("A Dsmc process is already running")
+            raise DsmcAlreadyRunningError("Too many Dsmc processes are already running")
         if db_flow_cell and db_flow_cell.has_backup:
             raise FlowCellAlreadyBackedUpError(
                 f"Flow cell: {db_flow_cell.name} is already backed-up"

--- a/cg/meta/backup/pdc.py
+++ b/cg/meta/backup/pdc.py
@@ -42,6 +42,7 @@ class PdcAPI:
         try:
             for process in psutil.process_iter():
                 if "dsmc" in process.name():
+                    LOG.debug(process.name())
                     is_dsmc_running = True
         except Exception as error:
             LOG.debug(f"{error}")

--- a/cg/meta/backup/pdc.py
+++ b/cg/meta/backup/pdc.py
@@ -39,15 +39,18 @@ class PdcAPI:
             Exception: for all non-exit exceptions.
         """
         is_dsmc_running: bool = False
+        dsmc_count: int = 0
         try:
             for process in psutil.process_iter():
                 LOG.debug(process.name())
-                if "dsmc" in process.name():
-                    is_dsmc_running = True
+                if "dsmc" == process.name():
+                    dsmc_count += 1
         except Exception as error:
             LOG.debug(f"{error}")
+        if dsmc_count >= 3:
+            is_dsmc_running = True
         if is_dsmc_running:
-            LOG.debug("A Dsmc process is already running")
+            LOG.debug("Too many Dsmc processes are already running")
         return is_dsmc_running
 
     def archive_file_to_pdc(self, file_path: str) -> None:

--- a/tests/cli/backup/test_backup_command.py
+++ b/tests/cli/backup/test_backup_command.py
@@ -63,8 +63,8 @@ def test_backup_flow_cells_when_dsmc_is_running(
     # THEN exits without any errors
     assert result.exit_code == EXIT_SUCCESS
 
-    # THEN communicate Dsmc process is already running
-    assert "A Dsmc process is already running" in caplog.text
+    # THEN communicate too many Dsmc processes are already running
+    assert "Too many Dsmc processes are already running" in caplog.text
 
 
 def test_backup_flow_cells_when_flow_cell_already_has_backup(


### PR DESCRIPTION
## Description

There seem to almost always be a dsmc process running globally on hasta. This PR relaxes the criteria for starting flow-cell backups to allow a maximum of 3 dsmc proccees when doing backups.

### Changed

- Allow 3 running dsmc processes


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b fix-dsmc -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
