### PR TITLE
Include is_delivered in orders response

### DIFF
--- a/cg/server/dto/orders/orders_response.py
+++ b/cg/server/dto/orders/orders_response.py
@@ -9,6 +9,7 @@ class Order(BaseModel):
     ticket_id: int
     order_date: str
     id: int
+    is_delivered: bool
     workflow: Workflow
     summary: OrderSummary | None = None
 

--- a/cg/services/orders/order_service/utils.py
+++ b/cg/services/orders/order_service/utils.py
@@ -8,6 +8,7 @@ def create_order_response(order: DatabaseOrder, summary: OrderSummary | None = N
         ticket_id=order.ticket_id,
         order_date=str(order.order_date.date()),
         id=order.id,
+        is_delivered=order.is_delivered,
         workflow=order.workflow,
         summary=summary,
     )


### PR DESCRIPTION
The new `is_delivered` field needs to be included in the response from `/orders`.