### PR TITLE
fix(ORM) Correct default for Flow cell status

### DIFF
--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -659,7 +659,7 @@ class Flowcell(Base):
     sequencer_name: Mapped[Str32 | None]
     sequenced_at: Mapped[datetime | None]
     status: Mapped[str | None] = mapped_column(
-        types.Enum(*(status.value for status in FlowCellStatus), default="ondisk")
+        types.Enum(*(status.value for status in FlowCellStatus)), default="ondisk"
     )
     archived_at: Mapped[datetime | None]
     has_backup: Mapped[bool] = mapped_column(default=False)


### PR DESCRIPTION
## Description
A parenthesis mismatch led to the default value for Flowcell.status not being set

### Fixed

- Flowcell.status now has the default "ondisk" again


### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
