### PR TITLE
add pon sex-specific functionality

### DIFF
--- a/tests/meta/workflow/test_balsamic.py
+++ b/tests/meta/workflow/test_balsamic.py
@@ -68,12 +68,31 @@ def test_get_verified_pon():
     invalid_pon_cnn = "/path/PON/gmssolid_15.2_hg19_design_CNVkit_PON_reference_v2.cnn"
 
     # WHEN validating the PON
-    validated_pon: str = BalsamicAnalysisAPI.get_verified_pon(None, panel_bed, pon_cnn)
+    validated_pon: str = BalsamicAnalysisAPI.get_verified_pon(None, panel_bed, pon_cnn, Sex.MALE)
 
     # THEN the PON verification should be performed successfully
     assert pon_cnn == validated_pon
     with pytest.raises(BalsamicStartError):
         BalsamicAnalysisAPI.get_verified_pon(None, panel_bed, invalid_pon_cnn)
+
+def test_get_verified_sex_specific_pon():
+    """Tests PON verification."""
+
+    # GIVEN specific panel bed and PON files
+    panel_bed = "/path/gmslymphoid_7.3_hg19_design.bed"
+    pon_cnn = "/path/PON/gmslymphoid_7.3_hg19_design_male_CNVkit_PON_reference_v1.cnn"
+    invalid_pon_cnn = "/path/PON/gmslymphoid_7.3_hg19_design_female_CNVkit_PON_reference_v1.cnn"
+
+    # WHEN validating the sex-specific PON using the correct PON for the sample sex
+    validated_pon: str = BalsamicAnalysisAPI.get_verified_pon(None, panel_bed, pon_cnn, Sex.MALE)
+
+    # THEN the PON verification should be performed successfully
+    assert pon_cnn == validated_pon
+
+    # WHEN validating the PON using a sex-specific PON which does not match the sample sex
+    # THEN the PON verification should fail
+    with pytest.raises(BalsamicStartError):
+        BalsamicAnalysisAPI.get_verified_pon(None, panel_bed, invalid_pon_cnn, Sex.MALE)
 
 
 def test_get_latest_file_by_pattern(


### PR DESCRIPTION
## Description

This PR adds functionality to supply sex-specific panel of normals for CNVkit in Balsamic, this can be useful in order to correctly normalise coverage across sex-chromosomes. 

### Added

- 

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
