### PR TITLE
Use workflow instead of order_type

### DIFF
--- a/cg/store/crud/create.py
+++ b/cg/store/crud/create.py
@@ -409,10 +409,11 @@ class CreateHandler(BaseHandler):
 
     def add_order(self, order_data: OrderIn):
         customer: Customer = self.get_customer_by_internal_id(order_data.customer)
+        workflow: str = order_data.samples[0].data_analysis
         order = Order(
             customer_id=customer.id,
             ticket_id=order_data.ticket,
-            workflow=order_data.order_type,
+            workflow=workflow,
         )
         session = get_session()
         session.add(order)


### PR DESCRIPTION
## Description

Currently order entries are created using order type as workflow. This is not quite correct since for example sars-cov-2 orders should have mutant as workflow but sars-cov-2 as order type.

### Fixed

- Use workflow instead of order type when creating orders.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
