### PR TITLE
Patch delivery bug

### DIFF
--- a/cg/meta/deliver/delivery_api.py
+++ b/cg/meta/deliver/delivery_api.py
@@ -197,11 +197,11 @@ class DeliveryAPI:
         return sample_files
 
     def _is_case_deliverable(self, case: Case, workflow: str) -> bool:
-        bundle_exist: bool = self._bundle_exists(case.internal_id)
+        bundle_exists: bool = self._bundle_exists(case.internal_id)
         ignore_missing_bundle: bool = self.ignore_missing_bundle(workflow)
-        if not bundle_exist and not ignore_missing_bundle:
+        if not bundle_exists and not ignore_missing_bundle:
             raise SyntaxError(f"Could not find bundle {case.internal_id}")
-        return bundle_exist or ignore_missing_bundle
+        return bundle_exists or ignore_missing_bundle
 
     def _sample_passes_quality_check(self, sample: Sample) -> bool:
         return (

--- a/cg/meta/deliver/delivery_api.py
+++ b/cg/meta/deliver/delivery_api.py
@@ -148,7 +148,7 @@ class DeliveryAPI:
         samples: list[Sample] = self.store.get_samples_by_case_id(case.internal_id)
         for sample in samples:
             bundle_name: str = get_bundle_name(case=case, sample=sample, workflow=workflow)
-            bundle_exists: bool = self._bundle_exists(bundle_name=bundle_name, workflow=workflow)
+            bundle_exists: bool = self._bundle_exists(bundle_name)
             sample_is_deliverable: bool = self._is_sample_deliverable(sample)
             if bundle_exists and sample_is_deliverable:
                 deliverable_samples.append(sample)
@@ -190,7 +190,7 @@ class DeliveryAPI:
 
     def _is_case_deliverable(self, case: Case, workflow: str) -> bool:
         bundle_name: str = case.internal_id
-        return self._bundle_exists(bundle_name=bundle_name, workflow=workflow)
+        return self._bundle_exists(bundle_name)
 
     def _is_sample_deliverable(self, sample: Sample) -> bool:
         return (
@@ -199,12 +199,8 @@ class DeliveryAPI:
             or sample.application_version.application.is_external
         )
 
-    def _bundle_exists(self, bundle_name: str, workflow: str) -> bool:
-        if self.hk_api.last_version(bundle_name):
-            return True
-        if self.ignore_missing_bundle(workflow):
-            return False
-        raise SyntaxError(f"Could not find any version for {bundle_name}")
+    def _bundle_exists(self, bundle_name: str) -> bool:
+        return self.hk_api.last_version(bundle_name)
 
     def ignore_missing_bundle(self, workflow: str) -> bool:
         return workflow in constants.SKIP_MISSING or self.ignore_missing_bundles

--- a/cg/meta/deliver/delivery_api.py
+++ b/cg/meta/deliver/delivery_api.py
@@ -155,9 +155,12 @@ class DeliveryAPI:
         bundle_name: str = get_bundle_name(case=case, sample=sample, workflow=workflow)
         bundle_exists: bool = self._bundle_exists(bundle_name)
         ignore_missing_bundle: bool = self.ignore_missing_bundle(workflow)
-        sample_bundle_is_deliverable: bool = bundle_exists or ignore_missing_bundle
+
+        if not bundle_exists and not ignore_missing_bundle:
+            raise SyntaxError(f"Could not find bundle {bundle_name}")
+
         sample_passes_qc: bool = self._sample_passes_quality_check(sample)
-        return sample_bundle_is_deliverable and sample_passes_qc
+        return bundle_exists and sample_passes_qc
 
     def _get_version_for_sample(self, sample: Sample, case: Case, workflow: str) -> Version:
         bundle: str = sample.internal_id if workflow == DataDelivery.FASTQ else case.internal_id
@@ -196,6 +199,8 @@ class DeliveryAPI:
     def _is_case_deliverable(self, case: Case, workflow: str) -> bool:
         bundle_exist: bool = self._bundle_exists(case.internal_id)
         ignore_missing_bundle: bool = self.ignore_missing_bundle(workflow)
+        if not bundle_exist and not ignore_missing_bundle:
+            raise SyntaxError(f"Could not find bundle {case.internal_id}")
         return bundle_exist or ignore_missing_bundle
 
     def _sample_passes_quality_check(self, sample: Sample) -> bool:

--- a/cg/meta/deliver/delivery_api.py
+++ b/cg/meta/deliver/delivery_api.py
@@ -211,7 +211,7 @@ class DeliveryAPI:
         )
 
     def _bundle_exists(self, bundle_name: str) -> bool:
-        return self.hk_api.last_version(bundle_name)
+        return bool(self.hk_api.last_version(bundle_name))
 
     def ignore_missing_bundle(self, workflow: str) -> bool:
         return workflow in constants.SKIP_MISSING or self.ignore_missing_bundles

--- a/cg/meta/deliver/delivery_api.py
+++ b/cg/meta/deliver/delivery_api.py
@@ -147,19 +147,17 @@ class DeliveryAPI:
         deliverable_samples: list[Sample] = []
         samples: list[Sample] = self.store.get_samples_by_case_id(case.internal_id)
         for sample in samples:
-            sample_bundle_is_deliverable: bool = self.is_sample_bundle_deliverable(
-                case=case, sample=sample, workflow=workflow
-            )
-            sample_passes_qc: bool = self._sample_passes_quality_check(sample)
-            if sample_bundle_is_deliverable and sample_passes_qc:
+            if self.is_sample_deliverable(case=case, sample=sample, workflow=workflow):
                 deliverable_samples.append(sample)
         return deliverable_samples
 
-    def is_sample_bundle_deliverable(self, case: Case, sample: Sample, workflow: str) -> bool:
+    def is_sample_deliverable(self, case: Case, sample: Sample, workflow: str) -> bool:
         bundle_name: str = get_bundle_name(case=case, sample=sample, workflow=workflow)
         bundle_exists: bool = self._bundle_exists(bundle_name)
         ignore_missing_bundle: bool = self.ignore_missing_bundle(workflow)
-        return bundle_exists or ignore_missing_bundle
+        sample_bundle_is_deliverable: bool = bundle_exists or ignore_missing_bundle
+        sample_passes_qc: bool = self._sample_passes_quality_check(sample)
+        return sample_bundle_is_deliverable and sample_passes_qc
 
     def _get_version_for_sample(self, sample: Sample, case: Case, workflow: str) -> Version:
         bundle: str = sample.internal_id if workflow == DataDelivery.FASTQ else case.internal_id


### PR DESCRIPTION
## Description
Based on the old code, the intended logic seems to be
- If a bundle is missing for case but missing bundles should be ignored: just continue the flow.
- If a bundle is missing for a sample but missing bundles should be ignored: skip copying files for that sample.
- Only do the sample bundle check above if it is a fastq delivery - otherwise, just  redo the case bundle check 
- Otherwise, raise an exception if a bundle is missing.


