### PR TITLE
Fix bug in config-case

### DIFF
--- a/cg/models/taxprofiler/taxprofiler.py
+++ b/cg/models/taxprofiler/taxprofiler.py
@@ -68,13 +68,13 @@ class TaxprofilerSampleSheetEntry(NextflowSampleSheetEntry):
         return [
             [
                 self.name,
-                self.run_accession,
+                run_accession + 1,
                 self.instrument_platform,
                 fastq_forward_read_path,
                 fastq_reverse_read_path,
                 self.fasta,
             ]
-            for fastq_forward_read_path, fastq_reverse_read_path in zip(
-                self.fastq_forward_read_paths, self.fastq_reverse_read_paths
+            for run_accession, (fastq_forward_read_path, fastq_reverse_read_path) in enumerate(
+                zip(self.fastq_forward_read_paths, self.fastq_reverse_read_paths)
             )
         ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3375,7 +3375,7 @@ def taxprofiler_sample_sheet_content(
     row: str = ",".join(
         [
             sample_name,
-            sample_name,
+            "1",
             sequencing_platform,
             fastq_forward_read_path.as_posix(),
             fastq_reverse_read_path.as_posix(),


### PR DESCRIPTION
### Fixed

- Bug in `cg workflow taxprofiler config-case`. The` sample_name `column and the `run_accession` should be unique so that `run_merging` can work properly.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b patch_taxprofiler -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
