### PR TITLE
Add column to determine if eligible for skip qc

### DIFF
--- a/alembic/versions/2023_12_11_79454ff320bf_add_eligible_for_skip_qc.py
+++ b/alembic/versions/2023_12_11_79454ff320bf_add_eligible_for_skip_qc.py
@@ -1,0 +1,27 @@
+"""add-eligible-for-skip-qc
+
+Revision ID: 79454ff320bf
+Revises: b105b426af99
+Create Date: 2023-12-11 15:02:40.593762
+
+"""
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "79454ff320bf"
+down_revision = "b105b426af99"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "application",
+        sa.Column("is_eligible_for_skip_qc", sa.Boolean(), nullable=False),
+    )
+
+
+def downgrade():
+    op.drop_column("application", "is_eligible_for_skip_qc")

--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -86,6 +86,7 @@ class ApplicationView(BaseView):
         "sample_concentration",
         "priority_processing",
         "is_archived",
+        "is_eligible_for_skip_qc",
     ]
     column_exclude_list = [
         "minimum_order",

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -116,6 +116,8 @@ class Application(Model):
     created_at = Column(types.DateTime, default=dt.datetime.now)
     updated_at = Column(types.DateTime, onupdate=dt.datetime.now)
 
+    is_eligible_for_skip_qc = Column(types.Boolean, default=False, nullable=False)
+
     versions = orm.relationship(
         "ApplicationVersion", order_by="ApplicationVersion.version", back_populates="application"
     )


### PR DESCRIPTION
## Description

As part of the ongoing developments to let some customers bypass our qc, we need to keep track of which applications are allowed. The ones currently allowed are described here https://github.com/Clinical-Genomics/project-planning/issues/485#issuecomment-1845032498. This PR adds a column to the Application table which shows whether the application is eligible for skipping qc.

### Added

- New `is_eligible_for_skip_qc` column to the Application table.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b add-eligible-column -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
