### PR TITLE
Avoid duplicating TB statuses in the order summary

### DIFF
--- a/cg/apps/tb/dto/summary_response.py
+++ b/cg/apps/tb/dto/summary_response.py
@@ -1,13 +1,33 @@
 from pydantic import BaseModel
 
 
+class StatusSummary(BaseModel):
+    count: int = 0
+    case_ids: list[str] = []
+
+
 class AnalysisSummary(BaseModel):
     order_id: int
-    cancelled: int
-    completed: int
-    delivered: int
-    failed: int
-    running: int
+    cancelled: StatusSummary
+    completed: StatusSummary
+    delivered: StatusSummary
+    failed: StatusSummary
+    running: StatusSummary
+
+    @property
+    def case_ids(self) -> list[str]:
+        cancelled_case_ids: list[str] = self.cancelled.case_ids
+        completed_case_ids: list[str] = self.completed.case_ids
+        delivered_case_ids: list[str] = self.delivered.case_ids
+        failed_case_ids: list[str] = self.failed.case_ids
+        running_case_ids: list[str] = self.running.case_ids
+        return (
+            cancelled_case_ids
+            + completed_case_ids
+            + delivered_case_ids
+            + failed_case_ids
+            + running_case_ids
+        )
 
 
 class SummariesResponse(BaseModel):

--- a/cg/services/orders/order_summary_service/dto/case_summary.py
+++ b/cg/services/orders/order_summary_service/dto/case_summary.py
@@ -1,9 +1,0 @@
-from pydantic import BaseModel
-
-
-class CaseSummary(BaseModel):
-    order_id: int
-    failed_sequencing_qc: int | None = None
-    in_preparation: int | None = None
-    in_sequencing: int | None = None
-    not_received: int | None = None

--- a/cg/services/orders/order_summary_service/order_summary_service.py
+++ b/cg/services/orders/order_summary_service/order_summary_service.py
@@ -1,9 +1,8 @@
 from cg.apps.tb.api import TrailblazerAPI
 from cg.apps.tb.dto.summary_response import AnalysisSummary
-from cg.services.orders.order_summary_service.dto.case_summary import CaseSummary
 from cg.services.orders.order_summary_service.dto.order_summary import OrderSummary
 from cg.services.orders.order_summary_service.utils import (
-    create_summaries,
+    _get_analysis_map,
     get_cases_failed_sequencing_qc_count,
 )
 from cg.store.models import Order
@@ -20,27 +19,46 @@ class OrderSummaryService:
 
     def get_summaries(self, order_ids: list[int]) -> list[OrderSummary]:
         orders: list[Order] = self.store.get_orders_by_ids(order_ids)
-        cases: list[CaseSummary] = self._get_case_summaries(order_ids)
         analyses: list[AnalysisSummary] = self.analysis_client.get_summaries(order_ids)
-        return create_summaries(orders=orders, analysis_summaries=analyses, case_summaries=cases)
+        order_summaries = self.create_summaries(orders=orders, analysis_summaries=analyses)
+        return order_summaries
 
-    def _get_case_summaries(self, order_ids: list[int]):
-        summaries: list[CaseSummary] = []
+    def create_summaries(
+        self, orders: list[Order], analysis_summaries: list[AnalysisSummary]
+    ) -> list[OrderSummary]:
+        order_summaries: list[OrderSummary] = []
+        analysis_summary_map: dict = _get_analysis_map(analysis_summaries)
+        for order in orders:
+            analysis_summary: AnalysisSummary = analysis_summary_map.get(order.id)
+            order_summary = self.create_order_summary(order=order, summary=analysis_summary)
+            order_summaries.append(order_summary)
+        return order_summaries
 
-        for order_id in order_ids:
-            not_received: int = self.store.get_case_not_received_count(order_id)
-            in_preparation: int = self.store.get_case_in_preparation_count(order_id)
-            in_sequencing: int = self.store.get_case_in_sequencing_count(order_id)
-            order: Order = self.store.get_order_by_id(order_id)
-            failed_sequencing_qc: int = get_cases_failed_sequencing_qc_count(order)
-
-            summary = CaseSummary(
-                order_id=order_id,
-                not_received=not_received,
-                in_preparation=in_preparation,
-                in_sequencing=in_sequencing,
-                failed_sequencing_qc=failed_sequencing_qc,
-            )
-            summaries.append(summary)
-
-        return summaries
+    def create_order_summary(self, order: Order, summary: AnalysisSummary) -> OrderSummary:
+        order_id = order.id
+        counted_cases: list[str] = summary.case_ids if summary else []
+        not_received: int = self.store.get_case_not_received_count(
+            order_id=order_id, cases_to_exclude=counted_cases
+        )
+        in_preparation: int = self.store.get_case_in_preparation_count(
+            order_id=order_id, cases_to_exclude=counted_cases
+        )
+        in_sequencing: int = self.store.get_case_in_sequencing_count(
+            order_id=order_id, cases_to_exclude=counted_cases
+        )
+        failed_sequencing_qc: int = get_cases_failed_sequencing_qc_count(
+            order=order, cases_to_exclude=counted_cases
+        )
+        return OrderSummary(
+            order_id=order_id,
+            total=len(order.cases),
+            cancelled=summary.cancelled.count,
+            completed=summary.completed.count,
+            delivered=summary.delivered.count,
+            failed=summary.failed.count,
+            failed_sequencing_qc=failed_sequencing_qc,
+            in_lab_preparation=in_preparation,
+            in_sequencing=in_sequencing,
+            not_received=not_received,
+            running=summary.running.count,
+        )

--- a/cg/services/orders/order_summary_service/utils.py
+++ b/cg/services/orders/order_summary_service/utils.py
@@ -1,59 +1,20 @@
 from cg.apps.tb.dto.summary_response import AnalysisSummary
-from cg.services.orders.order_summary_service.dto.case_summary import CaseSummary
-from cg.services.orders.order_summary_service.dto.order_summary import OrderSummary
 from cg.services.sequencing_qc_service import SequencingQCService
 from cg.store.models import Case, Order
-
-
-def create_summaries(
-    orders: list[Order],
-    analysis_summaries: list[AnalysisSummary],
-    case_summaries: list[CaseSummary],
-) -> list[OrderSummary]:
-    summaries: list[OrderSummary] = []
-    analysis_map: dict = _get_analysis_map(analysis_summaries)
-    case_map: dict = _get_case_map(case_summaries)
-
-    for order in orders:
-        case: CaseSummary = case_map[order.id]
-        analysis: AnalysisSummary = analysis_map[order.id]
-        summary = create_order_summary(order=order, analysis_summary=analysis, case_summary=case)
-        summaries.append(summary)
-    return summaries
-
-
-def create_order_summary(
-    order: Order,
-    analysis_summary: AnalysisSummary,
-    case_summary: CaseSummary,
-) -> OrderSummary:
-    return OrderSummary(
-        order_id=order.id,
-        total=len(order.cases),
-        in_sequencing=case_summary.in_sequencing,
-        in_lab_preparation=case_summary.in_preparation,
-        not_received=case_summary.not_received,
-        running=analysis_summary.running,
-        delivered=analysis_summary.delivered,
-        cancelled=analysis_summary.cancelled,
-        failed=analysis_summary.failed,
-        completed=analysis_summary.completed,
-        failed_sequencing_qc=case_summary.failed_sequencing_qc,
-    )
 
 
 def _get_analysis_map(analysis_summaries: list[AnalysisSummary]) -> dict:
     return {summary.order_id: summary for summary in analysis_summaries}
 
 
-def _get_case_map(case_summaries: list[CaseSummary]) -> dict:
-    return {summary.order_id: summary for summary in case_summaries}
-
-
 def _is_case_failed_sequencing_qc(case: Case) -> bool:
     return case.are_all_samples_sequenced and not SequencingQCService.case_pass_sequencing_qc(case)
 
 
-def get_cases_failed_sequencing_qc_count(order: Order) -> int:
+def get_cases_failed_sequencing_qc_count(order: Order, cases_to_exclude: list[str]) -> int:
     cases: list[Case] = order.cases
-    return sum(1 for case in cases if _is_case_failed_sequencing_qc(case))
+    return sum(
+        1
+        for case in cases
+        if _is_case_failed_sequencing_qc(case) and case.internal_id not in cases_to_exclude
+    )

--- a/cg/store/crud/read.py
+++ b/cg/store/crud/read.py
@@ -51,8 +51,8 @@ from cg.store.filters.status_flow_cell_filters import (
     apply_flow_cell_filter,
 )
 from cg.store.filters.status_illumina_flow_cell_filters import (
-    apply_illumina_flow_cell_filters,
     IlluminaFlowCellFilter,
+    apply_illumina_flow_cell_filters,
 )
 from cg.store.filters.status_invoice_filters import InvoiceFilter, apply_invoice_filter
 from cg.store.filters.status_metrics_filters import (
@@ -80,6 +80,7 @@ from cg.store.models import (
     Collaboration,
     Customer,
     Flowcell,
+    IlluminaFlowCell,
     Invoice,
     Order,
     Organism,
@@ -88,7 +89,6 @@ from cg.store.models import (
     Sample,
     SampleLaneSequencingMetrics,
     User,
-    IlluminaFlowCell,
 )
 
 LOG = logging.getLogger(__name__)
@@ -1435,43 +1435,49 @@ class ReadHandler(BaseHandler):
         )
         return orders.first()
 
-    def get_case_not_received_count(self, order_id: int) -> int:
+    def get_case_not_received_count(self, order_id: int, cases_to_exclude: list[str]) -> int:
         filters: list[CaseSampleFilter] = [
             CaseSampleFilter.BY_ORDER,
             CaseSampleFilter.CASES_WITH_SAMPLES_NOT_RECEIVED,
+            CaseSampleFilter.EXCLUDE_CASES,
         ]
         case_samples: Query = self._join_sample_and_case()
         return apply_case_sample_filter(
             case_samples=case_samples,
             filter_functions=filters,
             order_id=order_id,
+            cases_to_exclude=cases_to_exclude,
         ).count()
 
-    def get_case_in_preparation_count(self, order_id: int) -> int:
+    def get_case_in_preparation_count(self, order_id: int, cases_to_exclude: list[str]) -> int:
         filters: list[CaseFilter] = [
             CaseSampleFilter.BY_ORDER,
             CaseSampleFilter.CASES_WITH_ALL_SAMPLES_RECEIVED,
             CaseSampleFilter.CASES_WITH_SAMPLES_NOT_PREPARED,
+            CaseSampleFilter.EXCLUDE_CASES,
         ]
         case_samples: Query = self._join_sample_and_case()
         return apply_case_sample_filter(
             case_samples=case_samples,
             filter_functions=filters,
             order_id=order_id,
+            cases_to_exclude=cases_to_exclude,
         ).count()
 
-    def get_case_in_sequencing_count(self, order_id: int) -> int:
+    def get_case_in_sequencing_count(self, order_id: int, cases_to_exclude: list[str]) -> int:
         filters: list[CaseSampleFilter] = [
             CaseSampleFilter.BY_ORDER,
             CaseSampleFilter.CASES_WITH_ALL_SAMPLES_RECEIVED,
             CaseSampleFilter.CASES_WITH_ALL_SAMPLES_PREPARED,
             CaseSampleFilter.CASES_WITH_SAMPLES_NOT_SEQUENCED,
+            CaseSampleFilter.EXCLUDE_CASES,
         ]
         case_samples: Query = self._join_sample_and_case()
         return apply_case_sample_filter(
             case_samples=case_samples,
             filter_functions=filters,
             order_id=order_id,
+            cases_to_exclude=cases_to_exclude,
         ).count()
 
     def get_illumina_flow_cell_by_internal_id(self, internal_id: str) -> IlluminaFlowCell:

--- a/cg/store/filters/status_case_sample_filters.py
+++ b/cg/store/filters/status_case_sample_filters.py
@@ -56,10 +56,15 @@ def get_not_sequenced_cases(case_samples: Query, **kwargs) -> Query:
     return case_samples.filter(Sample.last_sequenced_at == None).distinct()
 
 
+def exclude_cases(case_samples: Query, cases_to_exclude: list[str], **kwargs) -> Query:
+    return case_samples.filter(Case.internal_id not in cases_to_exclude)
+
+
 def apply_case_sample_filter(
     filter_functions: list[Callable],
     case_samples: Query,
     case_internal_id: str | None = None,
+    cases_to_exclude: list[str] = [],
     sample_entry_id: int | None = None,
     sample_internal_id: str | None = None,
     order_id: int | None = None,
@@ -70,6 +75,7 @@ def apply_case_sample_filter(
         case_samples: Query = function(
             case_samples=case_samples,
             case_internal_id=case_internal_id,
+            cases_to_exclude=cases_to_exclude,
             sample_entry_id=sample_entry_id,
             sample_internal_id=sample_internal_id,
             order_id=order_id,
@@ -87,4 +93,5 @@ class CaseSampleFilter(Enum):
     CASES_WITH_SAMPLES_NOT_PREPARED: Callable = get_not_prepared_cases
     CASES_WITH_ALL_SAMPLES_PREPARED: Callable = get_prepared_cases
     CASES_WITH_SAMPLES_NOT_SEQUENCED: Callable = get_not_sequenced_cases
+    EXCLUDE_CASES: Callable = exclude_cases
     BY_ORDER: Callable = filter_by_order

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,8 +26,15 @@ from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.apps.housekeeper.models import InputBundle
 from cg.apps.lims import LimsAPI
 from cg.apps.slurm.slurm_api import SlurmAPI
+from cg.apps.tb.dto.summary_response import AnalysisSummary, StatusSummary
 from cg.constants import FileExtensions, SequencingFileTag, Workflow
-from cg.constants.constants import CaseActions, CustomerId, FileFormat, GenomeVersion, Strandedness
+from cg.constants.constants import (
+    CaseActions,
+    CustomerId,
+    FileFormat,
+    GenomeVersion,
+    Strandedness,
+)
 from cg.constants.gene_panel import GenePanelMasterList
 from cg.constants.housekeeper_tags import HK_DELIVERY_REPORT_TAG
 from cg.constants.priority import SlurmQos
@@ -50,15 +57,20 @@ from cg.meta.workflow.tomte import TomteAnalysisAPI
 from cg.models import CompressionData
 from cg.models.cg_config import CGConfig, PDCArchivingDirectory
 from cg.models.downsample.downsample_data import DownsampleData
-from cg.models.run_devices.illumina_run_directory_data import IlluminaRunDirectoryData
-from cg.models.raredisease.raredisease import RarediseaseParameters, RarediseaseSampleSheetHeaders
+from cg.models.raredisease.raredisease import (
+    RarediseaseParameters,
+    RarediseaseSampleSheetHeaders,
+)
 from cg.models.rnafusion.rnafusion import RnafusionParameters, RnafusionSampleSheetEntry
-from cg.models.taxprofiler.taxprofiler import TaxprofilerParameters, TaxprofilerSampleSheetEntry
+from cg.models.run_devices.illumina_run_directory_data import IlluminaRunDirectoryData
+from cg.models.taxprofiler.taxprofiler import (
+    TaxprofilerParameters,
+    TaxprofilerSampleSheetEntry,
+)
 from cg.models.tomte.tomte import TomteParameters, TomteSampleSheetHeaders
 from cg.services.illumina_services.illumina_metrics_service.illumina_metrics_service import (
     IlluminaMetricsService,
 )
-
 from cg.store.database import create_all_tables, drop_all_tables, initialize_database
 from cg.store.models import Bed, BedVersion, Case, Customer, Order, Organism, Sample
 from cg.store.store import Store
@@ -3976,3 +3988,40 @@ def fastq_file_meta_raw(flow_cell_name: str) -> dict:
 @pytest.fixture()
 def illumina_metrics_service() -> IlluminaMetricsService:
     return IlluminaMetricsService()
+
+
+@pytest.fixture
+def completed_status_summary():
+    return StatusSummary(count=1, case_ids=["completed_case_id"])
+
+
+@pytest.fixture
+def delivered_status_summary():
+    return StatusSummary(count=1, case_ids=["delivered_case_id"])
+
+
+@pytest.fixture
+def failed_status_summary():
+    return StatusSummary(count=1, case_ids=["failed_case_id"])
+
+
+@pytest.fixture
+def empty_status_summary():
+    return StatusSummary()
+
+
+@pytest.fixture
+def analysis_summary(
+    empty_status_summary: StatusSummary,
+    completed_status_summary: StatusSummary,
+    delivered_status_summary: StatusSummary,
+    failed_status_summary: StatusSummary,
+):
+    return AnalysisSummary(
+        order_id=1,
+        cancelled=empty_status_summary,
+        completed=completed_status_summary,
+        running=empty_status_summary,
+        delivered=delivered_status_summary,
+        failed=failed_status_summary,
+    )

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -9,7 +9,7 @@ from flask import Flask
 from flask.testing import FlaskClient
 from mock import patch
 
-from cg.apps.tb.dto.summary_response import AnalysisSummary
+from cg.apps.tb.dto.summary_response import AnalysisSummary, StatusSummary
 from cg.apps.tb.models import TrailblazerAnalysis
 from cg.constants import DataDelivery, Workflow
 from cg.server.ext import db as store
@@ -172,12 +172,36 @@ def client(app: Flask) -> Generator[FlaskClient, None, None]:
 
 
 @pytest.fixture
-def analysis_summary():
-    return AnalysisSummary(
-        order_id=1,
-        cancelled=0,
-        completed=1,
-        running=0,
-        delivered=1,
-        failed=1,
-    )
+def analysis_summaries(
+    order: Order,
+    order_another: Order,
+    order_balsamic: Order,
+    completed_status_summary: StatusSummary,
+    empty_status_summary: StatusSummary,
+) -> list[AnalysisSummary]:
+    return [
+        AnalysisSummary(
+            order_id=order.id,
+            cancelled=empty_status_summary,
+            completed=completed_status_summary,
+            delivered=empty_status_summary,
+            failed=empty_status_summary,
+            running=empty_status_summary,
+        ),
+        AnalysisSummary(
+            order_id=order_another.id,
+            cancelled=empty_status_summary,
+            completed=completed_status_summary,
+            delivered=empty_status_summary,
+            failed=empty_status_summary,
+            running=empty_status_summary,
+        ),
+        AnalysisSummary(
+            order_id=order_balsamic.id,
+            cancelled=empty_status_summary,
+            completed=completed_status_summary,
+            delivered=empty_status_summary,
+            failed=empty_status_summary,
+            running=empty_status_summary,
+        ),
+    ]

--- a/tests/server/endpoints/test_orders_endpoint.py
+++ b/tests/server/endpoints/test_orders_endpoint.py
@@ -29,6 +29,7 @@ def test_orders_endpoint(
     limit: int | None,
     workflow: str,
     expected_orders: int,
+    analysis_summaries: list[AnalysisSummary],
 ):
     """Tests that orders are returned from the orders endpoint"""
     # GIVEN a store with three orders, two of which are MIP-DNA and the last is BALSAMIC
@@ -38,27 +39,7 @@ def test_orders_endpoint(
     with mock.patch.object(
         TrailblazerAPI,
         "get_summaries",
-        return_value=[
-            AnalysisSummary(
-                order_id=order.id, cancelled=0, completed=1, delivered=0, failed=0, running=0
-            ),
-            AnalysisSummary(
-                order_id=order_another.id,
-                cancelled=0,
-                completed=1,
-                delivered=0,
-                failed=0,
-                running=0,
-            ),
-            AnalysisSummary(
-                order_id=order_balsamic.id,
-                cancelled=0,
-                completed=1,
-                delivered=0,
-                failed=0,
-                running=0,
-            ),
-        ],
+        return_value=analysis_summaries,
     ):
         response = client.get(endpoint, query_string={"pageSize": limit, "workflow": workflow})
 

--- a/tests/services/orders/order_status_service/conftest.py
+++ b/tests/services/orders/order_status_service/conftest.py
@@ -13,13 +13,9 @@ from tests.store_helpers import StoreHelpers
 
 
 @pytest.fixture
-def summary_service(store: Store, order: Order):
+def summary_service(store: Store, order: Order, analysis_summary: AnalysisSummary):
     service = OrderSummaryService(analysis_client=Mock(), store=store)
-    service.analysis_client.get_summaries.return_value = [
-        AnalysisSummary(
-            order_id=order.id, cancelled=0, completed=1, delivered=0, failed=0, running=0
-        )
-    ]
+    service.analysis_client.get_summaries.return_value = [analysis_summary]
     return service
 
 


### PR DESCRIPTION
## Description

Concerns. https://github.com/Clinical-Genomics/trailblazer/issues/452 in conjunction with https://github.com/Clinical-Genomics/trailblazer/pull/454. It will need a patch in the frontend to handle the new response structure though.

### Fixed

- Cases in trailblazer do not get any additional statuses inferred.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
