### PR TITLE
Handle all orders being filtered away

### DIFF
--- a/cg/services/orders/order_service/order_service.py
+++ b/cg/services/orders/order_service/order_service.py
@@ -26,6 +26,8 @@ class OrderService:
     def get_orders(self, orders_request: OrdersRequest) -> OrdersResponse:
         orders, total_count = self.store.get_orders(orders_request)
         order_ids: list[int] = [order.id for order in orders]
+        if not order_ids:
+            return OrdersResponse(orders=[], total_count=0)
         summaries: list[OrderSummary] = self.summary_service.get_summaries(order_ids)
         return create_orders_response(orders=orders, summaries=summaries, total=total_count)
 


### PR DESCRIPTION
## Description
Closes https://github.com/Clinical-Genomics/cigrid-ui/issues/625 and https://github.com/Clinical-Genomics/cigrid-ui/issues/619.

We should return early when all orders are filtered away in the request against `/orders`.

### Fixed
- Handle all orders being filtered away correctly in the `/orders` endpoint.
