### PR TITLE
Lower archive rate

### DIFF
--- a/cg/constants/archiving.py
+++ b/cg/constants/archiving.py
@@ -1,6 +1,6 @@
 from enum import StrEnum
 
-DEFAULT_SPRING_ARCHIVE_COUNT = 500
+DEFAULT_SPRING_ARCHIVE_COUNT = 300
 
 
 class ArchiveLocations(StrEnum):


### PR DESCRIPTION
## Description

We went a bit heavy in #3356 and the jobs are not finishing until quite some time after they are started. This PR lowers the rate to a middle ground.

### Changed

- Default is to archive 300 spring files every 20th minute.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
