### PR TITLE
Update use_read_count_threshold for taxprofiler

### DIFF
--- a/cg/meta/workflow/nf_analysis.py
+++ b/cg/meta/workflow/nf_analysis.py
@@ -89,7 +89,7 @@ class NfAnalysisAPI(AnalysisAPI):
     def use_read_count_threshold(self) -> bool:
         """Defines whether the threshold for adequate read count should be passed for all samples
         when determining if the analysis for a case should be automatically started."""
-        return True
+        return NotImplementedError
 
     @property
     def sample_sheet_headers(self) -> list[str]:

--- a/cg/meta/workflow/raredisease.py
+++ b/cg/meta/workflow/raredisease.py
@@ -113,3 +113,9 @@ class RarediseaseAnalysisAPI(NfAnalysisAPI):
 
     def get_workflow_metrics(self) -> dict:
         return RAREDISEASE_METRIC_CONDITIONS
+
+    @property
+    def use_read_count_threshold(self) -> bool:
+        """Defines whether the threshold for adequate read count should be passed for all samples
+        when determining if the analysis for a case should be automatically started."""
+        return True

--- a/cg/meta/workflow/rnafusion.py
+++ b/cg/meta/workflow/rnafusion.py
@@ -122,3 +122,9 @@ class RnafusionAnalysisAPI(NfAnalysisAPI):
 
     def get_workflow_metrics(self) -> dict:
         return RNAFUSION_METRIC_CONDITIONS
+
+    @property
+    def use_read_count_threshold(self) -> bool:
+        """Defines whether the threshold for adequate read count should be passed for all samples
+        when determining if the analysis for a case should be automatically started."""
+        return True

--- a/cg/meta/workflow/taxprofiler.py
+++ b/cg/meta/workflow/taxprofiler.py
@@ -104,3 +104,9 @@ class TaxprofilerAnalysisAPI(NfAnalysisAPI):
     def get_genome_build(self, case_id: str) -> str:
         """Return the reference genome build version of a Taxprofiler analysis."""
         return GenomeVersion.T2T_CHM13.value
+
+    @property
+    def use_read_count_threshold(self) -> bool:
+        """Defines whether the threshold for adequate read count should be passed for all samples
+        when determining if the analysis for a case should be automatically started."""
+        return False

--- a/cg/meta/workflow/tomte.py
+++ b/cg/meta/workflow/tomte.py
@@ -82,3 +82,9 @@ class TomteAnalysisAPI(NfAnalysisAPI):
 
     def get_workflow_metrics(self) -> dict:
         return TOMTE_METRIC_CONDITIONS
+
+    @property
+    def use_read_count_threshold(self) -> bool:
+        """Defines whether the threshold for adequate read count should be passed for all samples
+        when determining if the analysis for a case should be automatically started."""
+        return True


### PR DESCRIPTION
## Description

### Changed

- According to previous communication, cust053 would like to have data and analysis even though they are just below the targeted threshold of 75%. In case the data are below the targeted threshold, they will assess if the quality of the data is good enough for the purposes. In this PR, the function `use_read_count_threshold` is updated to fit this purpose.

### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
