### PR TITLE
Ensure version when adding and including to Housekeeper

### DIFF
--- a/cg/apps/housekeeper/hk.py
+++ b/cg/apps/housekeeper/hk.py
@@ -7,11 +7,7 @@ from pathlib import Path
 from housekeeper.include import checksum as hk_checksum
 from housekeeper.include import include_version
 from housekeeper.store import Store, models
-from housekeeper.store.database import (
-    create_all_tables,
-    drop_all_tables,
-    initialize_database,
-)
+from housekeeper.store.database import create_all_tables, drop_all_tables, initialize_database
 from housekeeper.store.models import Archive, Bundle, File, Version
 from sqlalchemy.orm import Query
 
@@ -352,10 +348,7 @@ class HousekeeperAPI:
         self, bundle_name: str, file: Path, tags: list
     ) -> None:
         """Adds and includes a file in the latest version of a bundle."""
-        version: Version = self.last_version(bundle_name)
-        if not version:
-            LOG.warning(f"Bundle: {bundle_name} not found in Housekeeper")
-            raise HousekeeperBundleVersionMissingError
+        version: Version = self.get_create_version(bundle_name)
         hk_file: File = self.add_file(version_obj=version, tags=tags, path=str(file.absolute()))
         self.include_file(version_obj=version, file_obj=hk_file)
         self.commit()

--- a/cg/apps/housekeeper/hk.py
+++ b/cg/apps/housekeeper/hk.py
@@ -277,7 +277,7 @@ class HousekeeperAPI:
         LOG.debug(f"Found Housekeeper version object for {bundle_name}: {repr(last_version)}")
         return last_version
 
-    def get_create_version(self, bundle_name: str) -> Version:
+    def get_or_create_version(self, bundle_name: str) -> Version:
         """Returns the latest version of a bundle if it exists. If not creates a bundle and
         returns its version."""
         last_version: Version = self.last_version(bundle=bundle_name)
@@ -348,7 +348,7 @@ class HousekeeperAPI:
         self, bundle_name: str, file: Path, tags: list
     ) -> None:
         """Adds and includes a file in the latest version of a bundle."""
-        version: Version = self.get_create_version(bundle_name)
+        version: Version = self.get_or_create_version(bundle_name)
         hk_file: File = self.add_file(version_obj=version, tags=tags, path=str(file.absolute()))
         self.include_file(version_obj=version, file_obj=hk_file)
         self.commit()

--- a/cg/meta/transfer/external_data.py
+++ b/cg/meta/transfer/external_data.py
@@ -187,7 +187,7 @@ class ExternalDataAPI(MetaAPI):
                     sample_internal_id=sample.internal_id
                 )
             )
-            last_version: Version = self.housekeeper_api.get_create_version(
+            last_version: Version = self.housekeeper_api.get_or_create_version(
                 bundle_name=sample.internal_id
             )
             fastq_paths_to_add: list[Path] = self.get_fastq_paths_to_add(

--- a/tests/apps/hk/test_version.py
+++ b/tests/apps/hk/test_version.py
@@ -129,13 +129,13 @@ def test_get_create_version(
     version_obj = populated_housekeeper_api.bundle(case_id).versions[0]
 
     # When the case_id is given the function should return its latest version
-    latest_version = populated_housekeeper_api.get_create_version(case_id)
+    latest_version = populated_housekeeper_api.get_or_create_version(case_id)
 
     # Then assert that the versions match
     assert version_obj == latest_version
 
     # When a case_id not present in hk is given.
-    latest_version = populated_housekeeper_api.get_create_version(another_case_id)
+    latest_version = populated_housekeeper_api.get_or_create_version(another_case_id)
 
     # Then assert the new bundle is created the version is new.
     assert latest_version.bundle.name == another_case_id

--- a/tests/mocks/hk_mock.py
+++ b/tests/mocks/hk_mock.py
@@ -306,7 +306,7 @@ class MockHousekeeperAPI:
         """Fetch a version"""
         return self._version_obj
 
-    def get_create_version(self, bundle_name: str):
+    def get_or_create_version(self, bundle_name: str):
         """Returns the latest version of a bundle if it exists. If no creates a bundle and returns its version"""
         last_version = self.last_version(bundle=bundle_name)
         if not last_version:


### PR DESCRIPTION
## Description
Currently, when adding and including a file to Housekeeper through the Housekeeper API, a version is fetched using `last_version()` and an error is raised if the version is missing. This is changed now as the version is ensured using `get_create_version()` instead and removing the exception raising.

### Changed

- Use `get_create_version()` instead of `last_version()`
- Removed error raise
- Renamed `get_create_version` to `get_or_create_version`


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
