### PR TITLE
fix(allow multiple data analysis type in mip)

### DIFF
--- a/cg/meta/workflow/analysis.py
+++ b/cg/meta/workflow/analysis.py
@@ -712,7 +712,7 @@ class AnalysisAPI(MetaAPI):
         analysis_types: set[str] = {
             link.sample.application_version.application.analysis_type for link in case.links
         }
-        if len(analysis_types) > 1:
+        if len(analysis_types) > 1 and self.workflow != Workflow.MIP_DNA:
             raise ValueError(
                 f"Case samples have different analysis types {', '.join(analysis_types)}"
             )


### PR DESCRIPTION
## Description

Currently cg upload -c fails for mip-dna cases that have multiple analysis types (WES;WGS) for the same case. however, the workflow supports the use of multiple data analysis types for the same case.

### Added

-

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
