### PR TITLE
Exclude non-directories from flow cell lists

### DIFF
--- a/cg/apps/demultiplex/sample_sheet/api.py
+++ b/cg/apps/demultiplex/sample_sheet/api.py
@@ -17,7 +17,7 @@ from cg.meta.demultiplex.housekeeper_storage_functions import (
     delete_file_from_housekeeper,
 )
 from cg.models.flow_cell.flow_cell import FlowCellDirectoryData
-from cg.utils.files import link_or_overwrite_file
+from cg.utils.files import get_directories_in_path, link_or_overwrite_file
 
 LOG = logging.getLogger(__name__)
 
@@ -186,9 +186,7 @@ class SampleSheetAPI:
 
     def get_or_create_all_sample_sheets(self):
         """Ensure that a valid sample sheet is present in all flow cell directories."""
-        for flow_cell_dir in self.flow_cell_runs_dir.iterdir():
-            if not flow_cell_dir.is_dir():
-                continue
+        for flow_cell_dir in get_directories_in_path(self.flow_cell_runs_dir):
             try:
                 self.get_or_create_sample_sheet(
                     flow_cell_name=flow_cell_dir.name, bcl_converter=None

--- a/cg/apps/demultiplex/sample_sheet/api.py
+++ b/cg/apps/demultiplex/sample_sheet/api.py
@@ -187,6 +187,8 @@ class SampleSheetAPI:
     def get_or_create_all_sample_sheets(self):
         """Ensure that a valid sample sheet is present in all flow cell directories."""
         for flow_cell_dir in self.flow_cell_runs_dir.iterdir():
+            if not flow_cell_dir.is_dir():
+                continue
             try:
                 self.get_or_create_sample_sheet(
                     flow_cell_name=flow_cell_dir.name, bcl_converter=None


### PR DESCRIPTION
## Description
The flow cell directory in production holds some files that are not directories. The automation tries to create a sample sheet for those files interpreted as directories, which adds unnecessary errors to the logs.


### Fixed

- Checks that a flow cell directory is indeed a directory before trying to create a sample sheet for it


### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b patch-check-flowcell-isdir -a
    ```

### How to test

- [x] create a file in the flow cell dir
- [x] `cg -l DEBUG demultiplex samplesheet create-all`

### Expected test outcome

- [x] Check that the file is skipped

## Review

- [x] Tests executed by SD
- [x] "Merge and deploy" approved by CO
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
