### PR TITLE
Add sequencing times for PacBio run

### DIFF
--- a/alembic/versions/2024_08_07_817cf7fea40d_add_sequencing_times_pacbio.py
+++ b/alembic/versions/2024_08_07_817cf7fea40d_add_sequencing_times_pacbio.py
@@ -25,8 +25,13 @@ def upgrade():
         "pacbio_sequencing_run",
         sa.Column("run_completed_at", sa.DateTime(), nullable=True),
     )
+    op.drop_column("pacbio_sequencing_run", "movie_time_hours")
 
 
 def downgrade():
+    op.add_column(
+        "pacbio_sequencing_run",
+        sa.Column("movie_time_hours", sa.Integer(), nullable=True),
+    )
     op.drop_column("pacbio_sequencing_run", "run_completed_at")
     op.drop_column("pacbio_sequencing_run", "run_started_at")

--- a/alembic/versions/2024_08_07_817cf7fea40d_add_sequencing_times_pacbio.py
+++ b/alembic/versions/2024_08_07_817cf7fea40d_add_sequencing_times_pacbio.py
@@ -1,0 +1,32 @@
+"""Add sequencing times PacBio
+
+Revision ID: 817cf7fea40d
+Revises: 601a2f272754
+Create Date: 2024-08-07 10:19:57.450266
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "817cf7fea40d"
+down_revision = "601a2f272754"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "pacbio_sequencing_run", sa.Column("run_started_at", sa.DateTime(), nullable=True)
+    )
+    op.add_column(
+        "pacbio_sequencing_run",
+        sa.Column("run_completed_at", sa.DateTime(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_column("pacbio_sequencing_run", "run_completed_at")
+    op.drop_column("pacbio_sequencing_run", "run_started_at")

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -1089,7 +1089,9 @@ class PacBioSequencingRun(InstrumentRun):
     id: Mapped[int] = mapped_column(ForeignKey("instrument_run.id"), primary_key=True)
     well: Mapped[Str32]
     plate: Mapped[int]
-    movie_time_hours: Mapped[int]
+    run_started_at: Mapped[datetime | None]
+    run_completed_at: Mapped[datetime | None]
+    movie_time_hours: Mapped[int | None]
     movie_name: Mapped[Str32]
     hifi_reads: Mapped[BigInt]
     hifi_yield: Mapped[BigInt]

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -1089,9 +1089,8 @@ class PacBioSequencingRun(InstrumentRun):
     id: Mapped[int] = mapped_column(ForeignKey("instrument_run.id"), primary_key=True)
     well: Mapped[Str32]
     plate: Mapped[int]
-    run_started_at: Mapped[datetime | None]
-    run_completed_at: Mapped[datetime | None]
-    movie_time_hours: Mapped[int | None]
+    started_at: Mapped[datetime | None]
+    completed_at: Mapped[datetime | None]
     movie_name: Mapped[Str32]
     hifi_reads: Mapped[BigInt]
     hifi_yield: Mapped[BigInt]


### PR DESCRIPTION
## Description
Add the following fields to the `PacBioSequencingRun` db model:
- run_started_at
- run_completed_at

Remove `movie_time_hours`

Create the alembic migration

### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b feat-add-pacbio-dates-db -a
    ```

### How to test
- [x] Run the migration (upgrade)
- [x] Run the downgrade

### Expected test outcome

- [x] Check that the upgrade goes through
- [x] The new columns are shown in the table
<img width="569" alt="Screenshot 2024-08-07 at 10 53 19" src="https://github.com/user-attachments/assets/dc722ed0-be04-4c2d-b321-c7ca5121ab41">
- [ ] Check that the downgrade goes through

## Review

- [x] Tests executed by SD
- [x] "Merge and deploy" approved by VJ
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Deployed to stage:
```shell

```
- [ ] Deployed to production:
```shell

```
