### PR TITLE
reverted change from 2806

### DIFF
--- a/cg/models/flow_cell/flow_cell.py
+++ b/cg/models/flow_cell/flow_cell.py
@@ -8,12 +8,8 @@ from typing import Type
 from pydantic import ValidationError
 from typing_extensions import Literal
 
-from cg.apps.demultiplex.sample_sheet.read_sample_sheet import (
-    get_sample_sheet_from_file,
-    get_sample_type,
-)
+from cg.apps.demultiplex.sample_sheet.read_sample_sheet import get_sample_sheet_from_file
 from cg.apps.demultiplex.sample_sheet.sample_models import (
-    FlowCellSample,
     FlowCellSampleBcl2Fastq,
     FlowCellSampleBCLConvert,
 )
@@ -39,10 +35,6 @@ RUN_PARAMETERS_CONSTRUCTOR: dict[str, Type] = {
     Sequencers.HISEQX: RunParametersHiSeq,
     Sequencers.NOVASEQ: RunParametersNovaSeq6000,
     Sequencers.NOVASEQX: RunParametersNovaSeqX,
-}
-SAMPLE_MODEL_TO_BCL_CONVERTER: dict[Type[FlowCellSample], str] = {
-    FlowCellSampleBCLConvert: BclConverter.BCLCONVERT,
-    FlowCellSampleBcl2Fastq: BclConverter.BCL2FASTQ,
 }
 
 
@@ -221,16 +213,6 @@ class FlowCellDirectoryData:
 
     def validate_sample_sheet(self) -> bool:
         """Validate if sample sheet is on correct format."""
-        sample_type_from_sample_sheet: Type[FlowCellSample] = get_sample_type(
-            self.sample_sheet_path
-        )
-        if SAMPLE_MODEL_TO_BCL_CONVERTER[sample_type_from_sample_sheet] != self.bcl_converter:
-            LOG.warning(
-                f"Detected {SAMPLE_MODEL_TO_BCL_CONVERTER[sample_type_from_sample_sheet]} sample "
-                f"sheet for {self.bcl_converter} flow cell. "
-                "Generate the correct sample sheet or use the correct bcl converter."
-            )
-            return False
         try:
             get_sample_sheet_from_file(self.sample_sheet_path)
         except (SampleSheetError, ValidationError) as error:


### PR DESCRIPTION
## Description
Reverts the check in function `validate_sample_sheet` introduced in #2806 

### Fixed

- Revert the check inside the method `validate_sample_sheet` of the class `FlowCellDirectoryData` that compares the sample sheet type extracted from the sample sheet itself and the bcl converter of the `FlowCellDirectoryData`.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
