### PR TITLE
Fix sample name format in DownsampleData class

### DIFF
--- a/cg/models/downsample/downsample_data.py
+++ b/cg/models/downsample/downsample_data.py
@@ -42,8 +42,7 @@ class DownsampleData:
         self,
     ) -> str:
         """Return a new sample name with the number of reads to which it is down sampled in millions appended."""
-        number_of_reads: str = str(self.number_of_reads).replace(".", "C")
-        return f"{self.sample_id}D{number_of_reads}M"
+        return f"{self.sample_id}D{self.convert_number_of_reads_to_string}M"
 
     @property
     def downsampled_case_name(
@@ -51,6 +50,11 @@ class DownsampleData:
     ) -> str:
         """Return a case name with _downsampled appended."""
         return f"{self.case_name}_downsampled"
+
+    @property
+    def convert_number_of_reads_to_string(self) -> str:
+        """Convert the number of reads to a string."""
+        return str(self.number_of_reads).replace(".", "C")
 
     def get_sample_to_downsample(self) -> Sample:
         """

--- a/cg/models/downsample/downsample_data.py
+++ b/cg/models/downsample/downsample_data.py
@@ -41,7 +41,9 @@ class DownsampleData:
     def downsampled_sample_name(
         self,
     ) -> str:
-        """Return a new sample name with the number of reads to which it is down sampled in millions appended."""
+        """Return a new sample name with the number of reads to which it is down sampled in millions
+        appended. DS stands for downsampled. The number of reads is converted to a string and the
+        decimal point is replaced with a C."""
         return f"{self.sample_id}DS{self.convert_number_of_reads_to_string}M"
 
     @property

--- a/cg/models/downsample/downsample_data.py
+++ b/cg/models/downsample/downsample_data.py
@@ -42,7 +42,7 @@ class DownsampleData:
         self,
     ) -> str:
         """Return a new sample name with the number of reads to which it is down sampled in millions appended."""
-        return f"{self.sample_id}D{self.convert_number_of_reads_to_string}M"
+        return f"{self.sample_id}DS{self.convert_number_of_reads_to_string}M"
 
     @property
     def downsampled_case_name(

--- a/cg/models/downsample/downsample_data.py
+++ b/cg/models/downsample/downsample_data.py
@@ -42,7 +42,7 @@ class DownsampleData:
         self,
     ) -> str:
         """Return a new sample name with the number of reads to which it is down sampled in millions appended."""
-        return f"{self.sample_id}_{self.number_of_reads}M"
+        return f"{self.sample_id}-{self.number_of_reads}M"
 
     @property
     def downsampled_case_name(

--- a/cg/models/downsample/downsample_data.py
+++ b/cg/models/downsample/downsample_data.py
@@ -42,7 +42,8 @@ class DownsampleData:
         self,
     ) -> str:
         """Return a new sample name with the number of reads to which it is down sampled in millions appended."""
-        return f"{self.sample_id}-{self.number_of_reads}M"
+        number_of_reads: str = str(self.number_of_reads).replace(".", "C")
+        return f"{self.sample_id}D{number_of_reads}M"
 
     @property
     def downsampled_case_name(

--- a/tests/models/downsample/test_down_sample_meta_data.py
+++ b/tests/models/downsample/test_down_sample_meta_data.py
@@ -40,11 +40,10 @@ def test_downsample_meta_data_pass_checks(
         case_name=downsample_case_name,
         out_dir=tmp_path_factory.mktemp("tmp"),
     )
+    # WHEN the number of reads in millionts is converted to a string
+    number_of_reads: str = meta_data.convert_number_of_reads_to_string
 
     # THEN all necessary models to run the down sample command are created
-    assert (
-        meta_data.downsampled_sample.internal_id
-        == f"{sample.internal_id}-{number_of_reads_in_millions}M"
-    )
+    assert meta_data.downsampled_sample.internal_id == f"{sample.internal_id}D{number_of_reads}M"
     assert meta_data.downsampled_sample.reads == number_of_reads_in_millions * 1_000_000
     assert meta_data.downsampled_case.name == f"{downsample_case_name}_downsampled"

--- a/tests/models/downsample/test_down_sample_meta_data.py
+++ b/tests/models/downsample/test_down_sample_meta_data.py
@@ -44,6 +44,6 @@ def test_downsample_meta_data_pass_checks(
     number_of_reads: str = meta_data.convert_number_of_reads_to_string
 
     # THEN all necessary models to run the down sample command are created
-    assert meta_data.downsampled_sample.internal_id == f"{sample.internal_id}D{number_of_reads}M"
+    assert meta_data.downsampled_sample.internal_id == f"{sample.internal_id}DS{number_of_reads}M"
     assert meta_data.downsampled_sample.reads == number_of_reads_in_millions * 1_000_000
     assert meta_data.downsampled_case.name == f"{downsample_case_name}_downsampled"

--- a/tests/models/downsample/test_down_sample_meta_data.py
+++ b/tests/models/downsample/test_down_sample_meta_data.py
@@ -44,7 +44,7 @@ def test_downsample_meta_data_pass_checks(
     # THEN all necessary models to run the down sample command are created
     assert (
         meta_data.downsampled_sample.internal_id
-        == f"{sample.internal_id}_{number_of_reads_in_millions}M"
+        == f"{sample.internal_id}-{number_of_reads_in_millions}M"
     )
     assert meta_data.downsampled_sample.reads == number_of_reads_in_millions * 1_000_000
     assert meta_data.downsampled_case.name == f"{downsample_case_name}_downsampled"


### PR DESCRIPTION
## Description

Balsamic cannot handle internal IDs containing underscores, so this PR changes property `downsampled_sample_name` 
on the `DownsampleData` class. 

### Changed

- And underscore to a dash in the `downsampled_sample_name` property


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
