### PR TITLE
Turn off slurm scout upload

### DIFF
--- a/cg/apps/scout/scoutapi.py
+++ b/cg/apps/scout/scoutapi.py
@@ -45,9 +45,10 @@ class ScoutAPI:
                 existing_date = existing_case.analysis_date.date()
                 LOG.warning(f"Analysis of case already loaded: {existing_date}")
                 return
-        job_name = "scout_analysis_upload"
-        command: str = f"{self.scout_base_command} " + " ".join(load_command)
-        self.slurm_upload_service.upload(upload_command=command, job_name=job_name, case_id=case_id)
+        LOG.debug("load new Scout case")
+        self.process.run_command(load_command)
+        LOG.debug("Case loaded successfully to Scout")
+
 
     def export_panels(self, panels: list[str], build: str = GENOME_BUILD_37) -> list[str]:
         """Pass through to export of a list of gene panels.

--- a/cg/apps/scout/scoutapi.py
+++ b/cg/apps/scout/scoutapi.py
@@ -49,7 +49,6 @@ class ScoutAPI:
         self.process.run_command(load_command)
         LOG.debug("Case loaded successfully to Scout")
 
-
     def export_panels(self, panels: list[str], build: str = GENOME_BUILD_37) -> list[str]:
         """Pass through to export of a list of gene panels.
 


### PR DESCRIPTION
## Description
We need to get the visualization in place for the uploads before running them via slurm, so lets toggle it off for the scout upload for now.

Also need to get the logic in place for setting the uploaded date in trailblazer correctly.


### Fixed
- Turn off uploads via slurm

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
