### PR TITLE
Drop order_id column

### DIFF
--- a/alembic/versions/2024_03_25_b614a52759c5_drop_order_id_column.py
+++ b/alembic/versions/2024_03_25_b614a52759c5_drop_order_id_column.py
@@ -1,0 +1,30 @@
+"""Drop order id column
+
+Revision ID: b614a52759c5
+Revises: 24c1e9e1476d
+Create Date: 2024-03-25 15:52:29.658272
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b614a52759c5"
+down_revision = "24c1e9e1476d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_column("case", "order_id")
+
+
+def downgrade():
+    op.add_column(
+        "case",
+        sa.Column(
+            "order_id", sa.Integer(), sa.ForeignKey("order.id", name="case_ibfk_2"), nullable=True
+        ),
+    )

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -17,7 +17,6 @@ from sqlalchemy import Text as SLQText
 from sqlalchemy import UniqueConstraint, orm, types
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 from sqlalchemy.orm.attributes import InstrumentedAttribute
-from sqlalchemy.util import deprecated
 
 from cg.constants import DataDelivery, FlowCellStatus, Priority, Workflow
 from cg.constants.archiving import PDC_ARCHIVE_LOCATION
@@ -463,7 +462,6 @@ class Case(Base, PriorityMixin):
     internal_id: Mapped[UniqueStr]
     is_compressible: Mapped[bool] = mapped_column(default=True)
     name: Mapped[Str128]
-    order_id: Mapped[int | None] = mapped_column(ForeignKey("order.id"))
     ordered_at: Mapped[datetime | None] = mapped_column(default=datetime.now)
     _panels: Mapped[Text | None]
 


### PR DESCRIPTION
## Description

The use of the order_id column on Case has been replaced by the order_case table. This PR drops the column.

### Changed

- order_id was dropped from Case


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
