### PR TITLE
feat(SQLAlchemy) Replace like operators with contains

### DIFF
--- a/cg/cli/backup.py
+++ b/cg/cli/backup.py
@@ -169,7 +169,7 @@ def archive_spring_files(config: CGConfig, context: click.Context, dry_run: bool
     LOG.info("Getting all spring files from Housekeeper.")
     spring_files: Iterable[hk_models.File] = housekeeper_api.files(
         tags=[SequencingFileTag.SPRING]
-    ).filter(hk_models.File.path.like(f"%{config.environment}/{config.demultiplex.out_dir}%"))
+    ).filter(hk_models.File.path.contains(f"{config.environment}/{config.demultiplex.out_dir}"))
     for spring_file in spring_files:
         LOG.info(f"Attempting encryption and PDC archiving for file {spring_file.path}")
         if Path(spring_file.path).exists():

--- a/cg/store/filters/status_case_filters.py
+++ b/cg/store/filters/status_case_filters.py
@@ -25,8 +25,8 @@ def filter_cases_by_case_search(cases: Query, case_search: str, **kwargs) -> Que
     return (
         cases.filter(
             or_(
-                Case.internal_id.like(f"%{case_search}%"),
-                Case.name.like(f"%{case_search}%"),
+                Case.internal_id.contains(case_search),
+                Case.name.contains(case_search),
             )
         )
         if case_search
@@ -58,7 +58,7 @@ def filter_case_by_internal_id(cases: Query, internal_id: str, **kwargs) -> Quer
 
 def filter_cases_by_internal_id_search(cases: Query, internal_id_search: str, **kwargs) -> Query:
     """Filter cases with internal ids matching the search pattern."""
-    return cases.filter(Case.internal_id.like(f"%{internal_id_search}%"))
+    return cases.filter(Case.internal_id.contains(internal_id_search))
 
 
 def filter_cases_by_name(cases: Query, name: str, **kwargs) -> Query:
@@ -68,12 +68,12 @@ def filter_cases_by_name(cases: Query, name: str, **kwargs) -> Query:
 
 def filter_cases_by_name_search(cases: Query, name_search: str, **kwargs) -> Query:
     """Filter cases with names matching the search pattern."""
-    return cases.filter(Case.name.like(f"%{name_search}%"))
+    return cases.filter(Case.name.contains(name_search))
 
 
 def filter_cases_by_workflow_search(cases: Query, workflow_search: str, **kwargs) -> Query:
     """Filter cases with a workflow search pattern."""
-    return cases.filter(Case.data_analysis.ilike(f"%{workflow_search}%"))
+    return cases.filter(Case.data_analysis.contains(workflow_search))
 
 
 def filter_cases_by_priority(cases: Query, priority: str, **kwargs) -> Query:

--- a/cg/store/filters/status_flow_cell_filters.py
+++ b/cg/store/filters/status_flow_cell_filters.py
@@ -18,7 +18,7 @@ def filter_flow_cell_by_name(flow_cells: Query, flow_cell_name: str, **kwargs) -
 
 def filter_flow_cell_by_name_search(flow_cells: Query, name_search: str, **kwargs) -> Query:
     """Return flow cell by flow cell id enquiry."""
-    return flow_cells.filter(Flowcell.name.like(f"%{name_search}%"))
+    return flow_cells.filter(Flowcell.name.contains(name_search))
 
 
 def filter_flow_cells_with_statuses(

--- a/cg/store/filters/status_pool_filters.py
+++ b/cg/store/filters/status_pool_filters.py
@@ -13,12 +13,12 @@ def filter_pools_by_customer_id(pools: Query, customer_ids: list[int], **kwargs)
 
 def filter_pools_by_name_enquiry(pools: Query, name_enquiry: str, **kwargs) -> Query:
     """Return pools by name enquiry."""
-    return pools.filter(Pool.name.like(f"%{name_enquiry}%"))
+    return pools.filter(Pool.name.contains(name_enquiry))
 
 
 def filter_pools_by_order_enquiry(pools: Query, order_enquiry: str, **kwargs) -> Query:
     """Return pools by order enquiry."""
-    return pools.filter(Pool.order.like(f"%{order_enquiry}%"))
+    return pools.filter(Pool.order.contains(order_enquiry))
 
 
 def filter_pools_by_entry_id(pools: Query, entry_id: int, **kwargs) -> Query:

--- a/cg/store/filters/status_sample_filters.py
+++ b/cg/store/filters/status_sample_filters.py
@@ -125,7 +125,7 @@ def filter_samples_by_internal_id_pattern(
     samples: Query, internal_id_pattern: str, **kwargs
 ) -> Query:
     """Return samples matching the internal id pattern."""
-    return samples.filter(Sample.internal_id.like(f"%{internal_id_pattern}%"))
+    return samples.filter(Sample.internal_id.contains(internal_id_pattern))
 
 
 def filter_samples_by_internal_id_or_name_search(
@@ -134,8 +134,8 @@ def filter_samples_by_internal_id_or_name_search(
     """Return samples matching the internal id or name search."""
     return samples.filter(
         or_(
-            Sample.name.like(f"%{search_pattern}%"),
-            Sample.internal_id.like(f"%{search_pattern}%"),
+            Sample.name.contains(search_pattern),
+            Sample.internal_id.contains(search_pattern),
         )
     )
 

--- a/tests/meta/upload/scout/test_meta_upload_scoutapi_rna.py
+++ b/tests/meta/upload/scout/test_meta_upload_scoutapi_rna.py
@@ -580,7 +580,7 @@ def test_add_rna_sample(
     # GIVEN an RNA case and the associated RNA samples
     rna_case: Case = rna_store.get_case_by_internal_id(internal_id=rna_case_id)
     rna_sample_list: list[Sample] = (
-        rna_store._get_query(table=Sample).filter(Sample.internal_id.like("rna")).all()
+        rna_store._get_query(table=Sample).filter(Sample.internal_id.contains("rna")).all()
     )
 
     # WHEN running the method to create a list of RNADNACollections
@@ -592,7 +592,7 @@ def test_add_rna_sample(
     # THEN the resulting RNADNACollections should contain all RNA samples in the case
     for sample in rna_sample_list:
         assert sample.internal_id in [
-            rna_dna_collection.rna_sample_id for rna_dna_collection in rna_dna_collections
+            rna_dna_collection.rna_sample_internal_id for rna_dna_collection in rna_dna_collections
         ]
 
 

--- a/tests/meta/upload/scout/test_meta_upload_scoutapi_rna.py
+++ b/tests/meta/upload/scout/test_meta_upload_scoutapi_rna.py
@@ -590,6 +590,7 @@ def test_add_rna_sample(
     )
 
     # THEN the resulting RNADNACollections should contain all RNA samples in the case
+    assert rna_sample_list
     for sample in rna_sample_list:
         assert sample.internal_id in [
             rna_dna_collection.rna_sample_internal_id for rna_dna_collection in rna_dna_collections


### PR DESCRIPTION
## Description
The LIKE operator in SQL is used for pattern matching. In cg however it's use can be replaced by the more pythonic `contains`.

Also the `like` method did not work well with Enums when typed properly. 

### Changed

- All usages of the `like` methods are replaced by `contains`


### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

