### PR TITLE
Implement convert errors method

### DIFF
--- a/cg/services/order_validation_service/models/errors.py
+++ b/cg/services/order_validation_service/models/errors.py
@@ -19,10 +19,10 @@ class CaseSampleError(CaseError, SampleError):
 
 
 class ValidationErrors(BaseModel):
-    order_errors: list[OrderError] | None = None
-    case_errors: list[CaseError] | None = None
-    sample_errors: list[SampleError] | None = None
-    case_sample_errors: list[CaseSampleError] | None = None
+    order_errors: list[OrderError] = []
+    case_errors: list[CaseError] = []
+    sample_errors: list[SampleError] = []
+    case_sample_errors: list[CaseSampleError] = []
 
 
 class UserNotAssociatedWithCustomerError(OrderError):

--- a/cg/services/order_validation_service/utils.py
+++ b/cg/services/order_validation_service/utils.py
@@ -1,11 +1,13 @@
 from typing import Callable
 
 from pydantic import ValidationError
+from pydantic_core import ErrorDetails
 
 from cg.services.order_validation_service.models.errors import (
     CaseError,
     CaseSampleError,
     OrderError,
+    SampleError,
     ValidationErrors,
 )
 from cg.services.order_validation_service.models.order import Order
@@ -38,5 +40,99 @@ def apply_case_sample_validation(
     return errors
 
 
-def convert_errors(pydantic_errors: list[ValidationError]) -> ValidationErrors:
-    pass
+def convert_errors(pydantic_errors: ValidationError, order: dict) -> ValidationErrors:
+    error_details: list[ErrorDetails] = pydantic_errors.errors()
+    order_errors = convert_order_errors(error_details)
+    case_errors = convert_case_errors(error_details=error_details, order=order)
+    case_sample_errors = convert_case_sample_errors(error_details=error_details, order=order)
+    sample_errors = convert_sample_errors(error_details=error_details, order=order)
+    return ValidationErrors(
+        order_errors=order_errors,
+        case_errors=case_errors,
+        case_sample_errors=case_sample_errors,
+        sample_errors=sample_errors,
+    )
+
+
+def convert_sample_errors(error_details: list[ErrorDetails], order: dict) -> list[SampleError]:
+    errors: list[SampleError] = []
+    sample_details = get_sample_error_details(error_details)
+    for error in sample_details:
+        sample_name = order["samples"][error["loc"][1]]["name"]
+        field_name = error["loc"][2]
+        message = error["msg"]
+        error = SampleError(sample_name=sample_name, field=field_name, message=message)
+        errors.append(error)
+    return errors
+
+
+def get_sample_error_details(error_details: list[ErrorDetails]) -> list[ErrorDetails]:
+    return [error for error in error_details if is_sample_error(error)]
+
+
+def is_sample_error(error: ErrorDetails) -> bool:
+    return len(error["loc"]) == 3 and error["loc"][0] == "samples"
+
+
+def convert_order_errors(error_details: list[ErrorDetails]) -> list[OrderError]:
+    errors: list[OrderError] = []
+    order_details = get_order_error_details(error_details)
+    for error in order_details:
+        field_name = error["loc"][0]
+        message = error["msg"]
+        error = OrderError(field=field_name, message=message)
+        errors.append(error)
+    return errors
+
+
+def convert_case_errors(error_details: list[ErrorDetails], order: dict) -> list[CaseError]:
+    errors: list[CaseError] = []
+    case_details = get_case_error_details(error_details)
+    for error in case_details:
+        case_name = order["cases"][error["loc"][1]]["name"]
+        field_name = error["loc"][2]
+        message = error["msg"]
+        error = CaseError(case_name=case_name, field=field_name, message=message)
+        errors.append(error)
+    return errors
+
+
+def convert_case_sample_errors(
+    error_details: list[ErrorDetails], order: dict
+) -> list[CaseSampleError]:
+    errors: list[CaseSampleError] = []
+    case_sample_details = get_case_sample_error_details(error_details)
+    for error in case_sample_details:
+        case_name = order["cases"][error["loc"][1]]["name"]
+        sample_name = order["cases"][error["loc"][1]]["samples"][error["loc"][3]]["name"]
+        field_name = error["loc"][4]
+        message = error["msg"]
+        error = CaseSampleError(
+            case_name=case_name, sample_name=sample_name, field_name=field_name, message=message
+        )
+        errors.append(error)
+    return errors
+
+
+def get_case_sample_error_details(error_details: list[ErrorDetails]) -> list[ErrorDetails]:
+    return [error for error in error_details if is_case_sample_error(error)]
+
+
+def is_case_sample_error(error: ErrorDetails) -> bool:
+    return len(error["loc"]) == 5
+
+
+def get_case_error_details(error_details: list[ErrorDetails]) -> list[ErrorDetails]:
+    return [error for error in error_details if is_case_error(error)]
+
+
+def get_order_error_details(error_details: list[ErrorDetails]) -> list[ErrorDetails]:
+    return [error for error in error_details if is_order_error(error)]
+
+
+def is_case_error(error: ErrorDetails) -> bool:
+    return len(error["loc"]) == 3 and error["loc"][0] == "cases"
+
+
+def is_order_error(error: ErrorDetails) -> bool:
+    return len(error["loc"]) == 1

--- a/cg/services/order_validation_service/utils.py
+++ b/cg/services/order_validation_service/utils.py
@@ -1,14 +1,9 @@
 from typing import Callable
 
-from pydantic import ValidationError
-from pydantic_core import ErrorDetails
-
 from cg.services.order_validation_service.models.errors import (
     CaseError,
     CaseSampleError,
     OrderError,
-    SampleError,
-    ValidationErrors,
 )
 from cg.services.order_validation_service.models.order import Order
 from cg.store.store import Store
@@ -38,101 +33,3 @@ def apply_case_sample_validation(
         rule_errors: list[CaseSampleError] = rule(order=order, store=store)
         errors.extend(rule_errors)
     return errors
-
-
-def convert_errors(pydantic_errors: ValidationError, order: dict) -> ValidationErrors:
-    error_details: list[ErrorDetails] = pydantic_errors.errors()
-    order_errors = convert_order_errors(error_details)
-    case_errors = convert_case_errors(error_details=error_details, order=order)
-    case_sample_errors = convert_case_sample_errors(error_details=error_details, order=order)
-    sample_errors = convert_sample_errors(error_details=error_details, order=order)
-    return ValidationErrors(
-        order_errors=order_errors,
-        case_errors=case_errors,
-        case_sample_errors=case_sample_errors,
-        sample_errors=sample_errors,
-    )
-
-
-def convert_sample_errors(error_details: list[ErrorDetails], order: dict) -> list[SampleError]:
-    errors: list[SampleError] = []
-    sample_details = get_sample_error_details(error_details)
-    for error in sample_details:
-        sample_name = order["samples"][error["loc"][1]]["name"]
-        field_name = error["loc"][2]
-        message = error["msg"]
-        error = SampleError(sample_name=sample_name, field=field_name, message=message)
-        errors.append(error)
-    return errors
-
-
-def get_sample_error_details(error_details: list[ErrorDetails]) -> list[ErrorDetails]:
-    return [error for error in error_details if is_sample_error(error)]
-
-
-def is_sample_error(error: ErrorDetails) -> bool:
-    return len(error["loc"]) == 3 and error["loc"][0] == "samples"
-
-
-def convert_order_errors(error_details: list[ErrorDetails]) -> list[OrderError]:
-    errors: list[OrderError] = []
-    order_details = get_order_error_details(error_details)
-    for error in order_details:
-        field_name = error["loc"][0]
-        message = error["msg"]
-        error = OrderError(field=field_name, message=message)
-        errors.append(error)
-    return errors
-
-
-def convert_case_errors(error_details: list[ErrorDetails], order: dict) -> list[CaseError]:
-    errors: list[CaseError] = []
-    case_details = get_case_error_details(error_details)
-    for error in case_details:
-        case_name = order["cases"][error["loc"][1]]["name"]
-        field_name = error["loc"][2]
-        message = error["msg"]
-        error = CaseError(case_name=case_name, field=field_name, message=message)
-        errors.append(error)
-    return errors
-
-
-def convert_case_sample_errors(
-    error_details: list[ErrorDetails], order: dict
-) -> list[CaseSampleError]:
-    errors: list[CaseSampleError] = []
-    case_sample_details = get_case_sample_error_details(error_details)
-    for error in case_sample_details:
-        case_name = order["cases"][error["loc"][1]]["name"]
-        sample_name = order["cases"][error["loc"][1]]["samples"][error["loc"][3]]["name"]
-        field_name = error["loc"][4]
-        message = error["msg"]
-        error = CaseSampleError(
-            case_name=case_name, sample_name=sample_name, field_name=field_name, message=message
-        )
-        errors.append(error)
-    return errors
-
-
-def get_case_sample_error_details(error_details: list[ErrorDetails]) -> list[ErrorDetails]:
-    return [error for error in error_details if is_case_sample_error(error)]
-
-
-def is_case_sample_error(error: ErrorDetails) -> bool:
-    return len(error["loc"]) == 5
-
-
-def get_case_error_details(error_details: list[ErrorDetails]) -> list[ErrorDetails]:
-    return [error for error in error_details if is_case_error(error)]
-
-
-def get_order_error_details(error_details: list[ErrorDetails]) -> list[ErrorDetails]:
-    return [error for error in error_details if is_order_error(error)]
-
-
-def is_case_error(error: ErrorDetails) -> bool:
-    return len(error["loc"]) == 3 and error["loc"][0] == "cases"
-
-
-def is_order_error(error: ErrorDetails) -> bool:
-    return len(error["loc"]) == 1

--- a/cg/services/order_validation_service/workflows/tomte/validation/field/tomte_model_validator.py
+++ b/cg/services/order_validation_service/workflows/tomte/validation/field/tomte_model_validator.py
@@ -1,8 +1,10 @@
 from pydantic_core import ValidationError
 
 from cg.services.order_validation_service.models.errors import ValidationErrors
-from cg.services.order_validation_service.utils import convert_errors
 from cg.services.order_validation_service.workflows.tomte.models.order import TomteOrder
+from cg.services.order_validation_service.workflows.tomte.validation.field.utils import (
+    convert_errors,
+)
 
 
 class TomteModelValidator:

--- a/cg/services/order_validation_service/workflows/tomte/validation/field/tomte_model_validator.py
+++ b/cg/services/order_validation_service/workflows/tomte/validation/field/tomte_model_validator.py
@@ -1,0 +1,16 @@
+from pydantic_core import ValidationError
+
+from cg.services.order_validation_service.models.errors import ValidationErrors
+from cg.services.order_validation_service.utils import convert_errors
+from cg.services.order_validation_service.workflows.tomte.models.order import TomteOrder
+
+
+class TomteModelValidator:
+
+    @classmethod
+    def validate(cls, order_json: str) -> tuple[TomteOrder | None, ValidationErrors]:
+        try:
+            order = TomteOrder.model_validate_json(order_json)
+            return order, ValidationErrors()
+        except ValidationError as error:
+            return None, convert_errors(error)

--- a/cg/services/order_validation_service/workflows/tomte/validation/field/tomte_model_validator.py
+++ b/cg/services/order_validation_service/workflows/tomte/validation/field/tomte_model_validator.py
@@ -10,9 +10,9 @@ from cg.services.order_validation_service.workflows.tomte.validation.field.utils
 class TomteModelValidator:
 
     @classmethod
-    def validate(cls, order_json: str) -> tuple[TomteOrder | None, ValidationErrors]:
+    def validate(cls, raw_order: dict) -> tuple[TomteOrder | None, ValidationErrors]:
         try:
-            order = TomteOrder.model_validate_json(order_json)
+            order = TomteOrder.model_validate(raw_order)
             return order, ValidationErrors()
         except ValidationError as error:
-            return None, convert_errors(error)
+            return None, convert_errors(pydantic_errors=error, order=raw_order)

--- a/cg/services/order_validation_service/workflows/tomte/validation/field/utils.py
+++ b/cg/services/order_validation_service/workflows/tomte/validation/field/utils.py
@@ -1,4 +1,5 @@
 from pydantic_core import ErrorDetails, ValidationError
+
 from cg.services.order_validation_service.models.errors import (
     CaseError,
     CaseSampleError,
@@ -91,7 +92,7 @@ def create_case_sample_error(error: ErrorDetails, order: dict) -> CaseSampleErro
     error = CaseSampleError(
         case_name=case_name,
         sample_name=sample_name,
-        field_name=field_name,
+        field=field_name,
         message=message,
     )
     return error

--- a/cg/services/order_validation_service/workflows/tomte/validation/field/utils.py
+++ b/cg/services/order_validation_service/workflows/tomte/validation/field/utils.py
@@ -26,9 +26,7 @@ def convert_order_errors(error_details: list[ErrorDetails]) -> list[OrderError]:
     errors: list[OrderError] = []
     order_details = get_order_error_details(error_details)
     for error in order_details:
-        field_name = get_order_field_name(error)
-        message = get_error_message(error)
-        error = OrderError(field=field_name, message=message)
+        error = create_order_error(error)
         errors.append(error)
     return errors
 
@@ -49,6 +47,13 @@ def convert_sample_errors(error_details: list[ErrorDetails], order: dict) -> lis
         error = create_sample_error(error=error, order=order)
         errors.append(error)
     return errors
+
+
+def create_order_error(error: ErrorDetails) -> OrderError:
+    field_name = get_order_field_name(error)
+    message = get_error_message(error)
+    error = OrderError(field=field_name, message=message)
+    return error
 
 
 def create_sample_error(error: ErrorDetails, order: dict) -> SampleError:

--- a/cg/services/order_validation_service/workflows/tomte/validation/field/utils.py
+++ b/cg/services/order_validation_service/workflows/tomte/validation/field/utils.py
@@ -1,0 +1,106 @@
+from pydantic_core import ErrorDetails, ValidationError
+from cg.services.order_validation_service.models.errors import (
+    CaseError,
+    CaseSampleError,
+    OrderError,
+    SampleError,
+    ValidationErrors,
+)
+
+
+def convert_errors(pydantic_errors: ValidationError, order: dict) -> ValidationErrors:
+    error_details: list[ErrorDetails] = pydantic_errors.errors()
+    order_errors = convert_order_errors(error_details)
+    case_errors = convert_case_errors(error_details=error_details, order=order)
+    case_sample_errors = convert_case_sample_errors(error_details=error_details, order=order)
+    sample_errors = convert_sample_errors(error_details=error_details, order=order)
+    return ValidationErrors(
+        order_errors=order_errors,
+        case_errors=case_errors,
+        case_sample_errors=case_sample_errors,
+        sample_errors=sample_errors,
+    )
+
+
+def convert_sample_errors(error_details: list[ErrorDetails], order: dict) -> list[SampleError]:
+    errors: list[SampleError] = []
+    sample_details = get_sample_error_details(error_details)
+    for error in sample_details:
+        sample_name = order["samples"][error["loc"][1]]["name"]
+        field_name = error["loc"][2]
+        message = error["msg"]
+        error = SampleError(sample_name=sample_name, field=field_name, message=message)
+        errors.append(error)
+    return errors
+
+
+def get_sample_error_details(error_details: list[ErrorDetails]) -> list[ErrorDetails]:
+    return [error for error in error_details if is_sample_error(error)]
+
+
+def is_sample_error(error: ErrorDetails) -> bool:
+    return len(error["loc"]) == 3 and error["loc"][0] == "samples"
+
+
+def convert_order_errors(error_details: list[ErrorDetails]) -> list[OrderError]:
+    errors: list[OrderError] = []
+    order_details = get_order_error_details(error_details)
+    for error in order_details:
+        field_name = error["loc"][0]
+        message = error["msg"]
+        error = OrderError(field=field_name, message=message)
+        errors.append(error)
+    return errors
+
+
+def convert_case_errors(error_details: list[ErrorDetails], order: dict) -> list[CaseError]:
+    errors: list[CaseError] = []
+    case_details = get_case_error_details(error_details)
+    for error in case_details:
+        case_name = order["cases"][error["loc"][1]]["name"]
+        field_name = error["loc"][2]
+        message = error["msg"]
+        error = CaseError(case_name=case_name, field=field_name, message=message)
+        errors.append(error)
+    return errors
+
+
+def convert_case_sample_errors(
+    error_details: list[ErrorDetails], order: dict
+) -> list[CaseSampleError]:
+    errors: list[CaseSampleError] = []
+    case_sample_details = get_case_sample_error_details(error_details)
+    for error in case_sample_details:
+        case_name = order["cases"][error["loc"][1]]["name"]
+        sample_name = order["cases"][error["loc"][1]]["samples"][error["loc"][3]]["name"]
+        field_name = error["loc"][4]
+        message = error["msg"]
+        error = CaseSampleError(
+            case_name=case_name, sample_name=sample_name, field_name=field_name, message=message
+        )
+        errors.append(error)
+    return errors
+
+
+def get_case_sample_error_details(error_details: list[ErrorDetails]) -> list[ErrorDetails]:
+    return [error for error in error_details if is_case_sample_error(error)]
+
+
+def is_case_sample_error(error: ErrorDetails) -> bool:
+    return len(error["loc"]) == 5
+
+
+def get_case_error_details(error_details: list[ErrorDetails]) -> list[ErrorDetails]:
+    return [error for error in error_details if is_case_error(error)]
+
+
+def get_order_error_details(error_details: list[ErrorDetails]) -> list[ErrorDetails]:
+    return [error for error in error_details if is_order_error(error)]
+
+
+def is_case_error(error: ErrorDetails) -> bool:
+    return len(error["loc"]) == 3 and error["loc"][0] == "cases"
+
+
+def is_order_error(error: ErrorDetails) -> bool:
+    return len(error["loc"]) == 1

--- a/cg/services/order_validation_service/workflows/tomte/validation/field/utils.py
+++ b/cg/services/order_validation_service/workflows/tomte/validation/field/utils.py
@@ -92,36 +92,60 @@ def create_case_sample_error(error: ErrorDetails, order: dict) -> CaseSampleErro
     return error
 
 
-def get_sample_name(error: ErrorDetails, order: dict) -> str:
-    return order["samples"][error["loc"][1]]["name"]
+def is_sample_error(error: ErrorDetails) -> bool:
+    return len(error["loc"]) == 3 and error["loc"][0] == "samples"
 
 
-def get_sample_field_name(error: ErrorDetails) -> str:
-    return error["loc"][2]
+def is_case_error(error: ErrorDetails) -> bool:
+    return len(error["loc"]) == 3 and error["loc"][0] == "cases"
 
 
-def get_error_message(error: ErrorDetails) -> str:
-    return error["msg"]
+def is_case_sample_error(error: ErrorDetails) -> bool:
+    return len(error["loc"]) == 5
+
+
+def is_order_error(error: ErrorDetails) -> bool:
+    return len(error["loc"]) == 1
 
 
 def get_sample_error_details(error_details: list[ErrorDetails]) -> list[ErrorDetails]:
     return [error for error in error_details if is_sample_error(error)]
 
 
-def is_sample_error(error: ErrorDetails) -> bool:
-    return len(error["loc"]) == 3 and error["loc"][0] == "samples"
+def get_case_error_details(error_details: list[ErrorDetails]) -> list[ErrorDetails]:
+    return [error for error in error_details if is_case_error(error)]
+
+
+def get_case_sample_error_details(error_details: list[ErrorDetails]) -> list[ErrorDetails]:
+    return [error for error in error_details if is_case_sample_error(error)]
+
+
+def get_order_error_details(error_details: list[ErrorDetails]) -> list[ErrorDetails]:
+    return [error for error in error_details if is_order_error(error)]
+
+
+def get_error_message(error: ErrorDetails) -> str:
+    return error["msg"]
+
+
+def get_sample_field_name(error: ErrorDetails) -> str:
+    return error["loc"][2]
+
+
+def get_case_field_name(error: ErrorDetails) -> str:
+    return error["loc"][2]
+
+
+def get_case_sample_field_name(error: ErrorDetails) -> str:
+    return error["loc"][4]
 
 
 def get_order_field_name(error: ErrorDetails) -> str:
     return error["loc"][0]
 
 
-def get_case_name(error: ErrorDetails, order: dict) -> str:
-    return order["cases"][error["loc"][1]]["name"]
-
-
-def get_case_field_name(error: ErrorDetails) -> str:
-    return error["loc"][2]
+def get_sample_name(error: ErrorDetails, order: dict) -> str:
+    return order["samples"][error["loc"][1]]["name"]
 
 
 def get_case_name(error: ErrorDetails, order: dict) -> str:
@@ -130,31 +154,3 @@ def get_case_name(error: ErrorDetails, order: dict) -> str:
 
 def get_case_sample_name(error: ErrorDetails, order: dict) -> str:
     return order["cases"][error["loc"][1]]["samples"][error["loc"][3]]["name"]
-
-
-def get_case_sample_field_name(error: ErrorDetails) -> str:
-    return error["loc"][4]
-
-
-def get_case_sample_error_details(error_details: list[ErrorDetails]) -> list[ErrorDetails]:
-    return [error for error in error_details if is_case_sample_error(error)]
-
-
-def is_case_sample_error(error: ErrorDetails) -> bool:
-    return len(error["loc"]) == 5
-
-
-def get_case_error_details(error_details: list[ErrorDetails]) -> list[ErrorDetails]:
-    return [error for error in error_details if is_case_error(error)]
-
-
-def get_order_error_details(error_details: list[ErrorDetails]) -> list[ErrorDetails]:
-    return [error for error in error_details if is_order_error(error)]
-
-
-def is_case_error(error: ErrorDetails) -> bool:
-    return len(error["loc"]) == 3 and error["loc"][0] == "cases"
-
-
-def is_order_error(error: ErrorDetails) -> bool:
-    return len(error["loc"]) == 1

--- a/cg/services/order_validation_service/workflows/tomte/validation/field/utils.py
+++ b/cg/services/order_validation_service/workflows/tomte/validation/field/utils.py
@@ -39,26 +39,6 @@ def create_sample_error(error: ErrorDetails, order: dict) -> SampleError:
     return error
 
 
-def get_sample_name(error: ErrorDetails, order: dict) -> str:
-    return order["samples"][error["loc"][1]]["name"]
-
-
-def get_sample_field_name(error: ErrorDetails) -> str:
-    return error["loc"][2]
-
-
-def get_error_message(error: ErrorDetails) -> str:
-    return error["msg"]
-
-
-def get_sample_error_details(error_details: list[ErrorDetails]) -> list[ErrorDetails]:
-    return [error for error in error_details if is_sample_error(error)]
-
-
-def is_sample_error(error: ErrorDetails) -> bool:
-    return len(error["loc"]) == 3 and error["loc"][0] == "samples"
-
-
 def convert_order_errors(error_details: list[ErrorDetails]) -> list[OrderError]:
     errors: list[OrderError] = []
     order_details = get_order_error_details(error_details)
@@ -68,10 +48,6 @@ def convert_order_errors(error_details: list[ErrorDetails]) -> list[OrderError]:
         error = OrderError(field=field_name, message=message)
         errors.append(error)
     return errors
-
-
-def get_order_field_name(error: ErrorDetails) -> str:
-    return error["loc"][0]
 
 
 def convert_case_errors(error_details: list[ErrorDetails], order: dict) -> list[CaseError]:
@@ -89,14 +65,6 @@ def create_case_error(error: ErrorDetails, order: dict) -> CaseError:
     message = get_error_message(error)
     error = CaseError(case_name=case_name, field=field_name, message=message)
     return error
-
-
-def get_case_name(error: ErrorDetails, order: dict) -> str:
-    return order["cases"][error["loc"][1]]["name"]
-
-
-def get_case_field_name(error: ErrorDetails) -> str:
-    return error["loc"][2]
 
 
 def convert_case_sample_errors(
@@ -122,6 +90,38 @@ def create_case_sample_error(error: ErrorDetails, order: dict) -> CaseSampleErro
         message=message,
     )
     return error
+
+
+def get_sample_name(error: ErrorDetails, order: dict) -> str:
+    return order["samples"][error["loc"][1]]["name"]
+
+
+def get_sample_field_name(error: ErrorDetails) -> str:
+    return error["loc"][2]
+
+
+def get_error_message(error: ErrorDetails) -> str:
+    return error["msg"]
+
+
+def get_sample_error_details(error_details: list[ErrorDetails]) -> list[ErrorDetails]:
+    return [error for error in error_details if is_sample_error(error)]
+
+
+def is_sample_error(error: ErrorDetails) -> bool:
+    return len(error["loc"]) == 3 and error["loc"][0] == "samples"
+
+
+def get_order_field_name(error: ErrorDetails) -> str:
+    return error["loc"][0]
+
+
+def get_case_name(error: ErrorDetails, order: dict) -> str:
+    return order["cases"][error["loc"][1]]["name"]
+
+
+def get_case_field_name(error: ErrorDetails) -> str:
+    return error["loc"][2]
 
 
 def get_case_name(error: ErrorDetails, order: dict) -> str:

--- a/cg/services/order_validation_service/workflows/tomte/validation/field/utils.py
+++ b/cg/services/order_validation_service/workflows/tomte/validation/field/utils.py
@@ -26,12 +26,29 @@ def convert_sample_errors(error_details: list[ErrorDetails], order: dict) -> lis
     errors: list[SampleError] = []
     sample_details = get_sample_error_details(error_details)
     for error in sample_details:
-        sample_name = order["samples"][error["loc"][1]]["name"]
-        field_name = error["loc"][2]
-        message = error["msg"]
-        error = SampleError(sample_name=sample_name, field=field_name, message=message)
+        error = create_sample_error(error=error, order=order)
         errors.append(error)
     return errors
+
+
+def create_sample_error(error: ErrorDetails, order: dict) -> SampleError:
+    sample_name = get_sample_name(error=error, order=order)
+    field_name = get_sample_field_name(error)
+    message = get_error_message(error)
+    error = SampleError(sample_name=sample_name, field=field_name, message=message)
+    return error
+
+
+def get_sample_name(error: ErrorDetails, order: dict) -> str:
+    return order["samples"][error["loc"][1]]["name"]
+
+
+def get_sample_field_name(error: ErrorDetails) -> str:
+    return error["loc"][2]
+
+
+def get_error_message(error: ErrorDetails) -> str:
+    return error["msg"]
 
 
 def get_sample_error_details(error_details: list[ErrorDetails]) -> list[ErrorDetails]:
@@ -46,23 +63,40 @@ def convert_order_errors(error_details: list[ErrorDetails]) -> list[OrderError]:
     errors: list[OrderError] = []
     order_details = get_order_error_details(error_details)
     for error in order_details:
-        field_name = error["loc"][0]
-        message = error["msg"]
+        field_name = get_order_field_name(error)
+        message = get_error_message(error)
         error = OrderError(field=field_name, message=message)
         errors.append(error)
     return errors
+
+
+def get_order_field_name(error: ErrorDetails) -> str:
+    return error["loc"][0]
 
 
 def convert_case_errors(error_details: list[ErrorDetails], order: dict) -> list[CaseError]:
     errors: list[CaseError] = []
     case_details = get_case_error_details(error_details)
     for error in case_details:
-        case_name = order["cases"][error["loc"][1]]["name"]
-        field_name = error["loc"][2]
-        message = error["msg"]
-        error = CaseError(case_name=case_name, field=field_name, message=message)
+        error = create_case_error(error=error, order=order)
         errors.append(error)
     return errors
+
+
+def create_case_error(error: ErrorDetails, order: dict) -> CaseError:
+    case_name = get_case_name(error=error, order=order)
+    field_name = get_case_field_name(error)
+    message = get_error_message(error)
+    error = CaseError(case_name=case_name, field=field_name, message=message)
+    return error
+
+
+def get_case_name(error: ErrorDetails, order: dict) -> str:
+    return order["cases"][error["loc"][1]]["name"]
+
+
+def get_case_field_name(error: ErrorDetails) -> str:
+    return error["loc"][2]
 
 
 def convert_case_sample_errors(
@@ -71,15 +105,35 @@ def convert_case_sample_errors(
     errors: list[CaseSampleError] = []
     case_sample_details = get_case_sample_error_details(error_details)
     for error in case_sample_details:
-        case_name = order["cases"][error["loc"][1]]["name"]
-        sample_name = order["cases"][error["loc"][1]]["samples"][error["loc"][3]]["name"]
-        field_name = error["loc"][4]
-        message = error["msg"]
-        error = CaseSampleError(
-            case_name=case_name, sample_name=sample_name, field_name=field_name, message=message
-        )
+        error = create_case_sample_error(error=error, order=order)
         errors.append(error)
     return errors
+
+
+def create_case_sample_error(error: ErrorDetails, order: dict) -> CaseSampleError:
+    case_name = get_case_name(error=error, order=order)
+    sample_name = get_case_sample_name(error=error, order=order)
+    field_name = get_case_sample_field_name(error)
+    message = get_error_message(error)
+    error = CaseSampleError(
+        case_name=case_name,
+        sample_name=sample_name,
+        field_name=field_name,
+        message=message,
+    )
+    return error
+
+
+def get_case_name(error: ErrorDetails, order: dict) -> str:
+    return order["cases"][error["loc"][1]]["name"]
+
+
+def get_case_sample_name(error: ErrorDetails, order: dict) -> str:
+    return order["cases"][error["loc"][1]]["samples"][error["loc"][3]]["name"]
+
+
+def get_case_sample_field_name(error: ErrorDetails) -> str:
+    return error["loc"][4]
 
 
 def get_case_sample_error_details(error_details: list[ErrorDetails]) -> list[ErrorDetails]:

--- a/cg/services/order_validation_service/workflows/tomte/validation/field/utils.py
+++ b/cg/services/order_validation_service/workflows/tomte/validation/field/utils.py
@@ -22,23 +22,6 @@ def convert_errors(pydantic_errors: ValidationError, order: dict) -> ValidationE
     )
 
 
-def convert_sample_errors(error_details: list[ErrorDetails], order: dict) -> list[SampleError]:
-    errors: list[SampleError] = []
-    sample_details = get_sample_error_details(error_details)
-    for error in sample_details:
-        error = create_sample_error(error=error, order=order)
-        errors.append(error)
-    return errors
-
-
-def create_sample_error(error: ErrorDetails, order: dict) -> SampleError:
-    sample_name = get_sample_name(error=error, order=order)
-    field_name = get_sample_field_name(error)
-    message = get_error_message(error)
-    error = SampleError(sample_name=sample_name, field=field_name, message=message)
-    return error
-
-
 def convert_order_errors(error_details: list[ErrorDetails]) -> list[OrderError]:
     errors: list[OrderError] = []
     order_details = get_order_error_details(error_details)
@@ -57,6 +40,23 @@ def convert_case_errors(error_details: list[ErrorDetails], order: dict) -> list[
         error = create_case_error(error=error, order=order)
         errors.append(error)
     return errors
+
+
+def convert_sample_errors(error_details: list[ErrorDetails], order: dict) -> list[SampleError]:
+    errors: list[SampleError] = []
+    sample_details = get_sample_error_details(error_details)
+    for error in sample_details:
+        error = create_sample_error(error=error, order=order)
+        errors.append(error)
+    return errors
+
+
+def create_sample_error(error: ErrorDetails, order: dict) -> SampleError:
+    sample_name = get_sample_name(error=error, order=order)
+    field_name = get_sample_field_name(error)
+    message = get_error_message(error)
+    error = SampleError(sample_name=sample_name, field=field_name, message=message)
+    return error
 
 
 def create_case_error(error: ErrorDetails, order: dict) -> CaseError:

--- a/cg/services/order_validation_service/workflows/tomte/validation_service.py
+++ b/cg/services/order_validation_service/workflows/tomte/validation_service.py
@@ -1,5 +1,3 @@
-from pydantic import ValidationError
-
 from cg.services.order_validation_service.models.errors import (
     CaseError,
     CaseSampleError,
@@ -14,7 +12,6 @@ from cg.services.order_validation_service.utils import (
     apply_case_validation,
     apply_order_validation,
 )
-from cg.services.order_validation_service.workflows.tomte.models.order import TomteOrder
 from cg.services.order_validation_service.workflows.tomte.validation.field.tomte_model_validator import (
     TomteModelValidator,
 )
@@ -32,8 +29,8 @@ class TomteValidationService(OrderValidationService):
         self.store = store
         self.model_validator = model_validator
 
-    def validate(self, order_json: str) -> ValidationErrors:
-        order, field_errors = self.model_validator.validate(order_json)
+    def validate(self, raw_order: dict) -> ValidationErrors:
+        order, field_errors = self.model_validator.validate(raw_order)
 
         if field_errors:
             return field_errors

--- a/tests/services/order_validation_service/conftest.py
+++ b/tests/services/order_validation_service/conftest.py
@@ -214,8 +214,3 @@ def tomte_validation_service(
         store=base_store,
         model_validator=tomte_model_validator,
     )
-
-
-@pytest.fixture
-def tomte_model_validator():
-    pass

--- a/tests/services/order_validation_service/conftest.py
+++ b/tests/services/order_validation_service/conftest.py
@@ -10,6 +10,9 @@ from cg.services.order_validation_service.workflows.tomte.models.order import To
 from cg.services.order_validation_service.workflows.tomte.models.sample import (
     TomteSample,
 )
+from cg.services.order_validation_service.workflows.tomte.validation.field.tomte_model_validator import (
+    TomteModelValidator,
+)
 from cg.services.order_validation_service.workflows.tomte.validation_service import (
     TomteValidationService,
 )
@@ -198,5 +201,21 @@ def sample_with_missing_container_name() -> TomteSample:
 
 
 @pytest.fixture
-def tomte_validation_service(base_store: Store) -> TomteValidationService:
-    return TomteValidationService(base_store)
+def tomte_model_validator():
+    return TomteModelValidator()
+
+
+@pytest.fixture
+def tomte_validation_service(
+    base_store: Store,
+    tomte_model_validator: TomteModelValidator,
+) -> TomteValidationService:
+    return TomteValidationService(
+        store=base_store,
+        model_validator=tomte_model_validator,
+    )
+
+
+@pytest.fixture
+def tomte_model_validator():
+    pass

--- a/tests/services/order_validation_service/test_tomte_field_validator.py
+++ b/tests/services/order_validation_service/test_tomte_field_validator.py
@@ -1,0 +1,21 @@
+from cg.services.order_validation_service.workflows.tomte.models.order import TomteOrder
+from cg.services.order_validation_service.workflows.tomte.validation.field.tomte_model_validator import (
+    TomteModelValidator,
+)
+
+
+def test_valid_order_is_parsed(
+    valid_order: TomteOrder,
+    tomte_model_validator: TomteModelValidator,
+):
+    # GIVEN a valid order
+    order_json = valid_order.model_dump_json()
+
+    # WHEN parsing the order
+    order, errors = tomte_model_validator.validate(order_json)
+
+    # THEN the parsed order is returned
+    assert order
+
+    # THEN no errors should be returned
+    assert not errors

--- a/tests/services/order_validation_service/test_tomte_field_validator.py
+++ b/tests/services/order_validation_service/test_tomte_field_validator.py
@@ -28,25 +28,75 @@ def test_order_field_error(
     valid_order: TomteOrder,
     tomte_model_validator: TomteModelValidator,
 ):
-    pass
+    # GIVEN an order with an order field error
+    valid_order.name = None
+    order = valid_order.model_dump(by_alias=True)
+
+    # WHEN validating the order
+    order, errors = tomte_model_validator.validate(order)
+
+    # THEN there should be an order error
+    assert errors.order_errors
+
+    # THEN the error should concern the missing name
+    assert errors.order_errors[0].field == "name"
 
 
 def test_case_field_error(
     valid_order: TomteOrder,
     tomte_model_validator: TomteModelValidator,
 ):
-    pass
+    # GIVEN an order with a case field error
+    valid_order.cases[0].data_delivery = None
+    order = valid_order.model_dump(by_alias=True)
+
+    # WHEN validating the order
+    order, errors = tomte_model_validator.validate(order)
+
+    # THEN there should be a case error
+    assert errors.case_errors
+
+    # THEN the error should concern the missing name
+    assert errors.case_errors[0].field == "data_delivery"
 
 
-def test_sample_case_field_error(
+def test_case_sample_field_error(
     valid_order: TomteOrder,
     tomte_model_validator: TomteModelValidator,
 ):
-    pass
+
+    # GIVEN an order with a case sample error
+    valid_order.cases[0].samples[0].well_position = 1.8
+    order = valid_order.model_dump(by_alias=True)
+
+    # WHEN validating the order
+    order, errors = tomte_model_validator.validate(order)
+
+    # THEN a case sample error should be returned
+    assert errors.case_sample_errors
+
+    # THEN the case sample error should concern the invalid data type
+    assert errors.case_sample_errors[0].field == "well_position"
 
 
-def test_sample_field_error(
-    valid_order: TomteOrder,
-    tomte_model_validator: TomteModelValidator,
+def test_order_case_and_case_sample_field_error(
+    valid_order: TomteOrder, tomte_model_validator: TomteModelValidator
 ):
-    pass
+    # GIVEN an order with an order, case and case sample error
+    valid_order.name = None
+    valid_order.cases[0].data_delivery = None
+    valid_order.cases[0].samples[0].well_position = 1.8
+    order = valid_order.model_dump(by_alias=True)
+
+    # WHEN validating the order
+    order, errors = tomte_model_validator.validate(order)
+
+    # THEN all errors should be returned
+    assert errors.order_errors
+    assert errors.case_errors
+    assert errors.case_sample_errors
+
+    # THEN the errors should concern the relevant fields
+    assert errors.order_errors[0].field == "name"
+    assert errors.case_errors[0].field == "data_delivery"
+    assert errors.case_sample_errors[0].field == "well_position"

--- a/tests/services/order_validation_service/test_tomte_field_validator.py
+++ b/tests/services/order_validation_service/test_tomte_field_validator.py
@@ -1,3 +1,4 @@
+from cg.services.order_validation_service.models.errors import ValidationErrors
 from cg.services.order_validation_service.workflows.tomte.models.order import TomteOrder
 from cg.services.order_validation_service.workflows.tomte.validation.field.tomte_model_validator import (
     TomteModelValidator,
@@ -9,13 +10,13 @@ def test_valid_order_is_parsed(
     tomte_model_validator: TomteModelValidator,
 ):
     # GIVEN a valid order
-    order_json = valid_order.model_dump_json()
+    order = valid_order.model_dump(by_alias=True)
 
     # WHEN parsing the order
-    order, errors = tomte_model_validator.validate(order_json)
+    order, errors = tomte_model_validator.validate(order)
 
     # THEN the parsed order is returned
     assert order
 
     # THEN no errors should be returned
-    assert not errors
+    assert errors == ValidationErrors()

--- a/tests/services/order_validation_service/test_tomte_field_validator.py
+++ b/tests/services/order_validation_service/test_tomte_field_validator.py
@@ -15,10 +15,38 @@ def test_valid_order_is_parsed(
     order, errors = tomte_model_validator.validate(order)
 
     # THEN the parsed order is returned
-    assert order is not None
+    assert order
 
     # THEN the errors are empty
     assert not errors.case_errors
     assert not errors.case_sample_errors
     assert not errors.order_errors
     assert not errors.sample_errors
+
+
+def test_order_field_error(
+    valid_order: TomteOrder,
+    tomte_model_validator: TomteModelValidator,
+):
+    pass
+
+
+def test_case_field_error(
+    valid_order: TomteOrder,
+    tomte_model_validator: TomteModelValidator,
+):
+    pass
+
+
+def test_sample_case_field_error(
+    valid_order: TomteOrder,
+    tomte_model_validator: TomteModelValidator,
+):
+    pass
+
+
+def test_sample_field_error(
+    valid_order: TomteOrder,
+    tomte_model_validator: TomteModelValidator,
+):
+    pass


### PR DESCRIPTION
## Description

This PR implements the `convert_errors` method, translating Pydantics errors from validating the models into our own Error classes.

## Changed
- convert_errors are now implemented and tests have been added.
