### PR TITLE
Add analysis ids to the delivery message response

### DIFF
--- a/cg/server/dto/delivery_message/delivery_message_response.py
+++ b/cg/server/dto/delivery_message/delivery_message_response.py
@@ -3,3 +3,7 @@ from pydantic import BaseModel
 
 class DeliveryMessageResponse(BaseModel):
     message: str
+
+
+class DeliveryMessageOrderResponse(DeliveryMessageResponse):
+    analysis_ids: list[int]

--- a/cg/services/delivery_message/delivery_message_service.py
+++ b/cg/services/delivery_message/delivery_message_service.py
@@ -1,14 +1,15 @@
 from cg.apps.tb import TrailblazerAPI
 from cg.apps.tb.models import TrailblazerAnalysis
-from cg.exc import OrderNotDeliverableError, OrderNotFoundError
+from cg.exc import OrderNotDeliverableError
 from cg.server.dto.delivery_message.delivery_message_request import (
     DeliveryMessageRequest,
 )
 from cg.server.dto.delivery_message.delivery_message_response import (
+    DeliveryMessageOrderResponse,
     DeliveryMessageResponse,
 )
 from cg.services.delivery_message.utils import get_message, validate_cases
-from cg.store.models import Case, Order
+from cg.store.models import Case
 from cg.store.store import Store
 
 
@@ -21,9 +22,10 @@ class DeliveryMessageService:
         self, delivery_message_request: DeliveryMessageRequest
     ) -> DeliveryMessageResponse:
         case_ids: list[str] = delivery_message_request.case_ids
-        return self._get_delivery_message(set(case_ids))
+        message: str = self._get_delivery_message(set(case_ids))
+        return DeliveryMessageResponse(message=message)
 
-    def get_order_message(self, order_id: int) -> DeliveryMessageResponse:
+    def get_order_message(self, order_id: int) -> DeliveryMessageOrderResponse:
         self.store.get_order_by_id(order_id)
         analyses: list[TrailblazerAnalysis] = self.trailblazer_api.get_analyses_to_deliver(order_id)
         if not analyses:
@@ -31,10 +33,12 @@ class DeliveryMessageService:
                 f"No analyses ready to be delivered for order {order_id}"
             )
         case_ids: set[str] = {analysis.case_id for analysis in analyses}
-        return self._get_delivery_message(case_ids)
+        message: str = self._get_delivery_message(case_ids)
+        analysis_ids: list[int] = [analysis.id for analysis in analyses]
+        return DeliveryMessageOrderResponse(message=message, analysis_ids=analysis_ids)
 
-    def _get_delivery_message(self, case_ids: set[str]):
+    def _get_delivery_message(self, case_ids: set[str]) -> str:
         cases: list[Case] = self.store.get_cases_by_internal_ids(case_ids)
         validate_cases(cases=cases, case_ids=case_ids)
         message: str = get_message(cases)
-        return DeliveryMessageResponse(message=message)
+        return message


### PR DESCRIPTION
## Description

In order to mark the analyses included in the delivery message for an order as delivered, the analysis ids used are now included in the response object.

### Changed

- The analysis ids which the order delivery message was generated for are included in the response.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
