### PR TITLE
Patch microsalt qc jobs tracking

### DIFF
--- a/cg/meta/workflow/microsalt/microsalt.py
+++ b/cg/meta/workflow/microsalt/microsalt.py
@@ -88,18 +88,9 @@ class MicrosaltAnalysisAPI(AnalysisAPI):
         return Path(self.queries_path, filename).with_suffix(".json")
 
     def get_job_ids_path(self, case_id: str) -> Path:
-        case_path: Path = self.get_case_path(case_id)
-        job_ids_file_name: str = self.get_job_ids_file_name(case_id)
-        return Path(case_path, job_ids_file_name)
-
-    def get_job_ids_file_name(self, case_id: str) -> str:
-        project_id: str = self.get_lims_project_id(case_id)
-        return f"{project_id}_slurm_ids.yaml"
-
-    def get_lims_project_id(self, case_id: str):
         case: Case = self.status_db.get_case_by_internal_id(case_id)
-        sample: Sample = case.links[0].sample
-        return self.get_project(sample.internal_id)
+        ticket_id: str = case.latest_ticket
+        return Path(self.root_dir, f"results/reports/trailblazer/{ticket_id}_slurm_ids.yaml")
 
     def get_deliverables_file_path(self, case_id: str) -> Path:
         """Returns a path where the microSALT deliverables file for the order_id should be

--- a/cg/meta/workflow/microsalt/microsalt.py
+++ b/cg/meta/workflow/microsalt/microsalt.py
@@ -88,9 +88,8 @@ class MicrosaltAnalysisAPI(AnalysisAPI):
         return Path(self.queries_path, filename).with_suffix(".json")
 
     def get_job_ids_path(self, case_id: str) -> Path:
-        case: Case = self.status_db.get_case_by_internal_id(case_id)
-        ticket_id: str = case.latest_ticket
-        return Path(self.root_dir, f"results/reports/trailblazer/{ticket_id}_slurm_ids.yaml")
+        project_id: str = self.get_project_id(case_id)
+        return Path(self.root_dir, f"results/reports/trailblazer/{project_id}_slurm_ids.yaml")
 
     def get_deliverables_file_path(self, case_id: str) -> Path:
         """Returns a path where the microSALT deliverables file for the order_id should be


### PR DESCRIPTION
## Description
Closes https://github.com/Clinical-Genomics/cg/issues/2896, see for details.

The missing `trailblazer` directory has been created on Hasta, meaning the microsalt pipeline should be able to write the second job ids file.

### Fixed
- Use separate path for microsalt job ids


- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
