### PR TITLE
fix(Backup) Fix file-touching post decription

### DIFF
--- a/cg/meta/backup/backup.py
+++ b/cg/meta/backup/backup.py
@@ -99,6 +99,7 @@ class BackupAPI:
         """Process a flow cell from backup. Return elapsed time."""
         start_time: float = get_start_time()
         run_dir: Path = Path(self.flow_cells_dir)
+        flow_cell_output_directory: Path = Path(run_dir, archived_flow_cell.name.split(".")[0])
         self.retrieve_archived_key(archived_key=archived_key, flow_cell=flow_cell, run_dir=run_dir)
         self.retrieve_archived_flow_cell(
             archived_flow_cell=archived_flow_cell, flow_cell=flow_cell, run_dir=run_dir
@@ -113,8 +114,8 @@ class BackupAPI:
             ) = self.decrypt_flow_cell(archived_flow_cell, archived_key, run_dir)
 
             self.extract_flow_cell(decrypted_flow_cell, run_dir)
-            self.create_rta_complete(decrypted_flow_cell, run_dir)
-            self.create_copy_complete(decrypted_flow_cell, run_dir)
+            self.create_rta_complete(flow_cell_output_directory)
+            self.create_copy_complete(flow_cell_output_directory)
             self.unlink_files(
                 decrypted_flow_cell, encryption_key, retrieved_flow_cell, retrieved_key
             )
@@ -157,20 +158,14 @@ class BackupAPI:
             LOG.info(message)
 
     @staticmethod
-    def create_rta_complete(decrypted_flow_cell: Path, run_dir: Path):
+    def create_rta_complete(flow_cell_directory: Path):
         """Create an RTAComplete.txt file in the flow cell run directory."""
-        rta_complete_file = Path(
-            run_dir, decrypted_flow_cell.stem, DemultiplexingDirsAndFiles.RTACOMPLETE
-        )
-        rta_complete_file.touch()
+        Path(flow_cell_directory, DemultiplexingDirsAndFiles.RTACOMPLETE).touch()
 
     @staticmethod
-    def create_copy_complete(decrypted_flow_cell: Path, run_dir: Path):
+    def create_copy_complete(flow_cell_directory: Path):
         """Create a CopyComplete.txt file in the flow cell run directory."""
-        copy_complete_file = Path(
-            run_dir, decrypted_flow_cell.stem, DemultiplexingDirsAndFiles.COPY_COMPLETE
-        )
-        copy_complete_file.touch()
+        Path(flow_cell_directory, DemultiplexingDirsAndFiles.COPY_COMPLETE).touch()
 
     def extract_flow_cell(self, decrypted_flow_cell, run_dir):
         """Extract the flow cell tar archive."""

--- a/tests/meta/backup/test_meta_backup.py
+++ b/tests/meta/backup/test_meta_backup.py
@@ -676,7 +676,6 @@ def test_create_copy_complete_file_exist(
 
     # GIVEN a flow cell that has been decrypted in flow_cell directory
     flow_cell_dir: Path = novaseq_x_flow_cell.path
-    flow_cells: Path = flow_cell_dir.parent
 
     # GIVEN the copy complete to be created
     copy_complete_txt: str = DemultiplexingDirsAndFiles.COPY_COMPLETE
@@ -685,7 +684,7 @@ def test_create_copy_complete_file_exist(
     flow_cell_dir.joinpath(copy_complete_txt).touch()
 
     # WHEN creating a copy complete file
-    backup_api.create_copy_complete(decrypted_flow_cell=flow_cell_dir, run_dir=flow_cells)
+    backup_api.create_copy_complete(flow_cell_dir)
 
     # THEN the copy complete file should exist in the flow cell directory
     assert flow_cell_dir.joinpath(copy_complete_txt).exists() is True
@@ -700,7 +699,6 @@ def test_create_copy_complete_file_does_not_exist(
 
     # GIVEN a flow cell that has been decrypted in flow_cell directory
     flow_cell_dir: Path = novaseq_x_flow_cell.path
-    flow_cells: Path = flow_cell_dir.parent
 
     # GIVEN the copy complete to be created
     copy_complete_txt: str = DemultiplexingDirsAndFiles.COPY_COMPLETE
@@ -709,7 +707,7 @@ def test_create_copy_complete_file_does_not_exist(
     flow_cell_dir.joinpath(copy_complete_txt).unlink(missing_ok=True)
 
     # WHEN creating a copy complete file
-    backup_api.create_copy_complete(decrypted_flow_cell=flow_cell_dir, run_dir=flow_cells)
+    backup_api.create_copy_complete(flow_cell_dir)
 
     # THEN the copy complete file should exist in the flow cell directory
     assert flow_cell_dir.joinpath(copy_complete_txt).exists() is True


### PR DESCRIPTION
## Description
Fixes the bug in production where copycomplete and RTAcomplete files cannot be created

### Fixed

- Fixed path to be correct
- Simplified some functions



### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
