### PR TITLE
Remove existing slurm job ids

### DIFF
--- a/cg/meta/workflow/microsalt/microsalt.py
+++ b/cg/meta/workflow/microsalt/microsalt.py
@@ -89,13 +89,16 @@ class MicrosaltAnalysisAPI(AnalysisAPI):
 
     def get_job_ids_path(self, case_id: str) -> Path:
         project_id: str = self.get_project_id(case_id)
-        return Path(
+        job_ids_path = Path(
             self.root_dir,
             "results",
             "reports",
             "trailblazer",
             f"{project_id}_slurm_ids{FileExtensions.YAML}",
         )
+        if job_ids_path.exists():
+            job_ids_path.unlink()
+        return job_ids_path
 
     def get_deliverables_file_path(self, case_id: str) -> Path:
         """Returns a path where the microSALT deliverables file for the order_id should be

--- a/cg/meta/workflow/microsalt/microsalt.py
+++ b/cg/meta/workflow/microsalt/microsalt.py
@@ -96,9 +96,12 @@ class MicrosaltAnalysisAPI(AnalysisAPI):
             "trailblazer",
             f"{project_id}_slurm_ids{FileExtensions.YAML}",
         )
+        self._ensure_old_job_ids_file_removed(job_ids_path)
+        return job_ids_path
+
+    def _ensure_old_job_ids_file_removed(self, job_ids_path: Path) -> None:
         if job_ids_path.exists():
             job_ids_path.unlink()
-        return job_ids_path
 
     def get_deliverables_file_path(self, case_id: str) -> Path:
         """Returns a path where the microSALT deliverables file for the order_id should be

--- a/cg/meta/workflow/microsalt/microsalt.py
+++ b/cg/meta/workflow/microsalt/microsalt.py
@@ -96,10 +96,10 @@ class MicrosaltAnalysisAPI(AnalysisAPI):
             "trailblazer",
             f"{project_id}_slurm_ids{FileExtensions.YAML}",
         )
-        self._ensure_old_job_ids_file_removed(job_ids_path)
+        self._ensure_old_job_ids_are_removed(job_ids_path)
         return job_ids_path
 
-    def _ensure_old_job_ids_file_removed(self, job_ids_path: Path) -> None:
+    def _ensure_old_job_ids_are_removed(self, job_ids_path: Path) -> None:
         if job_ids_path.exists():
             job_ids_path.unlink()
 

--- a/cg/meta/workflow/microsalt/microsalt.py
+++ b/cg/meta/workflow/microsalt/microsalt.py
@@ -101,7 +101,8 @@ class MicrosaltAnalysisAPI(AnalysisAPI):
         return job_ids_path
 
     def _ensure_old_job_ids_are_removed(self, job_ids_path: Path) -> None:
-        if job_ids_path.exists():
+        is_yaml_file: bool = job_ids_path.suffix == FileExtensions.YAML
+        if job_ids_path.exists() and is_yaml_file:
             job_ids_path.unlink()
 
     def get_deliverables_file_path(self, case_id: str) -> Path:

--- a/cg/meta/workflow/microsalt/microsalt.py
+++ b/cg/meta/workflow/microsalt/microsalt.py
@@ -96,6 +96,7 @@ class MicrosaltAnalysisAPI(AnalysisAPI):
             "trailblazer",
             f"{project_id}_slurm_ids{FileExtensions.YAML}",
         )
+        # Necessary due to how microsalt structures its output
         self._ensure_old_job_ids_are_removed(job_ids_path)
         return job_ids_path
 


### PR DESCRIPTION
## Description
Closes https://github.com/Clinical-Genomics/cg/issues/2966.
When a microsalt analysis is started, this fix ensures the previous job id:s are removed.

Fixing this properly would involve restructuring the microsalt output, but I don't think the effort of doing that is justified since it is supposed to be replaced.

### Fixed
- Old jobs being tracked for restarted microsalt analyses

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

