### PR TITLE
Replaced get_samples in CRUD to work with Illumina

### DIFF
--- a/cg/cli/backup.py
+++ b/cg/cli/backup.py
@@ -33,7 +33,7 @@ from cg.services.illumina_services.backup_services.encrypt_service import (
     IlluminaRunEncryptionService,
 )
 from cg.services.pdc_service.pdc_service import PdcService
-from cg.store.models import Flowcell, IlluminaSequencingRun, Sample
+from cg.store.models import IlluminaSequencingRun, Sample
 from cg.store.store import Store
 
 LOG = logging.getLogger(__name__)
@@ -238,7 +238,9 @@ def retrieve_spring_files(
     status_api: Store = config.status_db
     housekeeper_api: HousekeeperAPI = config.housekeeper_api
 
-    samples: list[Sample] = _get_samples(status_api, object_type, identifier)
+    samples: list[Sample] = status_api.get_samples_by_identifier(
+        object_type=object_type, identifier=identifier
+    )
 
     for sample in samples:
         latest_version: hk_models.Version = housekeeper_api.last_version(bundle=sample.internal_id)
@@ -249,17 +251,6 @@ def retrieve_spring_files(
         )
         for spring_file in spring_files:
             context.invoke(retrieve_spring_file, spring_file_path=spring_file.path, dry_run=dry_run)
-
-
-def _get_samples(status_api: Store, object_type: str, identifier: str) -> list[Sample]:
-    """Gets all samples belonging to a sample, case or flow cell id"""
-    get_samples = {
-        "sample": status_api.sample,
-        "case": status_api.get_samples_by_case_id,
-        "flow_cell": status_api.get_samples_from_flow_cell,
-    }
-    samples: Sample | list[Sample] = get_samples[object_type](identifier)
-    return samples if isinstance(samples, list) else [samples]
 
 
 @backup.command("retrieve-spring-file")

--- a/cg/cli/compress/fastq.py
+++ b/cg/cli/compress/fastq.py
@@ -164,7 +164,7 @@ def decompress_flowcell(context: click.Context, flow_cell_id: str, dry_run: bool
     """Decompress SPRING files for flow cell, and include links to FASTQ files in Housekeeper."""
 
     store: Store = context.obj.status_db
-    samples: Iterable[Sample] = store.get_samples_from_flow_cell(flow_cell_id=flow_cell_id)
+    samples: Iterable[Sample] = store.get_samples_by_illumina_flow_cell_internal_id(flow_cell_id)
     decompressed_individuals = 0
     for sample in samples:
         decompressed_count = context.invoke(

--- a/cg/cli/store/store.py
+++ b/cg/cli/store/store.py
@@ -77,7 +77,7 @@ def store_flow_cell(context: click.Context, flow_cell_id: str, dry_run: bool) ->
     """Include links to decompressed FASTQ files belonging to this flow cell in Housekeeper."""
 
     status_db: Store = context.obj.status_db
-    samples: list[Sample] = status_db.get_samples_from_flow_cell(flow_cell_id=flow_cell_id)
+    samples: list[Sample] = status_db.get_samples_by_illumina_flow_cell_internal_id(flow_cell_id)
     stored_individuals: int = invoke_store_samples(
         context=context, dry_run=dry_run, sample_ids=[sample.internal_id for sample in samples]
     )
@@ -108,7 +108,7 @@ def store_demultiplexed_flow_cell(context: click.Context, flow_cell_id: str, dry
     status_db: Store = context.status_db
     update_compress_api(compress_api, dry_run=dry_run)
 
-    samples: list[Sample] = status_db.get_samples_from_flow_cell(flow_cell_id=flow_cell_id)
+    samples: list[Sample] = status_db.get_samples_by_illumina_flow_cell_internal_id(flow_cell_id)
     bundle_names: list[str] = (
         [sample.internal_id for sample in samples if sample.internal_id] + [flow_cell_id]
         if samples

--- a/cg/store/crud/read.py
+++ b/cg/store/crud/read.py
@@ -479,7 +479,7 @@ class ReadHandler(BaseHandler):
             self.get_illumina_sequencing_run_by_device_internal_id(device_internal_id=flow_cell_id)
         )
         if sequencing_run:
-            return [metric.sample for metric in sequencing_run.sample_metrics]
+            return sequencing_run.device.samples
 
     def are_all_flow_cells_on_disk(self, case_id: str) -> bool:
         """Check if flow cells are on disk for sample before starting the analysis."""

--- a/cg/store/crud/read.py
+++ b/cg/store/crud/read.py
@@ -471,11 +471,15 @@ class ReadHandler(BaseHandler):
             case=case,
         ).all()
 
-    def get_samples_from_flow_cell(self, flow_cell_id: str) -> list[Sample] | None:
-        """Return samples present on flow cell."""
-        flow_cell: Flowcell = self.get_flow_cell_by_name(flow_cell_name=flow_cell_id)
-        if flow_cell:
-            return flow_cell.samples
+    def get_samples_by_illumina_flow_cell_internal_id(
+        self, flow_cell_id: str
+    ) -> list[Sample] | None:
+        """Return samples present on an Illumina flow cell."""
+        sequencing_run: IlluminaSequencingRun = (
+            self.get_illumina_sequencing_run_by_device_internal_id(device_internal_id=flow_cell_id)
+        )
+        if sequencing_run:
+            return [metric.sample for metric in sequencing_run.sample_metrics]
 
     def are_all_flow_cells_on_disk(self, case_id: str) -> bool:
         """Check if flow cells are on disk for sample before starting the analysis."""
@@ -1058,6 +1062,16 @@ class ReadHandler(BaseHandler):
             samples=self._get_query(table=Sample),
             internal_id=internal_id,
         ).first()
+
+    def get_samples_by_identifier(self, object_type: str, identifier: str) -> list[Sample]:
+        """Return all samples from a flow cell, case or sample id"""
+        object_to_filter: dict[str, Callable] = {
+            "sample": self.get_sample_by_internal_id,
+            "case": self.get_samples_by_case_id,
+            "flow_cell": self.get_samples_by_illumina_flow_cell_internal_id,
+        }
+        samples: Sample | list[Sample] = object_to_filter[object_type](identifier)
+        return samples if isinstance(samples, list) else [samples]
 
     def get_samples_by_internal_id(self, internal_id: str) -> list[Sample]:
         """Return all samples by lims id."""

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -859,7 +859,7 @@ class Sample(Base, PriorityMixin):
     @property
     def _run_devices(self) -> list["RunDevice"]:
         """Return the run_devices a sample has been sequenced on."""
-        return list({metric.run_metrics.device for metric in self._sample_run_metrics})
+        return list({metric.instrument_run.device for metric in self._sample_run_metrics})
 
     @property
     def sample_run_metrics(self) -> list["SampleRunMetrics"]:

--- a/tests/cli/store/test_store.py
+++ b/tests/cli/store/test_store.py
@@ -192,7 +192,7 @@ def test_store_demultiplexed_flow_cell(
     sample: Sample = real_populated_compress_context.status_db.get_sample_by_internal_id(sample_id)
 
     # GIVEN samples objects on a flow cell
-    mocker.patch.object(Store, "get_samples_from_flow_cell")
+    mocker.patch.object(Store, "get_samples_by_illumina_flow_cell_internal_id")
     Store.get_samples_by_illumina_flow_cell_internal_id.return_value = [sample]
 
     # GIVEN an updated metadata file

--- a/tests/cli/store/test_store.py
+++ b/tests/cli/store/test_store.py
@@ -130,25 +130,25 @@ def test_store_flow_cell(
     caplog.set_level(logging.DEBUG)
     # GIVEN a context with a sample
     sample: Sample = populated_compress_context.status_db.get_sample_by_internal_id(sample_id)
+    assert sample
 
     # GIVEN samples objects on a flow cell
-    mocker.patch.object(Store, "get_samples_from_flow_cell")
-    Store.get_samples_from_flow_cell.return_value = [sample]
+    with mocker.patch.object(
+        Store, "get_samples_by_illumina_flow_cell_internal_id", return_value=[sample]
+    ), mocker.patch.object(CompressAPI, "add_decompressed_fastq", return_value=True):
 
-    # GIVEN that decompression is not finished
-    mocker.patch.object(CompressAPI, "add_decompressed_fastq")
-    CompressAPI.add_decompressed_fastq.return_value = True
+        # WHEN running the store flow cell command
+        res = cli_runner.invoke(
+            store_flow_cell,
+            [novaseq_6000_pre_1_5_kits_flow_cell_id],
+            obj=populated_compress_context,
+        )
 
-    # WHEN running the store flow cell command
-    res = cli_runner.invoke(
-        store_flow_cell, [novaseq_6000_pre_1_5_kits_flow_cell_id], obj=populated_compress_context
-    )
+        # THEN assert that the command exits successfully
+        assert res.exit_code == EXIT_SUCCESS
 
-    # THEN assert that the command exits successfully
-    assert res.exit_code == EXIT_SUCCESS
-
-    # THEN assert that we log that we stored FASTQ files
-    assert f"Stored fastq files for {sample_id}" in caplog.text
+        # THEN assert that we log that we stored FASTQ files
+        assert f"Stored fastq files for {sample_id}" in caplog.text
 
 
 def test_store_ticket(
@@ -177,7 +177,7 @@ def test_store_ticket(
     assert f"Stored fastq files for {sample_id}" in caplog.text
 
 
-def test_store_store_demultiplexed_flow_cell(
+def test_store_demultiplexed_flow_cell(
     caplog,
     cli_runner: CliRunner,
     novaseq_6000_pre_1_5_kits_flow_cell_id: str,
@@ -193,7 +193,7 @@ def test_store_store_demultiplexed_flow_cell(
 
     # GIVEN samples objects on a flow cell
     mocker.patch.object(Store, "get_samples_from_flow_cell")
-    Store.get_samples_from_flow_cell.return_value = [sample]
+    Store.get_samples_by_illumina_flow_cell_internal_id.return_value = [sample]
 
     # GIVEN an updated metadata file
     mocker.patch("cg.cli.store.store.update_metadata_paths", return_value=None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,13 +28,7 @@ from cg.apps.lims import LimsAPI
 from cg.apps.slurm.slurm_api import SlurmAPI
 from cg.apps.tb.dto.summary_response import AnalysisSummary, StatusSummary
 from cg.constants import FileExtensions, SequencingFileTag, Workflow
-from cg.constants.constants import (
-    CaseActions,
-    CustomerId,
-    FileFormat,
-    GenomeVersion,
-    Strandedness,
-)
+from cg.constants.constants import CaseActions, CustomerId, FileFormat, GenomeVersion, Strandedness
 from cg.constants.gene_panel import GenePanelMasterList
 from cg.constants.housekeeper_tags import HK_DELIVERY_REPORT_TAG
 from cg.constants.priority import SlurmQos
@@ -44,9 +38,6 @@ from cg.constants.tb import AnalysisTypes
 from cg.io.controller import WriteFile
 from cg.io.json import read_json, write_json
 from cg.io.yaml import read_yaml, write_yaml
-from cg.services.illumina_services.backup_services.encrypt_service import (
-    IlluminaRunEncryptionService,
-)
 from cg.meta.rsync import RsyncAPI
 from cg.meta.tar.tar import TarAPI
 from cg.meta.transfer.external_data import ExternalDataAPI
@@ -63,21 +54,24 @@ from cg.models.rnafusion.rnafusion import RnafusionParameters, RnafusionSampleSh
 from cg.models.run_devices.illumina_run_directory_data import IlluminaRunDirectoryData
 from cg.models.taxprofiler.taxprofiler import TaxprofilerParameters, TaxprofilerSampleSheetEntry
 from cg.models.tomte.tomte import TomteParameters, TomteSampleSheetHeaders
+from cg.services.illumina_services.backup_services.encrypt_service import (
+    IlluminaRunEncryptionService,
+)
 from cg.services.illumina_services.illumina_metrics_service.illumina_metrics_service import (
     IlluminaMetricsService,
 )
 from cg.store.database import create_all_tables, drop_all_tables, initialize_database
 from cg.store.models import (
+    Application,
+    ApplicationVersion,
     Bed,
     BedVersion,
     Case,
     Customer,
+    IlluminaSequencingRun,
     Order,
     Organism,
     Sample,
-    IlluminaSequencingRun,
-    Application,
-    ApplicationVersion,
 )
 from cg.store.store import Store
 from cg.utils import Process
@@ -440,20 +434,6 @@ def demultiplex_context(
     )
     cg_context.housekeeper_api_ = illumina_demultiplexed_runs_post_proccesing_hk_api
     cg_context.status_db_ = store_with_illumina_sequencing_data
-    return cg_context
-
-
-@pytest.fixture
-def updated_demultiplex_context(
-    demultiplexing_api: DemultiplexingAPI,
-    real_housekeeper_api: HousekeeperAPI,
-    cg_context: CGConfig,
-    updated_store_with_demultiplexed_samples: Store,
-) -> CGConfig:
-    """Return cg context with a demultiplex context."""
-    cg_context.demultiplex_api_ = demultiplexing_api
-    cg_context.housekeeper_api_ = real_housekeeper_api
-    cg_context.status_db_ = updated_store_with_demultiplexed_samples
     return cg_context
 
 
@@ -1279,26 +1259,6 @@ def store_with_demultiplexed_samples(
             store,
             sample_internal_id=sample_internal_id,
             flow_cell_name=hiseq_x_dual_index_flow_cell_id,
-        )
-    return store
-
-
-@pytest.fixture
-def updated_store_with_demultiplexed_samples(
-    store: Store,
-    helpers: StoreHelpers,
-    seven_canonical_flow_cells: list[IlluminaRunDirectoryData],
-    seven_canonical_flow_cells_selected_sample_ids: list[list[str]],
-) -> Store:
-    """Return a store with the 7 canonical flow cells with samples added to store."""
-    for flow_cell, sample_internal_ids in zip(
-        seven_canonical_flow_cells, seven_canonical_flow_cells_selected_sample_ids
-    ):
-        helpers.add_flow_cell_and_samples_with_sequencing_metrics(
-            flow_cell_name=flow_cell.id,
-            sequencer=flow_cell.sequencer_type,
-            sample_ids=sample_internal_ids,
-            store=store,
         )
     return store
 

--- a/tests/store/crud/read/test_read.py
+++ b/tests/store/crud/read/test_read.py
@@ -535,7 +535,7 @@ def test_get_flow_cells(re_sequenced_sample_store: Store):
     # GIVEN a store with two flow cells
 
     # WHEN fetching the flow cells
-    flow_cells: list[Flowcell] = re_sequenced_sample_store._get_query(table=Flowcell)
+    flow_cells: list[Flowcell] = re_sequenced_sample_store._get_query(table=Flowcell).all()
 
     # THEN a flow cells should be returned
     assert flow_cells
@@ -589,20 +589,25 @@ def test_get_flow_cells_by_case(
     assert flow_cells[0].name == novaseq_6000_pre_1_5_kits_flow_cell_id
 
 
-def test_get_samples_from_flow_cell(
-    novaseq_6000_pre_1_5_kits_flow_cell_id: str, sample_id: str, re_sequenced_sample_store: Store
+def test_get_samples_from_illumina_flow_cell_internal_id(
+    novaseq_x_flow_cell_id: str, store_with_illumina_sequencing_data: Store
 ):
-    """Test returning samples present on the latest flow cell from the database."""
+    """Test getting samples from an Illumina flow cell by internal ID"""
+    # GIVEN a store with an Illumina flow cell and samples
 
-    # GIVEN a store with two flow cells
-
-    # WHEN fetching the samples from the latest flow cell
-    samples: list[Sample] = re_sequenced_sample_store.get_samples_from_flow_cell(
-        flow_cell_id=novaseq_6000_pre_1_5_kits_flow_cell_id
+    # WHEN fetching the samples from the flow cell
+    samples: list[Sample] = (
+        store_with_illumina_sequencing_data.get_samples_by_illumina_flow_cell_internal_id(
+            flow_cell_id=novaseq_x_flow_cell_id
+        )
     )
 
-    # THEN the returned sample id should have the same id as the one in the database
-    assert samples[0].internal_id == sample_id
+    # THEN a list of samples should be returned
+    assert isinstance(samples, list)
+    assert isinstance(samples[0], Sample)
+
+    # THEN the samples should be from the flow cell
+    assert samples[0]._run_devices[0].internal_id == novaseq_x_flow_cell_id
 
 
 def test_is_all_flow_cells_on_disk_when_no_flow_cell(
@@ -664,7 +669,6 @@ def test_are_all_flow_cells_on_disk_when_requested(
     case_id: str,
     helpers: StoreHelpers,
     sample: Sample,
-    request,
 ):
     """Test check if all flow cells for samples on a case is on disk when requested."""
     caplog.set_level(logging.DEBUG)
@@ -769,7 +773,7 @@ def test_get_application_by_case(case_id: str, rml_pool_store: Store):
 def test_get_application_limitations_by_tag(
     store_with_application_limitations: Store,
     tag: str = StoreConstants.TAG_APPLICATION_WITHOUT_ATTRIBUTES.value,
-) -> ApplicationLimitations:
+):
     """Test get application limitations by application tag."""
 
     # GIVEN a store with some application limitations
@@ -794,7 +798,7 @@ def test_get_application_limitation_by_tag_and_workflow(
     store_with_application_limitations: Store,
     tag: str = StoreConstants.TAG_APPLICATION_WITH_ATTRIBUTES.value,
     workflow: Workflow = Workflow.MIP_DNA,
-) -> ApplicationLimitations:
+):
     """Test get application limitations by application tag and workflow."""
 
     # GIVEN a store with some application limitations


### PR DESCRIPTION
## Description
Replaced old CRUD function `get_samples_from_flow_cell` with `get_samples_by_illumina_flow_cell_internal_id` which works with the new database models.

### Changed

- Updated CLI commands with the new CRUD function:
  - `cg backup retrieve-spring-files`
  - `cg decompress flow-cell`
  - `cg store flow-cell`
  - `cg store demultiplexed-flow-cell`
- Updated tests 

### Fixed

- Remove idling method `_get_samples` defined in the CLI module and redefined it in the CRUD as `get_samples_by_identifier`
- Removed old store fixtures


## Review

- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- Merging to development branch, no deployment yet
