### PR TITLE
Fix datetime format

### DIFF
--- a/cg/meta/archive/ddn/utils.py
+++ b/cg/meta/archive/ddn/utils.py
@@ -19,7 +19,9 @@ def get_metadata(sample: Sample) -> list[dict]:
         },
         {
             MetadataFields.NAME.value: MetadataFields.SEQUENCED_AT.value,
-            MetadataFields.VALUE.value: sample.last_sequenced_at,
+            MetadataFields.VALUE.value: str(sample.last_sequenced_at)
+            if sample.last_sequenced_at
+            else sample.last_sequenced_at,
         },
         {
             MetadataFields.NAME.value: MetadataFields.TICKET_NUMBER.value,

--- a/tests/meta/archive/conftest.py
+++ b/tests/meta/archive/conftest.py
@@ -260,6 +260,7 @@ def archive_store(
         ),
     ]
     new_samples[0].customer = customer_ddn
+    new_samples[0].last_sequenced_at = datetime.now()
     new_samples[1].customer = customer_ddn
     new_samples[2].customer = customer_without_ddn
 


### PR DESCRIPTION
## Description

When attaching the last_sequenced_at date, the json is not parsed correctly, since it has datetime format. This PR addresses that.

### Fixed

- Wrap last_sequenced_at as string in metadata, if present.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
