### PR TITLE
Patch rnafusion store

### DIFF
--- a/cg/resources/rnafusion_bundle_filenames.csv
+++ b/cg/resources/rnafusion_bundle_filenames.csv
@@ -66,7 +66,7 @@
   tag: multiqc-html
 - format: csv
   id: CASEID
-  path: PATHTOCASE/workflow_info/samplesheet.valid.csv
+  path: PATHTOCASE/pipeline_info/samplesheet.valid.csv
   path_index: ~
   step: samplesheet-valid
   tag: samplesheet-valid


### PR DESCRIPTION
## Description

A bug was introduced in https://github.com/Clinical-Genomics/cg/pull/2894 that breaks the rnafusion store of files into HK

### Fixed

- Restored file deliverables path


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
