### PR TITLE
fix(bcl2fastqt) Change hard-coded paths in bcl2fastq demux script

### DIFF
--- a/cg/apps/demultiplex/sbatch.py
+++ b/cg/apps/demultiplex/sbatch.py
@@ -5,9 +5,9 @@ from cg.constants.demultiplexing import BclConverter
 DEMULTIPLEX_COMMAND = {
     BclConverter.BCL2FASTQ: """
 log "singularity exec --bind \
-/home/proj/{environment}/sequencing_data/illumina_novaseq_flow_cells/demultiplexed-runs,\
-/home/proj/{environment}/sequencing_data/illumina_novaseq_flow_cells/flow_cells,\
-/home/proj/{environment}/sequencing_data/illumina_novaseq_flow_cells/flow_cells/'$SLURM_JOB_ID':/run/user/$(id -u) \
+/home/proj/{environment}/sequencing_data/illumina/demultiplexed-runs,\
+/home/proj/{environment}/sequencing_data/illumina/flow_cells,\
+/home/proj/{environment}/sequencing_data/illumina/flow_cells/'$SLURM_JOB_ID':/run/user/$(id -u) \
 /home/proj/{environment}/demux-on-hasta/novaseq/container/bcl2fastq_v2-20-0.sif \
 bcl2fastq --loading-threads 3 --processing-threads 15 --writing-threads 3 \
 --runfolder-dir {run_dir} --output-dir {unaligned_dir} \
@@ -16,9 +16,9 @@ bcl2fastq --loading-threads 3 --processing-threads 15 --writing-threads 3 \
 touch {demux_completed_file}"
 
 singularity exec --bind \
-/home/proj/{environment}/sequencing_data/illumina_novaseq_flow_cells/demultiplexed-runs,\
-/home/proj/{environment}/sequencing_data/illumina_novaseq_flow_cells/flow_cells,\
-/home/proj/{environment}/sequencing_data/illumina_novaseq_flow_cells/flow_cells/'$SLURM_JOB_ID':/run/user/$(id -u) \
+/home/proj/{environment}/sequencing_data/illumina/demultiplexed-runs,\
+/home/proj/{environment}/sequencing_data/illumina/low_cells,\
+/home/proj/{environment}/sequencing_data/illumina/flow_cells/'$SLURM_JOB_ID':/run/user/$(id -u) \
 /home/proj/{environment}/demux-on-hasta/novaseq/container/bcl2fastq_v2-20-0.sif \
 bcl2fastq --loading-threads 3 --processing-threads 15 --writing-threads 3 \
 --runfolder-dir {run_dir} --output-dir {unaligned_dir} \


### PR DESCRIPTION
## Description
A intermediate change was kept in #2824 and not changed to the final decision.


### Fixed

- Change hard-coded paths in bcl2fastq demux script to match the file structure


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
