### PR TITLE
Fix verification of HTTPS requests

### DIFF
--- a/cg/io/controller.py
+++ b/cg/io/controller.py
@@ -88,6 +88,6 @@ class APIRequest:
 
     @classmethod
     def api_request_from_content(
-        cls, api_method: str, url: str, headers: dict, json: dict, verify: bool = False
+        cls, api_method: str, url: str, headers: dict, json: dict, verify: bool = True
     ) -> Response:
         return cls.api_request[api_method](url=url, headers=headers, json=json, verify=verify)


### PR DESCRIPTION
## Description

In the new Archiving workflow, we need to send unverified requests but unfortunately I set the default to be that we do not verify the requests as well. This PR changes the default.

### Fixed

- Unless otherwise specified, api requests are verified.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b fix-default-verify -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
