### PR TITLE
Fixed percentage calculations in productivity metrics

### DIFF
--- a/cg/services/pacbio/metrics/models.py
+++ b/cg/services/pacbio/metrics/models.py
@@ -63,24 +63,22 @@ class ProductivityMetrics(BaseModel):
     p_0: int = Field(..., alias=LoadingAttributesIDs.P_0)
     p_1: int = Field(..., alias=LoadingAttributesIDs.P_1)
     p_2: int = Field(..., alias=LoadingAttributesIDs.P_2)
+    percentage_p_0: float
+    percentage_p_1: float
+    percentage_p_2: float
 
-    @property
-    def percentage_p_0(self) -> float:
-        return self._calculate_percentage(self.p_0)
-
-    @property
-    def percentage_p_1(self) -> float:
-        return self._calculate_percentage(self.p_1)
-
-    @property
-    def percentage_p_2(self) -> float:
-        return self._calculate_percentage(self.p_2)
-
-    def _calculate_percentage(self, value: int) -> float:
-        """Calculates the percentage of a value to productive_zmws."""
-        if self.productive_zmws == 0:
-            return 0.0
-        return round((value / self.productive_zmws) * 100, 0)
+    @model_validator(mode="before")
+    @classmethod
+    def set_percentages(cls, data: Any):
+        if isinstance(data, dict):
+            productive_zmws = data.get(LoadingAttributesIDs.PRODUCTIVE_ZMWS)
+            p_0 = data.get(LoadingAttributesIDs.P_0)
+            p_1 = data.get(LoadingAttributesIDs.P_1)
+            p_2 = data.get(LoadingAttributesIDs.P_2)
+            data["percentage_p_0"] = round((p_0 / productive_zmws) * 100, 0)
+            data["percentage_p_1"] = round((p_1 / productive_zmws) * 100, 0)
+            data["percentage_p_2"] = round((p_2 / productive_zmws) * 100, 0)
+        return data
 
 
 class PolymeraseMetrics(BaseModel):


### PR DESCRIPTION
## Description
Changed the calculation of percentage values in PacBio Productivity metrics model from a property to a model validator. This to be more "pydantic" and so that these values are exported when dumping into dictionaries


### How to test

- [x] No production code touched

## Review

- [ ] "Merge and deploy" approved by SA
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Deployed to stage:
```shell

```
- [ ] Deployed to production:
```shell

```
