### PR TITLE
Remove call to trailblazer endpoint without effect

### DIFF
--- a/cg/apps/tb/api.py
+++ b/cg/apps/tb/api.py
@@ -91,20 +91,6 @@ class TrailblazerAPI:
     def is_latest_analysis_qc(self, case_id: str) -> bool:
         return self.get_latest_analysis_status(case_id=case_id) == AnalysisStatus.QC
 
-    def mark_analyses_deleted(self, case_id: str) -> list | None:
-        """Mark all analyses for case deleted without removing analysis files"""
-        request_body = {
-            "case_id": case_id,
-        }
-        response = self.query_trailblazer(
-            command="mark-analyses-deleted", request_body=request_body
-        )
-        if response:
-            if isinstance(response, list):
-                return [TrailblazerAnalysis.model_validate(analysis) for analysis in response]
-            if isinstance(response, dict):
-                return [TrailblazerAnalysis.model_validate(response)]
-
     def add_pending_analysis(
         self,
         case_id: str,

--- a/cg/meta/workflow/analysis.py
+++ b/cg/meta/workflow/analysis.py
@@ -207,7 +207,6 @@ class AnalysisAPI(MetaAPI):
 
     def add_pending_trailblazer_analysis(self, case_id: str) -> None:
         self.check_analysis_ongoing(case_id)
-        self.trailblazer_api.mark_analyses_deleted(case_id)
         self.trailblazer_api.add_pending_analysis(
             case_id=case_id,
             email=environ_email(),

--- a/tests/cli/workflow/conftest.py
+++ b/tests/cli/workflow/conftest.py
@@ -135,7 +135,6 @@ class MockTB:
 
     def __init__(self):
         self._link_was_called = False
-        self._mark_analyses_deleted_called = False
         self._add_pending_was_called = False
         self._add_pending_analysis_was_called = False
         self._family = None
@@ -187,11 +186,6 @@ class MockTB:
 
         return Row()
 
-    def mark_analyses_deleted(self, case_id: str):
-        """Mock this function"""
-        self._case_id = case_id
-        self._mark_analyses_deleted_called = True
-
     def add_pending(self, case_id: str, email: str):
         """Mock this function"""
         self._case_id = case_id
@@ -203,10 +197,6 @@ class MockTB:
         self._case_id = case_id
         self._email = email
         self._add_pending_analysis_was_called = True
-
-    def mark_analyses_deleted_called(self):
-        """check if mark_analyses_deleted was called"""
-        return self._mark_analyses_deleted_called
 
     def add_pending_was_called(self):
         """check if add_pending was called"""

--- a/tests/mocks/tb_mock.py
+++ b/tests/mocks/tb_mock.py
@@ -12,9 +12,6 @@ class MockTB:
     def add_pending_analysis(self, *args, **kwargs) -> None:
         return None
 
-    def mark_analyses_deleted(self, *args, **kwargs) -> None:
-        return None
-
     def add_commit(self, *args, **kwargs) -> None:
         return None
 


### PR DESCRIPTION
## Description
The `mark-analyses-deleted` did not do anything (it just set a boolean on the cases which is not used anywhere). The endpoint is being removed from trailblazer and we should not call it in cg.

### Fixed
- Remove call to endpoint in trailblazer which does not do anything


### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions