### PR TITLE
Update imports of Housekeeper store

### DIFF
--- a/cg/apps/housekeeper/hk.py
+++ b/cg/apps/housekeeper/hk.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 from housekeeper.include import checksum as hk_checksum
 from housekeeper.include import include_version
-from housekeeper.store import models
 from housekeeper.store.database import create_all_tables, drop_all_tables, initialize_database
 from housekeeper.store.models import Archive, Bundle, File, Tag, Version
 from housekeeper.store.store import Store

--- a/cg/apps/housekeeper/hk.py
+++ b/cg/apps/housekeeper/hk.py
@@ -7,9 +7,10 @@ from pathlib import Path
 
 from housekeeper.include import checksum as hk_checksum
 from housekeeper.include import include_version
-from housekeeper.store import Store, models
+from housekeeper.store import models
 from housekeeper.store.database import create_all_tables, drop_all_tables, initialize_database
-from housekeeper.store.models import Archive, Bundle, File, Version
+from housekeeper.store.models import Archive, Bundle, File, Tag, Version
+from housekeeper.store.store import Store
 from sqlalchemy.orm import Query
 
 from cg.constants import SequencingFileTag
@@ -256,7 +257,7 @@ class HousekeeperAPI:
             self._store._get_query(table=Version)
             .join(Version.bundle)
             .filter(Bundle.name == bundle)
-            .order_by(models.Version.created_at.desc())
+            .order_by(Version.created_at.desc())
             .first()
         )
 
@@ -299,13 +300,13 @@ class HousekeeperAPI:
         """Create a new tag."""
         return self._store.new_tag(name, category)
 
-    def add_tag(self, name: str, category: str = None) -> models.Tag:
+    def add_tag(self, name: str, category: str = None) -> Tag:
         """Add a tag to the database."""
         tag_obj = self._store.new_tag(name, category)
         self.add_commit(tag_obj)
         return tag_obj
 
-    def get_tag(self, name: str) -> models.Tag:
+    def get_tag(self, name: str) -> Tag:
         """Fetch a tag."""
         return self._store.get_tag(name)
 

--- a/cg/meta/upload/gt.py
+++ b/cg/meta/upload/gt.py
@@ -1,9 +1,10 @@
 import logging
 from pathlib import Path
 
+from housekeeper.store.models import File, Version
+
 from cg.apps.gt import GenotypeAPI
 from cg.apps.housekeeper.hk import HousekeeperAPI
-from cg.apps.housekeeper.hk import models as housekeeper_models
 from cg.constants.constants import FileFormat, Pipeline, PrepCategory
 from cg.constants.housekeeper_tags import HkMipAnalysisTag
 from cg.constants.subject import Sex
@@ -55,7 +56,7 @@ class UploadGenotypesAPI(object):
             raise ValueError(f"Pipeline {analysis_obj.pipeline} does not support Genotype upload")
         return data
 
-    def _get_samples_sex_mip(self, case_obj: Case, hk_version: housekeeper_models.Version) -> dict:
+    def _get_samples_sex_mip(self, case_obj: Case, hk_version: Version) -> dict:
         qc_metrics_file = self.get_qcmetrics_file(hk_version)
         analysis_sexes = self.analysis_sex(qc_metrics_file)
         samples_sex = {}
@@ -87,7 +88,7 @@ class UploadGenotypesAPI(object):
             for sample_id_metric in qc_metrics.sample_id_metrics
         }
 
-    def get_bcf_file(self, hk_version_obj: housekeeper_models.Version) -> housekeeper_models.File:
+    def get_bcf_file(self, hk_version_obj: Version) -> File:
         """Fetch a bcf file and return the file object"""
         genotype_files: list = self._get_genotype_files(version_id=hk_version_obj.id)
         for genotype_file in genotype_files:
@@ -96,7 +97,7 @@ class UploadGenotypesAPI(object):
                 return genotype_file
         raise FileNotFoundError(f"No vcf or bcf file found for bundle {hk_version_obj.bundle_id}")
 
-    def get_qcmetrics_file(self, hk_version_obj: housekeeper_models.Version) -> Path:
+    def get_qcmetrics_file(self, hk_version_obj: Version) -> Path:
         """Fetch a qc_metrics file and return the path"""
         hk_qcmetrics = self.hk.files(
             version=hk_version_obj.id, tags=HkMipAnalysisTag.QC_METRICS
@@ -117,7 +118,7 @@ class UploadGenotypesAPI(object):
         self.gt.upload(str(data["bcf"]), data["samples_sex"], force=replace)
 
     @staticmethod
-    def _is_variant_file(genotype_file: housekeeper_models.File):
+    def _is_variant_file(genotype_file: File):
         return genotype_file.full_path.endswith("vcf.gz") or genotype_file.full_path.endswith("bcf")
 
     def _get_genotype_files(self, version_id: int) -> list:

--- a/poetry.lock
+++ b/poetry.lock
@@ -858,13 +858,13 @@ files = [
 
 [[package]]
 name = "housekeeper"
-version = "4.11.1"
+version = "4.11.3"
 description = "Housekeeper takes care of files"
 optional = false
 python-versions = "*"
 files = [
-    {file = "housekeeper-4.11.1-py2.py3-none-any.whl", hash = "sha256:4999ad8769971ef58c9398647250fe026fca7ceee0802e7fd45ac801742372f1"},
-    {file = "housekeeper-4.11.1.tar.gz", hash = "sha256:e5b0586ffddafd7a6d9a8d73c23b100ef951557868f51d8506a92feeec3519d0"},
+    {file = "housekeeper-4.11.3-py2.py3-none-any.whl", hash = "sha256:35d0b3155ad166edb0c7d384d5ef1246bd660c1637276926addbe9793a01b68f"},
+    {file = "housekeeper-4.11.3.tar.gz", hash = "sha256:fd8b112e8be78aaf0a77695e53f4058cb4922c788d4daa20305db26a572d0035"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
## Description
In https://github.com/Clinical-Genomics/housekeeper/pull/191 the location of the Housekeeepr Store was changed


### Fixed

- The imports to Housekeeper store point to the correct location


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
