### PR TITLE
fix - catch sample sheet errors in sample sheet generation automation

### DIFF
--- a/cg/cli/demultiplex/sample_sheet.py
+++ b/cg/cli/demultiplex/sample_sheet.py
@@ -12,7 +12,7 @@ from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.apps.lims.sample_sheet import get_flow_cell_samples
 from cg.constants.constants import DRY_RUN, FileFormat
 from cg.constants.demultiplexing import OPTION_BCL_CONVERTER
-from cg.exc import FlowCellError, HousekeeperFileMissingError
+from cg.exc import FlowCellError, HousekeeperFileMissingError, SampleSheetError
 from cg.io.controller import WriteFile, WriteStream
 from cg.meta.demultiplex.housekeeper_storage_functions import add_sample_sheet_path_to_housekeeper
 from cg.models.cg_config import CGConfig
@@ -182,7 +182,14 @@ def create_all_sheets(context: CGConfig, dry_run: bool):
                 flow_cell=flow_cell,
                 lims_samples=lims_samples,
             )
-        except (FileNotFoundError, FileExistsError, ValidationError, FlowCellError):
+        except (
+            FileNotFoundError,
+            FileExistsError,
+            ValidationError,
+            FlowCellError,
+            SampleSheetError,
+        ) as exc:
+            LOG.warning(f"Sample sheet generation failed for flow cell {flow_cell_id} due to {exc}")
             continue
 
         if dry_run:


### PR DESCRIPTION
## Description
Flow cells with only single-index samples raise a `SampleSheetError` in the creation of their sample sheet, which is not caught and therefore blocks the automation.

This patch could be removed after the creation of sample sheets is refactored to only V2.

### Added

- `SampleSheetError` to the list of caught exceptions in the cli command `cg demultiplex samplesheet create-all`
- A meaningful warning to the log when a sample sheet can't be created


### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b fix-old-sample-sheets -a
    ```

### How to test

- [x] Make sure that a flow cell with only single indexes is to be demultiplexed
- [x] `cg demultiplex samplesheet create-all`

### Expected test outcome

- [x] Check that the automation runs smoothly and informs the reason why the sample sheet could not be created

## Review

- [x] Tests executed by SD
- [x] "Merge and deploy" approved by HS IO
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Deploy this branch on 
  - [ ] cg stage
  - [ ] cg production 
