### PR TITLE
Add subject id for fastq orders

### DIFF
--- a/cg/meta/orders/fastq_submitter.py
+++ b/cg/meta/orders/fastq_submitter.py
@@ -46,6 +46,7 @@ class FastqSubmitter(Submitter):
                     "name": sample.name,
                     "priority": sample.priority,
                     "sex": sample.sex,
+                    "subject_id": sample.subject_id,
                     "tumour": sample.tumour,
                     "volume": sample.volume,
                 }
@@ -99,6 +100,7 @@ class FastqSubmitter(Submitter):
                     priority=sample["priority"],
                     tumour=sample["tumour"],
                     capture_kit=sample["capture_kit"],
+                    subject_id=sample["subject_id"],
                 )
                 new_sample.customer: Customer = customer
                 application_tag: str = sample["application"]

--- a/cg/models/orders/samples.py
+++ b/cg/models/orders/samples.py
@@ -179,6 +179,7 @@ class FastqSample(OrderInSample):
     capture_kit: str | None
     # "Not Required"
     quantity: int | None
+    subject_id: str | None
 
     @validator("quantity", pre=True)
     def str_to_int(cls, v: str) -> int | None:

--- a/cg/models/orders/samples.py
+++ b/cg/models/orders/samples.py
@@ -44,10 +44,6 @@ class OrderInSample(BaseModel):
     require_qc_ok: bool = False
     volume: str
     concentration_ng_ul: str | None
-    subject_id: (
-        constr(regex=NAME_PATTERN, max_length=Sample.subject_id.property.columns[0].type.length)
-        | None
-    )
 
     @classmethod
     def is_sample_for(cls, project: OrderType):
@@ -107,6 +103,10 @@ class Of1508Sample(OrderInSample):
     phenotype_terms: list[str] | None
     require_qc_ok: bool = False
     quantity: int | None
+    subject_id: (
+        constr(regex=NAME_PATTERN, max_length=Sample.subject_id.property.columns[0].type.length)
+        | None
+    )
     synopsis: str | None
 
     @validator("container", "container_name", "name", "source", "subject_id", "volume")
@@ -221,6 +221,7 @@ class MetagenomeSample(Of1508Sample):
     # "This information is not required"
     concentration_sample: float | None
     family_name: None = None
+    subject_id: None = None
 
     @validator("concentration_sample", pre=True)
     def str_to_float(cls, v: str) -> float | None:

--- a/cg/models/orders/samples.py
+++ b/cg/models/orders/samples.py
@@ -44,6 +44,10 @@ class OrderInSample(BaseModel):
     require_qc_ok: bool = False
     volume: str
     concentration_ng_ul: str | None
+    subject_id: (
+        constr(regex=NAME_PATTERN, max_length=Sample.subject_id.property.columns[0].type.length)
+        | None
+    )
 
     @classmethod
     def is_sample_for(cls, project: OrderType):
@@ -103,10 +107,6 @@ class Of1508Sample(OrderInSample):
     phenotype_terms: list[str] | None
     require_qc_ok: bool = False
     quantity: int | None
-    subject_id: (
-        constr(regex=NAME_PATTERN, max_length=Sample.subject_id.property.columns[0].type.length)
-        | None
-    )
     synopsis: str | None
 
     @validator("container", "container_name", "name", "source", "subject_id", "volume")
@@ -221,7 +221,6 @@ class MetagenomeSample(Of1508Sample):
     # "This information is not required"
     concentration_sample: float | None
     family_name: None = None
-    subject_id: None = None
 
     @validator("concentration_sample", pre=True)
     def str_to_float(cls, v: str) -> float | None:

--- a/cg/store/crud/create.py
+++ b/cg/store/crud/create.py
@@ -178,7 +178,6 @@ class CreateHandler(BaseHandler):
         priority: Priority = None,
         received: datetime = None,
         original_ticket: str = None,
-        subject_id: str | None = None,
         tumour: bool = False,
         **kwargs,
     ) -> Sample:
@@ -199,7 +198,6 @@ class CreateHandler(BaseHandler):
             priority=priority,
             received_at=received,
             sex=sex,
-            subject_id=subject_id,
             **kwargs,
         )
 

--- a/cg/store/crud/create.py
+++ b/cg/store/crud/create.py
@@ -1,14 +1,13 @@
 import logging
 from datetime import datetime
-from cg.models.orders.order import OrderIn
-from cg.models.orders.orderform_schema import Orderform
-from cg.store.database import get_session
 
 import petname
 
 from cg.constants import DataDelivery, FlowCellStatus, Pipeline, Priority
 from cg.constants.archiving import PDC_ARCHIVE_LOCATION
+from cg.models.orders.order import OrderIn
 from cg.store.base import BaseHandler
+from cg.store.database import get_session
 from cg.store.models import (
     Analysis,
     Application,
@@ -179,6 +178,7 @@ class CreateHandler(BaseHandler):
         priority: Priority = None,
         received: datetime = None,
         original_ticket: str = None,
+        subject_id: str | None = None,
         tumour: bool = False,
         **kwargs,
     ) -> Sample:
@@ -199,6 +199,7 @@ class CreateHandler(BaseHandler):
             priority=priority,
             received_at=received,
             sex=sex,
+            subject_id=subject_id,
             **kwargs,
         )
 

--- a/cg/store/crud/create.py
+++ b/cg/store/crud/create.py
@@ -178,7 +178,6 @@ class CreateHandler(BaseHandler):
         priority: Priority = None,
         received: datetime = None,
         original_ticket: str = None,
-        subject_id: str = None,
         tumour: bool = False,
         **kwargs,
     ) -> Sample:
@@ -199,7 +198,6 @@ class CreateHandler(BaseHandler):
             priority=priority,
             received_at=received,
             sex=sex,
-            subject_id=subject_id,
             **kwargs,
         )
 

--- a/cg/store/crud/create.py
+++ b/cg/store/crud/create.py
@@ -178,6 +178,7 @@ class CreateHandler(BaseHandler):
         priority: Priority = None,
         received: datetime = None,
         original_ticket: str = None,
+        subject_id: str = None,
         tumour: bool = False,
         **kwargs,
     ) -> Sample:
@@ -198,6 +199,7 @@ class CreateHandler(BaseHandler):
             priority=priority,
             received_at=received,
             sex=sex,
+            subject_id=subject_id,
             **kwargs,
         )
 


### PR DESCRIPTION
## Description

Addresses #2884.

### Fixed

- Fastq orders get subject_id set on sample level.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
