### PR TITLE
fix(start analyses) Move case-limit to final step before iteration

### DIFF
--- a/cg/meta/workflow/balsamic.py
+++ b/cg/meta/workflow/balsamic.py
@@ -98,7 +98,6 @@ class BalsamicAnalysisAPI(AnalysisAPI):
         cases_query: list[Case] = self.status_db.cases_to_analyze(
             workflow=self.workflow,
             threshold=self.use_read_count_threshold,
-            limit=MAX_CASES_TO_START_IN_50_MINUTES,
         )
         cases_to_analyze = []
         for case_obj in cases_query:
@@ -109,7 +108,7 @@ class BalsamicAnalysisAPI(AnalysisAPI):
                 == "failed"
             ):
                 cases_to_analyze.append(case_obj)
-        return cases_to_analyze
+        return cases_to_analyze[:MAX_CASES_TO_START_IN_50_MINUTES]
 
     def get_deliverables_file_path(self, case_id: str) -> Path:
         """Returns a path where the Balsamic deliverables file for the case_id should be located.

--- a/cg/meta/workflow/mip.py
+++ b/cg/meta/workflow/mip.py
@@ -273,7 +273,6 @@ class MipAnalysisAPI(AnalysisAPI):
         cases_query: list[Case] = self.status_db.cases_to_analyze(
             workflow=self.workflow,
             threshold=self.use_read_count_threshold,
-            limit=MAX_CASES_TO_START_IN_50_MINUTES,
         )
         cases_to_analyze = []
         for case_obj in cases_query:
@@ -284,7 +283,7 @@ class MipAnalysisAPI(AnalysisAPI):
                 == "failed"
             ):
                 cases_to_analyze.append(case_obj)
-        return cases_to_analyze
+        return cases_to_analyze[:MAX_CASES_TO_START_IN_50_MINUTES]
 
     @staticmethod
     def _append_value_for_non_flags(parameters: list, value) -> None:


### PR DESCRIPTION
## Description
Currently the limit is applied before additional filtering is performed. This results in a lot fewer cases being started than intended.

### Changed

- Moved the limit to take place just before iteration