### PR TITLE
Update the lowest python version to 3.11 to include StrEnum

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.13"
+python = ">=3.11,<3.13"
 
 # Database
 alembic = "*"


### PR DESCRIPTION
StrEnum is used in multiple places including tests and alembic scripts and was introduced in Python 3.11 (See https://docs.python.org/3/library/enum.html#enum.StrEnum ).

This currently breaks using the poetry environment if the user accdientally is using a python version lower than 3.11 in poetry, causing errors complaning that `StrEnum` is not found.


## Reproducing the error:

1. Set poetry to use python 3.10:
  ```
  poetry env use 3.10
  ```
2. Check out the cg repository and cd into it:
  ```
  git clone git@github.com:Clinical-Genomics/cg.git
  cd cg
  ```
3. Install poetry dependencies:
  ```
  poetry install
  ```
4. Start the poetry shell:
  ```
  poetry shell
  ```
5. Run pytest
  ```
  pytest
  ```

You will now see errors like below:
```
$ pytest
ImportError while loading conftest '/home/shl/proj/23/01-jasen/cg/tests/conftest.py'.
tests/conftest.py:18: in <module>
    from cg.apps.crunchy import CrunchyAPI
cg/apps/crunchy/__init__.py:3: in <module>
    from .crunchy import CrunchyAPI
cg/apps/crunchy/crunchy.py:12: in <module>
    from cg.apps.crunchy import files
cg/apps/crunchy/files.py:8: in <module>
    from cg.constants.constants import FileFormat
cg/constants/__init__.py:8: in <module>
    from cg.constants.constants import (
cg/constants/constants.py:3: in <module>
    from enum import IntEnum, StrEnum
E   ImportError: cannot import name 'StrEnum' from 'enum' (/home/shl/opt/mc3/lib/python3.10/enum.py)
```

This is fixed though when doing:

1. Removing the old poetry env (warning, make sure you know what you are doing!):
  ```bash
  rm -rf $(dirname $(dirname $(which python)))
  ```
2. Setting poetry to use python 3.11
  ```bash
  poetry env use 3.11
  ```
3. Installing the poetry dependencies anew:
  ```bash
  poetry install
  ```
4. Starting the poetry shell again
  ```bash
  poetry shell
  ```
5. Running the pytest
  ```bash
  pytest
  ```

(Then I get other errors, but at least different ones :slightly_smiling_face:  ):

```
[...]
  File "/home/shl/.pyenv/versions/3.11.8/lib/python3.11/sqlite3/dbapi2.py", line 27, in <module>
    from _sqlite3 import *
ModuleNotFoundError: No module named '_sqlite3'
```

## Description

### Changed

- Changed the lowest allowed python version from `3.9` to `3.11` in `pyproject.toml`

### How to prepare for test

- [ ] TBC

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
