### PR TITLE
Patch delivered filter

### DIFF
--- a/cg/store/filters/status_order_filters.py
+++ b/cg/store/filters/status_order_filters.py
@@ -1,10 +1,10 @@
 from enum import Enum
 from typing import Callable
+
 from sqlalchemy import asc, desc, or_
-
 from sqlalchemy.orm import Query
-from cg.server.dto.orders.orders_request import OrderSortField, SortOrder
 
+from cg.server.dto.orders.orders_request import OrderSortField, SortOrder
 from cg.store.models import Customer, Order
 
 
@@ -43,7 +43,7 @@ def filter_orders_by_search(orders: Query, search: str | None, **kwargs) -> Quer
 
 
 def filter_orders_by_delivered(orders: Query, delivered: bool | None, **kwargs) -> Query:
-    return orders.filter(Order.delivered == delivered) if delivered is not None else orders
+    return orders.filter(Order.is_delivered == delivered) if delivered is not None else orders
 
 
 def apply_sorting(


### PR DESCRIPTION
## Description

The filtering of orders on `is_delivered` is broken since the referred field does not exist. This PR addresses that.

### Fixed

- order.delivered changed to order.is_delivered


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
