### PR TITLE
Patch broken enums

### DIFF
--- a/cg/constants/constants.py
+++ b/cg/constants/constants.py
@@ -40,7 +40,7 @@ class CaseActions(StrEnum):
 
     @classmethod
     def actions(cls) -> list[str]:
-        return list(cls)
+        return list(map(lambda action: action.value, cls))
 
 
 CONTAINER_OPTIONS = ("Tube", "96 well plate", "No container")
@@ -71,7 +71,7 @@ class FlowCellStatus(StrEnum):
 
     @classmethod
     def statuses(cls) -> list[str]:
-        return list(cls)
+        return list(map(lambda status: status.value, cls))
 
 
 class AnalysisType(StrEnum):

--- a/cg/constants/gene_panel.py
+++ b/cg/constants/gene_panel.py
@@ -45,7 +45,7 @@ class GenePanelMasterList(StrEnum):
     @classmethod
     def get_panel_names(cls, panels=None) -> list[str]:
         """Return requested panel names from the Master list, or all panels if none are specified."""
-        return list(panels) if panels else list(cls)
+        return list(panels) if panels else list(map(lambda panel: panel.value, cls))
 
     @staticmethod
     def collaborators() -> set[str]:

--- a/cg/constants/housekeeper_tags.py
+++ b/cg/constants/housekeeper_tags.py
@@ -18,7 +18,7 @@ class AlignmentFileTag(StrEnum):
 
     @classmethod
     def file_tags(cls) -> list[str]:
-        return list(cls)
+        return list(map(lambda tag: tag.value, cls))
 
 
 class ArchiveTag(StrEnum):

--- a/cg/meta/workflow/fluffy.py
+++ b/cg/meta/workflow/fluffy.py
@@ -40,7 +40,7 @@ class FluffySampleSheetHeaders(StrEnum):
 
     @classmethod
     def headers(cls) -> list[str]:
-        return list(cls)
+        return list(map(lambda header: header.value, cls))
 
 
 class FluffySample(BaseModel):


### PR DESCRIPTION
## Description

Addresses #2748. Turns out that `list(cls)` on a StrEnum class returns a list of enums, which work well in most instances but they hinder some fields from being set in the front end. This PR patches this by mapping the enums to their values, although there might be more beautiful ways of doing it.

### Fixed

- Map enums to their values.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
