### PR TITLE
(Archiving) Patch HTTP method

### DIFF
--- a/cg/meta/archive/ddn/ddn_data_flow_client.py
+++ b/cg/meta/archive/ddn/ddn_data_flow_client.py
@@ -257,7 +257,7 @@ class DDNDataFlowClient(ArchiveHandler):
 
         url: str = urljoin(self.url, DataflowEndpoints.GET_JOB_STATUS + str(job_id))
         response: Response = APIRequest.api_request_from_content(
-            api_method=APIMethods.POST,
+            api_method=APIMethods.GET,
             url=url,
             headers=headers,
             json={},


### PR DESCRIPTION
## Description

In #2855 I unfortunately changed the GET method in get_job_status to a POST. This PR reverts this change, which currently blocks the method from being used.

### Fixed

- get_job_status uses GET


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b patch-job-status-method -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
