### PR TITLE
Add sample internal_id when fetching sample files from hk

### DIFF
--- a/cg/meta/deliver/utils.py
+++ b/cg/meta/deliver/utils.py
@@ -1,10 +1,12 @@
 import logging
 import os
 from pathlib import Path
+
+from housekeeper.store.models import File
+
 from cg.constants import delivery as constants
 from cg.constants.constants import Workflow
 from cg.store.models import Case, Sample
-from housekeeper.store.models import File
 
 LOG = logging.getLogger(__name__)
 
@@ -98,6 +100,7 @@ def should_include_file_sample(file: File, workflow: str) -> bool:
     At least one tag should match between file and the sample tags.
     """
     file_tags = {tag.name for tag in file.tags}
+    file_tags.add(file.version.bundle.name)
     sample_tags = get_sample_tags_for_workflow(workflow)
     return any(tags.issubset(file_tags) for tags in sample_tags)
 

--- a/cg/meta/deliver/utils.py
+++ b/cg/meta/deliver/utils.py
@@ -94,13 +94,13 @@ def should_include_file_case(file: File, sample_ids: set[str], workflow: str) ->
     return any(tags.issubset(tags_on_file) for tags in case_tags)
 
 
-def should_include_file_sample(file: File, workflow: str) -> bool:
+def should_include_file_sample(file: File, workflow: str, sample_internal_id: str) -> bool:
     """Check if file should be included in sample bundle.
 
     At least one tag should match between file and the sample tags.
     """
     file_tags = {tag.name for tag in file.tags}
-    file_tags.add(file.version.bundle.name)
+    file_tags.add(sample_internal_id)
     sample_tags = get_sample_tags_for_workflow(workflow)
     return any(tags.issubset(file_tags) for tags in sample_tags)
 

--- a/tests/meta/deliver/test_delivery_api.py
+++ b/tests/meta/deliver/test_delivery_api.py
@@ -123,7 +123,7 @@ def test_get_sample_files_from_version(
 
     # WHEN fetching the sample specific files
     sample_files = deliver_api._get_sample_files_from_version(
-        version=version, workflow=Workflow.MIP_DNA
+        version=version, workflow=Workflow.MIP_DNA, sample_internal_id="ADM1"
     )
 
     # THEN assert that only the sample specific file was returned


### PR DESCRIPTION
## Description

### Added

-

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b fix-sample-fetching-from-hk -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
