### PR TITLE
Fix the name and signature of store cli using flow-cell

### DIFF
--- a/cg/cli/compress/base.py
+++ b/cg/cli/compress/base.py
@@ -7,7 +7,7 @@ import click
 from cg.cli.compress.fastq import (
     clean_fastq,
     decompress_case,
-    decompress_flowcell,
+    decompress_illumina_run,
     decompress_sample,
     decompress_ticket,
     fastq_cmd,
@@ -15,10 +15,10 @@ from cg.cli.compress.fastq import (
 )
 from cg.cli.utils import CLICK_CONTEXT_SETTINGS
 from cg.meta.backup.backup import SpringBackupAPI
-from cg.services.pdc_service.pdc_service import PdcService
 from cg.meta.compress import CompressAPI
 from cg.meta.encryption.encryption import SpringEncryptionAPI
 from cg.models.cg_config import CGConfig
+from cg.services.pdc_service.pdc_service import PdcService
 
 LOG = logging.getLogger(__name__)
 
@@ -83,4 +83,4 @@ def decompress(context: CGConfig):
 decompress.add_command(decompress_sample)
 decompress.add_command(decompress_case)
 decompress.add_command(decompress_ticket)
-decompress.add_command(decompress_flowcell)
+decompress.add_command(decompress_illumina_run)

--- a/cg/cli/compress/fastq.py
+++ b/cg/cli/compress/fastq.py
@@ -156,11 +156,11 @@ def decompress_case(context: click.Context, case_id, dry_run):
     LOG.info(f"Decompressed spring archives in {decompressed_individuals} samples")
 
 
-@click.command("flow-cell")
+@click.command("illumina-run")
 @click.argument("flow-cell-id", type=str)
 @DRY_RUN
 @click.pass_obj
-def decompress_flowcell(context: click.Context, flow_cell_id: str, dry_run: bool):
+def decompress_illumina_run(context: click.Context, flow_cell_id: str, dry_run: bool):
     """Decompress SPRING files for flow cell, and include links to FASTQ files in Housekeeper."""
 
     store: Store = context.obj.status_db

--- a/cg/cli/store/base.py
+++ b/cg/cli/store/base.py
@@ -8,7 +8,7 @@ from cg.apps.crunchy.crunchy import CrunchyAPI
 from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.cli.store.store import (
     store_case,
-    store_demultiplexed_run,
+    store_demultiplexed_illumina_run,
     store_illumina_run,
     store_qc_metrics,
     store_sample,
@@ -39,7 +39,7 @@ def store(context: CGConfig):
 
 for sub_cmd in [
     store_case,
-    store_demultiplexed_run,
+    store_demultiplexed_illumina_run,
     store_illumina_run,
     store_sample,
     store_ticket,

--- a/cg/cli/store/base.py
+++ b/cg/cli/store/base.py
@@ -6,18 +6,17 @@ import click
 
 from cg.apps.crunchy.crunchy import CrunchyAPI
 from cg.apps.housekeeper.hk import HousekeeperAPI
-from cg.cli.utils import CLICK_CONTEXT_SETTINGS
-from cg.meta.compress.compress import CompressAPI
-from cg.models.cg_config import CGConfig
-
-from .store import (
+from cg.cli.store.store import (
     store_case,
-    store_demultiplexed_flow_cell,
-    store_flow_cell,
+    store_demultiplexed_run,
+    store_illumina_run,
     store_qc_metrics,
     store_sample,
     store_ticket,
 )
+from cg.cli.utils import CLICK_CONTEXT_SETTINGS
+from cg.meta.compress.compress import CompressAPI
+from cg.models.cg_config import CGConfig
 
 LOG = logging.getLogger(__name__)
 
@@ -40,8 +39,8 @@ def store(context: CGConfig):
 
 for sub_cmd in [
     store_case,
-    store_demultiplexed_flow_cell,
-    store_flow_cell,
+    store_demultiplexed_run,
+    store_illumina_run,
     store_sample,
     store_ticket,
     store_qc_metrics,

--- a/cg/cli/store/store.py
+++ b/cg/cli/store/store.py
@@ -101,7 +101,9 @@ def store_ticket(context: click.Context, ticket: str, dry_run: bool) -> None:
 @click.argument("flow-cell-id", type=str)
 @DRY_RUN
 @click.pass_obj
-def store_demultiplexed_run(context: click.Context, flow_cell_id: str, dry_run: bool) -> None:
+def store_demultiplexed_illumina_run(
+    context: click.Context, flow_cell_id: str, dry_run: bool
+) -> None:
     """
     Include all flow cell bundle and sequencing files to Housekeeper. Updates SPRING metadata file.
     """

--- a/cg/cli/store/store.py
+++ b/cg/cli/store/store.py
@@ -69,13 +69,12 @@ def store_case(context: click.Context, case_id: str, dry_run: bool) -> None:
     LOG.info(f"Stored fastq files for {stored_individuals} samples")
 
 
-@click.command("flow-cell")
+@click.command("illumina-run")
 @click.argument("flow-cell-id", type=str)
 @DRY_RUN
 @click.pass_context
-def store_flow_cell(context: click.Context, flow_cell_id: str, dry_run: bool) -> None:
-    """Include links to decompressed FASTQ files belonging to this flow cell in Housekeeper."""
-
+def store_illumina_run(context: click.Context, flow_cell_id: str, dry_run: bool) -> None:
+    """Include links to decompressed FASTQ files belonging to this Illumina run to Housekeeper."""
     status_db: Store = context.obj.status_db
     samples: list[Sample] = status_db.get_samples_by_illumina_flow_cell(flow_cell_id)
     stored_individuals: int = invoke_store_samples(
@@ -98,12 +97,14 @@ def store_ticket(context: click.Context, ticket: str, dry_run: bool) -> None:
     LOG.info(f"Stored fastq files for {stored_individuals} samples")
 
 
-@click.command("demultiplexed-flow-cell")
+@click.command("demultiplexed-run")
 @click.argument("flow-cell-id", type=str)
 @DRY_RUN
 @click.pass_obj
-def store_demultiplexed_flow_cell(context: click.Context, flow_cell_id: str, dry_run: bool) -> None:
-    """Include all files in a flow cell bundle and its corresponding sequencing files. Updates SPRING metadata file"""
+def store_demultiplexed_run(context: click.Context, flow_cell_id: str, dry_run: bool) -> None:
+    """
+    Include all flow cell bundle and sequencing files to Housekeeper. Updates SPRING metadata file.
+    """
     compress_api: CompressAPI = context.meta_apis["compress_api"]
     status_db: Store = context.status_db
     update_compress_api(compress_api, dry_run=dry_run)

--- a/tests/cli/store/test_store.py
+++ b/tests/cli/store/test_store.py
@@ -4,7 +4,7 @@ from click.testing import CliRunner
 
 from cg.cli.store.store import (
     store_case,
-    store_demultiplexed_run,
+    store_demultiplexed_illumina_run,
     store_illumina_run,
     store_sample,
     store_ticket,
@@ -200,7 +200,7 @@ def test_store_demultiplexed_flow_cell(
 
     # WHEN running the store demultiplexed flow cell command
     res = cli_runner.invoke(
-        store_demultiplexed_run,
+        store_demultiplexed_illumina_run,
         [novaseq_6000_pre_1_5_kits_flow_cell_id],
         obj=real_populated_compress_context,
     )

--- a/tests/cli/store/test_store.py
+++ b/tests/cli/store/test_store.py
@@ -4,8 +4,8 @@ from click.testing import CliRunner
 
 from cg.cli.store.store import (
     store_case,
-    store_demultiplexed_flow_cell,
-    store_flow_cell,
+    store_demultiplexed_run,
+    store_illumina_run,
     store_sample,
     store_ticket,
 )
@@ -139,7 +139,7 @@ def test_store_flow_cell(
 
         # WHEN running the store flow cell command
         res = cli_runner.invoke(
-            store_flow_cell,
+            store_illumina_run,
             [novaseq_6000_pre_1_5_kits_flow_cell_id],
             obj=populated_compress_context,
         )
@@ -200,7 +200,7 @@ def test_store_demultiplexed_flow_cell(
 
     # WHEN running the store demultiplexed flow cell command
     res = cli_runner.invoke(
-        store_demultiplexed_flow_cell,
+        store_demultiplexed_run,
         [novaseq_6000_pre_1_5_kits_flow_cell_id],
         obj=real_populated_compress_context,
     )


### PR DESCRIPTION
## Description

Some CLI commands still had `flow-cell` in their signature and name. Changed for the appropriate name from Illumina.

### Changed

- `cg store flow-cell`-> `cg store illumina-run`
- `cg store demultiplexed-flow-cell` -> `cg store demultiplexed-run`
- `cg decompress flow-cell` -> `cg decompress illumina-run`

As soon as this is merged to the dev branch, I will update the list of commands to test