### PR TITLE
Add microsalt upload api

### DIFF
--- a/cg/meta/upload/microsalt/microsalt_upload_api.py
+++ b/cg/meta/upload/microsalt/microsalt_upload_api.py
@@ -1,0 +1,25 @@
+import logging
+
+import click
+
+from cg.cli.upload.clinical_delivery import upload_clinical_delivery
+from cg.meta.upload.upload_api import UploadAPI
+from cg.meta.workflow.microsalt.microsalt import MicrosaltAnalysisAPI
+from cg.models.cg_config import CGConfig
+from cg.store.models import Analysis, Case
+
+LOG = logging.getLogger(__name__)
+
+
+class MicrosaltUploadAPI(UploadAPI):
+    def __init__(self, config: CGConfig):
+        self.analysis_api = MicrosaltAnalysisAPI(config)
+        super().__init__(config=config, analysis_api=self.analysis_api)
+
+    def upload(self, ctx: click.Context, case: Case, restart: bool) -> None:
+        """Uploads MIP-DNA analysis data and files."""
+        analysis: Analysis = case.analyses[0]
+        self.update_upload_started_at(analysis)
+
+        ctx.invoke(upload_clinical_delivery, case_id=case.internal_id)
+        self.update_uploaded_at(analysis=analysis)


### PR DESCRIPTION
## Description
Add microsalt support for `cg upload -c`.

### Added
- Microsalt cases can now be uploaded via `cg upload`

### This [version](https://semver.org/) is a
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
