### PR TITLE
Fix order search filter

### DIFF
--- a/cg/store/filters/status_order_filters.py
+++ b/cg/store/filters/status_order_filters.py
@@ -31,7 +31,7 @@ def filter_orders_by_ticket_id(orders: Query, ticket_id: int | None, **kwargs) -
 def filter_orders_by_search(orders: Query, search: str | None, **kwargs) -> Query:
     if search:
         orders = orders.join(Order.customer)
-        orders.filter(
+        return orders.filter(
             or_(
                 Order.id == search,
                 Order.ticket_id == search,


### PR DESCRIPTION
## Description
The search filter was missing a return.

### Fixed
- Order search filter

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
