### PR TITLE
(Streamline delivery) Add summary to response

### DIFF
--- a/cg/services/orders/order_service/order_service.py
+++ b/cg/services/orders/order_service/order_service.py
@@ -8,7 +8,9 @@ from cg.services.orders.order_service.utils import (
     create_orders_response,
 )
 from cg.services.orders.order_status_service import OrderStatusService
-from cg.services.orders.order_status_service.dto.order_status_summary import OrderSummary
+from cg.services.orders.order_status_service.dto.order_status_summary import (
+    OrderSummary,
+)
 from cg.store.models import Order
 from cg.store.store import Store
 
@@ -22,7 +24,8 @@ class OrderService:
         order: Order | None = self.store.get_order_by_id(order_id)
         if not order:
             raise OrderNotFoundError(f"Order {order_id} not found.")
-        return create_order_response(order)
+        summary: OrderSummary = self.summary_service.get_status_summaries([order_id])[0]
+        return create_order_response(order=order, summary=summary)
 
     def get_orders(self, orders_request: OrdersRequest) -> OrdersResponse:
         orders: list[Order] = self.store.get_orders(orders_request)
@@ -30,7 +33,7 @@ class OrderService:
         summaries: list[OrderSummary] = []
         if orders_request.include_summary:
             order_ids: list[int] = [order.id for order in orders]
-            summaries = self.summary_service.get_status_summaries(order_ids)
+            summaries: list[OrderSummary] = self.summary_service.get_status_summaries(order_ids)
 
         return create_orders_response(orders=orders, summaries=summaries)
 

--- a/cg/services/orders/order_service/utils.py
+++ b/cg/services/orders/order_service/utils.py
@@ -1,14 +1,15 @@
-from cg.server.dto.orders.orders_response import Order, OrderSummary, OrdersResponse
+from cg.server.dto.orders.orders_response import Order, OrdersResponse, OrderSummary
 from cg.store.models import Order as DatabaseOrder
 
 
-def create_order_response(order: DatabaseOrder) -> Order:
+def create_order_response(order: DatabaseOrder, summary: OrderSummary | None = None) -> Order:
     return Order(
         customer_id=order.customer.internal_id,
         ticket_id=order.ticket_id,
         order_date=str(order.order_date.date()),
         order_id=order.id,
         workflow=order.workflow,
+        summary=summary,
     )
 
 

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -9,6 +9,7 @@ from flask import Flask
 from flask.testing import FlaskClient
 from mock import patch
 
+from cg.apps.tb.dto.summary_response import AnalysisSummary
 from cg.constants import DataDelivery, Workflow
 from cg.server.ext import db as store
 from cg.store.database import create_all_tables, drop_all_tables
@@ -103,3 +104,13 @@ def client(app: Flask) -> Generator[FlaskClient, None, None]:
     # Bypass authentication
     with patch.object(app, "before_request_funcs", new={}):
         yield app.test_client()
+
+
+@pytest.fixture
+def analysis_summary():
+    return AnalysisSummary(
+        order_id=1,
+        total=2,
+        delivered=1,
+        failed=1,
+    )

--- a/tests/server/endpoints/test_orders_endpoint.py
+++ b/tests/server/endpoints/test_orders_endpoint.py
@@ -1,10 +1,17 @@
 from http import HTTPStatus
 
+import mock.mock
 import pytest
 from flask.testing import FlaskClient
 
+from cg.apps.tb import TrailblazerAPI
+from cg.apps.tb.dto.summary_response import AnalysisSummary
 from cg.constants import Workflow
 from cg.services.orders.order_service.utils import create_order_response
+from cg.services.orders.order_status_service.dto.order_status_summary import (
+    OrderSummary,
+)
+from cg.services.orders.order_status_service.utils import create_summaries
 from cg.store.models import Order
 
 
@@ -43,9 +50,7 @@ def test_orders_endpoint(
 
 
 def test_order_endpoint(
-    client: FlaskClient,
-    order: Order,
-    order_another: Order,
+    client: FlaskClient, order: Order, order_another: Order, analysis_summary: AnalysisSummary
 ):
     """Tests that the order endpoint returns the order with matching id"""
     # GIVEN a store with two orders
@@ -54,13 +59,17 @@ def test_order_endpoint(
 
     # WHEN a request is made to get a specific order
     endpoint: str = f"/api/v1/orders/{order_id_to_fetch}"
-    response = client.get(endpoint)
+    with mock.patch.object(TrailblazerAPI, "get_summaries", return_value=[analysis_summary]):
+        response = client.get(endpoint)
 
     # THEN the response should be successful
     assert response.status_code == HTTPStatus.OK
 
+    order_summary: OrderSummary = create_summaries(
+        orders=[order], analysis_summaries=[analysis_summary]
+    )[0]
     # THEN the response should only contain the specified order
-    assert response.json == create_order_response(order).model_dump()
+    assert response.json == create_order_response(order=order, summary=order_summary).model_dump()
 
 
 def test_order_endpoint_not_found(


### PR DESCRIPTION
## Description

Closes https://github.com/Clinical-Genomics/streamline-delivery/issues/38. Includes a summary of an order's analyses' statuses in the response from `/orders/<order_i>`.

### Changed

- The analyses' statuses are included when fetching an order


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
