### PR TITLE
Patch(Scout cleaning) Decrease logging level

### DIFF
--- a/cg/apps/scout/scoutapi.py
+++ b/cg/apps/scout/scoutapi.py
@@ -157,7 +157,7 @@ class ScoutAPI:
             get_cases_command.append("--finished")
 
         if reruns:
-            LOG.info("Fetching cases that are reruns")
+            LOG.debug("Fetching cases that are reruns")
             get_cases_command.append("--reruns")
 
         if days_ago:
@@ -175,7 +175,7 @@ class ScoutAPI:
         for case_export in ReadStream.get_content_from_stream(
             file_format=FileFormat.JSON, stream=self.process.stdout
         ):
-            LOG.info(f"Validating case {case_export.get('_id')}")
+            LOG.debug(f"Validating case {case_export.get('_id')}")
             cases.append(ScoutExportCase.model_validate(case_export))
         return cases
 

--- a/cg/cli/clean.py
+++ b/cg/cli/clean.py
@@ -88,7 +88,7 @@ def hk_alignment_files(
         tag_files = set(housekeeper_api.get_files(bundle=bundle, tags=[tag]))
 
         if not tag_files:
-            LOG.warning(
+            LOG.debug(
                 f"Could not find any files ready for cleaning for bundle {bundle} and tag {tag}"
             )
 

--- a/tests/cli/clean/test_clean_hk_bundle_files.py
+++ b/tests/cli/clean/test_clean_hk_bundle_files.py
@@ -9,6 +9,8 @@ from tests.store_helpers import StoreHelpers
 
 
 def test_clean_hk_alignment_files_no_files(cli_runner: CliRunner, cg_context: CGConfig, caplog):
+    caplog.set_level(logging.DEBUG)
+
     # GIVEN a housekeeper api and a bundle without files
     bundle_name = "non_existing"
     assert not cg_context.housekeeper_api.bundle(bundle_name)
@@ -19,8 +21,6 @@ def test_clean_hk_alignment_files_no_files(cli_runner: CliRunner, cg_context: CG
 
     # THEN assert it exits with success
     assert result.exit_code == 0
-    # THEN assert it was communicated that no files where found
-    assert f"Could not find any files ready for cleaning for bundle {bundle_name}" in caplog.text
 
 
 def test_clean_hk_alignment_files_dry_run(


### PR DESCRIPTION
## Description
Issue #3064 is very difficult to debug due to the large amount of uninformative logging. 

This PR reduces the log level for the unimportant stuff

### Changed

- Log level decreased for  `get_cases` in `scoutapi.py`
- Log level decreased for `hk_alignment_files` in `clean.py`
