### PR TITLE
Parent classes for the new Run models

### DIFF
--- a/cg/constants/constants.py
+++ b/cg/constants/constants.py
@@ -1,6 +1,6 @@
 """Constants for cg."""
 
-from enum import IntEnum, StrEnum
+from enum import Enum, IntEnum, StrEnum
 
 import click
 
@@ -289,3 +289,9 @@ class MultiQC(StrEnum):
 
 
 NG_UL_SUFFIX: str = " ng/uL"
+
+
+class MachinesTypes(Enum):
+    """Types of machines we use for analysing samples"""
+
+    pass

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -815,6 +815,10 @@ class Sample(Base, PriorityMixin):
     )
     invoice: Mapped["Invoice | None"] = orm.relationship(back_populates="samples")
 
+    _non_illumina_metrics: Mapped["SampleDigitisationMetrics"] = orm.relationship(
+        back_populates="sample"
+    )
+
     def __str__(self) -> str:
         return f"{self.internal_id} ({self.name})"
 
@@ -1039,7 +1043,7 @@ class SampleDigitisationMetrics(Base):
     batch_id: Mapped[int] = mapped_column(ForeignKey("batch_digitisation.id"))
 
     batch: Mapped[BatchDigitisation] = orm.relationship(back_populates="sample_metrics")
-    sample: Mapped[Sample] = orm.relationship(back_populates="non_illumina_metrics")
+    sample: Mapped[Sample] = orm.relationship(back_populates="_non_illumina_metrics")
 
     __mapper_args__ = {
         "polymorphic_on": "type",


### PR DESCRIPTION
## Description
With new instruments being bought and implemented there is a need to store different types of data in the database but still be able to treat the samples the same way. 

This PR implements parent classes which define the relationships between the new models (see image below). This way each child class can hold its own columns but the way they relate to each other is the same across instruments making the flow as a whole less complex (even though this code is more complex...).
![image](https://github.com/Clinical-Genomics/cg/assets/69356202/cd11a679-0df6-443e-8e7c-5fcfd4d19c29)

This flow is designed for the Illumina flow to be integrated into the models as well, but my intention in the near future is to just add the new models and save the refactoring for the future.

### Points to keep in mind:
- An ONT flow cell can be used multiple times
- Saphyr is not a "sequencing" instrument, hence the term digitisation. I'm up for going with sequencing if you like though

Closes: Clinical-Genomics/add-new-tech#1