### PR TITLE
Add extra tag to metrics deliverables YAML file.

### DIFF
--- a/cg/constants/housekeeper_tags.py
+++ b/cg/constants/housekeeper_tags.py
@@ -76,9 +76,9 @@ class HkMipAnalysisTag:
     SAMPLE_INFO: list[str] = ["sample-info"]
 
 
-class BalsamicAnalysisTag(StrEnum):
-    CONFIG: str = "balsamic-config"
-    QC_METRICS: str = "qc-metrics"
+class BalsamicAnalysisTag:
+    CONFIG: list[str] = ["balsamic-config"]
+    QC_METRICS: list[str] = ["qc-metrics", "deliverable"]
 
 
 class GensAnalysisTag:

--- a/cg/meta/workflow/balsamic.py
+++ b/cg/meta/workflow/balsamic.py
@@ -324,8 +324,8 @@ class BalsamicAnalysisAPI(AnalysisAPI):
     def get_latest_metadata(self, case_id: str) -> BalsamicAnalysis:
         """Get the latest metadata of a specific BALSAMIC case"""
 
-        config_raw_data = self.get_latest_raw_file_data(case_id, [BalsamicAnalysisTag.CONFIG])
-        metrics_raw_data = self.get_latest_raw_file_data(case_id, [BalsamicAnalysisTag.QC_METRICS])
+        config_raw_data = self.get_latest_raw_file_data(case_id, BalsamicAnalysisTag.CONFIG)
+        metrics_raw_data = self.get_latest_raw_file_data(case_id, BalsamicAnalysisTag.QC_METRICS)
 
         if config_raw_data and metrics_raw_data:
             try:


### PR DESCRIPTION
## Description

We need to have unique tags in HK. `qc-metrics` tag will start to be used also for multiqc data (https://github.com/Clinical-Genomics/hermes/pull/95).

This PR adds this extra tag.

### Added
- `deliveable` tag to `<case_id>_metrics_deliverables.yaml`


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
