### PR TITLE
Add internal_id column to RunDevice model

### DIFF
--- a/alembic/versions/92a0b4c8fe24_add_device_internal_id.py
+++ b/alembic/versions/92a0b4c8fe24_add_device_internal_id.py
@@ -1,0 +1,32 @@
+"""add_device_internal_id
+
+Revision ID: 92a0b4c8fe24
+Revises: 078884a6b2d2
+Create Date: 2024-05-13 16:15:45.639070
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "92a0b4c8fe24"
+down_revision = "078884a6b2d2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        table_name="run_device",
+        column=sa.Column(__name_pos="internal_id", __type_pos=sa.String(length=64), nullable=False),
+    )
+    op.create_unique_constraint(
+        constraint_name="uq_internal_id", table_name="run_device", columns=["internal_id"]
+    )
+
+
+def downgrade():
+    op.drop_constraint(constraint_name="uq_internal_id", table_name="run_device", type_="unique")
+    op.drop_column(table_name="run_device", column_name="internal_id")

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -45,6 +45,7 @@ VarChar128 = Annotated[str, 128]
 
 PrimaryKeyInt = Annotated[int, mapped_column(primary_key=True)]
 UniqueStr = Annotated[str, mapped_column(String(32), unique=True)]
+UniqueStr64 = Annotated[str, mapped_column(String(64), unique=True)]
 
 
 class Base(DeclarativeBase):
@@ -963,6 +964,7 @@ class RunDevice(Base):
 
     id: Mapped[PrimaryKeyInt]
     type: Mapped[DeviceType]
+    internal_id: Mapped[UniqueStr64]
 
     __mapper_args__ = {
         "polymorphic_on": "type",


### PR DESCRIPTION
## Description
Closes https://github.com/Clinical-Genomics/add-new-tech/issues/19

### Added

- `intenal_id` column to `RunDevice` model
- New alembic migration with the changes



### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
