### PR TITLE
rnafusion HK tags as constants

### DIFF
--- a/cg/constants/delivery.py
+++ b/cg/constants/delivery.py
@@ -1,7 +1,7 @@
 """Constants for delivery."""
 
 from cg.constants.constants import Pipeline
-from cg.constants.housekeeper_tags import AlignmentFileTag
+from cg.constants.housekeeper_tags import AlignmentFileTag, AnalysisTag, HK_DELIVERY_REPORT_TAG
 
 ONLY_ONE_CASE_PER_TICKET: list[Pipeline] = [
     Pipeline.FASTQ,

--- a/cg/constants/delivery.py
+++ b/cg/constants/delivery.py
@@ -115,12 +115,12 @@ MIP_RNA_ANALYSIS_CASE_TAGS: list[set[str]] = [
 ]
 
 MIP_RNA_ANALYSIS_SAMPLE_TAGS: list[set[str]] = [
-    {"fusion", "star-fusion"},
-    {"fusion", "arriba"},
+    {AnalysisTag.FUSION, AnalysisTag.STARFUSION},
+    {AnalysisTag.FUSION, AnalysisTag.ARRIBA},
     {AlignmentFileTag.CRAM},
     {AlignmentFileTag.CRAM_INDEX},
-    {"fusion", "vcf"},
-    {"fusion", "vcf-index"},
+    {AnalysisTag.FUSION, "vcf"},
+    {AnalysisTag.FUSION, "vcf-index"},
     {"salmon-quant"},
 ]
 

--- a/cg/constants/delivery.py
+++ b/cg/constants/delivery.py
@@ -1,6 +1,7 @@
 """Constants for delivery."""
 
 from cg.constants.constants import Pipeline
+from cg.constants.housekeeper_tags import AlignmentFileTag
 
 ONLY_ONE_CASE_PER_TICKET: list[Pipeline] = [
     Pipeline.FASTQ,
@@ -37,8 +38,8 @@ BALSAMIC_ANALYSIS_CASE_TAGS: list[set[str]] = [
 ]
 
 BALSAMIC_ANALYSIS_SAMPLE_TAGS: list[set[str]] = [
-    {"cram"},
-    {"cram-index"},
+    {AlignmentFileTag.CRAM},
+    {AlignmentFileTag.CRAM_INDEX},
 ]
 
 BALSAMIC_QC_ANALYSIS_CASE_TAGS: list[set[str]] = [
@@ -95,10 +96,10 @@ MIP_DNA_ANALYSIS_CASE_TAGS: list[set[str]] = [
 ]
 
 MIP_DNA_ANALYSIS_SAMPLE_TAGS: list[set[str]] = [
-    {"bam"},
-    {"bam-index"},
-    {"cram"},
-    {"cram-index"},
+    {AlignmentFileTag.BAM},
+    {AlignmentFileTag.BAM_BAI},
+    {AlignmentFileTag.CRAM},
+    {AlignmentFileTag.CRAM_INDEX},
 ]
 
 MIP_RNA_ANALYSIS_CASE_TAGS: list[set[str]] = [
@@ -116,8 +117,8 @@ MIP_RNA_ANALYSIS_CASE_TAGS: list[set[str]] = [
 MIP_RNA_ANALYSIS_SAMPLE_TAGS: list[set[str]] = [
     {"fusion", "star-fusion"},
     {"fusion", "arriba"},
-    {"cram"},
-    {"cram-index"},
+    {AlignmentFileTag.CRAM},
+    {AlignmentFileTag.CRAM_INDEX},
     {"fusion", "vcf"},
     {"fusion", "vcf-index"},
     {"salmon-quant"},
@@ -150,23 +151,23 @@ SARSCOV2_ANALYSIS_SAMPLE_TAGS: list[set[str]] = [
 ]
 
 RNAFUSION_ANALYSIS_CASE_TAGS: list[set[str]] = [
-    {"fusion", "arriba"},
-    {"fusion", "star-fusion"},
-    {"fusion", "fusioncatcher"},
-    {"fusioncatcher-summary"},
-    {"fusioninspector"},
-    {"fusionreport", "research"},
-    {"fusioninspector-html", "research"},
-    {"arriba-visualisation", "research"},
-    {"multiqc-html", "rna"},
-    {"delivery-report"},
-    {"vcf-fusion"},
-    {"gene-counts"},
+    {AnalysisTag.FUSION, AnalysisTag.ARRIBA},
+    {AnalysisTag.FUSION, AnalysisTag.STARFUSION},
+    {AnalysisTag.FUSION, AnalysisTag.FUSIONCATCHER},
+    {AnalysisTag.FUSIONCATCHER_SUMMARY},
+    {AnalysisTag.FUSIONINSPECTOR},
+    {AnalysisTag.FUSIONREPORT, AnalysisTag.RESEARCH},
+    {AnalysisTag.FUSIONINSPECTOR_HTML, AnalysisTag.RESEARCH},
+    {AnalysisTag.ARRIBA_VISUALIZATION, AnalysisTag.RESEARCH},
+    {AnalysisTag.MULTIQC_HTML, AnalysisTag.RNA},
+    {HK_DELIVERY_REPORT_TAG},
+    {AnalysisTag.VCF_FUSION},
+    {AnalysisTag.GENE_COUNTS},
 ]
 
 RNAFUSION_ANALYSIS_SAMPLE_TAGS: list[set[str]] = [
-    {"cram"},
-    {"cram-index"},
+    {AlignmentFileTag.CRAM},
+    {AlignmentFileTag.CRAM_INDEX},
 ]
 
 

--- a/cg/constants/housekeeper_tags.py
+++ b/cg/constants/housekeeper_tags.py
@@ -55,20 +55,20 @@ HK_DELIVERY_REPORT_TAG = "delivery-report"
 class AnalysisTag(StrEnum):
     """Tags for analysis files."""
 
-    MULTIQC_HTML: str = "multiqc-html"
-    FUSION: str = "fusion"
     ARRIBA: str = "arriba"
-    STARFUSION: str = "star-fusion"
+    ARRIBA_VISUALIZATION: str = "arriba-visualisation"
+    FUSION: str = "fusion"
     FUSIONCATCHER: str = "fusioncatcher"
     FUSIONCATCHER_SUMMARY: str = "fusioncatcher-summary"
     FUSIONINSPECTOR: str = "fusioninspector"
-    FUSIONREPORT: str = "fusionreport"
-    RESEARCH: str = "research"
     FUSIONINSPECTOR_HTML: str = "fusioninspector-html"
-    ARRIBA_VISUALIZATION: str = "arriba-visualisation"
-    RNA: str = "rna"
-    VCF_FUSION: str = "vcf-fusion"
+    FUSIONREPORT: str = "fusionreport"
     GENE_COUNTS: str = "gene-counts"
+    MULTIQC_HTML: str = "multiqc-html"
+    RESEARCH: str = "research"
+    RNA: str = "rna"
+    STARFUSION: str = "star-fusion"
+    VCF_FUSION: str = "vcf-fusion"
 
 
 class HkMipAnalysisTag:

--- a/cg/constants/housekeeper_tags.py
+++ b/cg/constants/housekeeper_tags.py
@@ -52,6 +52,25 @@ HK_FASTQ_TAGS = [SequencingFileTag.FASTQ]
 HK_DELIVERY_REPORT_TAG = "delivery-report"
 
 
+class AnalysisTag(StrEnum):
+    """Tags for analysis files."""
+
+    MULTIQC_HTML: str = "multiqc-html"
+    FUSION: str = "fusion"
+    ARRIBA: str = "arriba"
+    STARFUSION: str = "star-fusion"
+    FUSIONCATCHER: str = "fusioncatcher"
+    FUSIONCATCHER_SUMMARY: str = "fusioncatcher-summary"
+    FUSIONINSPECTOR: str = "fusioninspector"
+    FUSIONREPORT: str = "fusionreport"
+    RESEARCH: str = "research"
+    FUSIONINSPECTOR_HTML: str = "fusioninspector-html"
+    ARRIBA_VISUALIZATION: str = "arriba-visualisation"
+    RNA: str = "rna"
+    VCF_FUSION: str = "vcf-fusion"
+    GENE_COUNTS: str = "gene-counts"
+
+
 class HkMipAnalysisTag:
     CONFIG: list[str] = ["mip-config"]
     QC_METRICS: list[str] = ["qc-metrics", "deliverable"]


### PR DESCRIPTION
## Description

Closes https://github.com/Clinical-Genomics/cg/issues/2743

### Changed

- Use constants for rnafusion HK tags instead of strings



### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b delivery_constants -a
    ```

### How to test

- [ ] `cg upload -c RNAFUSION_CASE`. Make sure it's successful

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
