### PR TITLE
Limit analyses started in MIP and Balsamic

### DIFF
--- a/cg/meta/workflow/balsamic.py
+++ b/cg/meta/workflow/balsamic.py
@@ -94,7 +94,7 @@ class BalsamicAnalysisAPI(AnalysisAPI):
 
     def get_cases_to_analyze(self) -> list[Case]:
         cases_query: list[Case] = self.status_db.cases_to_analyze(
-            workflow=self.workflow, threshold=self.use_read_count_threshold
+            workflow=self.workflow, threshold=self.use_read_count_threshold, limit=21
         )
         cases_to_analyze = []
         for case_obj in cases_query:

--- a/cg/meta/workflow/balsamic.py
+++ b/cg/meta/workflow/balsamic.py
@@ -30,6 +30,8 @@ from cg.utils.utils import build_command_from_dict, get_string_from_list_by_patt
 
 LOG = logging.getLogger(__name__)
 
+MAX_CASES_TO_START_IN_50_MINUTES = 21
+
 
 class BalsamicAnalysisAPI(AnalysisAPI):
     """Handles communication between BALSAMIC processes
@@ -94,7 +96,9 @@ class BalsamicAnalysisAPI(AnalysisAPI):
 
     def get_cases_to_analyze(self) -> list[Case]:
         cases_query: list[Case] = self.status_db.cases_to_analyze(
-            workflow=self.workflow, threshold=self.use_read_count_threshold, limit=21
+            workflow=self.workflow,
+            threshold=self.use_read_count_threshold,
+            limit=MAX_CASES_TO_START_IN_50_MINUTES,
         )
         cases_to_analyze = []
         for case_obj in cases_query:

--- a/cg/meta/workflow/mip.py
+++ b/cg/meta/workflow/mip.py
@@ -269,7 +269,7 @@ class MipAnalysisAPI(AnalysisAPI):
     def get_cases_to_analyze(self) -> list[Case]:
         """Return cases to analyze."""
         cases_query: list[Case] = self.status_db.cases_to_analyze(
-            workflow=self.workflow, threshold=self.use_read_count_threshold
+            workflow=self.workflow, threshold=self.use_read_count_threshold, limit=33
         )
         cases_to_analyze = []
         for case_obj in cases_query:

--- a/cg/meta/workflow/mip.py
+++ b/cg/meta/workflow/mip.py
@@ -34,6 +34,8 @@ CLI_OPTIONS = {
 }
 LOG = logging.getLogger(__name__)
 
+MAX_CASES_TO_START_IN_50_MINUTES = 33
+
 
 class MipAnalysisAPI(AnalysisAPI):
     """The workflow is accessed through Trailblazer but cg provides additional conventions and
@@ -269,7 +271,9 @@ class MipAnalysisAPI(AnalysisAPI):
     def get_cases_to_analyze(self) -> list[Case]:
         """Return cases to analyze."""
         cases_query: list[Case] = self.status_db.cases_to_analyze(
-            workflow=self.workflow, threshold=self.use_read_count_threshold, limit=33
+            workflow=self.workflow,
+            threshold=self.use_read_count_threshold,
+            limit=MAX_CASES_TO_START_IN_50_MINUTES,
         )
         cases_to_analyze = []
         for case_obj in cases_query:


### PR DESCRIPTION
## Description

Addresses #3145. I added a margin of just over 10 minutes.

### Changed

- MIP cases started are limited to 33
- Balsamic cases started are limited to 21

### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b limit-mip-balsamic-starts -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
