### PR TITLE
Remove pandas from gsaid api

### DIFF
--- a/cg/cli/upload/fohm.py
+++ b/cg/cli/upload/fohm.py
@@ -80,7 +80,7 @@ def preprocess_all(
     upload_cases = []
     for case_id in cases:
         try:
-            gisaid_api.upload(case_id=case_id)
+            gisaid_api.upload_to_gisaid(case_id)
             fohm_api.update_upload_started_at(case_id=case_id)
             LOG.info(f"Upload of case {case_id} to GISAID was successful")
             upload_cases.append(case_id)

--- a/cg/cli/upload/gisaid.py
+++ b/cg/cli/upload/gisaid.py
@@ -1,4 +1,4 @@
-"""Code for uploading genotype data via CLI"""
+"""Code for uploading genotype data via CLI."""
 
 import logging
 
@@ -18,7 +18,7 @@ def upload_to_gisaid(context: CGConfig, case_id: str):
 
     LOG.info("----------------- GISAID UPLOAD -------------------")
 
-    gisaid_api = GisaidAPI(config=context)
+    gisaid_api = GisaidAPI(context)
 
-    gisaid_api.upload(case_id=case_id)
+    gisaid_api.upload_to_gisaid(case_id)
     LOG.info("Upload to GISAID successful")

--- a/cg/constants/constants.py
+++ b/cg/constants/constants.py
@@ -198,6 +198,7 @@ class FileExtensions(StrEnum):
     CONFIG: str = ".config"
     CRAM: str = ".cram"
     CSV: str = ".csv"
+    FASTA: str = ".fasta"
     FASTQ: str = ".fastq"
     FASTQ_GZ: str = ".fastq.gz"
     GPG: str = ".gpg"

--- a/cg/constants/housekeeper_tags.py
+++ b/cg/constants/housekeeper_tags.py
@@ -241,3 +241,10 @@ class JanusTags:
         "star",
         "general-stats",
     ]
+
+
+class GisaidTag(StrEnum):
+    FASTA = "gisaid-fasta"
+    CONSENSUS_SAMPLE = "consensus-sample"
+    CSV = "gisaid-csv"
+    LOG = "gisaid-log"

--- a/cg/io/csv.py
+++ b/cg/io/csv.py
@@ -42,6 +42,17 @@ def write_csv(content: list[list[Any]], file_path: Path, delimiter: str = ",") -
             csv_writer.writerow(row)
 
 
+def write_csv_from_dict(
+    content: list[dict[Any]], fieldnames: list[str], file_path: Path, delimiter: str = ","
+) -> None:
+    """Write content to a CSV file."""
+    with open(file_path, "w", newline="") as file:
+        csv_writer = csv.DictWriter(file, delimiter=delimiter, fieldnames=fieldnames)
+        csv_writer.writeheader()
+        for row in content:
+            csv_writer.writerow(row)
+
+
 def write_csv_stream(content: list[list[Any]], delimiter: str = ",") -> str:
     """Write content to a CSV stream."""
     csv_stream = io.StringIO()

--- a/cg/meta/upload/gisaid/gisaid.py
+++ b/cg/meta/upload/gisaid/gisaid.py
@@ -5,24 +5,24 @@ import re
 import tempfile
 from pathlib import Path
 
-import pandas as pd
 from housekeeper.store.models import File
 
 from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.apps.lims import LimsAPI
+from cg.constants import FileExtensions
 from cg.constants.constants import SARS_COV_REGEX, FileFormat
+from cg.constants.housekeeper_tags import GisaidTag
 from cg.exc import HousekeeperFileMissingError
 from cg.io.controller import ReadFile, WriteFile
 from cg.io.csv import write_csv_from_dict
-from cg.models.cg_config import CGConfig
+from cg.meta.upload.gisaid.constants import HEADERS
+from cg.meta.upload.gisaid.models import GisaidAccession, GisaidSample
+from cg.models.cg_config import CGConfig, EmailBaseSettings
 from cg.models.gisaid.reports import GisaidComplementaryReport
 from cg.store.models import Sample
 from cg.store.store import Store
 from cg.utils import Process
 from cg.utils.dict import remove_duplicate_dicts
-
-from .constants import HEADERS
-from .models import GisaidAccession, GisaidSample
 
 LOG = logging.getLogger(__name__)
 
@@ -30,7 +30,7 @@ UPLOADED_REGEX_MATCH = r"\[\"([A-Za-z0-9_]+)\"\]\}$"
 
 
 class GisaidAPI:
-    """Interface with Gisaid CLI upload."""
+    """Interface with GISAID CLI."""
 
     def __init__(self, config: CGConfig):
         self.housekeeper_api: HousekeeperAPI = config.housekeeper_api
@@ -42,9 +42,8 @@ class GisaidAPI:
         self.gisaid_binary: str = config.gisaid.binary_path
         self.gisaid_log_dir: str = config.gisaid.log_dir
         self.log_watch: str = config.gisaid.logwatch_email
-        self.email_base_settings = config.email_base_settings
+        self.email_base_settings: EmailBaseSettings = config.email_base_settings
         self.mutant_root_dir = Path(config.mutant.root)
-
         self.process = Process(binary=self.gisaid_binary)
 
     @staticmethod
@@ -61,7 +60,7 @@ class GisaidAPI:
         """Validate GISAID complementary reports.
         Raises:
             ValidateError."""
-        complementary_reports = []
+        complementary_reports: list[GisaidComplementaryReport] = []
         for report in reports:
             complementary_report = GisaidComplementaryReport.model_validate(report)
             complementary_reports.append(complementary_report)
@@ -78,8 +77,16 @@ class GisaidAPI:
     def get_complementary_report_sample_number(
         reports: list[GisaidComplementaryReport],
     ) -> set[str]:
-        """Return all unique samples in reports."""
+        """Return all unique sample numbers in reports."""
         return {report.sample_number for report in reports}
+
+    @staticmethod
+    def add_gisaid_accession_to_complementary_reports(
+        gisaid_accession: dict[str, str], reports: list[GisaidComplementaryReport]
+    ) -> None:
+        """Add GISAID accession to complementary reports."""
+        for report in reports:
+            report.gisaid_accession = gisaid_accession[report.sample_number]
 
     def get_complementary_report_samples(self, sample_numbers: set[str]) -> list[Sample]:
         """Return all unique samples in reports."""
@@ -89,7 +96,7 @@ class GisaidAPI:
         ]
 
     def get_complementary_file_from_hk(self, case_id: str) -> File:
-        """Return complementary file."""
+        """Return complementary file from Housekeeper."""
         complementary_file: File | None = self.housekeeper_api.get_file_from_latest_version(
             bundle_name=case_id, tags=["komplettering"]
         )
@@ -98,34 +105,17 @@ class GisaidAPI:
             raise HousekeeperFileMissingError(message=msg)
         return complementary_file
 
-    def get_completion_dataframe(self, completion_file: File) -> pd.DataFrame:
-        """Read completion file in to dataframe, drop duplicates, and return the dataframe"""
-        completion_df = pd.read_csv(completion_file.full_path, index_col=None, header=0)
-        completion_df.drop_duplicates(inplace=True)
-        completion_df = completion_df[completion_df["provnummer"].str.contains(SARS_COV_REGEX)]
-        return completion_df
-
-    def get_gisaid_sample_list(self, case_id: str) -> list[Sample]:
-        """Get list of Sample objects eligeble for upload.
-        The criteria is that the sample reached 20x coverage for >95% bases.
-        The sample will be included in completion file."""
-
-        completion_file = self.get_complementary_file_from_hk(case_id=case_id)
-        completion_df = self.get_completion_dataframe(completion_file=completion_file)
-        sample_names = list(completion_df["provnummer"].unique())
-        return [self.status_db.get_sample_by_name(name=sample_name) for sample_name in sample_names]
-
-    def get_gisaid_fasta_path(self, case_id: str) -> Path:
-        """Get path to gisaid fasta"""
-        return Path(self.mutant_root_dir, case_id, "results", f"{case_id}.fasta")
+    def get_gisaid_fasta_file_path(self, case_id: str) -> Path:
+        """Return the path to GISAID FASTA file."""
+        return Path(self.mutant_root_dir, case_id, "results", f"{case_id}{FileExtensions.FASTA}")
 
     def get_gisaid_csv_path(self, case_id: str) -> Path:
-        """Get path to gisaid csv"""
-        return Path(self.mutant_root_dir, case_id, "results", f"{case_id}.csv")
+        """Return the path to GISAID CSV file."""
+        return Path(self.mutant_root_dir, case_id, "results", f"{case_id}{FileExtensions.CSV}")
 
-    def get_gisaid_samples_csv(self, case_id: str, samples: list[Sample]) -> list[GisaidSample]:
-        """Return Gisaid samples."""
-        gisaid_samples = []
+    def get_gisaid_samples(self, case_id: str, samples: list[Sample]) -> list[GisaidSample]:
+        """Return GISAID samples."""
+        gisaid_samples: list[GisaidSample] = []
         for sample in samples:
             sample_id: str = sample.internal_id
             LOG.info(f"Creating GisaidSample for {sample_id}")
@@ -134,7 +124,7 @@ class GisaidAPI:
                 cg_lims_id=sample_id,
                 covv_subm_sample_id=sample.name,
                 submitter=self.gisaid_submitter,
-                fn=f"{case_id}.fasta",
+                fn=f"{case_id}{FileExtensions.FASTA}",
                 covv_collection_date=str(
                     self.lims_api.get_sample_attribute(lims_id=sample_id, key="collection_date")
                 ),
@@ -152,134 +142,81 @@ class GisaidAPI:
             gisaid_samples.append(gisaid_sample)
         return gisaid_samples
 
-    def get_gisaid_samples(self, case_id: str) -> list[GisaidSample]:
-        """Get list of Gisaid sample objects."""
+    def create_and_include_gisaid_fasta_to_hk(
+        self, gisaid_samples: list[GisaidSample], case_id: str
+    ) -> None:
+        """Create and include a FASTA with headers adjusted for GISAID upload results to GISAID."""
 
-        samples: list[Sample] = self.get_gisaid_sample_list(case_id=case_id)
-        gisaid_samples = []
-        for sample in samples:
-            sample_id: str = sample.internal_id
-            LOG.info(f"Creating GisaidSample for {sample_id}")
-            gisaid_sample = GisaidSample(
-                case_id=case_id,
-                cg_lims_id=sample_id,
-                covv_subm_sample_id=sample.name,
-                submitter=self.gisaid_submitter,
-                fn=f"{case_id}.fasta",
-                covv_collection_date=str(
-                    self.lims_api.get_sample_attribute(lims_id=sample_id, key="collection_date")
-                ),
-                region=self.lims_api.get_sample_attribute(lims_id=sample_id, key="region"),
-                region_code=self.lims_api.get_sample_attribute(
-                    lims_id=sample_id, key="region_code"
-                ),
-                covv_orig_lab=self.lims_api.get_sample_attribute(
-                    lims_id=sample_id, key="original_lab"
-                ),
-                covv_orig_lab_addr=self.lims_api.get_sample_attribute(
-                    lims_id=sample_id, key="original_lab_address"
-                ),
-            )
-            gisaid_samples.append(gisaid_sample)
-        return gisaid_samples
-
-    def create_gisaid_fasta(self, gisaid_samples: list[GisaidSample], case_id: str) -> None:
-        """Writing a new fasta with headers adjusted for gisaid upload_results_to_gisaid"""
-
-        gisaid_fasta_file = self.housekeeper_api.get_file_from_latest_version(
-            bundle_name=case_id, tags=["gisaid-fasta", case_id]
+        gisaid_fasta: File | None = self.housekeeper_api.get_file_from_latest_version(
+            bundle_name=case_id, tags={GisaidTag.FASTA, case_id}
         )
-        if gisaid_fasta_file:
-            gisaid_fasta_path = gisaid_fasta_file.full_path
+        if gisaid_fasta:
+            gisaid_fasta_path = Path(gisaid_fasta.full_path)
         else:
-            gisaid_fasta_path: Path = self.get_gisaid_fasta_path(case_id=case_id)
+            gisaid_fasta_path: Path = self.get_gisaid_fasta_file_path(case_id=case_id)
 
         fasta_lines: list[str] = []
 
         for sample in gisaid_samples:
-            fasta_file: File = self.housekeeper_api.get_file_from_latest_version(
-                bundle_name=case_id, tags=[sample.cg_lims_id, "consensus-sample"]
+            fasta_file: File | None = self.housekeeper_api.get_file_from_latest_version(
+                bundle_name=case_id, tags={sample.cg_lims_id, GisaidTag.CONSENSUS_SAMPLE}
             )
             if not fasta_file:
                 raise HousekeeperFileMissingError(
-                    message=f"No fasta file found for sample {sample.cg_lims_id}"
+                    message=f"No FASTA file found for sample {sample.cg_lims_id}"
                 )
-            with open(str(fasta_file.full_path)) as handle:
-                for line in handle.readlines():
+            with open(fasta_file.full_path) as read_handle:
+                for line in read_handle:
                     if line[0] == ">":
                         fasta_lines.append(f">{sample.covv_virus_name}\n")
                     else:
                         fasta_lines.append(line)
 
-        with open(gisaid_fasta_path, "w") as write_file_obj:
-            write_file_obj.writelines(fasta_lines)
+        with open(gisaid_fasta_path, "w") as write_handle:
+            write_handle.writelines(fasta_lines)
 
-        if gisaid_fasta_file:
+        if gisaid_fasta:
             return
 
         self.housekeeper_api.add_and_include_file_to_latest_version(
-            bundle_name=case_id, file=gisaid_fasta_path, tags=["gisaid-fasta", case_id]
+            bundle_name=case_id, file=gisaid_fasta_path, tags=[GisaidTag.FASTA, case_id]
         )
 
-    def create_gisaid_csv_hs(self, gisaid_samples: list[GisaidSample], case_id: str) -> None:
-        """Create CSV file for GISAID samples."""
-        gisaid_csv_file: File | None = self.housekeeper_api.get_file_from_latest_version(
-            bundle_name=case_id, tags=["gisaid-csv", case_id]
+    def create_and_include_gisaid_samples_to_hk(
+        self, gisaid_samples: list[GisaidSample], case_id: str
+    ) -> None:
+        """Create and include CSV file for GISAID samples to Housekeeper."""
+        gisaid_samples_csv: File | None = self.housekeeper_api.get_file_from_latest_version(
+            bundle_name=case_id, tags={GisaidTag.CSV, case_id}
         )
-        if gisaid_csv_file:
-            LOG.info(f"GISAID CSV for case {case_id} exists, will be replaced")
-            gisaid_csv_path = gisaid_csv_file.full_path
+        if gisaid_samples_csv:
+            LOG.info(f"GISAID samples CSV for case {case_id} exists, and will be replaced")
+            gisaid_csv_path = Path(gisaid_samples_csv.full_path)
         else:
             gisaid_csv_path: Path = self.get_gisaid_csv_path(case_id=case_id)
-        all_samples: list[dict] = [sample.model_dump() for sample in gisaid_samples]
-        write_csv_from_dict(content=all_samples, fieldnames=HEADERS, file_path=gisaid_csv_path)
-
-        if gisaid_csv_file:
+        samples: list[dict] = [sample.model_dump() for sample in gisaid_samples]
+        write_csv_from_dict(content=samples, fieldnames=HEADERS, file_path=gisaid_csv_path)
+        if gisaid_samples_csv:
             return
-
         self.housekeeper_api.add_and_include_file_to_latest_version(
-            bundle_name=case_id, file=gisaid_csv_path, tags=["gisaid-csv", case_id]
+            bundle_name=case_id, file=gisaid_csv_path, tags=[GisaidTag.CSV, case_id]
         )
 
-    def create_gisaid_csv(self, gisaid_samples: list[GisaidSample], case_id: str) -> None:
-        """Create csv file for gisaid upload"""
-        samples_df = pd.DataFrame(
-            data=[gisaid_sample.model_dump() for gisaid_sample in gisaid_samples],
-            columns=HEADERS,
-        )
-
-        gisaid_csv_file = self.housekeeper_api.get_file_from_latest_version(
-            bundle_name=case_id, tags=["gisaid-csv", case_id]
-        )
-        if gisaid_csv_file:
-            LOG.info(f"GISAID CSV for case {case_id} exists, will be replaced")
-            gisaid_csv_path = gisaid_csv_file.full_path
-        else:
-            gisaid_csv_path = self.get_gisaid_csv_path(case_id=case_id)
-        samples_df.to_csv(gisaid_csv_path, sep=",", index=False)
-
-        if gisaid_csv_file:
-            return
-
-        self.housekeeper_api.add_and_include_file_to_latest_version(
-            bundle_name=case_id, file=gisaid_csv_path, tags=["gisaid-csv", case_id]
-        )
-
-    def create_gisaid_log_file(self, case_id: str) -> None:
-        """Path for gisaid bundle log"""
+    def create_and_include_gisaid_log_file_to_hk(self, case_id: str) -> None:
+        """Create and include GISAID log file to a Housekeeper."""
         if _ := self.housekeeper_api.get_files(
-            bundle=case_id, tags=["gisaid-log", case_id]
+            bundle=case_id, tags=[GisaidTag.LOG, case_id]
         ).first():
-            LOG.info("GISAID log exists in case bundle in Housekeeper")
+            LOG.info(f"GISAID log exists in case: {case_id} bundle in Housekeeper")
             return
 
-        log_file_path = Path(self.gisaid_log_dir, case_id).with_suffix(".log")
+        log_file_path = Path(self.gisaid_log_dir, case_id).with_suffix(FileExtensions.LOG)
         if not log_file_path.parent.exists():
             raise ValueError(f"GISAID log dir: {self.gisaid_log_dir} does not exist")
         if not log_file_path.exists():
             log_file_path.touch()
         self.housekeeper_api.add_and_include_file_to_latest_version(
-            bundle_name=case_id, file=log_file_path, tags=["gisaid-log", case_id]
+            bundle_name=case_id, file=log_file_path, tags=[GisaidTag.LOG, case_id]
         )
 
     def parse_and_get_sars_cov_complementary_reports(
@@ -296,30 +233,23 @@ class GisaidAPI:
         )
         return self.get_sars_cov_complementary_reports(complementary_report_sars_cov)
 
-    def create_gisaid_files_in_housekeeper(self, case_id: str) -> None:
-        """Create all gisaid files in Housekeeper, if needed."""
-        gisaid_samples = self.get_gisaid_samples(case_id=case_id)
-        self.create_gisaid_csv(gisaid_samples=gisaid_samples, case_id=case_id)
-        self.create_gisaid_fasta(gisaid_samples=gisaid_samples, case_id=case_id)
-        self.create_gisaid_log_file(case_id=case_id)
-
-    def create_gisaid_files_in_housekeeper_csv(self, case_id: str) -> None:
-        """Create all GISAID files in Housekeeper."""
+    def create_and_include_gisaid_files_in_hk(self, case_id: str) -> None:
+        """Create and include all GISAID files in Housekeeper."""
         complementary_report_file: Path = self.get_complementary_file_from_hk(case_id)
-        complementary_report_sars_cov: list[GisaidComplementaryReport] = (
+        sars_cov_complementary_reports: list[GisaidComplementaryReport] = (
             self.parse_and_get_sars_cov_complementary_reports(complementary_report_file)
         )
         sample_numbers: set[str] = self.get_complementary_report_sample_number(
-            complementary_report_sars_cov
+            sars_cov_complementary_reports
         )
         samples: list[Sample] = self.get_complementary_report_samples(sample_numbers)
 
-        gisaid_samples: list[GisaidSample] = self.get_gisaid_samples_csv(
+        gisaid_samples: list[GisaidSample] = self.get_gisaid_samples(
             case_id=case_id, samples=samples
         )
-        self.create_gisaid_csv_hs(case_id=case_id, gisaid_samples=gisaid_samples)
-        self.create_gisaid_fasta(gisaid_samples=gisaid_samples, case_id=case_id)
-        self.create_gisaid_log_file(case_id=case_id)
+        self.create_and_include_gisaid_samples_to_hk(gisaid_samples=gisaid_samples, case_id=case_id)
+        self.create_and_include_gisaid_fasta_to_hk(gisaid_samples=gisaid_samples, case_id=case_id)
+        self.create_and_include_gisaid_log_file_to_hk(case_id)
 
     def authenticate_gisaid(self):
         load_call: list = [
@@ -335,21 +265,21 @@ class GisaidAPI:
         self.process.run_command(parameters=load_call)
 
     def upload_results_to_gisaid(self, case_id: str) -> None:
-        """Load batch data to GISAID using the gisiad cli."""
+        """Load batch data to GISAID using the GISAID CLI."""
 
         temp_log_file = tempfile.NamedTemporaryFile(
             dir=self.gisaid_log_dir, mode="w+", delete=False
         )
-        gisaid_csv_path = self.housekeeper_api.get_file_from_latest_version(
-            bundle_name=case_id, tags=["gisaid-csv", case_id]
+        gisaid_csv_file: str = self.housekeeper_api.get_file_from_latest_version(
+            bundle_name=case_id, tags={GisaidTag.CSV, case_id}
         ).full_path
 
-        gisaid_fasta_path = self.housekeeper_api.get_file_from_latest_version(
-            bundle_name=case_id, tags=["gisaid-fasta", case_id]
+        gisaid_fasta_file: str = self.housekeeper_api.get_file_from_latest_version(
+            bundle_name=case_id, tags={GisaidTag.FASTA, case_id}
         ).full_path
 
-        gisaid_log_path = (
-            self.housekeeper_api.get_files(bundle=case_id, tags=["gisaid-log", case_id])
+        gisaid_log_file: str = (
+            self.housekeeper_api.get_files(bundle=case_id, tags=[GisaidTag.LOG, case_id])
             .first()
             .full_path
         )
@@ -361,20 +291,22 @@ class GisaidAPI:
             "CoV",
             "upload",
             "--csv",
-            gisaid_csv_path,
+            gisaid_csv_file,
             "--fasta",
-            gisaid_fasta_path,
+            gisaid_fasta_file,
         ]
         self.process.run_command(parameters=load_call)
-        self.append_log(temp_log=Path(temp_log_file.name), gisaid_log=Path(gisaid_log_path))
+        self.append_to_gisaid_log(
+            temp_log=Path(temp_log_file.name), gisaid_log=Path(gisaid_log_file)
+        )
         temp_log_file.close()
         if self.process.stderr:
             LOG.info(f"gisaid stderr:\n{self.process.stderr}")
         if self.process.stdout:
             LOG.info(f"gisaid stdout:\n{self.process.stdout}")
 
-    def append_log(self, temp_log: Path, gisaid_log: Path) -> None:
-        """Appends temp log to gisaid log and delete temp file"""
+    def append_to_gisaid_log(self, temp_log: Path, gisaid_log: Path) -> None:
+        """Appends temp log to GISAID log and delete temp file."""
         new_log_data = ReadFile.get_content_from_file(
             file_format=FileFormat.JSON, file_path=temp_log.absolute()
         )
@@ -417,72 +349,38 @@ class GisaidAPI:
                 accession_numbers[gisaid_accession.sample_id] = gisaid_accession.accession_nr
         return accession_numbers
 
-    def add_gisaid_accession_to_complementary_reports(
-        self, gisaid_accession: dict[str, str], reports: list[GisaidComplementaryReport]
-    ) -> None:
-        """Add GISAID accession to complementary reports."""
-        for report in reports:
-            report.gisaid_accession = gisaid_accession[report.sample_number]
-
     def update_complementary_file_with_gisaid_accessions(self, case_id: str) -> None:
         """Update complementary file with GISAID accession numbers."""
         complementary_report: File | None = self.get_complementary_file_from_hk(case_id=case_id)
         accession: dict = self.get_gisaid_accession_numbers(case_id=case_id)
-        complementary_report_sars_cov: list[GisaidComplementaryReport] = (
+        sars_cov_complementary_reports: list[GisaidComplementaryReport] = (
             self.parse_and_get_sars_cov_complementary_reports(Path(complementary_report.full_path))
         )
         self.add_gisaid_accession_to_complementary_reports(
-            gisaid_accession=accession, reports=complementary_report_sars_cov
+            gisaid_accession=accession, reports=sars_cov_complementary_reports
         )
-        all_reports: list[dict] = [report.model_dump() for report in complementary_report_sars_cov]
+        reports: list[dict] = [report.model_dump() for report in sars_cov_complementary_reports]
         write_csv_from_dict(
-            content=all_reports, fieldnames=HEADERS, file_path=Path(complementary_report.full_path)
+            content=reports, fieldnames=HEADERS, file_path=Path(complementary_report.full_path)
         )
 
-    def update_completion_file(self, case_id: str) -> None:
-        """Update completion file with accession numbers"""
-        completion_file = self.get_complementary_file_from_hk(case_id=case_id)
-        accession_dict = self.get_gisaid_accession_numbers(case_id=case_id)
-        completion_df = self.get_completion_dataframe(completion_file=completion_file)
-        completion_df["GISAID_accession"] = completion_df["provnummer"].apply(
-            lambda x: accession_dict[x]
-        )
-        completion_df.to_csv(
-            completion_file.full_path,
-            sep=",",
-            index=False,
-        )
-
-    def upload(self, case_id: str) -> None:
-        """Uploading results to gisaid and saving the accession numbers in completion file"""
-
-        completion_file = self.get_complementary_file_from_hk(case_id=case_id)
-        completion_df = self.get_completion_dataframe(completion_file=completion_file)
-        if len(completion_df["GISAID_accession"].dropna()) == len(completion_df["provnummer"]):
-            LOG.info("All samples already uploaded")
-            return
-
-        self.create_gisaid_files_in_housekeeper(case_id=case_id)
-        self.upload_results_to_gisaid(case_id=case_id)
-        self.update_completion_file(case_id=case_id)
-
-    def upload_hs(self, case_id: str) -> None:
+    def upload_to_gisaid(self, case_id: str) -> None:
         """Uploading results to GISAID and saving the accession numbers in complementary file."""
         gisaid_accession_count: int = 0
         sample_number_count: int = 0
         complementary_report_file: File | None = self.get_complementary_file_from_hk(case_id)
-        complementary_report_sars_cov: list[GisaidComplementaryReport] = (
+        sars_cov_complementary_reports: list[GisaidComplementaryReport] = (
             self.parse_and_get_sars_cov_complementary_reports(complementary_report_file)
         )
-        for report in complementary_report_sars_cov:
+        for report in sars_cov_complementary_reports:
             if report.gisaid_accession:
                 gisaid_accession_count += 1
             if report.sample_number:
                 sample_number_count += 1
-        if len(gisaid_accession_count) == len(sample_number_count):
+        if gisaid_accession_count == sample_number_count:
             LOG.info("All samples already uploaded")
             return
 
-        self.create_gisaid_files_in_housekeeper_csv(case_id=case_id)
+        self.create_and_include_gisaid_files_in_hk(case_id=case_id)
         self.upload_results_to_gisaid(case_id=case_id)
         self.update_complementary_file_with_gisaid_accessions(case_id=case_id)

--- a/cg/meta/upload/gisaid/gisaid.py
+++ b/cg/meta/upload/gisaid/gisaid.py
@@ -101,7 +101,7 @@ class GisaidAPI:
             bundle_name=case_id, tags=["komplettering"]
         )
         if not complementary_file:
-            msg = f"completion file missing for bundle: {case_id}"
+            msg = f"Complementary file missing for bundle: {case_id}"
             raise HousekeeperFileMissingError(message=msg)
         return complementary_file
 
@@ -151,9 +151,9 @@ class GisaidAPI:
             bundle_name=case_id, tags={GisaidTag.FASTA, case_id}
         )
         if gisaid_fasta:
-            gisaid_fasta_path = Path(gisaid_fasta.full_path)
+            gisaid_fasta_file = Path(gisaid_fasta.full_path)
         else:
-            gisaid_fasta_path: Path = self.get_gisaid_fasta_file_path(case_id=case_id)
+            gisaid_fasta_file: Path = self.get_gisaid_fasta_file_path(case_id=case_id)
 
         fasta_lines: list[str] = []
 
@@ -172,14 +172,14 @@ class GisaidAPI:
                     else:
                         fasta_lines.append(line)
 
-        with open(gisaid_fasta_path, "w") as write_handle:
+        with open(gisaid_fasta_file, "w") as write_handle:
             write_handle.writelines(fasta_lines)
 
         if gisaid_fasta:
             return
 
         self.housekeeper_api.add_and_include_file_to_latest_version(
-            bundle_name=case_id, file=gisaid_fasta_path, tags=[GisaidTag.FASTA, case_id]
+            bundle_name=case_id, file=gisaid_fasta_file, tags=[GisaidTag.FASTA, case_id]
         )
 
     def create_and_include_gisaid_samples_to_hk(
@@ -191,15 +191,15 @@ class GisaidAPI:
         )
         if gisaid_samples_csv:
             LOG.info(f"GISAID samples CSV for case {case_id} exists, and will be replaced")
-            gisaid_csv_path = Path(gisaid_samples_csv.full_path)
+            gisaid_csv_file = Path(gisaid_samples_csv.full_path)
         else:
-            gisaid_csv_path: Path = self.get_gisaid_csv_path(case_id=case_id)
+            gisaid_csv_file: Path = self.get_gisaid_csv_path(case_id=case_id)
         samples: list[dict] = [sample.model_dump() for sample in gisaid_samples]
-        write_csv_from_dict(content=samples, fieldnames=HEADERS, file_path=gisaid_csv_path)
+        write_csv_from_dict(content=samples, fieldnames=HEADERS, file_path=gisaid_csv_file)
         if gisaid_samples_csv:
             return
         self.housekeeper_api.add_and_include_file_to_latest_version(
-            bundle_name=case_id, file=gisaid_csv_path, tags=[GisaidTag.CSV, case_id]
+            bundle_name=case_id, file=gisaid_csv_file, tags=[GisaidTag.CSV, case_id]
         )
 
     def create_and_include_gisaid_log_file_to_hk(self, case_id: str) -> None:
@@ -210,13 +210,13 @@ class GisaidAPI:
             LOG.info(f"GISAID log exists in case: {case_id} bundle in Housekeeper")
             return
 
-        log_file_path = Path(self.gisaid_log_dir, case_id).with_suffix(FileExtensions.LOG)
-        if not log_file_path.parent.exists():
+        log_file = Path(self.gisaid_log_dir, case_id).with_suffix(FileExtensions.LOG)
+        if not log_file.parent.exists():
             raise ValueError(f"GISAID log dir: {self.gisaid_log_dir} does not exist")
-        if not log_file_path.exists():
-            log_file_path.touch()
+        if not log_file.exists():
+            log_file.touch()
         self.housekeeper_api.add_and_include_file_to_latest_version(
-            bundle_name=case_id, file=log_file_path, tags=[GisaidTag.LOG, case_id]
+            bundle_name=case_id, file=log_file, tags=[GisaidTag.LOG, case_id]
         )
 
     def parse_and_get_sars_cov_complementary_reports(

--- a/cg/models/gisaid/reports.py
+++ b/cg/models/gisaid/reports.py
@@ -1,0 +1,11 @@
+"""GISAID report models."""
+
+from pydantic import BaseModel, Field
+
+
+class GisaidComplementaryReport(BaseModel):
+    """Model for validating a GSAID complementary reports."""
+
+    gsaid_accession: str = None
+    sample_number: str = Field(str, alias="provnummer")
+    selection_criteria: str = Field(str, alias="urvalskriterium")

--- a/cg/models/gisaid/reports.py
+++ b/cg/models/gisaid/reports.py
@@ -6,6 +6,6 @@ from pydantic import BaseModel, Field
 class GisaidComplementaryReport(BaseModel):
     """Model for validating a GSAID complementary reports."""
 
-    gsaid_accession: str = None
+    gisaid_accession: str = Field(None, alias="GISAID_accession")
     sample_number: str = Field(str, alias="provnummer")
     selection_criteria: str = Field(str, alias="urvalskriterium")

--- a/cg/utils/dict.py
+++ b/cg/utils/dict.py
@@ -1,6 +1,13 @@
 """Module to handle dictionary helper functions."""
 
 
+def remove_duplicate_dicts(dicts: list[dict]) -> list[dict]:
+    return [
+        dict(dictionary_tuple)
+        for dictionary_tuple in {tuple(dictionary.items()) for dictionary in dicts}
+    ]
+
+
 def get_list_from_dictionary(dictionary: dict) -> list:
     """Return a list of the passed dict non-empty key values."""
     list_from_dict: list[str] = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,13 @@ from cg.apps.lims import LimsAPI
 from cg.apps.slurm.slurm_api import SlurmAPI
 from cg.apps.tb.dto.summary_response import AnalysisSummary, StatusSummary
 from cg.constants import FileExtensions, SequencingFileTag, Workflow
-from cg.constants.constants import CaseActions, CustomerId, FileFormat, GenomeVersion, Strandedness
+from cg.constants.constants import (
+    CaseActions,
+    CustomerId,
+    FileFormat,
+    GenomeVersion,
+    Strandedness,
+)
 from cg.constants.gene_panel import GenePanelMasterList
 from cg.constants.housekeeper_tags import HK_DELIVERY_REPORT_TAG
 from cg.constants.priority import SlurmQos
@@ -51,10 +57,16 @@ from cg.meta.workflow.tomte import TomteAnalysisAPI
 from cg.models import CompressionData
 from cg.models.cg_config import CGConfig, PDCArchivingDirectory
 from cg.models.downsample.downsample_data import DownsampleData
-from cg.models.raredisease.raredisease import RarediseaseParameters, RarediseaseSampleSheetHeaders
+from cg.models.raredisease.raredisease import (
+    RarediseaseParameters,
+    RarediseaseSampleSheetHeaders,
+)
 from cg.models.rnafusion.rnafusion import RnafusionParameters, RnafusionSampleSheetEntry
 from cg.models.run_devices.illumina_run_directory_data import IlluminaRunDirectoryData
-from cg.models.taxprofiler.taxprofiler import TaxprofilerParameters, TaxprofilerSampleSheetEntry
+from cg.models.taxprofiler.taxprofiler import (
+    TaxprofilerParameters,
+    TaxprofilerSampleSheetEntry,
+)
 from cg.models.tomte.tomte import TomteParameters, TomteSampleSheetHeaders
 from cg.services.illumina_services.illumina_metrics_service.illumina_metrics_service import (
     IlluminaMetricsService,
@@ -90,6 +102,8 @@ pytest_plugins = [
     "tests.fixture_plugins.delivery_fixtures.context_fixtures",
     "tests.fixture_plugins.delivery_fixtures.bundle_fixtures",
     "tests.fixture_plugins.delivery_fixtures.path_fixtures",
+    "tests.fixture_plugins.io.csv_fixtures",
+    "tests.fixture_plugins.gisaid_fixtures.gisaid_fixtures",
     "tests.fixture_plugins.quality_controller_fixtures.sequencing_qc_fixtures",
     "tests.fixture_plugins.quality_controller_fixtures.sequencing_qc_check_scenario",
     "tests.fixture_plugins.loqusdb_fixtures.loqusdb_api_fixtures",

--- a/tests/fixture_plugins/gisaid_fixtures/gisaid_fixtures.py
+++ b/tests/fixture_plugins/gisaid_fixtures/gisaid_fixtures.py
@@ -1,0 +1,47 @@
+import pytest
+
+from cg.meta.upload.gisaid import GisaidAPI
+from cg.models.cg_config import CGConfig
+from cg.models.gisaid.reports import GisaidComplementaryReport
+
+
+@pytest.fixture
+def gisaid_complementary_report_raw() -> dict[str, str]:
+    """Return a raw GISAID complementary report."""
+    return {
+        "provnummer": "a_sample_number",
+        "urvalskriterium": "a_selection_criteria",
+    }
+
+
+@pytest.fixture
+def gisaid_complementary_report(
+    gisaid_complementary_report_raw: list[dict],
+) -> GisaidComplementaryReport:
+    """Return GisaidComplementaryReport."""
+    return GisaidComplementaryReport.model_validate(gisaid_complementary_report_raw)
+
+
+@pytest.fixture
+def gisaid_complementary_reports(
+    gisaid_complementary_report: GisaidComplementaryReport,
+) -> list[GisaidComplementaryReport]:
+    """Return GISAID complementary reports."""
+    report_1 = GisaidComplementaryReport.model_validate(
+        {"provnummer": "1CS", "urvalskriterium": "criteria", "GISAID_accession": "an_accession"}
+    )
+    complementary_report = GisaidComplementaryReport.model_validate(
+        {
+            "urvalskriterium": "criteria",
+            "provnummer": "44CS000000",
+        }
+    )
+    return [gisaid_complementary_report, complementary_report, report_1]
+
+
+@pytest.fixture
+def gisaid_api(
+    cg_context: CGConfig,
+) -> GisaidAPI:
+    """GISAID API fixture."""
+    return GisaidAPI(cg_context)

--- a/tests/fixture_plugins/io/csv_fixtures.py
+++ b/tests/fixture_plugins/io/csv_fixtures.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def csv_file_path(fixtures_dir: Path) -> Path:
+    """Return a file path to example CSV file."""
+    return Path(fixtures_dir, "io", "example.csv")
+
+
+@pytest.fixture
+def csv_stream() -> str:
+    """Return string with CSV format."""
+    return """Lorem,ipsum,sit,amet"""
+
+
+@pytest.fixture
+def csv_temp_path(cg_dir: Path) -> Path:
+    """Return a temp file path to use when writing csv."""
+    return Path(cg_dir, "write.csv")

--- a/tests/meta/upload/gisaid/test_gsaid.py
+++ b/tests/meta/upload/gisaid/test_gsaid.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+from cg.meta.upload.gisaid import GisaidAPI
+from cg.models.gisaid.reports import GisaidComplementaryReport
+
+
+def test_get_complementary_report_content(gisaid_api: GisaidAPI, csv_file_path: Path):
+    # GIVEN a list of csv files
+
+    # WHEN creating the delivery content
+    content: list[dict] = gisaid_api.get_complementary_report_content(csv_file_path)
+
+    # THEN each file is a list of dicts where each dict is a row in a CSV file
+    assert isinstance(content[0], dict)
+
+    # THEN two files are added as a list of dicts
+    assert len(content) == 3
+
+
+def test_validate_gisaid_complementary_reports(
+    gisaid_api: GisaidAPI, gisaid_complementary_report_raw: dict[str, str]
+):
+    # GIVEN a list of dicts
+
+    # WHEN matching values
+    content: list[GisaidComplementaryReport] = gisaid_api.validate_gisaid_complementary_reports(
+        [gisaid_complementary_report_raw]
+    )
+
+    # THEN a list of reports is returned
+    assert isinstance(content[0], GisaidComplementaryReport)
+
+
+def test_get_sars_cov_complementary_reports(
+    gisaid_complementary_reports: list[GisaidComplementaryReport], gisaid_api: GisaidAPI
+):
+    # GIVEN a list of reports
+
+    # WHEN matching values in reports
+    content: list[GisaidComplementaryReport] = gisaid_api.get_sars_cov_complementary_reports(
+        gisaid_complementary_reports
+    )
+
+    # THEN a list of reports is returned
+    assert isinstance(content[0], GisaidComplementaryReport)
+
+    # THEN only the report for Sars-cov2 reports remains
+    assert len(content) == 1
+    assert content[0].sample_number == "44CS000000"

--- a/tests/meta/upload/gisaid/test_gsaid.py
+++ b/tests/meta/upload/gisaid/test_gsaid.py
@@ -62,3 +62,21 @@ def test_get_complementary_report_sample_number(
     # THEN return sample numbers from reports
     for report in gisaid_complementary_reports:
         assert report.sample_number in sample_numbers
+
+
+def test_add_gisaid_accession_to_reports(
+    gisaid_complementary_reports: list[GisaidComplementaryReport], gisaid_api: GisaidAPI
+):
+    """Test adding gisaid accession to the reports."""
+    # GIVEN a GISAID API
+
+    # GIVEN a list of reports
+
+    # WHEN adding GISAID accession
+    gisaid_api.add_gisaid_accession_to_complementary_reports(
+        gisaid_accession={gisaid_complementary_reports[0].sample_number: "a_gisaid_accession"},
+        reports=[gisaid_complementary_reports[0]],
+    )
+
+    # THEN a region lab has been added
+    assert isinstance(gisaid_complementary_reports[0].gisaid_accession, str)

--- a/tests/meta/upload/gisaid/test_gsaid.py
+++ b/tests/meta/upload/gisaid/test_gsaid.py
@@ -47,3 +47,18 @@ def test_get_sars_cov_complementary_reports(
     # THEN only the report for Sars-cov2 reports remains
     assert len(content) == 1
     assert content[0].sample_number == "44CS000000"
+
+
+def test_get_complementary_report_sample_number(
+    gisaid_complementary_reports: list[GisaidComplementaryReport], gisaid_api: GisaidAPI
+):
+    # GIVEN a list of reports
+
+    # WHEN getting the sample numbers in the reports
+    sample_numbers: set[str] = gisaid_api.get_complementary_report_sample_number(
+        gisaid_complementary_reports
+    )
+
+    # THEN return sample numbers from reports
+    for report in gisaid_complementary_reports:
+        assert report.sample_number in sample_numbers

--- a/tests/meta/upload/gisaid/test_gsaid.py
+++ b/tests/meta/upload/gisaid/test_gsaid.py
@@ -5,24 +5,24 @@ from cg.models.gisaid.reports import GisaidComplementaryReport
 
 
 def test_get_complementary_report_content(gisaid_api: GisaidAPI, csv_file_path: Path):
-    # GIVEN a list of csv files
+    # GIVEN a list of CSV files
 
-    # WHEN creating the delivery content
+    # WHEN creating the report content
     content: list[dict] = gisaid_api.get_complementary_report_content(csv_file_path)
 
-    # THEN each file is a list of dicts where each dict is a row in a CSV file
+    # THEN each file is a list of dicts where each dict represents a row in a CSV file
     assert isinstance(content[0], dict)
 
-    # THEN two files are added as a list of dicts
+    # THEN the file ise added as a list of dicts
     assert len(content) == 3
 
 
 def test_validate_gisaid_complementary_reports(
     gisaid_api: GisaidAPI, gisaid_complementary_report_raw: dict[str, str]
 ):
-    # GIVEN a list of dicts
+    # GIVEN a dict
 
-    # WHEN matching values
+    # WHEN validating the dict
     content: list[GisaidComplementaryReport] = gisaid_api.validate_gisaid_complementary_reports(
         [gisaid_complementary_report_raw]
     )
@@ -36,7 +36,7 @@ def test_get_sars_cov_complementary_reports(
 ):
     # GIVEN a list of reports
 
-    # WHEN matching values in reports
+    # WHEN getting Sars-cov reports from reports
     content: list[GisaidComplementaryReport] = gisaid_api.get_sars_cov_complementary_reports(
         gisaid_complementary_reports
     )
@@ -72,11 +72,11 @@ def test_add_gisaid_accession_to_reports(
 
     # GIVEN a list of reports
 
-    # WHEN adding GISAID accession
+    # WHEN adding GISAID accession to reports
     gisaid_api.add_gisaid_accession_to_complementary_reports(
         gisaid_accession={gisaid_complementary_reports[0].sample_number: "a_gisaid_accession"},
         reports=[gisaid_complementary_reports[0]],
     )
 
-    # THEN a region lab has been added
+    # THEN a GISAID accession has been added
     assert isinstance(gisaid_complementary_reports[0].gisaid_accession, str)

--- a/tests/models/gisaid/test_report.py
+++ b/tests/models/gisaid/test_report.py
@@ -1,0 +1,13 @@
+from cg.models.gisaid.reports import GisaidComplementaryReport
+
+
+def test_instantiate_gisaid_complementary_report(gisaid_complementary_report_raw: dict[str, str]):
+    """Tests report dict against a pydantic GisaidomplementaryReport."""
+
+    # GIVEN report dicts
+
+    # WHEN instantiating a report object
+    report = GisaidComplementaryReport.model_validate(gisaid_complementary_report_raw)
+
+    # THEN assert that it was successfully created
+    assert isinstance(report, GisaidComplementaryReport)


### PR DESCRIPTION
## Description

### Added

-

### Changed

- Use Python naitive CSV and Pydantic instead of Pandas
- Remove Pandas from GISAID API

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
