### PR TITLE
Temp fix missing microsalt cases

### DIFF
--- a/cg/meta/workflow/microsalt/microsalt.py
+++ b/cg/meta/workflow/microsalt/microsalt.py
@@ -311,11 +311,10 @@ class MicrosaltAnalysisAPI(AnalysisAPI):
         matches: list[str] = [d for d in os.listdir(results_dir) if d.startswith(project_id)]
         if not matches:
             LOG.error(f"No result directory found for {case_id} with project id {project_id}")
-            raise MissingAnalysisDir
         return matches
 
     def get_case_path(self, case_id: str) -> Path:
         results_dir: Path = self.get_results_dir()
         matching_cases: list[str] = self.get_analyses_result_dirs(case_id)
-        case_dir: str = max(matching_cases, default=None)
+        case_dir: str = max(matching_cases, default="")
         return Path(results_dir, case_dir)


### PR DESCRIPTION
## Description
See https://github.com/Clinical-Genomics/cg/issues/2838.
This temp fix means the cases will be tracked in trailblazer, but jobs for it will not show up.

The issue is that microsalt uses a time stamp in the name for the output directory. This means we cannot pass the correct path when creating the pending analysis in trailblazer, which in turn means that jobs cannot be tracked correctly.

The actual solution consists of renaming the output directory created by microsalt to just use the case name. Making changes in https://github.com/Clinical-Genomics/microSALT seems to run the risk of introducing 1000 regression bugs, but maybe I feel lucky.

### Fixed
- Temp fix for missing microsalt cases

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
