### PR TITLE
Add subject_id different from sample name validation

### DIFF
--- a/cg/services/order_validation_service/models/errors.py
+++ b/cg/services/order_validation_service/models/errors.py
@@ -143,8 +143,8 @@ class RepeatedGenePanelsError(CaseError):
 class SubjectIdSameAsCaseNameError(CaseSampleError):
     field: str = "subject_id"
     message: str = "Subject id must be different from the case name"
-      
-      
+
+
 class SubjectIdSameAsSampleNameError(CaseSampleError):
     field: str = "subject_id"
     message: str = "Subject id must be different from the sample name"

--- a/cg/services/order_validation_service/models/errors.py
+++ b/cg/services/order_validation_service/models/errors.py
@@ -102,10 +102,15 @@ class InvalidGenePanelsError(CaseError):
 
 
 class InvalidBufferError(CaseSampleError):
-    field: str = "buffer"
+    field: str = "elution_buffer"
     message: str = "The chosen buffer is not allowed when skipping reception control"
 
 
 class RepeatedGenePanelsError(CaseError):
     field: str = "panels"
     message: str = "Gene panels must be unique"
+
+
+class SubjectIdSameAsSampleNameError(CaseSampleError):
+    field: str = "subject_id"
+    message: str = "Subject id must be different from the sample name"

--- a/cg/services/order_validation_service/validators/inter_field/rules.py
+++ b/cg/services/order_validation_service/validators/inter_field/rules.py
@@ -9,6 +9,7 @@ from cg.services.order_validation_service.models.errors import (
     InvalidBufferError,
     OrderError,
     OrderNameRequiredError,
+    SubjectIdSameAsSampleNameError,
     TicketNumberRequiredError,
 )
 from cg.services.order_validation_service.models.order import Order
@@ -68,5 +69,15 @@ def validate_buffers_are_allowed(order: TomteOrder) -> list[CaseSampleError]:
         for sample in case.samples:
             if sample.elution_buffer not in ALLOWED_SKIP_RC_BUFFERS:
                 error = InvalidBufferError(case_name=case.name, sample_name=sample.name)
+                errors.append(error)
+    return errors
+
+
+def validate_subject_ids_different_from_sample_names(order: TomteOrder) -> list[CaseSampleError]:
+    errors = []
+    for case in order.cases:
+        for sample in case.samples:
+            if sample.name == sample.subject_id:
+                error = SubjectIdSameAsSampleNameError(case_name=case.name, sample_name=sample.name)
                 errors.append(error)
     return errors

--- a/cg/services/order_validation_service/workflows/tomte/validation_rules.py
+++ b/cg/services/order_validation_service/workflows/tomte/validation_rules.py
@@ -10,6 +10,7 @@ from cg.services.order_validation_service.validators.data.rules import (
 from cg.services.order_validation_service.validators.inter_field.rules import (
     validate_application_compatibility,
     validate_buffer_skip_rc_condition,
+    validate_subject_ids_different_from_sample_names,
     validate_ticket_number_required_if_connected,
 )
 from cg.services.order_validation_service.workflows.tomte.validation.inter_field.rules import (
@@ -43,5 +44,6 @@ TOMTE_CASE_SAMPLE_RULES = [
     validate_fathers_in_same_case_as_children,
     validate_mothers_are_female,
     validate_sample_names_not_repeated,
+    validate_subject_ids_different_from_sample_names,
     validate_wells_contain_at_most_one_sample,
 ]

--- a/tests/services/order_validation_service/test_inter_field_validators.py
+++ b/tests/services/order_validation_service/test_inter_field_validators.py
@@ -1,5 +1,6 @@
 from cg.services.order_validation_service.models.errors import (
     ApplicationNotCompatibleError,
+    InvalidBufferError,
     OrderNameRequiredError,
     SubjectIdSameAsCaseNameError,
     TicketNumberRequiredError,
@@ -7,6 +8,7 @@ from cg.services.order_validation_service.models.errors import (
 from cg.services.order_validation_service.models.order import Order
 from cg.services.order_validation_service.validators.inter_field.rules import (
     validate_application_compatibility,
+    validate_buffers_are_allowed,
     validate_name_required_for_new_order,
     validate_ticket_number_required_if_connected,
 )
@@ -63,6 +65,7 @@ def test_application_is_incompatible(
 
     # THEN the error should be about the application compatiblity
     assert isinstance(errors[0], ApplicationNotCompatibleError)
+
 
 def test_elution_buffer_is_not_allowed(valid_order: TomteOrder):
 

--- a/tests/services/order_validation_service/test_inter_field_validators.py
+++ b/tests/services/order_validation_service/test_inter_field_validators.py
@@ -1,13 +1,11 @@
 from cg.services.order_validation_service.models.errors import (
     ApplicationNotCompatibleError,
-    InvalidBufferError,
     OrderNameRequiredError,
     TicketNumberRequiredError,
 )
 from cg.services.order_validation_service.models.order import Order
 from cg.services.order_validation_service.validators.inter_field.rules import (
     validate_application_compatibility,
-    validate_buffers_are_allowed,
     validate_name_required_for_new_order,
     validate_ticket_number_required_if_connected,
 )
@@ -61,18 +59,3 @@ def test_application_is_incompatible(
 
     # THEN the error should be about the application compatiblity
     assert isinstance(errors[0], ApplicationNotCompatibleError)
-
-
-def test_elution_buffer_is_not_allowed(valid_order: TomteOrder, base_store: Store):
-
-    # GIVEN an order with 'skip reception control' toggled but no buffers specfied
-    valid_order.skip_reception_control = True
-
-    # WHEN validating that the buffers conform to the 'skip reception control' requirements
-    errors = validate_buffers_are_allowed(valid_order)
-
-    # THEN an error should be returned
-    assert errors
-
-    # THEN the error should be about the buffer compatability
-    assert isinstance(errors[0], InvalidBufferError)

--- a/tests/services/order_validation_service/test_inter_field_validators.py
+++ b/tests/services/order_validation_service/test_inter_field_validators.py
@@ -1,6 +1,5 @@
 from cg.services.order_validation_service.models.errors import (
     ApplicationNotCompatibleError,
-    InvalidBufferError,
     OrderNameRequiredError,
     SubjectIdSameAsCaseNameError,
     TicketNumberRequiredError,
@@ -8,7 +7,6 @@ from cg.services.order_validation_service.models.errors import (
 from cg.services.order_validation_service.models.order import Order
 from cg.services.order_validation_service.validators.inter_field.rules import (
     validate_application_compatibility,
-    validate_buffers_are_allowed,
     validate_name_required_for_new_order,
     validate_ticket_number_required_if_connected,
 )
@@ -65,21 +63,6 @@ def test_application_is_incompatible(
 
     # THEN the error should be about the application compatiblity
     assert isinstance(errors[0], ApplicationNotCompatibleError)
-
-
-def test_elution_buffer_is_not_allowed(valid_order: TomteOrder):
-
-    # GIVEN an order with 'skip reception control' toggled but no buffers specfied
-    valid_order.skip_reception_control = True
-
-    # WHEN validating that the buffers conform to the 'skip reception control' requirements
-    errors = validate_buffers_are_allowed(valid_order)
-
-    # THEN an error should be returned
-    assert errors
-
-    # THEN the error should be about the buffer compatability
-    assert isinstance(errors[0], InvalidBufferError)
 
 
 def test_subject_ids_same_as_case_names_not_allowed(valid_order: TomteOrder):

--- a/tests/services/order_validation_service/test_tomte_inter_field_validators.py
+++ b/tests/services/order_validation_service/test_tomte_inter_field_validators.py
@@ -22,7 +22,6 @@ from cg.services.order_validation_service.workflows.tomte.validation.inter_field
     validate_sample_names_not_repeated,
     validate_wells_contain_at_most_one_sample,
 )
-from cg.store.store import Store
 
 
 def test_multiple_samples_in_well_not_allowed(order_with_samples_in_same_well: TomteOrder):
@@ -113,7 +112,7 @@ def test_father_in_wrong_case(order_with_father_in_wrong_case: TomteOrder):
     assert isinstance(errors[0], FatherNotInCaseError)
 
 
-def test_elution_buffer_is_not_allowed(valid_order: TomteOrder, base_store: Store):
+def test_elution_buffer_is_not_allowed(valid_order: TomteOrder):
 
     # GIVEN an order with 'skip reception control' toggled but no buffers specfied
     valid_order.skip_reception_control = True

--- a/tests/services/order_validation_service/test_tomte_inter_field_validators.py
+++ b/tests/services/order_validation_service/test_tomte_inter_field_validators.py
@@ -113,7 +113,6 @@ def test_father_in_wrong_case(order_with_father_in_wrong_case: TomteOrder):
     assert isinstance(errors[0], FatherNotInCaseError)
 
 
-
 def test_elution_buffer_is_not_allowed(valid_order: TomteOrder, base_store: Store):
 
     # GIVEN an order with 'skip reception control' toggled but no buffers specfied
@@ -143,6 +142,7 @@ def test_subject_id_same_as_sample_name_is_not_allowed(valid_order: TomteOrder):
 
     # THEN the error should be about the subject id being the same as the sample name
     assert isinstance(errors[0], SubjectIdSameAsSampleNameError)
+
 
 def test_valid_pedigree(valid_order: TomteOrder):
     # GIVEN a valid order with cases and samples


### PR DESCRIPTION
## Description

Subject ids need to be different from the sample's name.

### Added

- Validation ensuring that the sample name and subject id can not be the same.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
