### PR TITLE
Remove constants for symbols

### DIFF
--- a/cg/apps/demultiplex/sample_sheet/index.py
+++ b/cg/apps/demultiplex/sample_sheet/index.py
@@ -4,7 +4,6 @@ import logging
 from pydantic import BaseModel
 
 from cg.constants.constants import FileFormat
-from cg.constants.symbols import DASH
 from cg.io.controller import ReadFile
 from cg.resources import VALID_INDEXES_PATH
 from cg.utils.utils import get_hamming_distance
@@ -20,7 +19,7 @@ SHORT_SAMPLE_INDEX_LENGTH: int = 8
 
 def is_dual_index(index: str) -> bool:
     """Determines if an index in the raw sample sheet is dual index or not."""
-    return DASH in index
+    return "-" in index
 
 
 class Index(BaseModel):

--- a/cg/apps/demultiplex/sample_sheet/sample_models.py
+++ b/cg/apps/demultiplex/sample_sheet/sample_models.py
@@ -19,7 +19,7 @@ from cg.constants.demultiplexing import (
     SampleSheetBcl2FastqSections,
     SampleSheetBCLConvertSections,
 )
-from cg.constants.symbols import DASH, EMPTY_STRING, LOWER_CASE_NA
+from cg.constants.symbols import EMPTY_STRING
 from cg.exc import SampleSheetError
 from cg.models.demultiplex.run_parameters import RunParameters
 
@@ -38,7 +38,7 @@ class FlowCellSample(BaseModel):
     def separate_indexes(self, is_run_single_index: bool) -> None:
         """Update values for index and index2 splitting the original LIMS dual index."""
         if is_dual_index(self.index):
-            index1, index2 = self.index.split(DASH)
+            index1, index2 = self.index.split("-")
             self.index = index1.strip().replace(CUSTOM_INDEX_TAIL, EMPTY_STRING)
             self.index2 = index2.strip() if not is_run_single_index else EMPTY_STRING
 
@@ -189,9 +189,9 @@ class FlowCellSampleBCLConvert(FlowCellSample):
         """Assign zero to barcode_mismatches_2 if the hamming distance between self.index2
         and the index2 of any sample in the lane is below the minimum threshold.
         If the sample is single-indexed, assign 'na'."""
-        if self.index2 == EMPTY_STRING and DASH not in self.index:
+        if self.index2 == EMPTY_STRING and "-" not in self.index:
             LOG.info(f"Turning barcode mismatch for index 2 to 'na' for sample {self.sample_id}")
-            self.barcode_mismatches_2 = LOWER_CASE_NA
+            self.barcode_mismatches_2 = "na"
             return
         for sample in samples_to_compare:
             if self.sample_id == sample.sample_id:

--- a/cg/constants/symbols.py
+++ b/cg/constants/symbols.py
@@ -2,7 +2,6 @@
 
 ASTERISK = "*"
 COMMA = ","
-DASH = "-"
 DOT = "."
 EMPTY_STRING = ""
 FWD_SLASH = "/"

--- a/cg/utils/date.py
+++ b/cg/utils/date.py
@@ -3,7 +3,7 @@ import logging
 import re
 from datetime import datetime, timedelta
 
-from cg.constants.symbols import DASH, DOT, FWD_SLASH, SPACE
+from cg.constants.symbols import DOT, FWD_SLASH, SPACE
 
 DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S.%f"
 DATETIME_FORMAT_DATE = "%Y-%m-%d %H:%M:%S"
@@ -43,7 +43,7 @@ def get_date(date: str | None = None, date_format: str | None = None) -> datetim
         except ValueError:
             LOG.info("Date is not in standard format")
 
-    for separator in [DASH, SPACE, DOT, FWD_SLASH]:
+    for separator in ["-", SPACE, DOT, FWD_SLASH]:
         date_parts = date.split(separator)
         if len(date_parts) == 3:
             return datetime(*(int(number) for number in date_parts))

--- a/tests/apps/demultiplex/test_sample_models.py
+++ b/tests/apps/demultiplex/test_sample_models.py
@@ -19,7 +19,7 @@ from cg.constants.demultiplexing import (
     IndexOverrideCycles,
     IndexSettings,
 )
-from cg.constants.symbols import DASH, EMPTY_STRING
+from cg.constants.symbols import EMPTY_STRING
 from cg.models.demultiplex.run_parameters import RunParameters
 
 
@@ -364,7 +364,7 @@ def test_process_indexes_for_sample_sheet_bcl_convert(
     sample.process_indexes(run_parameters=run_parameters)
 
     # THEN the sample is processed correctly
-    assert DASH not in sample.index
+    assert "-" not in sample.index
     assert sample.override_cycles != EMPTY_STRING
 
 


### PR DESCRIPTION
## Description

Sysdev decided to get rid of all symbol constants except `EMPTY_STRING` and `SPACE`. 

### Changed

- Replaced usages of constants for their values

### Fixed

- Removed symbol constants


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
