### PR TITLE
Bump archive rate

### DIFF
--- a/cg/constants/archiving.py
+++ b/cg/constants/archiving.py
@@ -1,6 +1,6 @@
 from enum import StrEnum
 
-DEFAULT_SPRING_ARCHIVE_COUNT = 100
+DEFAULT_SPRING_ARCHIVE_COUNT = 500
 
 
 class ArchiveLocations(StrEnum):


### PR DESCRIPTION
## Description

We have changed our modus operandi and are now only archiving files via DDN at night. This means that we can bump up the archiving rate as well. This PR changes the default to archive 500 files every 20th minute at night.

### Changed

- Archive 500 files every 20 minutes between 22-08.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
