### PR TITLE
fix default capture kit in mip/raredisease 

### DIFF
--- a/cg/constants/constants.py
+++ b/cg/constants/constants.py
@@ -57,7 +57,7 @@ class ControlOptions(StrEnum):
     EMPTY: str = ""
 
 
-DEFAULT_CAPTURE_KIT = "twistexomerefseq_10.2_hg19_design.bed"
+DEFAULT_CAPTURE_KIT = "twistexomecomprehensive_10.2_hg19_design.bed"
 
 
 class CustomerId(StrEnum):


### PR DESCRIPTION
## Description
Due to a typo, a nonexisting default capture kit raised an error during WES runs in MIP-DNA. This name change should fix it.


### Added

-

### Changed

- DEFAULT_CAPTURE_KIT = twistexomecomprehensive_10.2_hg19_design.bed

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that file exists in the reference folder.
- [ ] Take a screenshot and attach or copy/paste the output.
- [ ] 
<img width="961" alt="image" src="https://github.com/Clinical-Genomics/cg/assets/57712924/92f17c17-46d4-4724-a54f-ceace5a94c4f">


## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
