### PR TITLE
Fix revision

### DIFF
--- a/alembic/versions/2024_08_02_601a2f272754_add_cancelled_status.py
+++ b/alembic/versions/2024_08_02_601a2f272754_add_cancelled_status.py
@@ -20,7 +20,7 @@ depends_on = None
 def upgrade():
     op.add_column(
         table_name="sample",
-        column=sa.Column("is_cancelled", sa.Boolean(), nullable=False, default=False),
+        column=sa.Column("is_cancelled", sa.Boolean(), nullable=False, server_default=False),
     )
 
 

--- a/alembic/versions/2024_08_02_601a2f272754_add_cancelled_status.py
+++ b/alembic/versions/2024_08_02_601a2f272754_add_cancelled_status.py
@@ -20,7 +20,7 @@ depends_on = None
 def upgrade():
     op.add_column(
         table_name="sample",
-        column=sa.Column("is_cancelled", sa.Boolean(), nullable=False, server_default=False),
+        column=sa.Column("is_cancelled", sa.Boolean(), nullable=False, server_default=sa.false()),
     )
 
 


### PR DESCRIPTION
The default parameter name was incorrect, resulting in the default value not being set for the new `is_cancelled` column in the sample table.