### PR TITLE
Connect manually created cases to an order

### DIFF
--- a/cg/cli/add.py
+++ b/cg/cli/add.py
@@ -280,6 +280,14 @@ def add_case(
         ticket=ticket,
     )
     order: Order = status_db.get_order_by_ticket_id(int(ticket))
+    if not order:
+        LOG.warning(f"No order found with ticket_id {ticket}")
+        click.confirm("No order found for the given ticket, proceed?", default=False, abort=True)
+        order = Order(
+            customer_id=customer.id,
+            ticket_id=int(ticket),
+            workflow=data_analysis,
+        )
     new_case.orders.append(order)
 
     new_case.customer: Customer = customer

--- a/cg/cli/add.py
+++ b/cg/cli/add.py
@@ -15,6 +15,7 @@ from cg.store.models import (
     CaseSample,
     Collaboration,
     Customer,
+    Order,
     Panel,
     Sample,
     User,
@@ -278,6 +279,8 @@ def add_case(
         priority=priority,
         ticket=ticket,
     )
+    order: Order = status_db.get_order_by_ticket_id(int(ticket))
+    new_case.orders.append(order)
 
     new_case.customer: Customer = customer
     status_db.session.add(new_case)

--- a/tests/cli/add/test_cli_add_family.py
+++ b/tests/cli/add/test_cli_add_family.py
@@ -1,7 +1,5 @@
 """Tests the CLI methods to add cases to the status database."""
 
-import datetime
-
 from click.testing import CliRunner
 
 from cg.cli.add import add
@@ -19,19 +17,12 @@ def test_add_case_required(
     cli_runner: CliRunner, base_context: CGConfig, helpers: StoreHelpers, ticket_id: str
 ):
     """Test to add a case using only the required arguments"""
-    # GIVEN a database with a customer and an order and a panel
+    # GIVEN a database with a customer and a panel
     disk_store: Store = base_context.status_db
 
     customer: Customer = helpers.ensure_customer(store=disk_store)
     customer_id = customer.internal_id
     panel: Panel = helpers.ensure_panel(store=disk_store)
-    helpers.add_order(
-        store=disk_store,
-        customer_id=customer_id,
-        ticket_id=int(ticket_id),
-        order_date=datetime.datetime.now(),
-        workflow=CLI_OPTION_ANALYSIS,
-    )
     panel_id = panel.name
     name = "case_name"
 
@@ -52,6 +43,7 @@ def test_add_case_required(
             name,
         ],
         obj=base_context,
+        input="y",
     )
 
     # THEN it should be added
@@ -93,6 +85,7 @@ def test_add_case_bad_workflow(
             customer_id,
             name,
         ],
+        input="y",
     )
 
     # THEN it should not be added
@@ -130,6 +123,7 @@ def test_add_case_bad_data_delivery(
             name,
         ],
         obj=base_context,
+        input="y",
     )
 
     # THEN it should not be added
@@ -161,6 +155,7 @@ def test_add_case_bad_customer(cli_runner: CliRunner, base_context: CGConfig, ti
             name,
         ],
         obj=base_context,
+        input="y",
     )
 
     # THEN it should complain about missing customer instead of adding a case
@@ -206,21 +201,13 @@ def test_add_case_priority(
     cli_runner: CliRunner, base_context: CGConfig, helpers: StoreHelpers, ticket_id: str
 ):
     """Test that the added case get the priority we send in"""
-    # GIVEN a database with a customer and an order and a panel
+    # GIVEN a database with a customer and a panel
     disk_store: Store = base_context.status_db
     # WHEN adding a case
     customer: Customer = helpers.ensure_customer(store=disk_store)
     customer_id = customer.internal_id
     panel: Panel = helpers.ensure_panel(store=disk_store)
     panel_id = panel.name
-
-    helpers.add_order(
-        store=disk_store,
-        customer_id=customer_id,
-        ticket_id=int(ticket_id),
-        order_date=datetime.datetime.now(),
-        workflow=CLI_OPTION_ANALYSIS,
-    )
 
     name = "case_name"
     priority = "priority"
@@ -243,6 +230,7 @@ def test_add_case_priority(
             name,
         ],
         obj=base_context,
+        input="y",
     )
 
     # THEN it should be added

--- a/tests/cli/add/test_cli_add_family.py
+++ b/tests/cli/add/test_cli_add_family.py
@@ -1,5 +1,7 @@
 """Tests the CLI methods to add cases to the status database."""
 
+import datetime
+
 from click.testing import CliRunner
 
 from cg.cli.add import add
@@ -17,12 +19,19 @@ def test_add_case_required(
     cli_runner: CliRunner, base_context: CGConfig, helpers: StoreHelpers, ticket_id: str
 ):
     """Test to add a case using only the required arguments"""
-    # GIVEN a database with a customer and an panel
+    # GIVEN a database with a customer and an order and a panel
     disk_store: Store = base_context.status_db
 
     customer: Customer = helpers.ensure_customer(store=disk_store)
     customer_id = customer.internal_id
     panel: Panel = helpers.ensure_panel(store=disk_store)
+    helpers.add_order(
+        store=disk_store,
+        customer_id=customer_id,
+        ticket_id=int(ticket_id),
+        order_date=datetime.datetime.now(),
+        workflow=CLI_OPTION_ANALYSIS,
+    )
     panel_id = panel.name
     name = "case_name"
 
@@ -197,13 +206,22 @@ def test_add_case_priority(
     cli_runner: CliRunner, base_context: CGConfig, helpers: StoreHelpers, ticket_id: str
 ):
     """Test that the added case get the priority we send in"""
-    # GIVEN a database with a customer and an panel
+    # GIVEN a database with a customer and an order and a panel
     disk_store: Store = base_context.status_db
     # WHEN adding a case
     customer: Customer = helpers.ensure_customer(store=disk_store)
     customer_id = customer.internal_id
     panel: Panel = helpers.ensure_panel(store=disk_store)
     panel_id = panel.name
+
+    helpers.add_order(
+        store=disk_store,
+        customer_id=customer_id,
+        ticket_id=int(ticket_id),
+        order_date=datetime.datetime.now(),
+        workflow=CLI_OPTION_ANALYSIS,
+    )
+
     name = "case_name"
     priority = "priority"
 


### PR DESCRIPTION
## Description

Cases created via the CLI do not get an entry in the `order_case` table, which blocks analyses from being uploaded. This PR connects the case to the order specified via the ticket_id.

### Fixed

- Cases added via the CLI gets connected to the order related to the ticket_id.

### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b fix-add-case -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
