### PR TITLE
Add PON to balsamic reports

### DIFF
--- a/cg/meta/report/balsamic.py
+++ b/cg/meta/report/balsamic.py
@@ -98,8 +98,6 @@ class BalsamicReportAPI(ReportAPI):
             million_read_pairs=million_read_pairs,
             pct_250x=sample_metrics.pct_target_bases_250x if sample_metrics else None,
             pct_500x=sample_metrics.pct_target_bases_500x if sample_metrics else None,
-            pon_cnvkit=analysis_metadata.config.panel.pon_cnvkit,
-            pon_cnvkit_version=analysis_metadata.config.panel.pon_cnvkit_version,
         )
 
     @staticmethod

--- a/cg/meta/report/balsamic.py
+++ b/cg/meta/report/balsamic.py
@@ -98,6 +98,8 @@ class BalsamicReportAPI(ReportAPI):
             million_read_pairs=million_read_pairs,
             pct_250x=sample_metrics.pct_target_bases_250x if sample_metrics else None,
             pct_500x=sample_metrics.pct_target_bases_500x if sample_metrics else None,
+            pon_cnvkit=analysis_metadata.config.panel.pon_cnvkit,
+            pon_cnvkit_version=analysis_metadata.config.panel.pon_cnvkit_version,
         )
 
     @staticmethod

--- a/cg/meta/report/report_api.py
+++ b/cg/meta/report/report_api.py
@@ -346,14 +346,15 @@ class ReportAPI(MetaAPI):
         return DataAnalysisModel(
             customer_workflow=case.data_analysis,
             data_delivery=case.data_delivery,
+            delivered_files=delivered_files,
+            genome_build=self.analysis_api.get_genome_build(case.internal_id),
+            panels=case.panels,
+            pons=self.analysis_api.get_pons(case.internal_id),
+            scout_files=self.get_scout_uploaded_files(case.internal_id),
+            type=self.analysis_api.get_data_analysis_type(case.internal_id),
+            variant_callers=self.analysis_api.get_variant_callers(case.internal_id),
             workflow=analysis.workflow,
             workflow_version=analysis.workflow_version,
-            type=self.analysis_api.get_data_analysis_type(case.internal_id),
-            genome_build=self.analysis_api.get_genome_build(case.internal_id),
-            variant_callers=self.analysis_api.get_variant_callers(case.internal_id),
-            panels=case.panels,
-            scout_files=self.get_scout_uploaded_files(case.internal_id),
-            delivered_files=delivered_files,
         )
 
     def get_scout_uploaded_files(self, case_id: str) -> ScoutReportFiles:

--- a/cg/meta/report/templates/macros/data_analysis/data_analysis.html
+++ b/cg/meta/report/templates/macros/data_analysis/data_analysis.html
@@ -19,7 +19,7 @@
     {% elif workflow == "rnafusion" %}
       <!-- Rnafusion QC metrics -->
       {{ rnafusion_qc_metrics(samples=case.samples) }}
-	  {% elif workflow == "tomte" %}
+    {% elif workflow == "tomte" %}
       <!-- Tomte QC metrics -->
       {{ tomte_qc_metrics(samples=case.samples) }}
     {% endif %}
@@ -38,6 +38,7 @@
         <th scope="col">Bioinformatisk analys</th>
         <th scope="col">Genomversion</th>
         <th scope="col">{% if "balsamic" in workflow %} Analystyp {% endif %}</th>
+        <th scope="col">{% if "balsamic" in workflow and case.data_analysis.pons != "N/A" %} Panel of Normals {% endif %}</th>
         <th scope="col">{% if workflow in ("balsamic", "balsamic-umi") %} Variantanropare {% endif %}</th>
         <th scope="col">{% if workflow in ("mip-dna", "rnafusion", "tomte") %} Genpaneler {% endif %}</th>
       </tr>
@@ -48,6 +49,7 @@
         <td>{{ workflow }} (v{{ case.data_analysis.workflow_version }})</td>
         <td>{{ case.data_analysis.genome_build }}</td>
         <td>{% if "balsamic" in workflow %} {{ case.data_analysis.type }} {% endif %}</td>
+        <td>{% if "balsamic" in workflow and case.data_analysis.pons != "N/A" %} {{ case.data_analysis.pons }} {% endif %}</th>
         <td class="text-start">{% if workflow in ("balsamic", "balsamic-umi") %} {{ case.data_analysis.variant_callers }} {% endif %}</td>
         <td>{% if workflow in ("mip-dna", "rnafusion", "tomte") %} {{ case.data_analysis.panels }} {% endif %}</td>
       </tr>

--- a/cg/meta/workflow/analysis.py
+++ b/cg/meta/workflow/analysis.py
@@ -537,6 +537,10 @@ class AnalysisAPI(MetaAPI):
         """Return list of variant-calling filters used during analysis."""
         return []
 
+    def get_pons(self, case_id: str) -> list[str]:
+        """Return list of panel of normals used for analysis."""
+        return []
+
     def parse_analysis(
         self, config_raw: dict, qc_metrics_raw: dict, sample_info_raw: dict
     ) -> AnalysisModel:

--- a/cg/meta/workflow/balsamic.py
+++ b/cg/meta/workflow/balsamic.py
@@ -648,6 +648,13 @@ class BalsamicAnalysisAPI(AnalysisAPI):
                 )
         return analysis_var_callers
 
+    def get_pons(self, case_id: str) -> list[str]:
+        """Return list of panel of normals used for analysis."""
+        analysis_metadata: BalsamicAnalysis = self.get_latest_metadata(case_id)
+        if analysis_metadata.config.panel:
+            return [analysis_metadata.config.panel.pon_cnvkit]
+        return []
+
     def get_data_analysis_type(self, case_id: str) -> str | None:
         """Return data analysis type carried out."""
         return self.get_bundle_deliverables_type(case_id)

--- a/cg/meta/workflow/balsamic.py
+++ b/cg/meta/workflow/balsamic.py
@@ -650,10 +650,13 @@ class BalsamicAnalysisAPI(AnalysisAPI):
 
     def get_pons(self, case_id: str) -> list[str]:
         """Return list of panel of normals used for analysis."""
+        pons: list[str] = []
         analysis_metadata: BalsamicAnalysis = self.get_latest_metadata(case_id)
         if analysis_metadata.config.panel:
-            return [analysis_metadata.config.panel.pon_cnvkit]
-        return []
+            pon_cnn: str | None = analysis_metadata.config.panel.pon_cnn
+            if pon_cnn:
+                pons.append(pon_cnn)
+        return pons
 
     def get_data_analysis_type(self, case_id: str) -> str | None:
         """Return data analysis type carried out."""

--- a/cg/meta/workflow/balsamic.py
+++ b/cg/meta/workflow/balsamic.py
@@ -653,8 +653,7 @@ class BalsamicAnalysisAPI(AnalysisAPI):
         pons: list[str] = []
         analysis_metadata: BalsamicAnalysis = self.get_latest_metadata(case_id)
         if analysis_metadata.config.panel:
-            pon_cnn: str | None = analysis_metadata.config.panel.pon_cnn
-            if pon_cnn:
+            if pon_cnn := analysis_metadata.config.panel.pon_cnn:
                 pons.append(pon_cnn)
         return pons
 

--- a/cg/models/balsamic/config.py
+++ b/cg/models/balsamic/config.py
@@ -66,13 +66,13 @@ class BalsamicConfigPanel(BaseModel):
         capture_kit: string representation of a panel BED filename
         capture_kit_version: capture kit version
         chrom: list of chromosomes in the panel BED file
-        pon_cnvkit: panel of normal name and version applied to the CNVkit variant calling
+        pon_cnn: panel of normal name and version applied to the CNVkit variant calling
     """
 
     capture_kit: str
     capture_kit_version: str | None
     chrom: list[str]
-    pon_cnvkit: str | None = None
+    pon_cnn: str | None = None
 
     @validator("capture_kit", pre=True)
     def get_filename_from_path(cls, path: str) -> str:
@@ -86,13 +86,14 @@ class BalsamicConfigPanel(BaseModel):
         """Return the panel bed version from its filename (e.g. gicfdna_3.1_hg19_design.bed)."""
         return values["capture_kit"].split("_")[-3]
 
-    @validator("pon_cnvkit", pre=True)
-    def get_pon_cnvkit_name_version_from_filename(cls, pon_cnvkit: str | None) -> str:
-        """Return the PON CNVkit name and version from its filename (gmsmyeloid_5.3_hg19_design_CNVkit_PON_reference_v1.cnn)."""
-        pon_cnvkit_filename_split: list[str] = Path(pon_cnvkit).stem.split("_")
-        pon_cnvkit_name: str = f"{pon_cnvkit_filename_split[0]} v{pon_cnvkit_filename_split[1]}"
-        pon_cnvkit_version: str = pon_cnvkit_filename_split[-1]
-        return f"CNVkit {pon_cnvkit_name (pon_cnvkit_version)}"
+    @validator("pon_cnn", pre=True)
+    def get_pon_cnn_name_version_from_filename(cls, pon_cnn: str | None) -> str:
+        """Return the CNVkit PON name and version from its filename (gmsmyeloid_5.3_hg19_design_CNVkit_PON_reference_v1.cnn)."""
+        pon_cnn_filename_split: list[str] = Path(pon_cnn).stem.split("_")
+        pon_cnn_name: str = f"{pon_cnn_filename_split[0]} v{pon_cnn_filename_split[1]}"
+        pon_cnn_version: str = pon_cnn_filename_split[-1]
+        pon_tool_name: str = pon_cnn_filename_split[5]
+        return f"{pon_tool_name} {pon_cnn_name (pon_cnn_version)}"
 
 
 class BalsamicConfigQC(BaseModel):

--- a/cg/models/balsamic/config.py
+++ b/cg/models/balsamic/config.py
@@ -66,16 +66,15 @@ class BalsamicConfigPanel(BaseModel):
         capture_kit: string representation of a panel BED filename
         capture_kit_version: capture kit version
         chrom: list of chromosomes in the panel BED file
-        pon_cnvkit: panel of normal applied to CNVkit variant calling
+        pon_cnvkit: panel of normal name and version applied to the CNVkit variant calling
     """
 
     capture_kit: str
     capture_kit_version: str | None
     chrom: list[str]
     pon_cnvkit: str | None = None
-    pon_cnvkit_version: str | None = None
 
-    @validator("capture_kit", "pon_cnvkit", pre=True)
+    @validator("capture_kit", pre=True)
     def get_filename_from_path(cls, path: str) -> str:
         """Return the base name of the provided file path."""
         return Path(path).name
@@ -87,12 +86,13 @@ class BalsamicConfigPanel(BaseModel):
         """Return the panel bed version from its filename (e.g. gicfdna_3.1_hg19_design.bed)."""
         return values["capture_kit"].split("_")[-3]
 
-    @validator("capture_kit_version")
-    def get_pon_cnvkit_version_from_filename(
-        cls, pon_cnvkit_version: str | None, values: dict[str, str | None]
-    ) -> str:
-        """Return the PON CNVkit version from its filename (e.g. gmsmyeloid_5.3_hg19_design_CNVkit_PON_reference_v1.cnn)."""
-        return values["pon_cnvkit"].split("_")[-1]
+    @validator("pon_cnvkit", pre=True)
+    def get_pon_cnvkit_name_version_from_filename(cls, pon_cnvkit: str | None) -> str:
+        """Return the PON CNVkit name and version from its filename (gmsmyeloid_5.3_hg19_design_CNVkit_PON_reference_v1.cnn)."""
+        pon_cnvkit_filename_split: list[str] = Path(pon_cnvkit).stem.split("_")
+        pon_cnvkit_name: str = f"{pon_cnvkit_filename_split[0]} v{pon_cnvkit_filename_split[1]}"
+        pon_cnvkit_version: str = pon_cnvkit_filename_split[-1]
+        return f"CNVkit {pon_cnvkit_name (pon_cnvkit_version)}"
 
 
 class BalsamicConfigQC(BaseModel):

--- a/cg/models/balsamic/config.py
+++ b/cg/models/balsamic/config.py
@@ -93,7 +93,7 @@ class BalsamicConfigPanel(BaseModel):
         pon_cnn_name: str = f"{pon_cnn_filename_split[0]} v{pon_cnn_filename_split[1]}"
         pon_cnn_version: str = pon_cnn_filename_split[-1]
         pon_tool_name: str = pon_cnn_filename_split[4]
-        return f"{pon_tool_name} {pon_cnn_name (pon_cnn_version)}"
+        return f"{pon_tool_name} {pon_cnn_name} ({pon_cnn_version})"
 
 
 class BalsamicConfigQC(BaseModel):

--- a/cg/models/balsamic/config.py
+++ b/cg/models/balsamic/config.py
@@ -66,23 +66,33 @@ class BalsamicConfigPanel(BaseModel):
         capture_kit: string representation of a panel BED filename
         capture_kit_version: capture kit version
         chrom: list of chromosomes in the panel BED file
+        pon_cnvkit: panel of normal applied to CNVkit variant calling
     """
 
     capture_kit: str
     capture_kit_version: str | None
     chrom: list[str]
+    pon_cnvkit: str | None = None
+    pon_cnvkit_version: str | None = None
 
-    @validator("capture_kit", pre=True)
-    def extract_capture_kit_name_from_path(cls, capture_kit: str) -> str:
-        """Return the base name of the provided capture kit path."""
-        return Path(capture_kit).name
+    @validator("capture_kit", "pon_cnvkit", pre=True)
+    def get_filename_from_path(cls, path: str) -> str:
+        """Return the base name of the provided file path."""
+        return Path(path).name
 
     @validator("capture_kit_version", always=True)
-    def extract_capture_kit_name_from_name(
-        cls, capture_kit_version: str | None, values: dict
+    def get_panel_version_from_filename(
+        cls, capture_kit_version: str | None, values: dict[str, str | None]
     ) -> str:
         """Return the panel bed version from its filename (e.g. gicfdna_3.1_hg19_design.bed)."""
         return values["capture_kit"].split("_")[-3]
+
+    @validator("capture_kit_version")
+    def get_pon_cnvkit_version_from_filename(
+        cls, pon_cnvkit_version: str | None, values: dict[str, str | None]
+    ) -> str:
+        """Return the PON CNVkit version from its filename (e.g. gmsmyeloid_5.3_hg19_design_CNVkit_PON_reference_v1.cnn)."""
+        return values["pon_cnvkit"].split("_")[-1]
 
 
 class BalsamicConfigQC(BaseModel):

--- a/cg/models/balsamic/config.py
+++ b/cg/models/balsamic/config.py
@@ -92,7 +92,7 @@ class BalsamicConfigPanel(BaseModel):
         pon_cnn_filename_split: list[str] = Path(pon_cnn).stem.split("_")
         pon_cnn_name: str = f"{pon_cnn_filename_split[0]} v{pon_cnn_filename_split[1]}"
         pon_cnn_version: str = pon_cnn_filename_split[-1]
-        pon_tool_name: str = pon_cnn_filename_split[5]
+        pon_tool_name: str = pon_cnn_filename_split[4]
         return f"{pon_tool_name} {pon_cnn_name (pon_cnn_version)}"
 
 

--- a/cg/models/report/metadata.py
+++ b/cg/models/report/metadata.py
@@ -48,8 +48,8 @@ class BalsamicSampleMetadataModel(SampleMetadataModel):
     """Metrics and trending data model associated to a specific BALSAMIC sample.
 
     Attributes:
-            mean_insert_size: mean insert size of the distribution; source: workflow
-            fold_80: fold 80 base penalty; source: workflow
+        mean_insert_size: mean insert size of the distribution; source: workflow
+        fold_80: fold 80 base penalty; source: workflow
     """
 
     mean_insert_size: Annotated[str, BeforeValidator(get_number_as_string)] = NA_FIELD
@@ -60,28 +60,33 @@ class BalsamicTargetedSampleMetadataModel(BalsamicSampleMetadataModel):
     """Metrics and trending data model associated to a specific BALSAMIC sample.
 
     Attributes:
-            bait_set: panel bed used for the analysis; source: LIMS
-            bait_set_version: panel bed version; source: workflow
-            median_target_coverage: median coverage of a target region in bases; source: workflow
-            pct_250x: percent of targeted bases that are covered to 250X coverage or more; source: workflow
-            pct_500x: percent of targeted bases that are covered to 500X coverage or more; source: workflow
+        bait_set: panel bed used for the analysis; source: LIMS
+        bait_set_version: panel bed version; source: workflow
+        median_target_coverage: median coverage of a target region in bases; source: workflow
+        pct_250x: percent of targeted bases that are covered to 250X coverage or more; source: workflow
+        pct_500x: percent of targeted bases that are covered to 500X coverage or more; source: workflow
+        pon_cnvkit: CNVkit PON used for analysis; source: workflow
+        pon_cnvkit_version: CNVkit PON version used for analysis; source: workflow
     """
 
     bait_set: Annotated[str, BeforeValidator(get_report_string)] = NA_FIELD
     bait_set_version: Annotated[str, BeforeValidator(get_report_string)] = NA_FIELD
+    gc_dropout: Annotated[str, BeforeValidator(get_number_as_string)] = NA_FIELD
     median_target_coverage: Annotated[str, BeforeValidator(get_number_as_string)] = NA_FIELD
     pct_250x: Annotated[str, BeforeValidator(get_number_as_string)] = NA_FIELD
     pct_500x: Annotated[str, BeforeValidator(get_number_as_string)] = NA_FIELD
-    gc_dropout: Annotated[str, BeforeValidator(get_number_as_string)] = NA_FIELD
+    pon_cnvkit: Annotated[str, BeforeValidator(get_report_string)] = NA_FIELD
+    pon_cnvkit_version: Annotated[str, BeforeValidator(get_report_string)] = NA_FIELD
 
 
 class BalsamicWGSSampleMetadataModel(BalsamicSampleMetadataModel):
     """Metrics and trending data model associated to a specific BALSAMIC sample.
 
     Attributes:
-            median_coverage: median coverage in bases of the genome territory; source: workflow
-            pct_15x: fraction of bases that attained at least 15X sequence coverage; source: workflow
-            pct_60x: fraction of bases that attained at least 15X sequence coverage; source: workflow
+        median_coverage: median coverage in bases of the genome territory; source: workflow
+        pct_15x: fraction of bases that attained at least 15X sequence coverage; source: workflow
+        pct_60x: fraction of bases that attained at least 15X sequence coverage; source: workflow
+        pct_reads_improper_pairs: fraction of reads that are not properly aligned in pairs
     """
 
     median_coverage: Annotated[str, BeforeValidator(get_number_as_string)] = NA_FIELD

--- a/cg/models/report/metadata.py
+++ b/cg/models/report/metadata.py
@@ -65,8 +65,6 @@ class BalsamicTargetedSampleMetadataModel(BalsamicSampleMetadataModel):
         median_target_coverage: median coverage of a target region in bases; source: workflow
         pct_250x: percent of targeted bases that are covered to 250X coverage or more; source: workflow
         pct_500x: percent of targeted bases that are covered to 500X coverage or more; source: workflow
-        pon_cnvkit: CNVkit PON used for analysis; source: workflow
-        pon_cnvkit_version: CNVkit PON version used for analysis; source: workflow
     """
 
     bait_set: Annotated[str, BeforeValidator(get_report_string)] = NA_FIELD
@@ -75,8 +73,6 @@ class BalsamicTargetedSampleMetadataModel(BalsamicSampleMetadataModel):
     median_target_coverage: Annotated[str, BeforeValidator(get_number_as_string)] = NA_FIELD
     pct_250x: Annotated[str, BeforeValidator(get_number_as_string)] = NA_FIELD
     pct_500x: Annotated[str, BeforeValidator(get_number_as_string)] = NA_FIELD
-    pon_cnvkit: Annotated[str, BeforeValidator(get_report_string)] = NA_FIELD
-    pon_cnvkit_version: Annotated[str, BeforeValidator(get_report_string)] = NA_FIELD
 
 
 class BalsamicWGSSampleMetadataModel(BalsamicSampleMetadataModel):

--- a/cg/models/report/report.py
+++ b/cg/models/report/report.py
@@ -84,10 +84,10 @@ class DataAnalysisModel(BaseModel):
     panels: Annotated[str, BeforeValidator(get_list_as_string)] = NA_FIELD
     pons: Annotated[str, BeforeValidator(get_list_as_string)] = NA_FIELD
     scout_files: ScoutReportFiles
-    type: Annotated[str, BeforeValidator(get_analysis_type_as_string)] = NA_FIELD
-    variant_callers: Annotated[str, BeforeValidator(get_list_as_string)] = NA_FIELD
     workflow: Annotated[str, BeforeValidator(get_report_string)] = NA_FIELD
     workflow_version: Annotated[str, BeforeValidator(get_report_string)] = NA_FIELD
+    type: Annotated[str, BeforeValidator(get_analysis_type_as_string)] = NA_FIELD
+    variant_callers: Annotated[str, BeforeValidator(get_list_as_string)] = NA_FIELD
 
     @model_validator(mode="after")
     def check_supported_workflow(self) -> "DataAnalysisModel":

--- a/cg/models/report/report.py
+++ b/cg/models/report/report.py
@@ -64,28 +64,30 @@ class DataAnalysisModel(BaseModel):
     Attributes:
         customer_workflow: data analysis requested by the customer; source: StatusDB/family/data_analysis
         data_delivery: data delivery requested by the customer; source: StatusDB/family/data_delivery
+        delivered_files: list of analysis case files to be delivered
+        genome_build: build version of the genome reference; source: workflow
+        panels: list of case specific panels; source: StatusDB/family/panels
+        pons: panel of normals used for analysis; source: workflow
+        scout_files: list of file names uploaded to Scout
+        type: analysis type carried out; source: workflow
+        variant_callers: variant-calling filters; source: workflow
         workflow: actual workflow used for analysis; source: statusDB/analysis/workflow
         workflow_version: workflow version; source: statusDB/analysis/workflow_version
-        type: analysis type carried out; source: workflow
-        genome_build: build version of the genome reference; source: workflow
-        variant_callers: variant-calling filters; source: workflow
-        panels: list of case specific panels; source: StatusDB/family/panels
-        scout_files: list of file names uploaded to Scout
-        delivered_files: list of analysis case files to be delivered
     """
 
     customer_workflow: Annotated[str, BeforeValidator(get_report_string)] = NA_FIELD
     data_delivery: Annotated[str, BeforeValidator(get_report_string)] = NA_FIELD
-    workflow: Annotated[str, BeforeValidator(get_report_string)] = NA_FIELD
-    workflow_version: Annotated[str, BeforeValidator(get_report_string)] = NA_FIELD
-    type: Annotated[str, BeforeValidator(get_analysis_type_as_string)] = NA_FIELD
-    genome_build: Annotated[str, BeforeValidator(get_report_string)] = NA_FIELD
-    variant_callers: Annotated[str, BeforeValidator(get_list_as_string)] = NA_FIELD
-    panels: Annotated[str, BeforeValidator(get_list_as_string)] = NA_FIELD
-    scout_files: ScoutReportFiles
     delivered_files: Annotated[
         list[str] | str, BeforeValidator(get_delivered_files_as_file_names)
     ] = None
+    genome_build: Annotated[str, BeforeValidator(get_report_string)] = NA_FIELD
+    panels: Annotated[str, BeforeValidator(get_list_as_string)] = NA_FIELD
+    pons: Annotated[str, BeforeValidator(get_list_as_string)] = NA_FIELD
+    scout_files: ScoutReportFiles
+    type: Annotated[str, BeforeValidator(get_analysis_type_as_string)] = NA_FIELD
+    variant_callers: Annotated[str, BeforeValidator(get_list_as_string)] = NA_FIELD
+    workflow: Annotated[str, BeforeValidator(get_report_string)] = NA_FIELD
+    workflow_version: Annotated[str, BeforeValidator(get_report_string)] = NA_FIELD
 
     @model_validator(mode="after")
     def check_supported_workflow(self) -> "DataAnalysisModel":

--- a/tests/fixtures/apps/balsamic/case/config.json
+++ b/tests/fixtures/apps/balsamic/case/config.json
@@ -1,354 +1,231 @@
 {
-    "QC": {
-        "picard_rmdup": false,
-        "adapter": "AATGATACGGCGACCACCGAGATCTACACTCTTTCCCTACACGACGCTCTTCCGATCT",
-        "quality_trim": true,
-        "adapter_trim": true,
-        "umi_trim": true,
-        "min_seq_length": "25",
-        "umi_trim_length": "5"
+  "QC": {
+    "picard_rmdup": false,
+    "adapter": "AATGATACGGCGACCACCGAGATCTACACTCTTTCCCTACACGACGCTCTTCCGATCT",
+    "quality_trim": true,
+    "adapter_trim": true,
+    "umi_trim": true,
+    "min_seq_length": "25",
+    "umi_trim_length": "5"
+  },
+  "vcf": {
+    "manta": {
+      "mutation": "somatic",
+      "mutation_type": "SV",
+      "analysis_type": ["paired", "single"],
+      "sequencing_type": ["targeted", "wgs"],
+      "workflow_solution": ["BALSAMIC"]
     },
-    "vcf": {
-        "manta": {
-            "mutation": "somatic",
-            "mutation_type": "SV",
-            "analysis_type": [
-                "paired",
-                "single"
-            ],
-            "sequencing_type": [
-                "targeted",
-                "wgs"
-            ],
-            "workflow_solution": [
-                "BALSAMIC"
-            ]
-        },
-        "cnvkit": {
-            "mutation": "somatic",
-            "mutation_type": "CNV",
-            "analysis_type": [
-                "paired",
-                "single"
-            ],
-            "sequencing_type": [
-                "targeted"
-            ],
-            "workflow_solution": [
-                "BALSAMIC"
-            ]
-        },
-        "vardict": {
-            "mutation": "somatic",
-            "mutation_type": "SNV",
-            "analysis_type": [
-                "paired",
-                "single"
-            ],
-            "sequencing_type": [
-                "targeted"
-            ],
-            "workflow_solution": [
-                "BALSAMIC"
-            ]
-        },
-        "tnscope": {
-            "mutation": "somatic",
-            "mutation_type": "SNV",
-            "analysis_type": [
-                "paired",
-                "single"
-            ],
-            "sequencing_type": [
-                "wgs"
-            ],
-            "workflow_solution": [
-                "Sentieon"
-            ]
-        },
-        "dnascope": {
-            "mutation": "germline",
-            "mutation_type": "SNV",
-            "analysis_type": [
-                "paired",
-                "single"
-            ],
-            "sequencing_type": [
-                "targeted",
-                "wgs"
-            ],
-            "workflow_solution": [
-                "Sentieon"
-            ]
-        },
-        "tnhaplotyper": {
-            "mutation": "somatic",
-            "mutation_type": "SNV",
-            "analysis_type": [
-                "paired",
-                "single"
-            ],
-            "sequencing_type": [
-                "targeted",
-                "wgs"
-            ],
-            "workflow_solution": [
-                "Sentieon"
-            ]
-        },
-        "manta_germline": {
-            "mutation": "germline",
-            "mutation_type": "SV",
-            "analysis_type": [
-                "paired",
-                "single"
-            ],
-            "sequencing_type": [
-                "targeted",
-                "wgs"
-            ],
-            "workflow_solution": [
-                "BALSAMIC"
-            ]
-        },
-        "haplotypecaller": {
-            "mutation": "germline",
-            "mutation_type": "SNV",
-            "analysis_type": [
-                "paired",
-                "single"
-            ],
-            "sequencing_type": [
-                "targeted"
-            ],
-            "workflow_solution": [
-                "BALSAMIC"
-            ]
-        },
-        "TNscope_umi": {
-            "mutation": "somatic",
-            "mutation_type": "SNV",
-            "analysis_type": [
-                "single",
-                "paired"
-            ],
-            "sequencing_type": [
-                "targeted"
-            ],
-            "workflow_solution": [
-                "Sentieon_umi"
-            ]
-        },
-        "delly": {
-            "mutation": "somatic",
-            "mutation_type": "SV",
-            "analysis_type": [
-                "paired",
-                "single"
-            ],
-            "sequencing_type": [
-                "wgs",
-                "targeted"
-            ],
-            "workflow_solution": [
-                "BALSAMIC"
-            ]
-        },
-        "ascat": {
-            "mutation": "somatic",
-            "mutation_type": "CNV",
-            "analysis_type": [
-                "paired"
-            ],
-            "sequencing_type": [
-                "wgs"
-            ],
-            "workflow_solution": [
-                "BALSAMIC"
-            ]
-        }
+    "cnvkit": {
+      "mutation": "somatic",
+      "mutation_type": "CNV",
+      "analysis_type": ["paired", "single"],
+      "sequencing_type": ["targeted"],
+      "workflow_solution": ["BALSAMIC"]
     },
-    "analysis": {
-        "case_id": "mock_case",
-        "analysis_type": "paired",
-        "analysis_workflow": "balsamic",
-        "sequencing_type": "targeted",
-        "analysis_dir": "/mock/path/cases",
-        "fastq_path": "/mock/path/cases/mock_case/analysis/fastq/",
-        "script": "/mock/path/cases/mock_case/scripts/",
-        "log": "/mock/path/cases/mock_case/logs/",
-        "result": "/mock/path/cases/mock_case/analysis",
-        "benchmark": "/mock/path/cases/mock_case/benchmarks/",
-        "dag": "/mock/path/cases/mock_case/mock_case_BALSAMIC_8.2.5_graph.pdf",
-        "BALSAMIC_version": "8.2.5",
-        "config_creation_date": "2021-12-28 13:12"
+    "vardict": {
+      "mutation": "somatic",
+      "mutation_type": "SNV",
+      "analysis_type": ["paired", "single"],
+      "sequencing_type": ["targeted"],
+      "workflow_solution": ["BALSAMIC"]
     },
-    "samples": [
-        {
-            "type": "normal",
-            "name": "ACC0000A0",
-            "fastq_info": {
-                "H3CVVDRXY_ACC0000A0_S68_L001": {
-                    "fwd": "/mock/path/cases/mock_case/analysis/fastq//H3CVVDRXY_ACC0000A0_S68_L001_R1_001.fastq.gz",
-                    "rev": "/mock/path/cases/mock_case/analysis/fastq//H3CVVDRXY_ACC0000A0_S68_L001_R2_001.fastq.gz"
-                },
-                "H3CVVDRXY_ACC0000A0_S68_L002": {
-                    "fwd": "/mock/path/cases/mock_case/analysis/fastq//H3CVVDRXY_ACC0000A0_S68_L002_R1_001.fastq.gz",
-                    "rev": "/mock/path/cases/mock_case/analysis/fastq//H3CVVDRXY_ACC0000A0_S68_L002_R2_001.fastq.gz"
-                }
-            }
-        },
-        {
-            "type": "tumor",
-            "name": "ACC0000A1",
-            "fastq_info": {
-                "H3CVVDRXY_ACC0000A1_S68_L001": {
-                    "fwd": "/mock/path/cases/mock_case/analysis/fastq//H3CVVDRXY_ACC0000A1_S68_L001_R1_001.fastq.gz",
-                    "rev": "/mock/path/cases/mock_case/analysis/fastq//H3CVVDRXY_ACC0000A1_S68_L001_R2_001.fastq.gz"
-                },
-                "H3CVVDRXY_ACC0000A1_S68_L002": {
-                    "fwd": "/mock/path/cases/mock_case/analysis/fastq//H3CVVDRXY_ACC0000A1_S68_L002_R1_001.fastq.gz",
-                    "rev": "/mock/path/cases/mock_case/analysis/fastq//H3CVVDRXY_ACC0000A1_S68_L002_R2_001.fastq.gz"
-                }
-            }
-        }
-    ],
-    "reference": {
-        "reference_genome": "/mock/path/balsamic_cache/8.2.5/hg19/genome/human_g1k_v37.fasta",
-        "dbsnp": "/mock/path/balsamic_cache/8.2.5/hg19/variants/dbsnp_grch37_b138.vcf.gz",
-        "1kg_snps_all": "/mock/path/balsamic_cache/8.2.5/hg19/variants/1k_genome_wgs_p1_v3_all_sites.vcf.gz",
-        "1kg_snps_high": "/mock/path/balsamic_cache/8.2.5/hg19/variants/1kg_phase1_snps_high_confidence_b37.vcf.gz",
-        "1kg_known_indel": "/mock/path/balsamic_cache/8.2.5/hg19/variants/1kg_known_indels_b37.vcf.gz",
-        "mills_1kg": "/mock/path/balsamic_cache/8.2.5/hg19/variants/mills_1kg_index.vcf.gz",
-        "gnomad_variant": "/mock/path/balsamic_cache/8.2.5/hg19/variants/gnomad.genomes.r2.1.1.sites.vcf.bgz",
-        "cosmic": "/mock/path/balsamic_cache/8.2.5/hg19/variants/cosmic_coding_muts_v94.vcf.gz",
-        "exon_bed": "/mock/path/balsamic_cache/8.2.5/hg19/genome/refGene.flat.bed",
-        "refflat": "/mock/path/balsamic_cache/8.2.5/hg19/genome/refGene.flat",
-        "refGene": "/mock/path/balsamic_cache/8.2.5/hg19/genome/refGene.txt",
-        "wgs_calling_interval": "/mock/path/balsamic_cache/8.2.5/hg19/genome/wgs_calling_regions.v1",
-        "genome_chrom_size": "/mock/path/balsamic_cache/8.2.5/hg19/genome/hg19.chrom.sizes",
-        "vep": "/mock/path/balsamic_cache/8.2.5/hg19/vep",
-        "rankscore": "/mock/path/balsamic_cache/8.2.5/hg19/genome/cancer_rank_model_-v0.1-.ini",
-        "access_regions": "/mock/path/balsamic_cache/8.2.5/hg19/genome/access_5kb_hg19.txt",
-        "delly_exclusion": "/mock/path/balsamic_cache/8.2.5/hg19/genome/delly_exclusion.tsv",
-        "delly_exclusion_converted": "/mock/path/balsamic_cache/8.2.5/hg19/genome/delly_exclusion_converted.tsv",
-        "ascat_gccorrection": "/mock/path/balsamic_cache/8.2.5/hg19/genome/GRCh37_SnpGcCorrections.tsv",
-        "ascat_chryloci": "/mock/path/balsamic_cache/8.2.5/hg19/genome/GRCh37_Y.loci",
-        "clinvar": "/mock/path/balsamic_cache/8.2.5/hg19/variants/clinvar.vcf.gz",
-        "reference_access_date": "/mock/path/cases/2021-12-20 23:32:13"
+    "tnscope": {
+      "mutation": "somatic",
+      "mutation_type": "SNV",
+      "analysis_type": ["paired", "single"],
+      "sequencing_type": ["wgs"],
+      "workflow_solution": ["Sentieon"]
     },
-    "singularity": {
-        "image": "/mock/path/balsamic_cache/8.2.5/containers"
+    "dnascope": {
+      "mutation": "germline",
+      "mutation_type": "SNV",
+      "analysis_type": ["paired", "single"],
+      "sequencing_type": ["targeted", "wgs"],
+      "workflow_solution": ["Sentieon"]
     },
-    "bioinfo_tools": {
-        "bedtools": "align_qc",
-        "bwa": "align_qc",
-        "fastqc": "align_qc",
-        "samtools": "align_qc",
-        "picard": "align_qc",
-        "multiqc": "align_qc",
-        "fastp": "align_qc",
-        "csvkit": "align_qc",
-        "ensembl-vep": "annotate",
-        "genmod": "annotate",
-        "vcfanno": "annotate",
-        "sambamba": "coverage_qc",
-        "mosdepth": "coverage_qc",
-        "bcftools": "varcall_py36",
-        "tabix": "varcall_py36",
-        "gatk": "varcall_py36",
-        "vardict": "varcall_py36",
-        "strelka": "varcall_py27",
-        "manta": "varcall_py27",
-        "cnvkit": "varcall_cnvkit",
-        "delly": "delly",
-        "ascatNgs": "ascatNgs",
-        "sentieon": "sentieon"
+    "tnhaplotyper": {
+      "mutation": "somatic",
+      "mutation_type": "SNV",
+      "analysis_type": ["paired", "single"],
+      "sequencing_type": ["targeted", "wgs"],
+      "workflow_solution": ["Sentieon"]
     },
-    "bioinfo_tools_version": {
-        "manta": [
-            "1.6.0"
-        ],
-        "bcftools": [
-            "1.9",
-            "1.11"
-        ],
-        "tabix": [
-            "0.2.6"
-        ],
-        "samtools": [
-            "1.9",
-            "1.12",
-            "1.11"
-        ],
-        "sentieon": [
-            "202010.02"
-        ],
-        "delly": [
-            "0.8.7"
-        ],
-        "sambamba": [
-            "0.6.6"
-        ],
-        "mosdepth": [
-            "0.2.9"
-        ],
-        "ascatNgs": [
-            "4.5.0"
-        ],
-        "gatk": [
-            "3.8"
-        ],
-        "vardict": [
-            "2019.06.04=pl526_0"
-        ],
-        "bedtools": [
-            "2.30.0"
-        ],
-        "bwa": [
-            "0.7.15"
-        ],
-        "fastqc": [
-            "0.11.9"
-        ],
-        "picard": [
-            "2.25.0"
-        ],
-        "multiqc": [
-            "1.11"
-        ],
-        "fastp": [
-            "0.20.1"
-        ],
-        "csvkit": [
-            "1.0.4"
-        ],
-        "ensembl-vep": [
-            "100.2"
-        ],
-        "vcfanno": [
-            "0.3.2"
-        ]
+    "manta_germline": {
+      "mutation": "germline",
+      "mutation_type": "SV",
+      "analysis_type": ["paired", "single"],
+      "sequencing_type": ["targeted", "wgs"],
+      "workflow_solution": ["BALSAMIC"]
     },
-    "panel": {
-        "capture_kit": "/mock/path/reference/target_capture_bed/production/balsamic/gicfdna_3.1_hg19_design.bed",
-        "chrom": [
-            "19",
-            "2",
-            "8",
-            "18",
-            "14",
-            "12",
-            "1",
-            "7",
-            "20",
-            "3",
-            "4",
-            "9",
-            "5",
-            "10",
-            "16",
-            "17"
-        ]
+    "haplotypecaller": {
+      "mutation": "germline",
+      "mutation_type": "SNV",
+      "analysis_type": ["paired", "single"],
+      "sequencing_type": ["targeted"],
+      "workflow_solution": ["BALSAMIC"]
+    },
+    "TNscope_umi": {
+      "mutation": "somatic",
+      "mutation_type": "SNV",
+      "analysis_type": ["single", "paired"],
+      "sequencing_type": ["targeted"],
+      "workflow_solution": ["Sentieon_umi"]
+    },
+    "delly": {
+      "mutation": "somatic",
+      "mutation_type": "SV",
+      "analysis_type": ["paired", "single"],
+      "sequencing_type": ["wgs", "targeted"],
+      "workflow_solution": ["BALSAMIC"]
+    },
+    "ascat": {
+      "mutation": "somatic",
+      "mutation_type": "CNV",
+      "analysis_type": ["paired"],
+      "sequencing_type": ["wgs"],
+      "workflow_solution": ["BALSAMIC"]
     }
+  },
+  "analysis": {
+    "case_id": "mock_case",
+    "analysis_type": "paired",
+    "analysis_workflow": "balsamic",
+    "sequencing_type": "targeted",
+    "analysis_dir": "/mock/path/cases",
+    "fastq_path": "/mock/path/cases/mock_case/analysis/fastq/",
+    "script": "/mock/path/cases/mock_case/scripts/",
+    "log": "/mock/path/cases/mock_case/logs/",
+    "result": "/mock/path/cases/mock_case/analysis",
+    "benchmark": "/mock/path/cases/mock_case/benchmarks/",
+    "dag": "/mock/path/cases/mock_case/mock_case_BALSAMIC_8.2.5_graph.pdf",
+    "BALSAMIC_version": "8.2.5",
+    "config_creation_date": "2021-12-28 13:12"
+  },
+  "samples": [
+    {
+      "type": "normal",
+      "name": "ACC0000A0",
+      "fastq_info": {
+        "H3CVVDRXY_ACC0000A0_S68_L001": {
+          "fwd": "/mock/path/cases/mock_case/analysis/fastq//H3CVVDRXY_ACC0000A0_S68_L001_R1_001.fastq.gz",
+          "rev": "/mock/path/cases/mock_case/analysis/fastq//H3CVVDRXY_ACC0000A0_S68_L001_R2_001.fastq.gz"
+        },
+        "H3CVVDRXY_ACC0000A0_S68_L002": {
+          "fwd": "/mock/path/cases/mock_case/analysis/fastq//H3CVVDRXY_ACC0000A0_S68_L002_R1_001.fastq.gz",
+          "rev": "/mock/path/cases/mock_case/analysis/fastq//H3CVVDRXY_ACC0000A0_S68_L002_R2_001.fastq.gz"
+        }
+      }
+    },
+    {
+      "type": "tumor",
+      "name": "ACC0000A1",
+      "fastq_info": {
+        "H3CVVDRXY_ACC0000A1_S68_L001": {
+          "fwd": "/mock/path/cases/mock_case/analysis/fastq//H3CVVDRXY_ACC0000A1_S68_L001_R1_001.fastq.gz",
+          "rev": "/mock/path/cases/mock_case/analysis/fastq//H3CVVDRXY_ACC0000A1_S68_L001_R2_001.fastq.gz"
+        },
+        "H3CVVDRXY_ACC0000A1_S68_L002": {
+          "fwd": "/mock/path/cases/mock_case/analysis/fastq//H3CVVDRXY_ACC0000A1_S68_L002_R1_001.fastq.gz",
+          "rev": "/mock/path/cases/mock_case/analysis/fastq//H3CVVDRXY_ACC0000A1_S68_L002_R2_001.fastq.gz"
+        }
+      }
+    }
+  ],
+  "reference": {
+    "reference_genome": "/mock/path/balsamic_cache/8.2.5/hg19/genome/human_g1k_v37.fasta",
+    "dbsnp": "/mock/path/balsamic_cache/8.2.5/hg19/variants/dbsnp_grch37_b138.vcf.gz",
+    "1kg_snps_all": "/mock/path/balsamic_cache/8.2.5/hg19/variants/1k_genome_wgs_p1_v3_all_sites.vcf.gz",
+    "1kg_snps_high": "/mock/path/balsamic_cache/8.2.5/hg19/variants/1kg_phase1_snps_high_confidence_b37.vcf.gz",
+    "1kg_known_indel": "/mock/path/balsamic_cache/8.2.5/hg19/variants/1kg_known_indels_b37.vcf.gz",
+    "mills_1kg": "/mock/path/balsamic_cache/8.2.5/hg19/variants/mills_1kg_index.vcf.gz",
+    "gnomad_variant": "/mock/path/balsamic_cache/8.2.5/hg19/variants/gnomad.genomes.r2.1.1.sites.vcf.bgz",
+    "cosmic": "/mock/path/balsamic_cache/8.2.5/hg19/variants/cosmic_coding_muts_v94.vcf.gz",
+    "exon_bed": "/mock/path/balsamic_cache/8.2.5/hg19/genome/refGene.flat.bed",
+    "refflat": "/mock/path/balsamic_cache/8.2.5/hg19/genome/refGene.flat",
+    "refGene": "/mock/path/balsamic_cache/8.2.5/hg19/genome/refGene.txt",
+    "wgs_calling_interval": "/mock/path/balsamic_cache/8.2.5/hg19/genome/wgs_calling_regions.v1",
+    "genome_chrom_size": "/mock/path/balsamic_cache/8.2.5/hg19/genome/hg19.chrom.sizes",
+    "vep": "/mock/path/balsamic_cache/8.2.5/hg19/vep",
+    "rankscore": "/mock/path/balsamic_cache/8.2.5/hg19/genome/cancer_rank_model_-v0.1-.ini",
+    "access_regions": "/mock/path/balsamic_cache/8.2.5/hg19/genome/access_5kb_hg19.txt",
+    "delly_exclusion": "/mock/path/balsamic_cache/8.2.5/hg19/genome/delly_exclusion.tsv",
+    "delly_exclusion_converted": "/mock/path/balsamic_cache/8.2.5/hg19/genome/delly_exclusion_converted.tsv",
+    "ascat_gccorrection": "/mock/path/balsamic_cache/8.2.5/hg19/genome/GRCh37_SnpGcCorrections.tsv",
+    "ascat_chryloci": "/mock/path/balsamic_cache/8.2.5/hg19/genome/GRCh37_Y.loci",
+    "clinvar": "/mock/path/balsamic_cache/8.2.5/hg19/variants/clinvar.vcf.gz",
+    "reference_access_date": "/mock/path/cases/2021-12-20 23:32:13"
+  },
+  "singularity": {
+    "image": "/mock/path/balsamic_cache/8.2.5/containers"
+  },
+  "bioinfo_tools": {
+    "bedtools": "align_qc",
+    "bwa": "align_qc",
+    "fastqc": "align_qc",
+    "samtools": "align_qc",
+    "picard": "align_qc",
+    "multiqc": "align_qc",
+    "fastp": "align_qc",
+    "csvkit": "align_qc",
+    "ensembl-vep": "annotate",
+    "genmod": "annotate",
+    "vcfanno": "annotate",
+    "sambamba": "coverage_qc",
+    "mosdepth": "coverage_qc",
+    "bcftools": "varcall_py36",
+    "tabix": "varcall_py36",
+    "gatk": "varcall_py36",
+    "vardict": "varcall_py36",
+    "strelka": "varcall_py27",
+    "manta": "varcall_py27",
+    "cnvkit": "varcall_cnvkit",
+    "delly": "delly",
+    "ascatNgs": "ascatNgs",
+    "sentieon": "sentieon"
+  },
+  "bioinfo_tools_version": {
+    "manta": ["1.6.0"],
+    "bcftools": ["1.9", "1.11"],
+    "tabix": ["0.2.6"],
+    "samtools": ["1.9", "1.12", "1.11"],
+    "sentieon": ["202010.02"],
+    "delly": ["0.8.7"],
+    "sambamba": ["0.6.6"],
+    "mosdepth": ["0.2.9"],
+    "ascatNgs": ["4.5.0"],
+    "gatk": ["3.8"],
+    "vardict": ["2019.06.04=pl526_0"],
+    "bedtools": ["2.30.0"],
+    "bwa": ["0.7.15"],
+    "fastqc": ["0.11.9"],
+    "picard": ["2.25.0"],
+    "multiqc": ["1.11"],
+    "fastp": ["0.20.1"],
+    "csvkit": ["1.0.4"],
+    "ensembl-vep": ["100.2"],
+    "vcfanno": ["0.3.2"]
+  },
+  "panel": {
+    "capture_kit": "/mock/path/reference/target_capture_bed/production/balsamic/gicfdna_3.1_hg19_design.bed",
+    "chrom": [
+      "19",
+      "2",
+      "8",
+      "18",
+      "14",
+      "12",
+      "1",
+      "7",
+      "20",
+      "3",
+      "4",
+      "9",
+      "5",
+      "10",
+      "16",
+      "17"
+    ],
+    "pon_cnn": "/mock/path/pon/gmsmyeloid_5.3_hg19_design_CNVkit_PON_reference_v1.cnn"
+  }
 }


### PR DESCRIPTION
## Description

### Added
- PON to balsamic reports

### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [x] `cg generate delivery-report <case-id>`

### Expected test outcome

- [x] Check that PON included in delivery report for TGA PON analysis
    <img width="777" alt="Screenshot 2024-07-05 at 15 27 26" src="https://github.com/Clinical-Genomics/cg/assets/26309194/4efb4ff9-3aea-4d27-80e8-4ec6a5517b90">
- [x] Check that PON is not included in the delivery report for TGA analysis
- [x] Check that PON is not included in the delivery report for WGS analysis
- [x] Check that PON is not included in the delivery report for workflow that are not Balsamic (Rnafusion 🤷 )

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
