### PR TITLE
(Streamline delivery) Add OrderCase table

### DIFF
--- a/alembic/versions/2024_02_19_43eb680d6181_add_order_case_table.py
+++ b/alembic/versions/2024_02_19_43eb680d6181_add_order_case_table.py
@@ -1,0 +1,31 @@
+"""Add order case table
+
+Revision ID: 43eb680d6181
+Revises: d241d8c493fb
+Create Date: 2024-02-19 10:13:21.075891
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "43eb680d6181"
+down_revision = "d241d8c493fb"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "order_case",
+        sa.Column("id", sa.Integer, nullable=False),
+        sa.Column("order_id", sa.ForeignKey("order.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("case_id", sa.ForeignKey("case.id", ondelete="CASCADE"), nullable=False),
+        sa.UniqueConstraint("order_id", "case_id", name="_order_case_uc"),
+    )
+
+
+def downgrade():
+    op.drop_table(table_name="order_case")

--- a/alembic/versions/2024_02_19_43eb680d6181_add_order_case_table.py
+++ b/alembic/versions/2024_02_19_43eb680d6181_add_order_case_table.py
@@ -21,8 +21,8 @@ def upgrade():
     op.create_table(
         "order_case",
         sa.Column("id", sa.Integer, nullable=False),
-        sa.Column("order_id", sa.Integer, nullable=False),
-        sa.Column("case_id", sa.Integer, nullable=False),
+        sa.Column("order_id", sa.Integer, nullable=False, index=True),
+        sa.Column("case_id", sa.Integer, nullable=False, index=True),
         sa.ForeignKeyConstraint(["order_id"], ["order.id"], ondelete="CASCADE"),
         sa.ForeignKeyConstraint(["case_id"], ["case.id"], ondelete="CASCADE"),
         sa.UniqueConstraint("order_id", "case_id", name="_order_case_uc"),

--- a/alembic/versions/2024_02_19_43eb680d6181_add_order_case_table.py
+++ b/alembic/versions/2024_02_19_43eb680d6181_add_order_case_table.py
@@ -20,7 +20,6 @@ depends_on = None
 def upgrade():
     op.create_table(
         "order_case",
-        sa.Column("id", sa.Integer, nullable=False),
         sa.Column("order_id", sa.Integer, nullable=False, index=True),
         sa.Column("case_id", sa.Integer, nullable=False, index=True),
         sa.ForeignKeyConstraint(["order_id"], ["order.id"], ondelete="CASCADE"),

--- a/alembic/versions/2024_02_19_43eb680d6181_add_order_case_table.py
+++ b/alembic/versions/2024_02_19_43eb680d6181_add_order_case_table.py
@@ -21,8 +21,10 @@ def upgrade():
     op.create_table(
         "order_case",
         sa.Column("id", sa.Integer, nullable=False),
-        sa.Column("order_id", sa.ForeignKey("order.id", ondelete="CASCADE"), nullable=False),
-        sa.Column("case_id", sa.ForeignKey("case.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("order_id", sa.Integer, nullable=False),
+        sa.Column("case_id", sa.Integer, nullable=False),
+        sa.ForeignKeyConstraint(["order_id"], ["order.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["case_id"], ["case.id"], ondelete="CASCADE"),
         sa.UniqueConstraint("order_id", "case_id", name="_order_case_uc"),
     )
 

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -922,4 +922,4 @@ class OrderCase(Model):
     order_id = Column(ForeignKey("order.id", ondelete="CASCADE"), nullable=False)
     case_id = Column(ForeignKey("case.id", ondelete="CASCADE"), nullable=False)
     case = orm.relationship(Case, back_populates="order_links")
-    sample = orm.relationship(Order, back_populates="links")
+    order = orm.relationship(Order, back_populates="links")

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -474,16 +474,6 @@ class Case(Model, PriorityMixin):
         return [link.sample for link in self.links]
 
     @property
-    def orders(self) -> list["Order"]:
-        """Return case samples."""
-        return self._get_orders
-
-    @property
-    def _get_orders(self) -> list["Order"]:
-        """Extract samples from a case."""
-        return [order_link.order for order_link in self.order_links]
-
-    @property
     def tumour_samples(self) -> list["Sample"]:
         """Return tumour samples."""
         return self._get_tumour_samples


### PR DESCRIPTION
## Description

We need to track what cases are included in an order, and since a case can be included in several orders, this will be a many-to-many relationship, similar to the case-sample connection. This PR adds an OrderCase table, which should allow us to track the cases in an order.

### Added

- OrderCase table

### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b add-order-case-table -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
