### PR TITLE
Use correct cases in the order_case table

### DIFF
--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -136,7 +136,7 @@ def submit_order(order_type):
             user_mail=g.current_user.email,
         )
         order_service = OrderService(db)
-        order_service.create_order(order_data=order_in)
+        order_service.create_order(order_in)
 
     except (  # user misbehaviour
         OrderError,

--- a/cg/server/api.py
+++ b/cg/server/api.py
@@ -136,7 +136,7 @@ def submit_order(order_type):
             user_mail=g.current_user.email,
         )
         order_service = OrderService(db)
-        order_service.create_order(order_data=order_in, cases=result["records"])
+        order_service.create_order(order_data=order_in)
 
     except (  # user misbehaviour
         OrderError,

--- a/cg/services/orders/order_service.py
+++ b/cg/services/orders/order_service.py
@@ -4,7 +4,7 @@ from cg.server.dto.orders.orders_request import OrdersRequest
 from cg.server.dto.orders.orders_response import Order as OrderResponse
 from cg.server.dto.orders.orders_response import OrdersResponse
 from cg.services.orders.utils import create_order_response, create_orders_response
-from cg.store.models import Case, Order
+from cg.store.models import Order
 from cg.store.store import Store
 
 
@@ -28,9 +28,10 @@ class OrderService:
             workflow=orders_request.workflow, limit=orders_request.limit
         )
 
-    def create_order(self, order_data: OrderIn, cases: list[Case]) -> OrderResponse:
+    def create_order(self, order_data: OrderIn) -> OrderResponse:
         """Creates an order and links it to the given cases."""
         order: Order = self.store.add_order(order_data)
+        cases = self.store.get_cases_by_ticket_id(order_data.ticket)
         for case in cases:
             self.store.link_case_to_order(order_id=order.id, case_id=case.id)
         return create_order_response(order)


### PR DESCRIPTION
## Description

In #2952 I wrote code on an assumption that a variable would always contain cases, when in reality it can contain samples or pools as well. This PR ensures that we only connect orders to cases included in new orders.

Order_case is not used anywhere yet, so should not cause any issues, but this should be patched before any functionality is bestowed upon the table.

Part of resolving https://github.com/Clinical-Genomics/streamline-delivery/issues/43.

### Fixed

- Use cases with the specified ticket_id for matching with a new order.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
