### PR TITLE
add tests for get_files_matching_pattern

### DIFF
--- a/cg/constants/constants.py
+++ b/cg/constants/constants.py
@@ -218,6 +218,7 @@ class FileExtensions(StrEnum):
     TAR: str = ".tar"
     TMP: str = ".tmp"
     TSV: str = ".tsv"
+    TXT: str = ".txt"
     VCF: str = ".vcf"
     XML: str = ".xml"
     YAML: str = ".yaml"

--- a/tests/utils/test_files.py
+++ b/tests/utils/test_files.py
@@ -1,15 +1,16 @@
-from datetime import datetime
 from pathlib import Path
 
 import pytest
 
+from cg.constants import FileExtensions
 from cg.utils.files import (
     get_directories_in_path,
-    get_source_creation_time_stamp,
     get_file_in_directory,
+    get_files_in_directory_with_pattern,
+    get_files_matching_pattern,
+    get_source_creation_time_stamp,
     remove_directory_and_contents,
     rename_file,
-    get_files_in_directory_with_pattern,
 )
 
 
@@ -37,6 +38,33 @@ def test_get_files_in_directory_by_pattern(nested_directory_with_file: Path, som
     for file_path in file_paths:
         assert file_path.exists()
         assert some_file in file_path.as_posix()
+
+
+def test_get_files_matching_pattern(nested_directory_with_file: Path, some_file: str):
+
+    # GIVEN a directory with a subdirectory containing a .txt file
+    directory_with_file = Path(nested_directory_with_file, "sub_directory")
+
+    # WHEN getting the file from the directory
+    files = get_files_matching_pattern(
+        directory=directory_with_file, pattern=f"*{FileExtensions.TXT}"
+    )
+
+    # THEN assert that the file is returned
+    assert len(files) == 1
+
+
+def test_get_files_matching_pattern_no_files(nested_directory_with_file: Path, some_file: str):
+
+    # GIVEN a directory with a subdirectory containing a .txt file
+
+    # WHEN getting the file from the directory
+    files = get_files_matching_pattern(
+        directory=nested_directory_with_file, pattern=f"*{FileExtensions.JSON}"
+    )
+
+    # THEN assert that the file is returned
+    assert len(files) == 0
 
 
 def test_rename_file(tmp_path: Path):


### PR DESCRIPTION
## Description
Add tests for a file utils function didn't have any

### Added

- Two test functions
- TXT extension constant


### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions