### PR TITLE
Rename validation rules

### DIFF
--- a/cg/services/order_validation_service/workflows/tomte/validation/inter_field/rules.py
+++ b/cg/services/order_validation_service/workflows/tomte/validation/inter_field/rules.py
@@ -1,4 +1,3 @@
-from cg.constants.subject import Sex
 from cg.services.order_validation_service.models.errors import (
     FatherNotInCaseError,
     InvalidFatherSexError,
@@ -8,7 +7,6 @@ from cg.services.order_validation_service.models.errors import (
     RepeatedSampleNameError,
 )
 from cg.services.order_validation_service.workflows.tomte.models.order import TomteOrder
-from cg.services.order_validation_service.workflows.tomte.models.sample import TomteSample
 from cg.services.order_validation_service.workflows.tomte.validation.inter_field.utils import (
     _get_errors,
     _get_excess_samples,
@@ -27,11 +25,11 @@ def validate_wells_contain_at_most_one_sample(order: TomteOrder) -> list[Occupie
     return _get_errors(samples)
 
 
-def validate_no_repeated_case_names(order: TomteOrder) -> list[RepeatedCaseNameError]:
+def validate_case_names_not_repeated(order: TomteOrder) -> list[RepeatedCaseNameError]:
     return get_repeated_case_name_errors(order)
 
 
-def validate_no_repeated_sample_names(order: TomteOrder) -> list[RepeatedSampleNameError]:
+def validate_sample_names_not_repeated(order: TomteOrder) -> list[RepeatedSampleNameError]:
     errors: list[RepeatedSampleNameError] = []
     for case in order.cases:
         case_errors = get_repeated_sample_name_errors(case)

--- a/cg/services/order_validation_service/workflows/tomte/validation_rules.py
+++ b/cg/services/order_validation_service/workflows/tomte/validation_rules.py
@@ -10,29 +10,29 @@ from cg.services.order_validation_service.validators.inter_field.rules import (
     validate_ticket_number_required_if_connected,
 )
 from cg.services.order_validation_service.workflows.tomte.validation.inter_field.rules import (
+    validate_case_names_not_repeated,
     validate_fathers_are_male,
     validate_fathers_in_same_case_as_children,
     validate_mothers_are_female,
-    validate_no_repeated_case_names,
-    validate_no_repeated_sample_names,
+    validate_sample_names_not_repeated,
     validate_wells_contain_at_most_one_sample,
 )
 
 TOMTE_ORDER_RULES = [
-    validate_customer_exists,
-    validate_user_belongs_to_customer,
-    validate_ticket_number_required_if_connected,
     validate_customer_can_skip_reception_control,
+    validate_customer_exists,
+    validate_ticket_number_required_if_connected,
+    validate_user_belongs_to_customer,
 ]
 
 TOMTE_CASE_SAMPLE_RULES = [
-    validate_no_repeated_case_names,
-    validate_no_repeated_sample_names,
-    validate_fathers_are_male,
-    validate_fathers_in_same_case_as_children,
-    validate_mothers_are_female,
     validate_application_compatibility,
     validate_application_exists,
     validate_application_not_archived,
+    validate_case_names_not_repeated,
+    validate_fathers_are_male,
+    validate_fathers_in_same_case_as_children,
+    validate_mothers_are_female,
+    validate_sample_names_not_repeated,
     validate_wells_contain_at_most_one_sample,
 ]

--- a/tests/services/order_validation_service/test_tomte_inter_field_validators.py
+++ b/tests/services/order_validation_service/test_tomte_inter_field_validators.py
@@ -7,10 +7,10 @@ from cg.services.order_validation_service.models.errors import (
 )
 from cg.services.order_validation_service.workflows.tomte.models.order import TomteOrder
 from cg.services.order_validation_service.workflows.tomte.validation.inter_field.rules import (
+    validate_case_names_not_repeated,
     validate_fathers_are_male,
     validate_fathers_in_same_case_as_children,
-    validate_no_repeated_case_names,
-    validate_no_repeated_sample_names,
+    validate_sample_names_not_repeated,
     validate_wells_contain_at_most_one_sample,
 )
 
@@ -44,7 +44,7 @@ def test_repeated_sample_names_not_allowed(order_with_repeated_sample_names: Tom
     # Given an order with samples in a case with the same name
 
     # WHEN validating the order
-    errors = validate_no_repeated_sample_names(order_with_repeated_sample_names)
+    errors = validate_sample_names_not_repeated(order_with_repeated_sample_names)
 
     # THEN errors are returned
     assert errors
@@ -57,7 +57,7 @@ def test_repeated_case_names_not_allowed(order_with_repeated_case_names: TomteOr
     # GIVEN an order with cases with the same name
 
     # WHEN validating the order
-    errors = validate_no_repeated_case_names(order_with_repeated_case_names)
+    errors = validate_case_names_not_repeated(order_with_repeated_case_names)
 
     # THEN errors are returned
     assert errors


### PR DESCRIPTION
## Description

In order to easier get an overview of the validation rules in use, this PR renames already existing rules to a "validate_field_name_rule" pattern and orders them in alphabetical order.

### Fixed

- Standardised rule naming.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
