### PR TITLE
Add new development priority to cases

### DIFF
--- a/alembic/versions/2023_12_01_3ac26865d2bf_add_dev_priority.py
+++ b/alembic/versions/2023_12_01_3ac26865d2bf_add_dev_priority.py
@@ -8,13 +8,19 @@ Create Date: 2023-12-01 11:39:35.273991
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = '3ac26865d2bf'
-down_revision = 'b105b426af99'
+revision = "3ac26865d2bf"
+down_revision = "b105b426af99"
 branch_labels = None
 depends_on = None
 
+
 def upgrade():
-    op.execute("ALTER TABLE `case` MODIFY COLUMN priority ENUM('research', 'standard', 'priority', 'express', 'clinical_trials', 'development')")
+    op.execute(
+        "ALTER TABLE `case` MODIFY COLUMN priority ENUM('research', 'standard', 'priority', 'express', 'clinical_trials', 'development')"
+    )
+
 
 def downgrade():
-    op.execute("ALTER TABLE `case` MODIFY COLUMN priority ENUM('research', 'standard', 'priority', 'express', 'clinical_trials')")
+    op.execute(
+        "ALTER TABLE `case` MODIFY COLUMN priority ENUM('research', 'standard', 'priority', 'express', 'clinical_trials')"
+    )

--- a/alembic/versions/2023_12_01_3ac26865d2bf_add_dev_priority.py
+++ b/alembic/versions/2023_12_01_3ac26865d2bf_add_dev_priority.py
@@ -1,0 +1,20 @@
+"""Add dev priority
+
+Revision ID: 3ac26865d2bf
+Revises: b105b426af99
+Create Date: 2023-12-01 11:39:35.273991
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '3ac26865d2bf'
+down_revision = 'b105b426af99'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.execute("ALTER TABLE `case` MODIFY COLUMN priority ENUM('research', 'standard', 'priority', 'express', 'clinical_trials', 'development')")
+
+def downgrade():
+    op.execute("ALTER TABLE `case` MODIFY COLUMN priority ENUM('research', 'standard', 'priority', 'express', 'clinical_trials')")

--- a/alembic/versions/2023_12_01_3ac26865d2bf_add_dev_priority.py
+++ b/alembic/versions/2023_12_01_3ac26865d2bf_add_dev_priority.py
@@ -21,6 +21,7 @@ def upgrade():
 
 
 def downgrade():
+    op.execute("UPDATE `case` SET priority = 'research' WHERE priority = 'development'")
     op.execute(
         "ALTER TABLE `case` MODIFY COLUMN priority ENUM('research', 'standard', 'priority', 'express', 'clinical_trials')"
     )

--- a/cg/constants/priority.py
+++ b/cg/constants/priority.py
@@ -24,6 +24,7 @@ class Priority(IntEnum):
     priority: int = 2
     express: int = 3
     clinical_trials: int = 4
+    development: int = 5
 
     @classmethod
     def priority_to_slurm_qos(cls) -> dict[int, str]:


### PR DESCRIPTION
## Description
This PR adds a `development` priority to cases, the first step of resolving https://github.com/Clinical-Genomics/cg/issues/2719. 

I guess the next step is to add a filter option for these in trailblazer, assuming the analyses receive their prio from the one set on the case.

### Fixed
- Add development prio to cases

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions