### PR TITLE
Add sample_id to error message.

### DIFF
--- a/cg/meta/deliver/deliver.py
+++ b/cg/meta/deliver/deliver.py
@@ -220,7 +220,7 @@ class DeliverAPI:
                 )
                 number_previously_linked_files += 1
         if number_previously_linked_files == 0 and number_linked_files_now == 0:
-            raise MissingFilesError(f"No files were linked for sample {sample_name}")
+            raise MissingFilesError(f"No files were linked for sample {sample_id} ({sample_name}).")
 
         LOG.info(
             f"There were {number_previously_linked_files} previously linked files and {number_linked_files_now} were linked for sample {sample_id}, case {case_id}"


### PR DESCRIPTION
## Description

Addresses https://github.com/Clinical-Genomics/cg/issues/3334.

### Added

- `sample_id` in the error message for when the fastq files for a sample cannot be delivered since they are not present in the sample bundle.

### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [X] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
