### PR TITLE
fix(look for run parameters in flow cell runs)

### DIFF
--- a/cg/constants/demultiplexing.py
+++ b/cg/constants/demultiplexing.py
@@ -6,6 +6,9 @@ from pydantic import BaseModel
 
 from cg.constants.sequencing import Sequencers
 
+DEMULTIPLEXED_RUNS: str = "demultiplexed_runs"
+FLOW_CELL_RUNS: str = "flow_cells"
+
 
 class DemultiplexingDirsAndFiles(StrEnum):
     """Demultiplexing related directories and files."""


### PR DESCRIPTION
## Description

`FlowCellsDirectoryData` can get initialised with a flow cell runs as well as a demultiplexed-runs dir. 
With the latter the run parameters file cannot be found. 

This PR introduces a solution that there will always be looked for a run paramters file in the appropriate directory.

### Added

-

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
