### PR TITLE
Include multiqc_report for mip-dna delivery

### DIFF
--- a/cg/constants/delivery.py
+++ b/cg/constants/delivery.py
@@ -78,6 +78,7 @@ BALSAMIC_UMI_ANALYSIS_SAMPLE_TAGS.extend(BALSAMIC_ANALYSIS_SAMPLE_TAGS)
 
 MIP_DNA_ANALYSIS_CASE_TAGS: list[set[str]] = [
     {"delivery-report"},
+    {"multiqc-html"},
     {"vcf-clinical-sv-bin"},
     {"vcf-clinical-sv-bin-index"},
     {"vcf-research-sv-bin"},


### PR DESCRIPTION
## Description

Addresses issue https://github.com/Clinical-Genomics/cg/issues/3258.

### Added

- "multiqc-html" tag to "MIP_DNA_ANALYSIS_CASE_TAGS.


### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b add-multiqc-report-to-mip-dna-delivery -a
    ```

### How to test

- [x] Run `cg deliver analysis -c happymuskox --delivery-type mip-dna`.

### Expected test outcome

- [x] Check that the `multiqc_report.html` file is sent to the customer directory in hasta.
- [x] Take a screenshot and attach or copy/paste the output.

## Review

- [x] Tests executed by BSV
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [X] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Deploy this branch on hasta production
