### PR TITLE
Include QC report in microsalt summary

### DIFF
--- a/cg/io/json.py
+++ b/cg/io/json.py
@@ -17,7 +17,7 @@ def read_json_stream(stream: str) -> Any:
 def write_json(content: Any, file_path: Path) -> None:
     """Write content to a json file"""
     with open(file_path, "w") as file:
-        json.dump(content, file)
+        json.dump(content, file, indent=4)
 
 
 def write_json_stream(content: Any) -> str:

--- a/cg/meta/workflow/microsalt/quality_controller/quality_controller.py
+++ b/cg/meta/workflow/microsalt/quality_controller/quality_controller.py
@@ -49,7 +49,9 @@ class QualityController:
         report_file: Path = get_report_path(case_metrics_file_path)
         ReportGenerator.report(out_file=report_file, samples=sample_results, case=case_result)
         ResultLogger.log_results(case=case_result, samples=sample_results, report=report_file)
-        summary: str = ReportGenerator.get_summary(case=case_result, samples=sample_results)
+        summary: str = ReportGenerator.get_summary(
+            case=case_result, samples=sample_results, report_path=report_file
+        )
         return QualityResult(case=case_result, samples=sample_results, summary=summary)
 
     def quality_control_samples(self, quality_metrics: QualityMetrics) -> list[SampleQualityResult]:

--- a/cg/meta/workflow/microsalt/quality_controller/report_generator.py
+++ b/cg/meta/workflow/microsalt/quality_controller/report_generator.py
@@ -21,7 +21,11 @@ class ReportGenerator:
         write_json(file_path=out_file, content=report_content)
 
     @staticmethod
-    def get_summary(case: CaseQualityResult, samples: List[SampleQualityResult]) -> str:
+    def get_summary(
+        case: CaseQualityResult, samples: List[SampleQualityResult], report_path: Path | None = None
+    ) -> str:
         case_summary: str = "Case passed QC. " if case.passes_qc else "Case failed QC. "
+        if report_path and not case.passes_qc:
+            case_summary += f"See QC report: {report_path}\n "
         sample_summary: str = sample_result_message(samples)
         return case_summary + sample_summary


### PR DESCRIPTION
## Description
Updated the microsalt QC summary (posted in trailblazer) for microsalt to include the report path when the QC fails.
Also applied some formatting to the way we write our json files.

### Fixed
- Add QC report path to analysis summary in Microsalt


### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

