### PR TITLE
(Streamline delivery) Fetch both completed and delivered in order summary

### DIFF
--- a/cg/apps/tb/dto/summary_response.py
+++ b/cg/apps/tb/dto/summary_response.py
@@ -3,10 +3,11 @@ from pydantic import BaseModel
 
 class AnalysisSummary(BaseModel):
     order_id: int
-    delivered: int | None = None
-    running: int | None = None
     cancelled: int | None = None
+    completed: int | None = None
+    delivered: int | None = None
     failed: int | None = None
+    running: int | None = None
 
 
 class SummariesResponse(BaseModel):

--- a/cg/apps/tb/dto/summary_response.py
+++ b/cg/apps/tb/dto/summary_response.py
@@ -3,11 +3,11 @@ from pydantic import BaseModel
 
 class AnalysisSummary(BaseModel):
     order_id: int
-    cancelled: int | None = None
-    completed: int | None = None
-    delivered: int | None = None
-    failed: int | None = None
-    running: int | None = None
+    cancelled: int
+    completed: int
+    delivered: int
+    failed: int
+    running: int
 
 
 class SummariesResponse(BaseModel):

--- a/cg/services/orders/order_status_service/dto/order_summary.py
+++ b/cg/services/orders/order_status_service/dto/order_summary.py
@@ -4,10 +4,11 @@ from pydantic import BaseModel, Field
 class OrderSummary(BaseModel):
     order_id: int = Field(exclude=True)
     total: int
-    delivered: int | None = None
-    running: int | None = None
     cancelled: int | None = None
+    completed: int | None = None
+    delivered: int | None = None
     failed: int | None = None
-    in_sequencing: int | None = None
     in_lab_preparation: int | None = None
+    in_sequencing: int | None = None
     not_received: int | None = None
+    running: int | None = None

--- a/cg/services/orders/order_status_service/dto/order_summary.py
+++ b/cg/services/orders/order_status_service/dto/order_summary.py
@@ -4,11 +4,11 @@ from pydantic import BaseModel, Field
 class OrderSummary(BaseModel):
     order_id: int = Field(exclude=True)
     total: int
-    cancelled: int | None = None
-    completed: int | None = None
-    delivered: int | None = None
-    failed: int | None = None
-    in_lab_preparation: int | None = None
-    in_sequencing: int | None = None
-    not_received: int | None = None
-    running: int | None = None
+    cancelled: int
+    completed: int
+    delivered: int
+    failed: int
+    in_lab_preparation: int
+    in_sequencing: int
+    not_received: int
+    running: int

--- a/cg/services/orders/order_status_service/utils.py
+++ b/cg/services/orders/order_status_service/utils.py
@@ -36,6 +36,7 @@ def create_order_summary(
         delivered=analysis_summary.delivered,
         cancelled=analysis_summary.cancelled,
         failed=analysis_summary.failed,
+        completed=analysis_summary.completed,
     )
 
 

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -156,7 +156,9 @@ def client(app: Flask) -> Generator[FlaskClient, None, None]:
 def analysis_summary():
     return AnalysisSummary(
         order_id=1,
-        total=2,
+        cancelled=0,
+        completed=1,
+        running=0,
         delivered=1,
         failed=1,
     )

--- a/tests/server/endpoints/test_orders_endpoint.py
+++ b/tests/server/endpoints/test_orders_endpoint.py
@@ -1,8 +1,8 @@
 from http import HTTPStatus
 
 import mock.mock
-from flask.testing import FlaskClient
 import pytest
+from flask.testing import FlaskClient
 
 from cg.apps.tb import TrailblazerAPI
 from cg.apps.tb.dto.summary_response import AnalysisSummary
@@ -29,7 +29,6 @@ def test_orders_endpoint(
     limit: int | None,
     workflow: str,
     expected_orders: int,
-    analysis_summary,
 ):
     """Tests that orders are returned from the orders endpoint"""
     # GIVEN a store with three orders, two of which are MIP-DNA and the last is BALSAMIC
@@ -40,9 +39,25 @@ def test_orders_endpoint(
         TrailblazerAPI,
         "get_summaries",
         return_value=[
-            AnalysisSummary(order_id=order.id),
-            AnalysisSummary(order_id=order_another.id),
-            AnalysisSummary(order_id=order_balsamic.id),
+            AnalysisSummary(
+                order_id=order.id, cancelled=0, completed=1, delivered=0, failed=0, running=0
+            ),
+            AnalysisSummary(
+                order_id=order_another.id,
+                cancelled=0,
+                completed=1,
+                delivered=0,
+                failed=0,
+                running=0,
+            ),
+            AnalysisSummary(
+                order_id=order_balsamic.id,
+                cancelled=0,
+                completed=1,
+                delivered=0,
+                failed=0,
+                running=0,
+            ),
         ],
     ):
         response = client.get(endpoint, query_string={"pageSize": limit, "workflow": workflow})

--- a/tests/services/orders/order_status_service/conftest.py
+++ b/tests/services/orders/order_status_service/conftest.py
@@ -1,9 +1,12 @@
 from datetime import datetime
-from mock import Mock
-import pytest
-from cg.apps.tb.dto.summary_response import AnalysisSummary
 
-from cg.services.orders.order_status_service.order_summary_service import OrderSummaryService
+import pytest
+from mock import Mock
+
+from cg.apps.tb.dto.summary_response import AnalysisSummary
+from cg.services.orders.order_status_service.order_summary_service import (
+    OrderSummaryService,
+)
 from cg.store.models import Case, Customer, Order, Sample
 from cg.store.store import Store
 from tests.store_helpers import StoreHelpers
@@ -12,7 +15,11 @@ from tests.store_helpers import StoreHelpers
 @pytest.fixture
 def summary_service(store: Store, order: Order):
     service = OrderSummaryService(analysis_client=Mock(), store=store)
-    service.analysis_client.get_summaries.return_value = [AnalysisSummary(order_id=order.id)]
+    service.analysis_client.get_summaries.return_value = [
+        AnalysisSummary(
+            order_id=order.id, cancelled=0, completed=1, delivered=0, failed=0, running=0
+        )
+    ]
     return service
 
 


### PR DESCRIPTION
## Description

With https://github.com/Clinical-Genomics/trailblazer/pull/424 we can now fetch both delivered and completed analyses from the TB backend. We should send both in the response.

### Fixed

- Both completed and delivered counts are reported in the order status summary.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
