### PR TITLE
Remove dryrun flag

### DIFF
--- a/cg/constants/constants.py
+++ b/cg/constants/constants.py
@@ -234,7 +234,6 @@ class APIMethods(StrEnum):
 
 
 DRY_RUN = click.option(
-    "-d",
     "--dry-run",
     is_flag=True,
     default=False,

--- a/tests/cli/clean/test_balsamic_clean.py
+++ b/tests/cli/clean/test_balsamic_clean.py
@@ -96,7 +96,9 @@ def test_dry_run(
     TrailblazerAPI.is_latest_analysis_ongoing.return_value = False
 
     # WHEN dry running with dry run specified
-    result = cli_runner.invoke(clean_run_dir, [balsamic_case_clean, "-d", "-y"], obj=clean_context)
+    result = cli_runner.invoke(
+        clean_run_dir, [balsamic_case_clean, "--dry-run", "-y"], obj=clean_context
+    )
     # THEN command should say it would have deleted
     assert result.exit_code == EXIT_SUCCESS
     assert "Would have deleted" in caplog.text
@@ -136,7 +138,7 @@ def test_cleaned_at_invalid(
     assert not base_store.get_case_by_internal_id(balsamic_case_not_clean).analyses[0].cleaned_at
     # WHEN dry running with dry run specified
 
-    result = cli_runner.invoke(past_run_dirs, ["2020-12-01", "-d", "-y"], obj=clean_context)
+    result = cli_runner.invoke(past_run_dirs, ["2020-12-01", "--dry-run", "-y"], obj=clean_context)
 
     # THEN case directory should not have been cleaned
     assert result.exit_code == EXIT_SUCCESS

--- a/tests/cli/clean/test_clean_flow_cell.py
+++ b/tests/cli/clean/test_clean_flow_cell.py
@@ -62,7 +62,7 @@ def test_clean_flow_cells_cmd_dry_run(
         "cg.meta.clean.clean_flow_cells.CleanFlowCellAPI.is_directory_older_than_21_days",
         return_value=True,
     ):
-        result = cli_runner.invoke(clean_flow_cells, ["-d"], obj=clean_flow_cells_context)
+        result = cli_runner.invoke(clean_flow_cells, ["--dry-run"], obj=clean_flow_cells_context)
 
     # THEN assert it exits with success
     assert result.exit_code == 0

--- a/tests/cli/clean/test_microbial_clean.py
+++ b/tests/cli/clean/test_microbial_clean.py
@@ -48,7 +48,7 @@ def test_dry_run(
 
     # WHEN dry running with dry run specified
     result = cli_runner.invoke(
-        clean_run_dir, [microsalt_case_clean_dry, "-d", "-y"], obj=clean_context_microsalt
+        clean_run_dir, [microsalt_case_clean_dry, "--dry-run", "-y"], obj=clean_context_microsalt
     )
 
     # THEN command should say it would have deleted

--- a/tests/cli/clean/test_rsync_past_run_dirs.py
+++ b/tests/cli/clean/test_rsync_past_run_dirs.py
@@ -26,7 +26,7 @@ def test_clean_rsync_past_run_dirs_young_process(
     assert rsync_process.exists()
     # WHEN attempting to remove said process same day
     result = cli_runner.invoke(
-        rsync_past_run_dirs, ["-d", "-y", str(timestamp_now)], obj=clean_context
+        rsync_past_run_dirs, ["--dry-run", "-y", str(timestamp_now)], obj=clean_context
     )
     # THEN the command should not fail and notice that the process is not old
     assert result.exit_code == EXIT_SUCCESS

--- a/tests/cli/workflow/microsalt/test_microsalt_case_config.py
+++ b/tests/cli/workflow/microsalt/test_microsalt_case_config.py
@@ -87,7 +87,9 @@ def test_dry_sample(
     # GIVEN project, organism and reference genome is specified in lims
 
     # WHEN dry running a sample name
-    result = cli_runner.invoke(config_case, [microbial_sample_id, "-s", "-d"], obj=base_context)
+    result = cli_runner.invoke(
+        config_case, [microbial_sample_id, "-s", "--dry-run"], obj=base_context
+    )
 
     # THEN command should give us a json dump
     assert result.exit_code == EXIT_SUCCESS
@@ -105,7 +107,7 @@ def test_dry_order(
     # WHEN dry running a sample name
     result = cli_runner.invoke(
         config_case,
-        [ticket_id, "-t", "-d"],
+        [ticket_id, "-t", "--dry-run"],
         obj=base_context,
     )
 
@@ -135,7 +137,9 @@ def test_gonorrhoeae(cli_runner: CliRunner, base_context: CGConfig, microbial_sa
     sample_obj.organism.internal_id = "gonorrhoeae"
 
     # WHEN getting the case config
-    result = cli_runner.invoke(config_case, [microbial_sample_id, "-d", "-s"], obj=base_context)
+    result = cli_runner.invoke(
+        config_case, [microbial_sample_id, "--dry-run", "-s"], obj=base_context
+    )
 
     # THEN the organism should now be  ...
     assert "Neisseria spp." in result.output
@@ -150,7 +154,9 @@ def test_cutibacterium_acnes(cli_runner: CliRunner, base_context: CGConfig, micr
     sample_obj.organism.internal_id = "Cutibacterium acnes"
 
     # WHEN getting the case config
-    result = cli_runner.invoke(config_case, [microbial_sample_id, "-s", "-d"], obj=base_context)
+    result = cli_runner.invoke(
+        config_case, [microbial_sample_id, "-s", "--dry-run"], obj=base_context
+    )
 
     # THEN the organism should now be ....
     assert "Propionibacterium acnes" in result.output
@@ -166,7 +172,9 @@ def test_vre_nc_017960(cli_runner: CliRunner, base_context: CGConfig, microbial_
     sample_obj.organism.reference_genome = "NC_017960.1"
 
     # WHEN getting the case config
-    result = cli_runner.invoke(config_case, [microbial_sample_id, "-s", "-d"], obj=base_context)
+    result = cli_runner.invoke(
+        config_case, [microbial_sample_id, "-s", "--dry-run"], obj=base_context
+    )
 
     # THEN the organism should now be ....
     assert "Enterococcus faecium" in result.output
@@ -182,7 +190,9 @@ def test_vre_nc_004668(cli_runner: CliRunner, base_context: CGConfig, microbial_
     sample_obj.organism.reference_genome = "NC_004668.1"
 
     # WHEN getting the case config
-    result = cli_runner.invoke(config_case, [microbial_sample_id, "-s", "-d"], obj=base_context)
+    result = cli_runner.invoke(
+        config_case, [microbial_sample_id, "-s", "--dry-run"], obj=base_context
+    )
 
     # THEN the organism should now be ....
     assert "Enterococcus faecalis" in result.output
@@ -201,7 +211,9 @@ def test_vre_comment(
     lims_sample.sample_data["comment"] = "ABCD123"
 
     # WHEN getting the case config
-    result = cli_runner.invoke(config_case, [microbial_sample_id, "-s", "-d"], obj=base_context)
+    result = cli_runner.invoke(
+        config_case, [microbial_sample_id, "-s", "--dry-run"], obj=base_context
+    )
 
     # THEN the organism should now be ....
     assert "ABCD123" in result.output

--- a/tests/cli/workflow/microsalt/test_microsalt_run.py
+++ b/tests/cli/workflow/microsalt/test_microsalt_run.py
@@ -29,7 +29,7 @@ def test_dry_arguments(cli_runner: CliRunner, base_context: CGConfig, ticket_id,
     caplog.set_level(logging.INFO)
 
     # WHEN dry running without anything specified
-    result = cli_runner.invoke(run, [ticket_id, "-t", "-d"], obj=base_context)
+    result = cli_runner.invoke(run, [ticket_id, "-t", "--dry-run"], obj=base_context)
 
     # THEN command should mention missing arguments
     assert result.exit_code == EXIT_SUCCESS

--- a/tests/cli/workflow/nf_analysis/test_cli_config_case.py
+++ b/tests/cli/workflow/nf_analysis/test_cli_config_case.py
@@ -212,7 +212,9 @@ def test_config_case_dry_run(
     mocker.patch.object(LimsAPI, "get_source", return_value="blood")
 
     # WHEN invoking the command with dry-run specified
-    result = cli_runner.invoke(workflow_cli, [workflow, "config-case", case_id, "-d"], obj=context)
+    result = cli_runner.invoke(
+        workflow_cli, [workflow, "config-case", case_id, "--dry-run"], obj=context
+    )
 
     # THEN command should exit successfully
     assert result.exit_code == EXIT_SUCCESS


### PR DESCRIPTION
## Description
This PR address issue #3234. It removes the short flag "-d" in the DRY_RUN option as it was conflicting with other commands with the same short flag. In test files, "-d" was changed to "--dry-run".

### Changed

- Removes the short flag "-d" in the DRY_RUN option in cg/constants/constants.py
- In test files, "-d" was changed to "--dry-run".

### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [X] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
