### PR TITLE
Update data delivery in DownsampleData class

### DIFF
--- a/cg/models/downsample/downsample_data.py
+++ b/cg/models/downsample/downsample_data.py
@@ -4,7 +4,7 @@ import logging
 from pathlib import Path
 
 from cg.apps.housekeeper.hk import HousekeeperAPI
-from cg.constants import Priority
+from cg.constants import DataDelivery, Priority
 from cg.store.models import ApplicationVersion, Case, Sample
 from cg.store.store import Store
 from cg.utils.calculations import multiply_by_million
@@ -111,7 +111,7 @@ class DownsampleData:
             return self.status_db.get_case_by_name(self.downsampled_case_name)
         downsampled_case: Case = self.status_db.add_case(
             data_analysis=self.original_case.data_analysis,
-            data_delivery=self.original_case.data_delivery,
+            data_delivery=DataDelivery.NO_DELIVERY,
             name=self.downsampled_case_name,
             panels=self.original_case.panels,
             priority=self.original_case.priority,


### PR DESCRIPTION
## Description

Downsampled cases in production are using the parent case to guide what DataDelivery options that should be used. However, we do not want these to be automatically delivered in prod, especially if the delivery is AnalysisFiles which would lead to a failed upload. 

### Changed

- `DataDelivery` is set to `NO_DELIVERY` for every downsampled case.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
