### PR TITLE
Add elution buffer check for skip rc

### DIFF
--- a/cg/services/order_validation_service/constants.py
+++ b/cg/services/order_validation_service/constants.py
@@ -9,6 +9,8 @@ class TissueBlockEnum(Enum):
     BLANK: str = ""
 
 
+ALLOWED_SKIP_RC_BUFFERS = ["Nuclease-free water", "Tris-HCl"]
+
 WORKFLOW_PREP_CATEGORIES: dict[Workflow, list[PrepCategory]] = {
     Workflow.TOMTE: [PrepCategory.WHOLE_TRANSCRIPTOME_SEQUENCING],
 }

--- a/cg/services/order_validation_service/models/errors.py
+++ b/cg/services/order_validation_service/models/errors.py
@@ -99,3 +99,8 @@ class InvalidGenePanelsError(CaseError):
     def __init__(self, case_name: str, panels: list[str]):
         message = "Invalid panels: " + ",".join(panels)
         super(CaseError, self).__init__(field="panels", case_name=case_name, message=message)
+
+
+class InvalidBufferError(CaseSampleError):
+    field: str = "buffer"
+    message: str = "The chosen buffer is not allowed when skipping reception control"

--- a/cg/services/order_validation_service/models/errors.py
+++ b/cg/services/order_validation_service/models/errors.py
@@ -105,8 +105,7 @@ class InvalidBufferError(CaseSampleError):
     field: str = "buffer"
     message: str = "The chosen buffer is not allowed when skipping reception control"
 
-      
+
 class RepeatedGenePanelsError(CaseError):
     field: str = "panels"
     message: str = "Gene panels must be unique"
-

--- a/cg/services/order_validation_service/validators/inter_field/rules.py
+++ b/cg/services/order_validation_service/validators/inter_field/rules.py
@@ -55,14 +55,14 @@ def validate_application_compatibility(
     return errors
 
 
-def validate_skip_rc_buffer_condition(order: TomteOrder) -> list[CaseSampleError]:
+def validate_buffer_skip_rc_condition(order: TomteOrder) -> list[CaseSampleError]:
     errors: list[CaseSampleError] = []
     if order.skip_reception_control:
         validate_buffers_are_allowed(order)
     return errors
 
 
-def validate_buffers_are_allowed(order: Order) -> list[CaseSampleError]:
+def validate_buffers_are_allowed(order: TomteOrder) -> list[CaseSampleError]:
     errors = []
     for case in order.cases:
         for sample in case.samples:

--- a/cg/services/order_validation_service/validators/inter_field/rules.py
+++ b/cg/services/order_validation_service/validators/inter_field/rules.py
@@ -1,5 +1,8 @@
 from cg.constants import PrepCategory, Workflow
-from cg.services.order_validation_service.constants import WORKFLOW_PREP_CATEGORIES
+from cg.services.order_validation_service.constants import (
+    ALLOWED_SKIP_RC_BUFFERS,
+    WORKFLOW_PREP_CATEGORIES,
+)
 from cg.services.order_validation_service.models.errors import (
     ApplicationNotCompatibleError,
     CaseSampleError,
@@ -54,7 +57,6 @@ def validate_application_compatibility(
 
 def validate_skip_rc_buffer_condition(order: TomteOrder) -> list[CaseSampleError]:
     errors: list[CaseSampleError] = []
-
     if order.skip_reception_control:
         validate_buffers_are_allowed(order)
     return errors
@@ -62,10 +64,9 @@ def validate_skip_rc_buffer_condition(order: TomteOrder) -> list[CaseSampleError
 
 def validate_buffers_are_allowed(order: Order) -> list[CaseSampleError]:
     errors = []
-    allowed_buffers = ["Nuclease-free water", "Tris-HCl"]
     for case in order.cases:
         for sample in case.samples:
-            if sample.elution_buffer not in allowed_buffers:
+            if sample.elution_buffer not in ALLOWED_SKIP_RC_BUFFERS:
                 error = InvalidBufferError(case_name=case.name, sample_name=sample.name)
                 errors.append(error)
     return errors

--- a/cg/services/order_validation_service/validators/inter_field/rules.py
+++ b/cg/services/order_validation_service/validators/inter_field/rules.py
@@ -58,7 +58,7 @@ def validate_application_compatibility(
 def validate_buffer_skip_rc_condition(order: TomteOrder) -> list[CaseSampleError]:
     errors: list[CaseSampleError] = []
     if order.skip_reception_control:
-        validate_buffers_are_allowed(order)
+        errors.extend(validate_buffers_are_allowed(order))
     return errors
 
 

--- a/cg/services/order_validation_service/workflows/tomte/validation_rules.py
+++ b/cg/services/order_validation_service/workflows/tomte/validation_rules.py
@@ -9,6 +9,7 @@ from cg.services.order_validation_service.validators.data.rules import (
 )
 from cg.services.order_validation_service.validators.inter_field.rules import (
     validate_application_compatibility,
+    validate_buffer_skip_rc_condition,
     validate_ticket_number_required_if_connected,
 )
 from cg.services.order_validation_service.workflows.tomte.validation.inter_field.rules import (
@@ -36,6 +37,7 @@ TOMTE_CASE_SAMPLE_RULES = [
     validate_application_compatibility,
     validate_application_exists,
     validate_application_not_archived,
+    validate_buffer_skip_rc_condition,
     validate_case_names_not_repeated,
     validate_fathers_are_male,
     validate_fathers_in_same_case_as_children,

--- a/tests/services/order_validation_service/test_inter_field_validators.py
+++ b/tests/services/order_validation_service/test_inter_field_validators.py
@@ -1,14 +1,17 @@
 from cg.services.order_validation_service.models.errors import (
     ApplicationNotCompatibleError,
+    InvalidBufferError,
     OrderNameRequiredError,
     TicketNumberRequiredError,
 )
 from cg.services.order_validation_service.models.order import Order
 from cg.services.order_validation_service.validators.inter_field.rules import (
     validate_application_compatibility,
+    validate_buffers_are_allowed,
     validate_name_required_for_new_order,
     validate_ticket_number_required_if_connected,
 )
+from cg.services.order_validation_service.workflows.tomte.models.order import TomteOrder
 from cg.store.store import Store
 
 
@@ -44,7 +47,7 @@ def test_order_name_is_required(valid_order: Order):
 
 
 def test_application_is_incompatible(
-    valid_order: Order, sample_with_non_compatible_application, base_store: Store
+    valid_order: TomteOrder, sample_with_non_compatible_application, base_store: Store
 ):
 
     # GIVEN an order that has a sample with an application which is incompatible with the workflow
@@ -58,3 +61,18 @@ def test_application_is_incompatible(
 
     # THEN the error should be about the application compatiblity
     assert isinstance(errors[0], ApplicationNotCompatibleError)
+
+
+def test_elution_buffer_is_not_allowed(valid_order: TomteOrder, base_store: Store):
+
+    # GIVEN an order with 'skip reception control' toggled but no buffers specfied
+    valid_order.skip_reception_control = True
+
+    # WHEN validating that the buffers conform to the 'skip reception control' requirements
+    errors = validate_buffers_are_allowed(valid_order)
+
+    # THEN an error should be returned
+    assert errors
+
+    # THEN the error should be about the buffer compatability
+    assert isinstance(errors[0], InvalidBufferError)


### PR DESCRIPTION
## Description

For orders with 'skip reception control' set to True, additional buffer validation is required.

### Added

- Buffer validation for orders attempting to skip reception control

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
