### PR TITLE
Patch demultiplexing

### DIFF
--- a/cg/apps/demultiplex/demultiplex_api.py
+++ b/cg/apps/demultiplex/demultiplex_api.py
@@ -34,8 +34,10 @@ class DemultiplexingAPI:
         self.hk_api = housekeeper_api
         self.slurm_account: str = config["demultiplex"]["slurm"]["account"]
         self.mail: str = config["demultiplex"]["slurm"]["mail_user"]
-        self.flow_cells_dir: Path = Path(config["flow_cells_dir"])
-        self.demultiplexed_runs_dir: Path = out_dir or Path(config["demultiplexed_flow_cells_dir"])
+        self.flow_cells_dir: Path = Path(config["illumina_flow_cells_directory"])
+        self.demultiplexed_runs_dir: Path = out_dir or Path(
+            config["illumina_demultiplexed_runs_directory"]
+        )
         self.environment: str = config.get("environment", "stage")
         LOG.info(f"Set environment to {self.environment}")
         self.dry_run: bool = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -376,8 +376,8 @@ def demultiplex_configs_for_demux(
 ) -> dict:
     """Return demultiplex configs."""
     return {
-        "flow_cells_dir": tmp_illumina_flow_cells_demux_all_directory.as_posix(),
-        "demultiplexed_flow_cells_dir": tmp_empty_demultiplexed_runs_directory.as_posix(),
+        "illumina_flow_cells_directory": tmp_illumina_flow_cells_demux_all_directory.as_posix(),
+        "illumina_demultiplexed_runs_directory": tmp_empty_demultiplexed_runs_directory.as_posix(),
         "demultiplex": {"slurm": {"account": "test", "mail_user": "testuser@github.se"}},
     }
 
@@ -389,8 +389,8 @@ def demultiplex_configs(
 ) -> dict:
     """Return demultiplex configs."""
     return {
-        "flow_cells_dir": tmp_illumina_flow_cells_directory.as_posix(),
-        "demultiplexed_flow_cells_dir": tmp_illumina_demultiplexed_flow_cells_directory.as_posix(),
+        "illumina_flow_cells_directory": tmp_illumina_flow_cells_directory.as_posix(),
+        "illumina_demultiplexed_runs_directory": tmp_illumina_demultiplexed_flow_cells_directory.as_posix(),
         "demultiplex": {"slurm": {"account": "test", "mail_user": "testuser@github.se"}},
     }
 


### PR DESCRIPTION
## Description
The demultiplexing_api uses dict keys for fetching values and were missed by the recent refactoring. Thanks @diitaz93 for noticing 🙏 

### Fixed

- Dict keys updated as well


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
