### PR TITLE
Add subject_id different from case name validation

### DIFF
--- a/cg/services/order_validation_service/models/errors.py
+++ b/cg/services/order_validation_service/models/errors.py
@@ -138,3 +138,8 @@ class InvalidBufferError(CaseSampleError):
 class RepeatedGenePanelsError(CaseError):
     field: str = "panels"
     message: str = "Gene panels must be unique"
+
+
+class SubjectIdSameAsCaseNameError(CaseSampleError):
+    field: str = "subject_id"
+    message: str = "Subject id must be different from the case name"

--- a/cg/services/order_validation_service/workflows/tomte/validation/inter_field/rules.py
+++ b/cg/services/order_validation_service/workflows/tomte/validation/inter_field/rules.py
@@ -1,10 +1,11 @@
 from cg.services.order_validation_service.models.errors import (
+    CaseSampleError,
     FatherNotInCaseError,
     InvalidFatherSexError,
     InvalidMotherSexError,
-    PedigreeError,
     MotherNotInCaseError,
     OccupiedWellError,
+    PedigreeError,
     RepeatedCaseNameError,
     RepeatedSampleNameError,
 )
@@ -22,6 +23,7 @@ from cg.services.order_validation_service.workflows.tomte.validation.inter_field
     get_mother_sex_errors,
     get_repeated_case_name_errors,
     get_repeated_sample_name_errors,
+    validate_subject_ids_in_case,
 )
 
 
@@ -80,4 +82,11 @@ def validate_mothers_in_same_case_as_children(order: TomteOrder) -> list[MotherN
     for case in order.cases:
         case_errors = get_mother_case_errors(case)
         errors.extend(case_errors)
+    return errors
+
+
+def validate_subject_ids_different_from_case_names(order: TomteOrder) -> list[CaseSampleError]:
+    errors = []
+    for case in order.cases:
+        errors.extend(validate_subject_ids_in_case(case))
     return errors

--- a/cg/services/order_validation_service/workflows/tomte/validation/inter_field/rules.py
+++ b/cg/services/order_validation_service/workflows/tomte/validation/inter_field/rules.py
@@ -88,5 +88,6 @@ def validate_mothers_in_same_case_as_children(order: TomteOrder) -> list[MotherN
 def validate_subject_ids_different_from_case_names(order: TomteOrder) -> list[CaseSampleError]:
     errors = []
     for case in order.cases:
-        errors.extend(validate_subject_ids_in_case(case))
+        case_errors = validate_subject_ids_in_case(case)
+        errors.extend(case_errors)
     return errors

--- a/cg/services/order_validation_service/workflows/tomte/validation/inter_field/rules.py
+++ b/cg/services/order_validation_service/workflows/tomte/validation/inter_field/rules.py
@@ -1,5 +1,4 @@
 from cg.services.order_validation_service.models.errors import (
-    CaseSampleError,
     FatherNotInCaseError,
     InvalidFatherSexError,
     InvalidMotherSexError,
@@ -8,6 +7,7 @@ from cg.services.order_validation_service.models.errors import (
     PedigreeError,
     RepeatedCaseNameError,
     RepeatedSampleNameError,
+    SubjectIdSameAsCaseNameError,
 )
 from cg.services.order_validation_service.workflows.tomte.models.order import TomteOrder
 from cg.services.order_validation_service.workflows.tomte.validation.inter_field.pedigree.validate_pedigree import (
@@ -85,7 +85,9 @@ def validate_mothers_in_same_case_as_children(order: TomteOrder) -> list[MotherN
     return errors
 
 
-def validate_subject_ids_different_from_case_names(order: TomteOrder) -> list[CaseSampleError]:
+def validate_subject_ids_different_from_case_names(
+    order: TomteOrder,
+) -> list[SubjectIdSameAsCaseNameError]:
     errors = []
     for case in order.cases:
         case_errors = validate_subject_ids_in_case(case)

--- a/cg/services/order_validation_service/workflows/tomte/validation/inter_field/utils.py
+++ b/cg/services/order_validation_service/workflows/tomte/validation/inter_field/utils.py
@@ -151,7 +151,7 @@ def create_mother_sex_error(case: TomteCase, sample: TomteSample) -> InvalidMoth
     return InvalidMotherSexError(sample_name=sample.name, case_name=case.name)
 
 
-def validate_subject_ids_in_case(case: TomteCase):
+def validate_subject_ids_in_case(case: TomteCase) -> list[SubjectIdSameAsCaseNameError]:
     errors = []
     for sample in case.samples:
         if sample.subject_id == case.name:

--- a/cg/services/order_validation_service/workflows/tomte/validation/inter_field/utils.py
+++ b/cg/services/order_validation_service/workflows/tomte/validation/inter_field/utils.py
@@ -1,4 +1,5 @@
 from collections import Counter
+
 from cg.constants.subject import Sex
 from cg.models.orders.sample_base import ContainerEnum
 from cg.services.order_validation_service.models.errors import (
@@ -9,6 +10,7 @@ from cg.services.order_validation_service.models.errors import (
     OccupiedWellError,
     RepeatedCaseNameError,
     RepeatedSampleNameError,
+    SubjectIdSameAsCaseNameError,
 )
 from cg.services.order_validation_service.workflows.tomte.models.case import TomteCase
 from cg.services.order_validation_service.workflows.tomte.models.order import TomteOrder
@@ -147,3 +149,12 @@ def is_mother_sex_invalid(child: TomteSample, case: TomteCase) -> bool:
 
 def create_mother_sex_error(case: TomteCase, sample: TomteSample) -> InvalidMotherSexError:
     return InvalidMotherSexError(sample_name=sample.name, case_name=case.name)
+
+
+def validate_subject_ids_in_case(case: TomteCase):
+    errors = []
+    for sample in case.samples:
+        if sample.subject_id == case.name:
+            error = SubjectIdSameAsCaseNameError(case_name=case.name, sample_name=sample.name)
+            errors.append(error)
+    return errors

--- a/cg/services/order_validation_service/workflows/tomte/validation_rules.py
+++ b/cg/services/order_validation_service/workflows/tomte/validation_rules.py
@@ -17,9 +17,10 @@ from cg.services.order_validation_service.workflows.tomte.validation.inter_field
     validate_fathers_are_male,
     validate_fathers_in_same_case_as_children,
     validate_mothers_are_female,
-    validate_pedigree,
     validate_mothers_in_same_case_as_children,
+    validate_pedigree,
     validate_sample_names_not_repeated,
+    validate_subject_ids_different_from_case_names,
     validate_wells_contain_at_most_one_sample,
 )
 
@@ -47,5 +48,6 @@ TOMTE_CASE_SAMPLE_RULES = [
     validate_pedigree,
     validate_mothers_in_same_case_as_children,
     validate_sample_names_not_repeated,
+    validate_subject_ids_different_from_case_names,
     validate_wells_contain_at_most_one_sample,
 ]

--- a/tests/services/order_validation_service/test_inter_field_validators.py
+++ b/tests/services/order_validation_service/test_inter_field_validators.py
@@ -2,6 +2,7 @@ from cg.services.order_validation_service.models.errors import (
     ApplicationNotCompatibleError,
     InvalidBufferError,
     OrderNameRequiredError,
+    SubjectIdSameAsCaseNameError,
     TicketNumberRequiredError,
 )
 from cg.services.order_validation_service.models.order import Order
@@ -12,6 +13,9 @@ from cg.services.order_validation_service.validators.inter_field.rules import (
     validate_ticket_number_required_if_connected,
 )
 from cg.services.order_validation_service.workflows.tomte.models.order import TomteOrder
+from cg.services.order_validation_service.workflows.tomte.validation.inter_field.rules import (
+    validate_subject_ids_different_from_case_names,
+)
 from cg.store.store import Store
 
 
@@ -63,7 +67,7 @@ def test_application_is_incompatible(
     assert isinstance(errors[0], ApplicationNotCompatibleError)
 
 
-def test_elution_buffer_is_not_allowed(valid_order: TomteOrder, base_store: Store):
+def test_elution_buffer_is_not_allowed(valid_order: TomteOrder):
 
     # GIVEN an order with 'skip reception control' toggled but no buffers specfied
     valid_order.skip_reception_control = True
@@ -76,3 +80,19 @@ def test_elution_buffer_is_not_allowed(valid_order: TomteOrder, base_store: Stor
 
     # THEN the error should be about the buffer compatability
     assert isinstance(errors[0], InvalidBufferError)
+
+
+def test_subject_ids_same_as_case_names_not_allowed(valid_order: TomteOrder):
+
+    # GIVEN an order with a sample having its subject_id same as the case's name
+    case_name = valid_order.cases[0].name
+    valid_order.cases[0].samples[0].subject_id = case_name
+
+    # WHEN validating that no subject ids are the same as the case name
+    errors = validate_subject_ids_different_from_case_names(valid_order)
+
+    # THEN an error should be returned
+    assert errors
+
+    # THEN the error should be concerning the subject id being the same as the case name
+    assert isinstance(errors[0], SubjectIdSameAsCaseNameError)


### PR DESCRIPTION
## Description

Subject ids are not allowed to be the same as the case's name.

### Added

- Validation ensuring that the subject id is not the same as the case name.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
