### PR TITLE
Remove remnant sars-cov-2 workflow occurence in order table (Fix #3179)

### DIFF
--- a/alembic/versions/2024_04_26_f7a1394cf7cd_remove_remnant_sars_cov_2_occurence.py
+++ b/alembic/versions/2024_04_26_f7a1394cf7cd_remove_remnant_sars_cov_2_occurence.py
@@ -5,6 +5,7 @@ Revises: ac5a804a9f47
 Create Date: 2024-04-26 09:52:08.303306
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/alembic/versions/2024_04_26_f7a1394cf7cd_remove_remnant_sars_cov_2_occurence.py
+++ b/alembic/versions/2024_04_26_f7a1394cf7cd_remove_remnant_sars_cov_2_occurence.py
@@ -8,6 +8,7 @@ Create Date: 2024-04-26 09:52:08.303306
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
 
 
 # revision identifiers, used by Alembic.

--- a/alembic/versions/2024_04_26_f7a1394cf7cd_remove_remnant_sars_cov_2_occurence.py
+++ b/alembic/versions/2024_04_26_f7a1394cf7cd_remove_remnant_sars_cov_2_occurence.py
@@ -1,0 +1,52 @@
+"""Remove remnant sars-cov-2 occurence
+
+Revision ID: f7a1394cf7cd
+Revises: ac5a804a9f47
+Create Date: 2024-04-26 09:52:08.303306
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "f7a1394cf7cd"
+down_revision = "ac5a804a9f47"
+branch_labels = None
+depends_on = None
+
+workflow_to_remove = "sars-cov-2"
+
+old_options = (
+    "balsamic",
+    "balsamic-pon",
+    "balsamic-qc",
+    "balsamic-umi",
+    "demultiplex",
+    "fastq",
+    "fluffy",
+    "microsalt",
+    "mip-dna",
+    "mip-rna",
+    "mutant",
+    "raredisease",
+    "rnafusion",
+    "rsync",
+    "sars-cov-2",
+    "spring",
+    "taxprofiler",
+)
+
+# Remove workflow_to_remove from old_options into new_options
+new_options = tuple([x for x in old_options if x != workflow_to_remove])
+
+old_analysis_enum = mysql.ENUM(*old_options)
+new_analysis_enum = mysql.ENUM(*new_options)
+
+
+def upgrade():
+    op.alter_column("order", "workflow", type_=new_analysis_enum)
+
+
+def downgrade():
+    op.alter_column("order", "workflow", type_=old_analysis_enum)


### PR DESCRIPTION
## Description

### Fixed

- See #3179 

### How to prepare for test

- [x] Ssh to hasta (depending on type of change)
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [x] Dump structure of hasta database
  ```
  mysqldump -u <user> -p -h 127.0.0.1 -P 18002 <dbname> --no-data > <dbname>.structure.sql
  ```
- [x] Grep for `sars-cov-2`:
  ```
  grep sars-cov-2 <dbname>.structure.sql
  ```

### Expected test outcome

- [x] Ensure that no occurence of the `sars-cov-2` string appears.
- [x] Take a screenshot and attach or copy/paste the output:

![image](https://github.com/Clinical-Genomics/cg/assets/125003/23399888-01c1-476f-88cb-c5568260b618)

- [x] Ensure that the removed `sars-cov-2` is the only thing changed by doing a diff between the database structure before and after
- [x] Take a screenshot and attach or copy/paste the output:

![image](https://github.com/Clinical-Genomics/cg/assets/125003/03026319-eb46-4de4-b2bf-f0654cbe8a99)

## Review

- [x] Tests executed by SHL
- [ ] "Merge and deploy" approved by

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] ~Document in ...~
- [ ] Deploy this branch on hasta
- [ ] Inform to `#cg-core-dev`
