### PR TITLE
Return case_ids per category

### DIFF
--- a/cg/services/orders/order_summary_service/dto/order_summary.py
+++ b/cg/services/orders/order_summary_service/dto/order_summary.py
@@ -1,15 +1,17 @@
 from pydantic import BaseModel, Field
 
+from cg.apps.tb.dto.summary_response import StatusSummary
+
 
 class OrderSummary(BaseModel):
     order_id: int = Field(exclude=True)
     total: int
-    cancelled: int
-    completed: int
-    delivered: int
-    failed: int
-    failed_sequencing_qc: int
-    in_lab_preparation: int
-    in_sequencing: int
-    not_received: int
-    running: int
+    cancelled: StatusSummary
+    completed: StatusSummary
+    delivered: StatusSummary
+    failed: StatusSummary
+    failed_sequencing_qc: StatusSummary
+    in_lab_preparation: StatusSummary
+    in_sequencing: StatusSummary
+    not_received: StatusSummary
+    running: StatusSummary

--- a/cg/services/orders/order_summary_service/order_summary_service.py
+++ b/cg/services/orders/order_summary_service/order_summary_service.py
@@ -1,11 +1,11 @@
 from cg.apps.tb.api import TrailblazerAPI
-from cg.apps.tb.dto.summary_response import AnalysisSummary
+from cg.apps.tb.dto.summary_response import AnalysisSummary, StatusSummary
 from cg.services.orders.order_summary_service.dto.order_summary import OrderSummary
 from cg.services.orders.order_summary_service.utils import (
     _get_analysis_map,
     get_cases_failed_sequencing_qc_count,
 )
-from cg.store.models import Order
+from cg.store.models import Case, Order
 from cg.store.store import Store
 
 
@@ -38,28 +38,46 @@ class OrderSummaryService:
         """Adds statuses inferred from StatusDB data for any cases not included in the provided summary."""
         order_id = order.id
         counted_cases: list[str] = summary.case_ids if summary else []
-        not_received: int = self.store.get_case_not_received_count(
-            order_id=order_id, cases_to_exclude=counted_cases
-        )
-        in_preparation: int = self.store.get_case_in_preparation_count(
-            order_id=order_id, cases_to_exclude=counted_cases
-        )
-        in_sequencing: int = self.store.get_case_in_sequencing_count(
-            order_id=order_id, cases_to_exclude=counted_cases
-        )
-        failed_sequencing_qc: int = get_cases_failed_sequencing_qc_count(
-            order=order, cases_to_exclude=counted_cases
+        not_received: list[Case] = [
+            case.name
+            for case in self.store.get_case_not_received_count(
+                order_id=order_id, cases_to_exclude=counted_cases
+            )
+        ]
+        not_received_summary = StatusSummary(case_ids=not_received, count=len(not_received))
+        in_preparation: list[Case] = [
+            case.name
+            for case in self.store.get_case_in_preparation_count(
+                order_id=order_id, cases_to_exclude=counted_cases
+            )
+        ]
+        in_preparation_summary = StatusSummary(case_ids=in_preparation, count=len(in_preparation))
+        in_sequencing: list[Case] = [
+            case.name
+            for case in self.store.get_case_in_sequencing_count(
+                order_id=order_id, cases_to_exclude=counted_cases
+            )
+        ]
+        in_sequencing_summary = StatusSummary(case_ids=in_sequencing, count=len(in_sequencing))
+        failed_sequencing_qc: list[Case] = [
+            case.name
+            for case in get_cases_failed_sequencing_qc_count(
+                order=order, cases_to_exclude=counted_cases
+            )
+        ]
+        failed_sequencing_qc_summary = StatusSummary(
+            case_ids=failed_sequencing_qc, count=len(failed_sequencing_qc)
         )
         return OrderSummary(
             order_id=order_id,
             total=len(order.cases),
-            cancelled=summary.cancelled.count,
-            completed=summary.completed.count,
-            delivered=summary.delivered.count,
-            failed=summary.failed.count,
-            failed_sequencing_qc=failed_sequencing_qc,
-            in_lab_preparation=in_preparation,
-            in_sequencing=in_sequencing,
-            not_received=not_received,
-            running=summary.running.count,
+            cancelled=summary.cancelled,
+            completed=summary.completed,
+            delivered=summary.delivered,
+            failed=summary.failed,
+            failed_sequencing_qc=failed_sequencing_qc_summary,
+            in_lab_preparation=in_preparation_summary,
+            in_sequencing=in_sequencing_summary,
+            not_received=not_received_summary,
+            running=summary.running,
         )

--- a/cg/services/orders/order_summary_service/order_summary_service.py
+++ b/cg/services/orders/order_summary_service/order_summary_service.py
@@ -39,28 +39,28 @@ class OrderSummaryService:
         order_id = order.id
         counted_cases: list[str] = summary.case_ids if summary else []
         not_received: list[Case] = [
-            case.name
+            case.internal_id
             for case in self.store.get_case_not_received_count(
                 order_id=order_id, cases_to_exclude=counted_cases
             )
         ]
         not_received_summary = StatusSummary(case_ids=not_received, count=len(not_received))
         in_preparation: list[Case] = [
-            case.name
+            case.internal_id
             for case in self.store.get_case_in_preparation_count(
                 order_id=order_id, cases_to_exclude=counted_cases
             )
         ]
         in_preparation_summary = StatusSummary(case_ids=in_preparation, count=len(in_preparation))
         in_sequencing: list[Case] = [
-            case.name
+            case.internal_id
             for case in self.store.get_case_in_sequencing_count(
                 order_id=order_id, cases_to_exclude=counted_cases
             )
         ]
         in_sequencing_summary = StatusSummary(case_ids=in_sequencing, count=len(in_sequencing))
         failed_sequencing_qc: list[Case] = [
-            case.name
+            case.internal_id
             for case in get_cases_failed_sequencing_qc_count(
                 order=order, cases_to_exclude=counted_cases
             )

--- a/cg/services/orders/order_summary_service/utils.py
+++ b/cg/services/orders/order_summary_service/utils.py
@@ -11,10 +11,10 @@ def _is_case_failed_sequencing_qc(case: Case) -> bool:
     return case.are_all_samples_sequenced and not SequencingQCService.case_pass_sequencing_qc(case)
 
 
-def get_cases_failed_sequencing_qc_count(order: Order, cases_to_exclude: list[str]) -> int:
+def get_cases_failed_sequencing_qc_count(order: Order, cases_to_exclude: list[str]) -> list[Case]:
     cases: list[Case] = order.cases
-    return sum(
-        1
+    return [
+        case
         for case in cases
         if _is_case_failed_sequencing_qc(case) and case.internal_id not in cases_to_exclude
-    )
+    ]

--- a/cg/store/crud/read.py
+++ b/cg/store/crud/read.py
@@ -1476,7 +1476,7 @@ class ReadHandler(BaseHandler):
         )
         return orders.first()
 
-    def get_case_not_received_count(self, order_id: int, cases_to_exclude: list[str]) -> int:
+    def get_case_not_received_count(self, order_id: int, cases_to_exclude: list[str]) -> list[Case]:
         filters: list[CaseSampleFilter] = [
             CaseSampleFilter.BY_ORDER,
             CaseSampleFilter.CASES_WITH_SAMPLES_NOT_RECEIVED,
@@ -1488,9 +1488,11 @@ class ReadHandler(BaseHandler):
             filter_functions=filters,
             order_id=order_id,
             cases_to_exclude=cases_to_exclude,
-        ).count()
+        ).all()
 
-    def get_case_in_preparation_count(self, order_id: int, cases_to_exclude: list[str]) -> int:
+    def get_case_in_preparation_count(
+        self, order_id: int, cases_to_exclude: list[str]
+    ) -> list[Case]:
         filters: list[CaseFilter] = [
             CaseSampleFilter.BY_ORDER,
             CaseSampleFilter.CASES_WITH_ALL_SAMPLES_RECEIVED,
@@ -1503,9 +1505,11 @@ class ReadHandler(BaseHandler):
             filter_functions=filters,
             order_id=order_id,
             cases_to_exclude=cases_to_exclude,
-        ).count()
+        ).all()
 
-    def get_case_in_sequencing_count(self, order_id: int, cases_to_exclude: list[str]) -> int:
+    def get_case_in_sequencing_count(
+        self, order_id: int, cases_to_exclude: list[str]
+    ) -> list[Case]:
         filters: list[CaseSampleFilter] = [
             CaseSampleFilter.BY_ORDER,
             CaseSampleFilter.CASES_WITH_ALL_SAMPLES_RECEIVED,
@@ -1519,7 +1523,7 @@ class ReadHandler(BaseHandler):
             filter_functions=filters,
             order_id=order_id,
             cases_to_exclude=cases_to_exclude,
-        ).count()
+        ).all()
 
     def get_illumina_flow_cell_by_internal_id(self, internal_id: str) -> IlluminaFlowCell:
         """Return a flow cell by internal id."""

--- a/tests/services/orders/order_status_service/test_order_summary_service.py
+++ b/tests/services/orders/order_status_service/test_order_summary_service.py
@@ -24,7 +24,7 @@ def test_not_received(summary_service: OrderSummaryService, order_with_cases: Or
     summary: OrderSummary = summary_service.get_summary(order_id)
 
     # THEN the summary should contain one case not received
-    assert summary.not_received == 1
+    assert summary.not_received.count == 1
 
 
 def test_in_preparation(summary_service: OrderSummaryService, order_with_cases: Order):
@@ -35,7 +35,7 @@ def test_in_preparation(summary_service: OrderSummaryService, order_with_cases: 
     summary: OrderSummary = summary_service.get_summary(order_id)
 
     # THEN the summary should contain one case in preparation
-    assert summary.in_lab_preparation == 1
+    assert summary.in_lab_preparation.count == 1
 
 
 def test_in_sequencing(summary_service: OrderSummaryService, order_with_cases: Order):
@@ -46,7 +46,7 @@ def test_in_sequencing(summary_service: OrderSummaryService, order_with_cases: O
     summary: OrderSummary = summary_service.get_summary(order_id)
 
     # THEN the summary should contain one case in sequencing
-    assert summary.in_sequencing == 1
+    assert summary.in_sequencing.count == 1
 
 
 def test_summarize_multiple_samples_not_received(
@@ -62,7 +62,7 @@ def test_summarize_multiple_samples_not_received(
     assert summary.total == 1
 
     # THEN the summary should contain one case not received
-    assert summary.not_received == 1
+    assert summary.not_received.count == 1
 
 
 def test_summarize_order_with_two_cases(
@@ -78,7 +78,7 @@ def test_summarize_order_with_two_cases(
     assert summary.total == 2
 
     # THEN the summary should contain one case not received
-    assert summary.not_received == 2
+    assert summary.not_received.count == 2
 
     # THEN the summary should not contain any case in sequencing
-    assert summary.in_sequencing == 0
+    assert summary.in_sequencing.count == 0


### PR DESCRIPTION
## Description

Should address Clinical-Genomics/cg#3396 together with a CiGRID patch. Now we return all the case_ids together with the counts in the order summary. Goal is to show the case_ids on hover.

### Added

-

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
