### PR TITLE
(Streamline delivery) Add get order endpoint

### DIFF
--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -28,7 +28,7 @@ from cg.models.orders.order import OrderIn, OrderType
 from cg.models.orders.orderform_schema import Orderform
 from cg.server.dto.delivery_message_response import DeliveryMessageResponse
 from cg.server.dto.orders.orders_request import OrdersRequest
-from cg.server.dto.orders.orders_response import OrdersResponse
+from cg.server.dto.orders.orders_response import Order, OrdersResponse
 from cg.server.ext import db, lims, osticket
 from cg.services.delivery_message.delivery_message_service import DeliveryMessageService
 from cg.services.orders.order_service import OrderService
@@ -481,11 +481,11 @@ def get_orders():
     return make_response(response.model_dump())
 
 
-@BLUEPRINT.route("/orders/<order_id")
+@BLUEPRINT.route("/orders/<order_id>")
 def get_order(order_id: int):
     """Return an order."""
     order_service = OrderService(db)
-    response: OrdersResponse = order_service.get_order(order_id)
+    response: Order = order_service.get_order(order_id)
     return make_response(response.model_dump())
 
 

--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -481,6 +481,14 @@ def get_orders():
     return make_response(response.model_dump())
 
 
+@BLUEPRINT.route("/orders/<order_id")
+def get_order(order_id: int):
+    """Return an order."""
+    order_service = OrderService(db)
+    response: OrdersResponse = order_service.get_order(order_id)
+    return make_response(response.model_dump())
+
+
 @BLUEPRINT.route("/orderform", methods=["POST"])
 def parse_orderform():
     """Parse an orderform/JSON export."""

--- a/cg/services/orders/order_service.py
+++ b/cg/services/orders/order_service.py
@@ -11,6 +11,9 @@ class OrderService:
     def __init__(self, store: Store) -> None:
         self.store = store
 
+    def get_order(self, order_id: int) -> Order:
+        return self.store.get_order(order_id)
+
     def get_orders(self, orders_request: OrdersRequest) -> OrdersResponse:
         orders: list[Order] = self._get_orders(orders_request)
         return create_orders_response(orders)

--- a/cg/services/orders/order_service.py
+++ b/cg/services/orders/order_service.py
@@ -11,8 +11,8 @@ class OrderService:
     def __init__(self, store: Store) -> None:
         self.store = store
 
-    def get_order(self, order_id: int) -> Order:
-        return self.store.get_order(order_id)
+    def get_order(self, order_id: int) -> OrderResponse:
+        return create_order_response(self.store.get_order_by_id(order_id))
 
     def get_orders(self, orders_request: OrdersRequest) -> OrdersResponse:
         orders: list[Order] = self._get_orders(orders_request)

--- a/cg/store/crud/read.py
+++ b/cg/store/crud/read.py
@@ -1751,10 +1751,10 @@ class ReadHandler(BaseHandler):
         )
         return orders.limit(limit).all()
 
-    def get_order(self, order_id: int) -> Order:
+    def get_order_by_id(self, order_id: int) -> Order:
         """Returns the entry in Order matching the given id."""
         orders: Query = self._get_query(table=Order)
-        order_filter_functions: list[Callable] = [OrderFilter.FILTER_ORDERS_BY_WORKFLOW]
+        order_filter_functions: list[Callable] = [OrderFilter.FILTER_ORDERS_BY_ID]
         orders: Query = apply_order_filters(
             orders=orders, filter_functions=order_filter_functions, id=order_id
         )

--- a/cg/store/crud/read.py
+++ b/cg/store/crud/read.py
@@ -1751,6 +1751,15 @@ class ReadHandler(BaseHandler):
         )
         return orders.limit(limit).all()
 
+    def get_order(self, order_id: int) -> Order:
+        """Returns the entry in Order matching the given id."""
+        orders: Query = self._get_query(table=Order)
+        order_filter_functions: list[Callable] = [OrderFilter.FILTER_ORDERS_BY_WORKFLOW]
+        orders: Query = apply_order_filters(
+            orders=orders, filter_functions=order_filter_functions, id=order_id
+        )
+        return orders.first()
+
     def _calculate_estimated_turnaround_time(
         self,
         is_rerun,

--- a/cg/store/filters/status_order_filters.py
+++ b/cg/store/filters/status_order_filters.py
@@ -17,11 +17,11 @@ def filter_orders_by_id(orders: Query, id: int, **kwargs) -> Query:
 
 
 def apply_order_filters(
-    filter_functions: list[Callable], orders: Query, id: int, workflow: str
+    filter_functions: list[Callable], orders: Query, id: int = None, workflow: str = None
 ) -> Query:
     """Apply filtering functions to the order queries and return filtered results."""
     for filter_function in filter_functions:
-        orders: Query = filter_function(orders=orders, workflow=workflow)
+        orders: Query = filter_function(orders=orders, id=id, workflow=workflow)
     return orders
 
 

--- a/cg/store/filters/status_order_filters.py
+++ b/cg/store/filters/status_order_filters.py
@@ -11,7 +11,14 @@ def filter_orders_by_workflow(orders: Query, workflow: str, **kwargs) -> Query:
     return orders.filter(Order.workflow == workflow) if workflow else orders
 
 
-def apply_order_filters(filter_functions: list[Callable], orders: Query, workflow: str) -> Query:
+def filter_orders_by_id(orders: Query, id: int, **kwargs) -> Query:
+    """Return orders filtered on id."""
+    return orders.filter(Order.id == id)
+
+
+def apply_order_filters(
+    filter_functions: list[Callable], orders: Query, id: int, workflow: str
+) -> Query:
     """Apply filtering functions to the order queries and return filtered results."""
     for filter_function in filter_functions:
         orders: Query = filter_function(orders=orders, workflow=workflow)
@@ -21,4 +28,5 @@ def apply_order_filters(filter_functions: list[Callable], orders: Query, workflo
 class OrderFilter(Enum):
     """Define order filter functions."""
 
+    FILTER_ORDERS_BY_ID: Callable = filter_orders_by_id
     FILTER_ORDERS_BY_WORKFLOW: Callable = filter_orders_by_workflow

--- a/tests/server/endpoints/test_orders_endpoint.py
+++ b/tests/server/endpoints/test_orders_endpoint.py
@@ -4,6 +4,7 @@ import pytest
 from flask.testing import FlaskClient
 
 from cg.constants import Workflow
+from cg.services.orders.utils import create_order_response
 from cg.store.models import Order
 
 
@@ -39,3 +40,25 @@ def test_orders_endpoint(
 
     # THEN the response contains the correct number of orders
     assert len(response.json["orders"]) == expected_orders
+
+
+def test_order_endpoint(
+    client: FlaskClient,
+    order: Order,
+    order_another: Order,
+    order_balsamic: Order,
+):
+    """Tests that the order endpoint returns the order with matching id"""
+    # GIVEN a store with three orders, two of which are MIP-DNA and the last is BALSAMIC
+
+    order_id_to_fetch: int = order.id
+
+    # WHEN a request is made to get a specific order
+    endpoint: str = f"/api/v1/orders/{order_id_to_fetch}"
+    response = client.get(endpoint)
+
+    # THEN the response should be successful
+    assert response.status_code == HTTPStatus.OK
+
+    # THEN the response should only contain the specified order
+    assert response.json == create_order_response(order).model_dump()


### PR DESCRIPTION
## Description

This PR adds an endpoint for fetching an order using the order_id by exposing a new endpoint

### Added

- Endpoint for fetching an order via order_id


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
