### PR TITLE
Remove order date from pool

### DIFF
--- a/alembic/versions/2024_04_16_dd3fd72df1ae_remove_order_date_from_pool.py
+++ b/alembic/versions/2024_04_16_dd3fd72df1ae_remove_order_date_from_pool.py
@@ -1,0 +1,23 @@
+"""Remove order date from pool
+
+Revision ID: dd3fd72df1ae
+Revises: ac5a804a9f47
+Create Date: 2024-04-16 18:51:33.598555
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+# revision identifiers, used by Alembic.
+revision = 'dd3fd72df1ae'
+down_revision = 'ac5a804a9f47'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_column('pool', 'ordered_at')
+
+def downgrade():
+    op.add_column('pool', sa.Column('ordered_at', mysql.DATETIME(), nullable=False))

--- a/alembic/versions/2024_04_16_dd3fd72df1ae_remove_order_date_from_pool.py
+++ b/alembic/versions/2024_04_16_dd3fd72df1ae_remove_order_date_from_pool.py
@@ -5,19 +5,21 @@ Revises: ac5a804a9f47
 Create Date: 2024-04-16 18:51:33.598555
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import mysql
 
 # revision identifiers, used by Alembic.
-revision = 'dd3fd72df1ae'
-down_revision = 'ac5a804a9f47'
+revision = "dd3fd72df1ae"
+down_revision = "ac5a804a9f47"
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
-    op.drop_column('pool', 'ordered_at')
+    op.drop_column("pool", "ordered_at")
+
 
 def downgrade():
-    op.add_column('pool', sa.Column('ordered_at', mysql.DATETIME(), nullable=False))
+    op.add_column("pool", sa.Column("ordered_at", mysql.DATETIME(), nullable=False))

--- a/cg/meta/orders/pool_submitter.py
+++ b/cg/meta/orders/pool_submitter.py
@@ -141,7 +141,6 @@ class PoolSubmitter(Submitter):
                 customer=customer,
                 name=pool["name"],
                 order=order,
-                ordered=ordered,
                 ticket=ticket_id,
             )
             sex: SexEnum = SexEnum.unknown

--- a/cg/store/crud/create.py
+++ b/cg/store/crud/create.py
@@ -314,7 +314,6 @@ class CreateHandler(BaseHandler):
         customer: Customer,
         name: str,
         order: str,
-        ordered: datetime,
         application_version: ApplicationVersion,
         ticket: str = None,
         comment: str = None,
@@ -327,7 +326,6 @@ class CreateHandler(BaseHandler):
 
         new_record: Pool = Pool(
             name=name,
-            ordered_at=ordered or datetime.now(),
             order=order,
             ticket=ticket,
             received_at=received_at,

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -747,7 +747,6 @@ class Pool(Base):
     name: Mapped[Str32]
     no_invoice: Mapped[bool | None] = mapped_column(default=False)
     order: Mapped[Str64]
-    ordered_at: Mapped[datetime]
     received_at: Mapped[datetime | None]
     ticket: Mapped[Str32 | None]
 

--- a/tests/store/conftest.py
+++ b/tests/store/conftest.py
@@ -504,7 +504,6 @@ def rml_pool_store(
         customer=new_customer,
         name="Test",
         order="Test",
-        ordered=dt.datetime.now(),
         application_version=app_version,
     )
     store.session.add(new_pool)

--- a/tests/store/crud/add/test_store_add_base.py
+++ b/tests/store/crud/add/test_store_add_base.py
@@ -105,7 +105,6 @@ def test_add_pool(rml_pool_store: Store):
         customer=customer,
         name="pool2",
         order="123456",
-        ordered=dt.now(),
         application_version=app_version,
     )
 

--- a/tests/store_helpers.py
+++ b/tests/store_helpers.py
@@ -855,7 +855,6 @@ class StoreHelpers:
 
         pool = store.add_pool(
             name=name,
-            ordered=datetime.now(),
             application_version=application_version,
             customer=customer,
             order=order,


### PR DESCRIPTION
The order date does not belong on a pool. We store it in the order table.

We also do not use `pool.ordered_at` date for anything, so I say: TRASH IT 🗑️ 

Blocked by https://github.com/Clinical-Genomics/cigrid-ui/issues/620

### Fixed
- Drop unused `ordered_at` column from pool table
