### PR TITLE
feature(always update chanjo samples)

### DIFF
--- a/cg/cli/upload/coverage.py
+++ b/cg/cli/upload/coverage.py
@@ -11,15 +11,9 @@ from .utils import suggest_cases_to_upload
 
 
 @click.command("coverage")
-@click.option(
-    "-r",
-    "--re-upload",
-    is_flag=True,
-    help="re-upload existing analysis",
-)
 @click.argument("family_id", required=False)
 @click.pass_obj
-def upload_coverage(context: CGConfig, re_upload, family_id):
+def upload_coverage(context: CGConfig, family_id):
     """Upload coverage from an analysis to Chanjo."""
 
     click.echo(click.style("----------------- COVERAGE --------------------"))
@@ -37,4 +31,4 @@ def upload_coverage(context: CGConfig, re_upload, family_id):
         chanjo_api=context.chanjo_api,
     )
     coverage_data = upload_coverage_api.data(case_obj.analyses[0])
-    upload_coverage_api.upload(coverage_data, replace=re_upload)
+    upload_coverage_api.upload(coverage_data)

--- a/cg/meta/upload/coverage.py
+++ b/cg/meta/upload/coverage.py
@@ -38,7 +38,10 @@ class UploadCoverageApi:
         return data
 
     def upload(self, data: dict):
-        """Upload coverage to Chanjo from an analysis."""
+        """
+        Upload coverage to Chanjo from an analysis.
+        If a previous coverage exists for a sample, it will be deleted before re-uploading.
+        """
         for sample_data in data["samples"]:
             chanjo_sample = self.chanjo_api.sample(sample_data["sample"])
             if chanjo_sample:

--- a/cg/meta/upload/coverage.py
+++ b/cg/meta/upload/coverage.py
@@ -42,10 +42,10 @@ class UploadCoverageApi:
         for sample_data in data["samples"]:
             chanjo_sample = self.chanjo_api.sample(sample_data["sample"])
             if chanjo_sample:
+                LOG.warning(
+                    f"sample already loaded, deleting previous entry for re-upload: {sample_data['sample']}"
+                )
                 self.chanjo_api.delete_sample(sample_data["sample"])
-            elif chanjo_sample:
-                LOG.warning(f"sample already loaded, skipping: {sample_data['sample']}")
-                continue
 
             LOG.debug(f"upload coverage for sample: {sample_data['sample']}")
             self.chanjo_api.upload(

--- a/cg/meta/upload/coverage.py
+++ b/cg/meta/upload/coverage.py
@@ -46,7 +46,7 @@ class UploadCoverageApi:
             chanjo_sample = self.chanjo_api.sample(sample_data["sample"])
             if chanjo_sample:
                 LOG.warning(
-                    f"sample already loaded, deleting previous entry for re-upload: {sample_data['sample']}"
+                    f"Sample already loaded, deleting previous entry and re-uploading: {sample_data['sample']}"
                 )
                 self.chanjo_api.delete_sample(sample_data["sample"])
 

--- a/cg/meta/upload/coverage.py
+++ b/cg/meta/upload/coverage.py
@@ -37,11 +37,11 @@ class UploadCoverageApi:
             )
         return data
 
-    def upload(self, data: dict, replace: bool = False):
+    def upload(self, data: dict):
         """Upload coverage to Chanjo from an analysis."""
         for sample_data in data["samples"]:
             chanjo_sample = self.chanjo_api.sample(sample_data["sample"])
-            if chanjo_sample and replace:
+            if chanjo_sample:
                 self.chanjo_api.delete_sample(sample_data["sample"])
             elif chanjo_sample:
                 LOG.warning(f"sample already loaded, skipping: {sample_data['sample']}")

--- a/cg/meta/upload/mip/mip_dna.py
+++ b/cg/meta/upload/mip/mip_dna.py
@@ -35,7 +35,7 @@ class MipDNAUploadAPI(UploadAPI):
         self.update_upload_started_at(analysis=analysis)
 
         # Main upload
-        ctx.invoke(upload_coverage, family_id=case.internal_id, re_upload=restart)
+        ctx.invoke(upload_coverage, family_id=case.internal_id)
         ctx.invoke(validate, family_id=case.internal_id)
         ctx.invoke(upload_genotypes, family_id=case.internal_id, re_upload=restart)
         ctx.invoke(upload_observations_to_loqusdb, case_id=case.internal_id)

--- a/tests/meta/upload/test_meta_upload_coverage.py
+++ b/tests/meta/upload/test_meta_upload_coverage.py
@@ -67,7 +67,7 @@ def test_upload(
     data = coverage_api.data(analysis_obj=analysis_obj)
 
     # WHEN uploading samples in data dictionary
-    coverage_api.upload(data=data, replace=True)
+    coverage_api.upload(data=data)
 
     # THEN methods sample, and upload should each have been called three times
     assert mock_upload.call_count == len(data["samples"])


### PR DESCRIPTION
## Description

Chanjo stores coverage reports of samples. Currently when samples have been uploaded once, upload with new data will not update samples in automation. This is due to the behaviour of the upload to require a `-r` or restart flag. 

Upon discussion with KN and KSV no reason was discovered why we do not want to update samples if they have new data regardless of pre-exisitng entries.


### Added

-

### Changed

- Remove the `-r` flag from the coverage upload.
- Chanjo upload behaviour changed to only require a pre-existing sample to delete the existing entry, which will then get a new entry with current data.

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
