### PR TITLE
Fix nextflow pipelines bug with cluster options and prio

### DIFF
--- a/cg/meta/workflow/analysis.py
+++ b/cg/meta/workflow/analysis.py
@@ -104,7 +104,6 @@ class AnalysisAPI(MetaAPI):
     def get_slurm_qos_for_case(self, case_id: str) -> str:
         """Get Quality of service (SLURM QOS) for the case."""
         priority: int = self.get_priority_for_case(case_id=case_id)
-        LOG.info(f"Get slurm qos: {Priority.priority_to_slurm_qos().get(priority)}")
         return Priority.priority_to_slurm_qos().get(priority)
 
     def get_workflow_manager(self) -> str:

--- a/cg/meta/workflow/analysis.py
+++ b/cg/meta/workflow/analysis.py
@@ -104,6 +104,7 @@ class AnalysisAPI(MetaAPI):
     def get_slurm_qos_for_case(self, case_id: str) -> str:
         """Get Quality of service (SLURM QOS) for the case."""
         priority: int = self.get_priority_for_case(case_id=case_id)
+        LOG.info(f"Get slurm qos: {Priority.priority_to_slurm_qos().get(priority)}")
         return Priority.priority_to_slurm_qos().get(priority)
 
     def get_workflow_manager(self) -> str:

--- a/cg/models/rnafusion/rnafusion.py
+++ b/cg/models/rnafusion/rnafusion.py
@@ -38,7 +38,8 @@ class RnafusionParameters(WorkflowParameters):
     fusioncatcher: bool = True
     starfusion: bool = True
     trim_tail: int = 50
-
+    clusterOptions: str = Field(..., alias="cluster_options")
+    priority: str
 
 class CommandArgs(BaseModel):
     """Model for arguments and options supported."""

--- a/cg/models/rnafusion/rnafusion.py
+++ b/cg/models/rnafusion/rnafusion.py
@@ -41,6 +41,7 @@ class RnafusionParameters(WorkflowParameters):
     clusterOptions: str = Field(..., alias="cluster_options")
     priority: str
 
+
 class CommandArgs(BaseModel):
     """Model for arguments and options supported."""
 

--- a/cg/models/taxprofiler/taxprofiler.py
+++ b/cg/models/taxprofiler/taxprofiler.py
@@ -42,6 +42,7 @@ class TaxprofilerParameters(WorkflowParameters):
     clusterOptions: str = Field(..., alias="cluster_options")
     priority: str
 
+
 class TaxprofilerSampleSheetEntry(NextflowSampleSheetEntry):
     """Taxprofiler sample model is used when building the sample sheet."""
 

--- a/cg/models/taxprofiler/taxprofiler.py
+++ b/cg/models/taxprofiler/taxprofiler.py
@@ -39,7 +39,8 @@ class TaxprofilerParameters(WorkflowParameters):
     centrifuge_save_reads: bool = True
     run_krona: bool = True
     run_profile_standardisation: bool = True
-
+    clusterOptions: str = Field(..., alias="cluster_options")
+    priority: str
 
 class TaxprofilerSampleSheetEntry(NextflowSampleSheetEntry):
     """Taxprofiler sample model is used when building the sample sheet."""


### PR DESCRIPTION
## Description

Priorities and cluster options were not written in params_file of nextflow pipelines rnafusion and taxprofiler, causing them to fail with command run

### Added

-

### Changed

-

### Fixed

- nextflow pipelines bug with cluster options and prio introduced in https://github.com/Clinical-Genomics/cg/pull/2725/files#


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
