### PR TITLE
Add OPTIC panel to scout panels masterlist

### DIFF
--- a/cg/constants/gene_panel.py
+++ b/cg/constants/gene_panel.py
@@ -32,6 +32,7 @@ class GenePanelMasterList(StrEnum):
     NEURODEG: str = "NEURODEG"
     NMD: str = "NMD"
     OMIM_AUTO: str = "OMIM-AUTO"
+    OPTIC: str = "OPTIC"
     PANELAPP_GREEN: str = "PANELAPP-GREEN"
     PEDHEP: str = "PEDHEP"
     PID: str = "PID"


### PR DESCRIPTION
## Description

Add a new scout panel to the gene panel masterlist, see user issue in scout -> https://github.com/Clinical-Genomics/scout/issues/4320

### Added

- OPTIC panel to the scout masterlist



### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [x] Check if panel is fetched when running a case containing a panel from the masterlist

### Expected test outcome

- [x] Check that OPTIC appears in the output when running case justhusky
- [x] Take a screenshot and attach or copy/paste the output.

## Review

- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
