### PR TITLE
Deliver the correct microsalt files

### DIFF
--- a/cg/constants/delivery.py
+++ b/cg/constants/delivery.py
@@ -124,14 +124,7 @@ MIP_RNA_ANALYSIS_SAMPLE_TAGS: list[set[str]] = [
     {"salmon-quant"},
 ]
 
-MICROSALT_ANALYSIS_CASE_TAGS: list[set[str]] = [
-    {"microsalt-qc"},
-    {"microsalt-type"},
-    {"assembly"},
-    {"trimmed-forward-reads"},
-    {"trimmed-reverse-reads"},
-    {"reference-alignment-deduplicated"},
-]
+MICROSALT_ANALYSIS_CASE_TAGS = [{"qc-report"}, {"typing-report"}]
 
 MICROSALT_ANALYSIS_SAMPLE_TAGS: list[set[str]] = []
 


### PR DESCRIPTION
## Description
Enables delivery of microsalt analyses files, based on https://github.com/Clinical-Genomics/cg/pull/1635. Part of https://github.com/Clinical-Genomics/project-planning/issues/400.

I'm guessing the last step is to add some system d/cron tab.