### PR TITLE
Revert "Fix analysis started at assignment (#3195)"

### DIFF
--- a/cg/meta/workflow/analysis.py
+++ b/cg/meta/workflow/analysis.py
@@ -233,17 +233,12 @@ class AnalysisAPI(MetaAPI):
             f"Analysis successfully stored in Housekeeper: {case_id} : {bundle_version.created_at}"
         )
 
-    def get_analysis_started_date(self, case_id: str) -> datetime.date:
-        """Return the start date of the analysis for a given case."""
-        return self.get_date_from_file_path(self.get_job_ids_path(case_id))
-
     def upload_bundle_statusdb(self, case_id: str, dry_run: bool = False) -> None:
-        """Storing analysis bundle in StatusDB for CASE_ID"""
-
+        """Storing an analysis bundle in StatusDB for a provided case."""
         LOG.info(f"Storing analysis in StatusDB for {case_id}")
-        case_obj: Case = self.status_db.get_case_by_internal_id(internal_id=case_id)
-        analysis_start: datetime.date = self.get_analysis_started_date(case_id)
-        workflow_version: str = self.get_workflow_version(case_id=case_id)
+        case_obj: Case = self.status_db.get_case_by_internal_id(case_id)
+        analysis_start: datetime.date = self.get_bundle_created_date(case_id)
+        workflow_version: str = self.get_workflow_version(case_id)
         new_analysis: Case = self.status_db.add_analysis(
             workflow=self.workflow,
             version=workflow_version,

--- a/tests/cli/workflow/balsamic/test_compound_commands.py
+++ b/tests/cli/workflow/balsamic/test_compound_commands.py
@@ -84,8 +84,7 @@ def test_store(
     # Make sure analysis not already stored in ClinicalDB
     assert not balsamic_context.status_db.get_case_by_internal_id(internal_id=case_id).analyses
 
-    # GIVEN a started analysis and a HermesAPI returning a deliverables output
-    mocker.patch.object(AnalysisAPI, "get_analysis_started_date", return_value=datetime.now())
+    # GIVEN a HermesAPI returning a deliverables output
     mocker.patch.object(HermesApi, "convert_deliverables")
     HermesApi.convert_deliverables.return_value = CGDeliverables(**hermes_deliverables)
 
@@ -173,7 +172,6 @@ def test_store_available(
 
     # GIVEN that HermesAPI returns a deliverables output and config case performed
     hermes_deliverables["bundle_id"] = case_id_success
-    mocker.patch.object(AnalysisAPI, "get_analysis_started_date", return_value=datetime.now())
     mocker.patch.object(
         HermesApi, "convert_deliverables", return_value=CGDeliverables(**hermes_deliverables)
     )

--- a/tests/cli/workflow/balsamic/test_store_housekeeper.py
+++ b/tests/cli/workflow/balsamic/test_store_housekeeper.py
@@ -143,7 +143,6 @@ def test_valid_case(
     assert not balsamic_context.status_db.get_case_by_internal_id(internal_id=case_id).analyses
 
     # GIVEN that HermesAPI returns a deliverables output
-    mocker.patch.object(AnalysisAPI, "get_analysis_started_date", return_value=datetime.now())
     mocker.patch.object(HermesApi, "convert_deliverables")
     HermesApi.convert_deliverables.return_value = CGDeliverables(**hermes_deliverables)
 

--- a/tests/cli/workflow/nf_analysis/test_cli_store_housekeeper.py
+++ b/tests/cli/workflow/nf_analysis/test_cli_store_housekeeper.py
@@ -163,7 +163,6 @@ def test_store_housekeeper_valid_case(
     assert not store.get_case_by_internal_id(internal_id=case_id).analyses
 
     # GIVEN that HermesAPI returns a deliverables output
-    mocker.patch.object(AnalysisAPI, "get_analysis_started_date", return_value=datetime.now())
     mocker.patch.object(HermesApi, "convert_deliverables")
     HermesApi.convert_deliverables.return_value = CGDeliverables(**hermes_deliverables)
 
@@ -213,7 +212,6 @@ def test_valid_case_already_added(
     assert not context.status_db.get_case_by_internal_id(internal_id=case_id).analyses
 
     # GIVEN that HermesAPI returns a deliverables output
-    mocker.patch.object(AnalysisAPI, "get_analysis_started_date", return_value=datetime.now())
     mocker.patch.object(HermesApi, "convert_deliverables")
     HermesApi.convert_deliverables.return_value = CGDeliverables(**hermes_deliverables)
 
@@ -261,7 +259,6 @@ def test_dry_run(
     context.meta_apis["analysis_api"].housekeeper_api = real_housekeeper_api
 
     # GIVEN that HermesAPI returns a deliverables output
-    mocker.patch.object(AnalysisAPI, "get_analysis_started_date", return_value=datetime.now())
     mocker.patch.object(HermesApi, "convert_deliverables")
     HermesApi.convert_deliverables.return_value = CGDeliverables(**hermes_deliverables)
 


### PR DESCRIPTION
## Description

Reverts #3195. `started_at` analysis should match the `created` date bundle as multiple functionalities rely on this date being the same (clean, delivery report, ..).

I will bring this for refinement to decide on the strategy we should follow: either using `completed_at` for the bundles `created` date, or adapting the storage in HK to employ the same method as for `started_at` assignment

### Fixed
- Revert "Fix analysis started at assignment (#3195)"


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
