### PR TITLE
Disallow reusing sample names across cases

### DIFF
--- a/cg/services/order_validation_service/models/errors.py
+++ b/cg/services/order_validation_service/models/errors.py
@@ -60,6 +60,6 @@ class RepeatedCaseNameError(CaseError):
     message: str = "Case name already used"
 
 
-class RepeatedSampleNameError(CaseSampleError):
+class RepeatedSampleNameError(SampleError):
     field: str = "name"
     message: str = "Sample name already used"

--- a/cg/services/order_validation_service/workflows/tomte/validation/inter_field/rules.py
+++ b/cg/services/order_validation_service/workflows/tomte/validation/inter_field/rules.py
@@ -24,8 +24,4 @@ def validate_no_repeated_case_names(order: TomteOrder) -> list[RepeatedCaseNameE
 
 
 def validate_no_repeated_sample_names(order: TomteOrder) -> list[RepeatedSampleNameError]:
-    errors: list[RepeatedSampleNameError] = []
-    for case in order.cases:
-        case_errors = get_repeated_sample_name_errors(case)
-        errors.extend(case_errors)
-    return errors
+    return get_repeated_sample_name_errors(order)

--- a/cg/services/order_validation_service/workflows/tomte/validation/inter_field/utils.py
+++ b/cg/services/order_validation_service/workflows/tomte/validation/inter_field/utils.py
@@ -65,12 +65,12 @@ def get_repeated_case_name_errors(order: TomteOrder) -> list[RepeatedCaseNameErr
     return [RepeatedCaseNameError(case_name=name) for name in case_names]
 
 
-def get_repeated_sample_names(case: TomteCase) -> list[str]:
-    sample_names = [sample.name for sample in case.samples]
+def get_repeated_sample_names(order: TomteOrder) -> list[str]:
+    sample_names = [sample.name for case in order.cases for sample in case.samples]
     count = Counter(sample_names)
     return [name for name, freq in count.items() if freq > 1]
 
 
-def get_repeated_sample_name_errors(case: TomteCase) -> list[RepeatedSampleNameError]:
-    sample_names = get_repeated_sample_names(case)
-    return [RepeatedSampleNameError(sample_name=name, case_name=case.name) for name in sample_names]
+def get_repeated_sample_name_errors(order: TomteOrder) -> list[RepeatedSampleNameError]:
+    sample_names = get_repeated_sample_names(order)
+    return [RepeatedSampleNameError(sample_name=name) for name in sample_names]


### PR DESCRIPTION
The customer needs to provide a sample internal id if they want to have the same sample in multiple cases. We should not allow them to reuse a sample name in different cases since it is a potential source of confusion for us and them.

Judgement call by @karlnyr 