### PR TITLE
Add cancelled status to samples

### DIFF
--- a/alembic/versions/2024_08_02_601a2f272754_add_cancelled_status.py
+++ b/alembic/versions/2024_08_02_601a2f272754_add_cancelled_status.py
@@ -1,0 +1,28 @@
+"""Add cancelled status
+
+Revision ID: 601a2f272754
+Revises: 0ca61967d364
+Create Date: 2024-08-02 11:59:42.391980
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+# revision identifiers, used by Alembic.
+revision = "601a2f272754"
+down_revision = "0ca61967d364"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        table_name="sample",
+        column=sa.Column("is_cancelled", sa.Boolean(), nullable=False, default=False),
+    )
+
+
+def downgrade():
+    op.drop_column(table_name="sample", column_name="is_cancelled")

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -743,6 +743,7 @@ class Sample(Base, PriorityMixin):
     application_version: Mapped[ApplicationVersion] = orm.relationship(
         foreign_keys=[application_version_id]
     )
+    is_cancelled: Mapped[bool] = mapped_column(default=False, nullable=False)
     capture_kit: Mapped[Str64 | None]
     comment: Mapped[Text | None]
     control: Mapped[str | None] = mapped_column(


### PR DESCRIPTION
Part of resolving https://github.com/Clinical-Genomics/clinical-genomics-ui/issues/431.

We'll add a more robust way of tracking sample actions in a `SampleAction` table but we are starting like this.