### PR TITLE
Added method get_managed_variants to mip rna workflow

### DIFF
--- a/cg/meta/workflow/mip.py
+++ b/cg/meta/workflow/mip.py
@@ -329,3 +329,6 @@ class MipAnalysisAPI(AnalysisAPI):
         )
         sample_info: MipBaseSampleInfo = MipBaseSampleInfo(**sample_info_raw)
         return sample_info.mip_version
+
+    def write_managed_variants(self, case_id: str, content: list[str]) -> None:
+        self._write_managed_variants(out_dir=Path(self.root, case_id), content=content)

--- a/cg/meta/workflow/mip_dna.py
+++ b/cg/meta/workflow/mip_dna.py
@@ -73,6 +73,3 @@ class MipDNAAnalysisAPI(MipAnalysisAPI):
     def get_managed_variants(self) -> list[str]:
         """Create and return the managed variants."""
         return self._get_managed_variants(genome_build=GENOME_BUILD_37)
-
-    def write_managed_variants(self, case_id: str, content: list[str]) -> None:
-        self._write_managed_variants(out_dir=Path(self.root, case_id), content=content)

--- a/cg/meta/workflow/mip_rna.py
+++ b/cg/meta/workflow/mip_rna.py
@@ -56,3 +56,7 @@ class MipRNAAnalysisAPI(MipAnalysisAPI):
     def get_gene_panel(self, case_id: str) -> list[str]:
         """Create and return the aggregated gene panel file."""
         return self._get_gene_panel(case_id=case_id, genome_build=GENOME_BUILD_38)
+
+    def get_managed_variants(self) -> list[str]:
+        """Create and return the managed variants."""
+        return self._get_managed_variants(genome_build=GENOME_BUILD_38)


### PR DESCRIPTION
## Description

The `MipRNAAnalysisAPI` didn't have a `get_managed_variants` method which raised an error when running `cg workflow mip-rna start -sa star_fusion hugewasp`

### Added

- Method `get_managed_variants` to `MipRNAAnalysisAPI`

### Changed

- Moved method `write_managed_variants` from `MipDNAAnalysisAPI` to `MipAnalysisAPI` so that it is available also for MipRNA

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
