### PR TITLE
Rnafusion/taxprofiler workflow: create and use nextflow config by default

### DIFF
--- a/cg/cli/workflow/rnafusion/base.py
+++ b/cg/cli/workflow/rnafusion/base.py
@@ -111,7 +111,9 @@ def run(
             "work_dir": analysis_api.get_workdir_path(case_id=case_id, work_dir=work_dir),
             "resume": not from_start,
             "profile": analysis_api.get_profile(profile=profile),
-            "config": analysis_api.get_nextflow_config_path(nextflow_config=config),
+            "config": analysis_api.get_nextflow_config_path(
+                case_id=case_id, nextflow_config=config
+            ),
             "params_file": analysis_api.get_params_file_path(
                 case_id=case_id, params_file=params_file
             ),

--- a/cg/cli/workflow/taxprofiler/base.py
+++ b/cg/cli/workflow/taxprofiler/base.py
@@ -18,10 +18,7 @@ from cg.cli.workflow.nf_analysis import (
     OPTION_WORKDIR,
     metrics_deliver,
 )
-from cg.cli.workflow.taxprofiler.options import (
-    OPTION_FROM_START,
-    OPTION_INSTRUMENT_PLATFORM,
-)
+from cg.cli.workflow.taxprofiler.options import OPTION_FROM_START, OPTION_INSTRUMENT_PLATFORM
 from cg.constants import EXIT_FAIL, EXIT_SUCCESS
 from cg.constants.constants import DRY_RUN, CaseActions, MetaApis
 from cg.constants.nf_analysis import NfTowerStatus
@@ -109,7 +106,9 @@ def run(
             "work_dir": analysis_api.get_workdir_path(case_id=case_id, work_dir=work_dir),
             "resume": not from_start,
             "profile": analysis_api.get_profile(profile=profile),
-            "config": analysis_api.get_nextflow_config_path(nextflow_config=config),
+            "config": analysis_api.get_nextflow_config_path(
+                case_id=case_id, nextflow_config=config
+            ),
             "params_file": analysis_api.get_params_file_path(
                 case_id=case_id, params_file=params_file
             ),

--- a/cg/constants/nf_analysis.py
+++ b/cg/constants/nf_analysis.py
@@ -21,3 +21,14 @@ RNAFUSION_METRIC_CONDITIONS: dict[str, dict[str, Any]] = {
     "PCT_RIBOSOMAL_BASES": {"norm": "lt", "threshold": 5},
     "PERCENT_DUPLICATION": {"norm": "lt", "threshold": 0.7},
 }
+
+
+MULTIQC_NEXFLOW_CONFIG = """process {
+    withName:'MULTIQC' {
+        memory = { 1.GB * task.attempt }
+        time   = { 4.h  * task.attempt }
+        cpus = 2
+        ext.args = ' --data-format json '
+    }
+}
+"""

--- a/cg/io/txt.py
+++ b/cg/io/txt.py
@@ -1,6 +1,7 @@
 """Module to read or write txt files."""
 
 from pathlib import Path
+from typing import Any
 
 
 def read_txt(file_path: Path, read_to_string: bool = False) -> list[str] | str:
@@ -11,7 +12,10 @@ def read_txt(file_path: Path, read_to_string: bool = False) -> list[str] | str:
         return list(file)
 
 
-def write_txt(content: list[str], file_path: Path) -> None:
+def write_txt(content: list[str] | Any, file_path: Path) -> None:
     """Write content to a text file."""
     with open(file_path, "w") as file:
-        file.writelines(content)
+        if isinstance(content, list):
+            file.writelines(content)
+        else:
+            file.write(content)

--- a/cg/io/txt.py
+++ b/cg/io/txt.py
@@ -12,7 +12,7 @@ def read_txt(file_path: Path, read_to_string: bool = False) -> list[str] | str:
         return list(file)
 
 
-def write_txt(content: list[str] | Any, file_path: Path) -> None:
+def write_txt(content: list[str] | str, file_path: Path) -> None:
     """Write content to a text file."""
     with open(file_path, "w") as file:
         if isinstance(content, list):

--- a/cg/meta/workflow/nf_analysis.py
+++ b/cg/meta/workflow/nf_analysis.py
@@ -71,6 +71,10 @@ class NfAnalysisAPI(AnalysisAPI):
         """Get pipeline version from config."""
         return self.revision
 
+    def get_nextflow_config_content(self) -> str:
+        """Return nextflow config content."""
+        return None
+
     def get_case_path(self, case_id: str) -> Path:
         """Path to case working directory."""
         return Path(self.root_dir, case_id)
@@ -85,7 +89,9 @@ class NfAnalysisAPI(AnalysisAPI):
         """Get the compute environment for the head job based on the case priority."""
         return f"{self.compute_env_base}-{self.get_slurm_qos_for_case(case_id=case_id)}"
 
-    def get_nextflow_config_path(self, case_id: str, nextflow_config: Path | None = None) -> Path:
+    def get_nextflow_config_path(
+        self, case_id: str, nextflow_config: Path | str | None = None
+    ) -> Path:
         """Path to nextflow config file."""
         if nextflow_config:
             return Path(nextflow_config).absolute()
@@ -176,10 +182,10 @@ class NfAnalysisAPI(AnalysisAPI):
 
     def write_nextflow_config(self, case_id: str) -> None:
         """Write nextflow config in json format."""
-        if self.get_nextflow_config_content:
+        if content := self.get_nextflow_config_content():
             LOG.debug("Writing nextflow config file")
             write_txt(
-                content=self.get_nextflow_config_content,
+                content=content,
                 file_path=self.get_nextflow_config_path(case_id=case_id),
             )
 

--- a/cg/meta/workflow/nf_analysis.py
+++ b/cg/meta/workflow/nf_analysis.py
@@ -71,7 +71,7 @@ class NfAnalysisAPI(AnalysisAPI):
         """Get pipeline version from config."""
         return self.revision
 
-    def get_nextflow_config_content(self) -> str:
+    def get_nextflow_config_content(self) -> str | None:
         """Return nextflow config content."""
         return None
 

--- a/cg/meta/workflow/rnafusion.py
+++ b/cg/meta/workflow/rnafusion.py
@@ -64,6 +64,19 @@ class RnafusionAnalysisAPI(NfAnalysisAPI):
             file_path=resources.RNAFUSION_BUNDLE_FILENAMES_PATH,
         )
 
+    @property
+    def get_nextflow_config_content(self) -> str:
+        """Return nextflow config content."""
+        return """process {
+    withName:'MULTIQC' {
+        memory = { check_max( 1.GB * task.attempt, 'memory'  ) }
+        time   = { check_max( 4.h  * task.attempt, 'time'    ) }
+        cpus = 2
+        ext.args = ' --data-format json '
+    }
+}
+"""
+
     def get_sample_sheet_content_per_sample(
         self, sample: Sample, case_id: str, strandedness: Strandedness
     ) -> list[list[str]]:
@@ -140,6 +153,7 @@ class RnafusionAnalysisAPI(NfAnalysisAPI):
             header=RnafusionSampleSheetEntry.headers(),
         )
         self.write_params_file(case_id=case_id, workflow_parameters=workflow_parameters.dict())
+        self.write_nextflow_config(case_id=case_id)
 
     def parse_multiqc_json_for_case(self, case_id: str) -> dict:
         """Parse a multiqc_data.json file and returns a dictionary with metric name and metric values for a case."""

--- a/cg/meta/workflow/rnafusion.py
+++ b/cg/meta/workflow/rnafusion.py
@@ -64,7 +64,6 @@ class RnafusionAnalysisAPI(NfAnalysisAPI):
             file_path=resources.RNAFUSION_BUNDLE_FILENAMES_PATH,
         )
 
-    @property
     def get_nextflow_config_content(self) -> str:
         """Return nextflow config content."""
         return """process {

--- a/cg/meta/workflow/rnafusion.py
+++ b/cg/meta/workflow/rnafusion.py
@@ -7,7 +7,7 @@ from typing import Any
 from cg import resources
 from cg.constants import Workflow
 from cg.constants.constants import FileFormat, Strandedness
-from cg.constants.nf_analysis import RNAFUSION_METRIC_CONDITIONS
+from cg.constants.nf_analysis import MULTIQC_NEXFLOW_CONFIG, RNAFUSION_METRIC_CONDITIONS
 from cg.exc import MissingMetrics
 from cg.io.controller import ReadFile
 from cg.io.json import read_json
@@ -66,15 +66,7 @@ class RnafusionAnalysisAPI(NfAnalysisAPI):
 
     def get_nextflow_config_content(self) -> str:
         """Return nextflow config content."""
-        return """process {
-    withName:'MULTIQC' {
-        memory = { 1.GB * task.attempt }
-        time   = { 4.h  * task.attempt }
-        cpus = 2
-        ext.args = ' --data-format json '
-    }
-}
-"""
+        return MULTIQC_NEXFLOW_CONFIG
 
     def get_sample_sheet_content_per_sample(
         self, sample: Sample, case_id: str, strandedness: Strandedness

--- a/cg/meta/workflow/rnafusion.py
+++ b/cg/meta/workflow/rnafusion.py
@@ -69,8 +69,8 @@ class RnafusionAnalysisAPI(NfAnalysisAPI):
         """Return nextflow config content."""
         return """process {
     withName:'MULTIQC' {
-        memory = { check_max( 1.GB * task.attempt, 'memory'  ) }
-        time   = { check_max( 4.h  * task.attempt, 'time'    ) }
+        memory = { 1.GB * task.attempt }
+        time   = { 4.h  * task.attempt }
         cpus = 2
         ext.args = ' --data-format json '
     }

--- a/cg/meta/workflow/taxprofiler.py
+++ b/cg/meta/workflow/taxprofiler.py
@@ -5,16 +5,14 @@ from pathlib import Path
 from typing import Any
 
 from cg.constants import Workflow
+from cg.constants.nf_analysis import MULTIQC_NEXFLOW_CONFIG
 from cg.constants.sequencing import SequencingPlatform
 from cg.io.json import read_json
 from cg.meta.workflow.nf_analysis import NfAnalysisAPI
 from cg.models.cg_config import CGConfig
 from cg.models.deliverables.metric_deliverables import MetricsBase, MultiqcDataJson
 from cg.models.fastq import FastqFileMeta
-from cg.models.taxprofiler.taxprofiler import (
-    TaxprofilerParameters,
-    TaxprofilerSampleSheetEntry,
-)
+from cg.models.taxprofiler.taxprofiler import TaxprofilerParameters, TaxprofilerSampleSheetEntry
 from cg.store.models import Case, Sample
 
 LOG = logging.getLogger(__name__)
@@ -44,6 +42,10 @@ class TaxprofilerAnalysisAPI(NfAnalysisAPI):
         self.email: str = config.taxprofiler.slurm.mail_user
         self.nextflow_binary_path: str = config.taxprofiler.binary_path
         self.compute_env_base: str = config.taxprofiler.compute_env
+
+    def get_nextflow_config_content(self) -> str:
+        """Return nextflow config content."""
+        return MULTIQC_NEXFLOW_CONFIG
 
     def get_sample_sheet_content_per_sample(
         self, sample: Sample, instrument_platform: SequencingPlatform.ILLUMINA, fasta: str = ""
@@ -122,6 +124,7 @@ class TaxprofilerAnalysisAPI(NfAnalysisAPI):
             header=TaxprofilerSampleSheetEntry.headers(),
         )
         self.write_params_file(case_id=case_id, workflow_parameters=workflow_parameters.dict())
+        self.write_nextflow_config(case_id=case_id)
 
     def get_multiqc_json_metrics(self, case_id: str) -> list[MetricsBase]:
         """Return a list of the metrics specified in a MultiQC json file for the case samples."""

--- a/tests/cli/workflow/rnafusion/test_cli_rnafusion_config_case.py
+++ b/tests/cli/workflow/rnafusion/test_cli_rnafusion_config_case.py
@@ -68,6 +68,7 @@ def test_config_case_default_parameters(
     rnafusion_case_id: str,
     rnafusion_sample_sheet_path: Path,
     rnafusion_params_file_path: Path,
+    rnafusion_nexflow_config_file_path: Path,
     rnafusion_sample_sheet_content: str,
     rnafusion_parameters_default: RnafusionParameters,
     caplog: LogCaptureFixture,
@@ -89,6 +90,7 @@ def test_config_case_default_parameters(
         "Writing sample sheet",
         "Getting parameters information",
         "Writing parameters file",
+        "Writing nextflow config file",
     ]
     for expected_log in expected_logs:
         assert expected_log in expected_logs
@@ -96,6 +98,7 @@ def test_config_case_default_parameters(
     # THEN files should be generated
     assert rnafusion_sample_sheet_path.is_file()
     assert rnafusion_params_file_path.is_file()
+    assert rnafusion_nexflow_config_file_path.is_file()
 
     # THEN the sample sheet content should match the expected values
     sample_sheet_content: list[list[str]] = ReadFile.get_content_from_file(

--- a/tests/cli/workflow/rnafusion/test_cli_rnafusion_config_case.py
+++ b/tests/cli/workflow/rnafusion/test_cli_rnafusion_config_case.py
@@ -93,7 +93,7 @@ def test_config_case_default_parameters(
         "Writing nextflow config file",
     ]
     for expected_log in expected_logs:
-        assert expected_log in expected_logs
+        assert expected_log in caplog.text
 
     # THEN files should be generated
     assert rnafusion_sample_sheet_path.is_file()

--- a/tests/cli/workflow/taxprofiler/test_cli_taxprofiler_config_case.py
+++ b/tests/cli/workflow/taxprofiler/test_cli_taxprofiler_config_case.py
@@ -11,10 +11,7 @@ from cg.constants import EXIT_SUCCESS
 from cg.constants.constants import FileFormat
 from cg.io.controller import ReadFile
 from cg.models.cg_config import CGConfig
-from cg.models.taxprofiler.taxprofiler import (
-    TaxprofilerParameters,
-    TaxprofilerSampleSheetEntry,
-)
+from cg.models.taxprofiler.taxprofiler import TaxprofilerParameters, TaxprofilerSampleSheetEntry
 
 
 def test_config_case_default_parameters(
@@ -46,7 +43,7 @@ def test_config_case_default_parameters(
         "Writing parameters file",
     ]
     for expected_log in expected_logs:
-        assert expected_log in expected_logs
+        assert expected_log in caplog.text
 
     # THEN files should be generated
     assert taxprofiler_sample_sheet_path.is_file()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2238,6 +2238,14 @@ def rnafusion_params_file_path(rnafusion_dir, rnafusion_case_id) -> Path:
 
 
 @pytest.fixture(scope="function")
+def rnafusion_nexflow_config_file_path(rnafusion_dir, rnafusion_case_id) -> Path:
+    """Path to config file."""
+    return Path(
+        rnafusion_dir, rnafusion_case_id, f"{rnafusion_case_id}_nextflow_config"
+    ).with_suffix(FileExtensions.JSON)
+
+
+@pytest.fixture(scope="function")
 def rnafusion_metrics_deliverables(rnafusion_analysis_dir: Path) -> list[dict]:
     """Returns the content of a mock metrics deliverables file."""
     return read_yaml(


### PR DESCRIPTION
## Description

### Added

- Nextflow config creation for rnafusion and taxprofiler when config-case

### Changed

- Use nextflow config by default in rnafusion/taxprofiler start



### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b multiqc_json -a
    ```

### How to test

- [x] `cg workflow rnafusion config-case tendergoose` runs an writes tendergoose_nextflow_config.json
- [x] `cg workflow rnafusion start tendergoose` uses config and succesfully completes
- [x] `cg workflow taxprofiler config-case case_id` runs an writes *_nextflow_config.json
- [x] `cg workflow taxprofiler start -d case_id` prints the command with the --config parameter

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
