### PR TITLE
Use list indices instead of case/sample names

### DIFF
--- a/cg/services/order_validation_service/models/case.py
+++ b/cg/services/order_validation_service/models/case.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from cg.constants.constants import DataDelivery
 from cg.constants.priority import PriorityTerms
 from cg.models.orders.sample_base import NAME_PATTERN
+from cg.services.order_validation_service.models.sample import Sample
 
 
 class Case(BaseModel):
@@ -10,5 +11,10 @@ class Case(BaseModel):
     internal_id: str | None = None
     name: str = Field(pattern=NAME_PATTERN, min_length=2, max_length=128)
     priority: PriorityTerms = PriorityTerms.STANDARD
+    samples: list[Sample]
+
+    @property
+    def enumerated_samples(self):
+        return enumerate(self.samples)
 
     model_config = ConfigDict(str_min_length=1)

--- a/cg/services/order_validation_service/models/errors.py
+++ b/cg/services/order_validation_service/models/errors.py
@@ -12,11 +12,11 @@ class OrderError(BaseModel):
 
 
 class CaseError(OrderError):
-    case_name: str
+    case_index: int
 
 
 class SampleError(OrderError):
-    sample_name: str
+    sample_index: int
 
 
 class CaseSampleError(CaseError, SampleError):
@@ -130,9 +130,9 @@ class MotherNotInCaseError(CaseSampleError):
 
 
 class InvalidGenePanelsError(CaseError):
-    def __init__(self, case_name: str, panels: list[str]):
+    def __init__(self, case_index: int, panels: list[str]):
         message = "Invalid panels: " + ",".join(panels)
-        super(CaseError, self).__init__(field="panels", case_name=case_name, message=message)
+        super(CaseError, self).__init__(field="panels", case_index=case_index, message=message)
 
 
 class InvalidBufferError(CaseSampleError):
@@ -161,13 +161,13 @@ class SubjectIdSameAsSampleNameError(CaseSampleError):
 
 
 class InvalidConcentrationIfSkipRCError(CaseSampleError):
-    def __init__(self, case_name: str, sample_name: str, allowed_interval: tuple[int, int]):
+    def __init__(self, case_index: int, sample_index: int, allowed_interval: tuple[int, int]):
         field: str = "concentration_ng_ul"
         message: str = (
             f"Concentration must be between {allowed_interval[0]} ng/μL and {allowed_interval[1]} ng/μL if reception control should be skipped"
         )
         super(CaseSampleError, self).__init__(
-            case_name=case_name, sample_name=sample_name, field=field, message=message
+            case_index=case_index, sample_index=sample_index, field=field, message=message
         )
 
 

--- a/cg/services/order_validation_service/validators/data/utils.py
+++ b/cg/services/order_validation_service/validators/data/utils.py
@@ -3,26 +3,14 @@ from cg.services.order_validation_service.constants import (
     MAXIMUM_VOLUME,
     MINIMUM_VOLUME,
 )
-from cg.services.order_validation_service.models.errors import InvalidGenePanelsError
 from cg.services.order_validation_service.models.sample import Sample
-from cg.services.order_validation_service.workflows.tomte.models.case import TomteCase
 from cg.store.store import Store
 
 
-def validate_panels_for_case(case: TomteCase, store: Store) -> list[InvalidGenePanelsError]:
-    errors: list[InvalidGenePanelsError] = []
-    invalid_panels: list[str] = get_invalid_panels(panels=case.panels, store=store)
-    if invalid_panels:
-        error = InvalidGenePanelsError(case_name=case.name, panels=invalid_panels)
-        errors.append(error)
-    return errors
-
-
 def get_invalid_panels(panels: list[str], store: Store) -> list[str]:
-    invalid_panels: list[str] = []
-    for panel in panels:
-        if not store.does_gene_panel_exist(panel):
-            invalid_panels.append(panel)
+    invalid_panels: list[str] = [
+        panel for panel in panels if not store.does_gene_panel_exist(panel)
+    ]
     return invalid_panels
 
 

--- a/cg/services/order_validation_service/validators/inter_field/rules.py
+++ b/cg/services/order_validation_service/validators/inter_field/rules.py
@@ -50,14 +50,16 @@ def validate_application_compatibility(
     errors: list[ApplicationNotCompatibleError] = []
     workflow: Workflow = order.workflow
     allowed_prep_categories: list[PrepCategory] = WORKFLOW_PREP_CATEGORIES[workflow]
-    for case in order.cases:
-        for sample in case.samples:
+    for case_index, case in order.enumerated_cases:
+        for sample_index, sample in case.enumerated_samples:
             if _is_application_not_compatible(
                 allowed_prep_categories=allowed_prep_categories,
                 application_tag=sample.application,
                 store=store,
             ):
-                error = ApplicationNotCompatibleError(case_name=case.name, sample_name=sample.name)
+                error = ApplicationNotCompatibleError(
+                    case_index=case_index, sample_index=sample_index
+                )
                 errors.append(error)
     return errors
 
@@ -71,10 +73,10 @@ def validate_buffer_skip_rc_condition(order: TomteOrder) -> list[CaseSampleError
 
 def validate_buffers_are_allowed(order: TomteOrder) -> list[CaseSampleError]:
     errors = []
-    for case in order.cases:
-        for sample in case.samples:
+    for case_index, case in order.enumerated_cases:
+        for sample_index, sample in case.enumerated_samples:
             if sample.elution_buffer not in ALLOWED_SKIP_RC_BUFFERS:
-                error = InvalidBufferError(case_name=case.name, sample_name=sample.name)
+                error = InvalidBufferError(case_index=case_index, sample_index=sample_index)
                 errors.append(error)
     return errors
 
@@ -85,11 +87,11 @@ def validate_concentration_required_if_skip_rc(
     if not order.skip_reception_control:
         return []
     errors = []
-    for case in order.cases:
-        for sample in case.samples:
+    for case_index, case in order.enumerated_cases:
+        for sample_index, sample in case.enumerated_samples:
             if is_concentration_missing(sample):
                 error = ConcentrationRequiredIfSkipRCError(
-                    case_name=case.name, sample_name=sample.name
+                    case_index=case_index, sample_index=sample_index
                 )
                 errors.append(error)
     return errors
@@ -97,29 +99,31 @@ def validate_concentration_required_if_skip_rc(
 
 def validate_subject_ids_different_from_sample_names(order: TomteOrder) -> list[CaseSampleError]:
     errors = []
-    for case in order.cases:
-        for sample in case.samples:
+    for case_index, case in order.enumerated_cases:
+        for sample_index, sample in case.enumerated_samples:
             if sample.name == sample.subject_id:
-                error = SubjectIdSameAsSampleNameError(case_name=case.name, sample_name=sample.name)
+                error = SubjectIdSameAsSampleNameError(
+                    case_index=case_index, sample_index=sample_index
+                )
                 errors.append(error)
     return errors
 
 
 def validate_well_positions_required(order: TomteOrder) -> list[WellPositionMissingError]:
     errors: list[WellPositionMissingError] = []
-    for case in order.cases:
-        for sample in case.samples:
+    for case_index, case in order.enumerated_cases:
+        for sample_index, sample in case.enumerated_samples:
             if is_well_position_missing(sample):
-                error = WellPositionMissingError(case_name=case.name, sample_name=sample.name)
+                error = WellPositionMissingError(case_index=case_index, sample_index=sample_index)
                 errors.append(error)
     return errors
 
 
 def validate_container_name_required(order: TomteOrder) -> list[ContainerNameMissingError]:
     errors: list[ContainerNameMissingError] = []
-    for case in order.cases:
-        for sample in case.samples:
+    for case_index, case in order.enumerated_cases:
+        for sample_index, sample in case.enumerated_samples:
             if is_container_name_missing(sample):
-                error = ContainerNameMissingError(case_name=case.name, sample_name=sample.name)
+                error = ContainerNameMissingError(case_index=case_index, sample_index=sample_index)
                 errors.append(error)
     return errors

--- a/cg/services/order_validation_service/workflows/tomte/models/case.py
+++ b/cg/services/order_validation_service/workflows/tomte/models/case.py
@@ -1,7 +1,11 @@
 from cg.constants import GenePanelMasterList
 from cg.services.order_validation_service.models.case import Case
-from cg.services.order_validation_service.workflows.tomte.constants import TomteDeliveryType
-from cg.services.order_validation_service.workflows.tomte.models.sample import TomteSample
+from cg.services.order_validation_service.workflows.tomte.constants import (
+    TomteDeliveryType,
+)
+from cg.services.order_validation_service.workflows.tomte.models.sample import (
+    TomteSample,
+)
 
 
 class TomteCase(Case):
@@ -16,16 +20,8 @@ class TomteCase(Case):
             if sample.name == sample_name:
                 return sample
 
-    def get_samples_with_father(self) -> list[TomteSample]:
-        samples = []
-        for sample in self.samples:
-            if sample.father:
-                samples.append(sample)
-        return samples
+    def get_samples_with_father(self) -> list[tuple[TomteSample, int]]:
+        return [(sample, index) for index, sample in self.enumerated_samples if sample.father]
 
-    def get_samples_with_mother(self) -> list[TomteSample]:
-        samples = []
-        for sample in self.samples:
-            if sample.mother:
-                samples.append(sample)
-        return samples
+    def get_samples_with_mother(self) -> list[tuple[TomteSample, int]]:
+        return [(sample, index) for index, sample in self.enumerated_samples if sample.mother]

--- a/cg/services/order_validation_service/workflows/tomte/models/order.py
+++ b/cg/services/order_validation_service/workflows/tomte/models/order.py
@@ -4,3 +4,7 @@ from cg.services.order_validation_service.workflows.tomte.models.case import Tom
 
 class TomteOrder(Order):
     cases: list[TomteCase]
+
+    @property
+    def enumerated_cases(self) -> enumerate[TomteCase]:
+        return enumerate(self.cases)

--- a/cg/services/order_validation_service/workflows/tomte/validation/field/tomte_model_validator.py
+++ b/cg/services/order_validation_service/workflows/tomte/validation/field/tomte_model_validator.py
@@ -15,4 +15,4 @@ class TomteModelValidator:
             order = TomteOrder.model_validate(raw_order)
             return order, ValidationErrors()
         except ValidationError as error:
-            return None, convert_errors(pydantic_errors=error, order=raw_order)
+            return None, convert_errors(pydantic_errors=error)

--- a/cg/services/order_validation_service/workflows/tomte/validation/field/utils.py
+++ b/cg/services/order_validation_service/workflows/tomte/validation/field/utils.py
@@ -9,12 +9,12 @@ from cg.services.order_validation_service.models.errors import (
 )
 
 
-def convert_errors(pydantic_errors: ValidationError, order: dict) -> ValidationErrors:
+def convert_errors(pydantic_errors: ValidationError) -> ValidationErrors:
     error_details: list[ErrorDetails] = pydantic_errors.errors()
     order_errors = convert_order_errors(error_details)
-    case_errors = convert_case_errors(error_details=error_details, order=order)
-    case_sample_errors = convert_case_sample_errors(error_details=error_details, order=order)
-    sample_errors = convert_sample_errors(error_details=error_details, order=order)
+    case_errors = convert_case_errors(error_details=error_details)
+    case_sample_errors = convert_case_sample_errors(error_details=error_details)
+    sample_errors = convert_sample_errors(error_details=error_details)
     return ValidationErrors(
         order_errors=order_errors,
         case_errors=case_errors,
@@ -32,20 +32,20 @@ def convert_order_errors(error_details: list[ErrorDetails]) -> list[OrderError]:
     return errors
 
 
-def convert_case_errors(error_details: list[ErrorDetails], order: dict) -> list[CaseError]:
+def convert_case_errors(error_details: list[ErrorDetails]) -> list[CaseError]:
     errors: list[CaseError] = []
     case_details = get_case_error_details(error_details)
     for error in case_details:
-        error = create_case_error(error=error, order=order)
+        error = create_case_error(error=error)
         errors.append(error)
     return errors
 
 
-def convert_sample_errors(error_details: list[ErrorDetails], order: dict) -> list[SampleError]:
+def convert_sample_errors(error_details: list[ErrorDetails]) -> list[SampleError]:
     errors: list[SampleError] = []
     sample_details = get_sample_error_details(error_details)
     for error in sample_details:
-        error = create_sample_error(error=error, order=order)
+        error = create_sample_error(error=error)
         errors.append(error)
     return errors
 
@@ -57,41 +57,39 @@ def create_order_error(error: ErrorDetails) -> OrderError:
     return error
 
 
-def create_sample_error(error: ErrorDetails, order: dict) -> SampleError:
-    sample_name = get_sample_name(error=error, order=order)
+def create_sample_error(error: ErrorDetails) -> SampleError:
+    sample_index = get_sample_index(error=error)
     field_name = get_sample_field_name(error)
     message = get_error_message(error)
-    error = SampleError(sample_name=sample_name, field=field_name, message=message)
+    error = SampleError(sample_index=sample_index, field=field_name, message=message)
     return error
 
 
-def create_case_error(error: ErrorDetails, order: dict) -> CaseError:
-    case_name = get_case_name(error=error, order=order)
+def create_case_error(error: ErrorDetails) -> CaseError:
+    case_index = get_case_index(error=error)
     field_name = get_case_field_name(error)
     message = get_error_message(error)
-    error = CaseError(case_name=case_name, field=field_name, message=message)
+    error = CaseError(case_index=case_index, field=field_name, message=message)
     return error
 
 
-def convert_case_sample_errors(
-    error_details: list[ErrorDetails], order: dict
-) -> list[CaseSampleError]:
+def convert_case_sample_errors(error_details: list[ErrorDetails]) -> list[CaseSampleError]:
     errors: list[CaseSampleError] = []
     case_sample_details = get_case_sample_error_details(error_details)
     for error in case_sample_details:
-        error = create_case_sample_error(error=error, order=order)
+        error = create_case_sample_error(error=error)
         errors.append(error)
     return errors
 
 
-def create_case_sample_error(error: ErrorDetails, order: dict) -> CaseSampleError:
-    case_name = get_case_name(error=error, order=order)
-    sample_name = get_case_sample_name(error=error, order=order)
+def create_case_sample_error(error: ErrorDetails) -> CaseSampleError:
+    case_index = get_case_index(error=error)
+    sample_index = get_case_sample_index(error=error)
     field_name = get_case_sample_field_name(error)
     message = get_error_message(error)
     error = CaseSampleError(
-        case_name=case_name,
-        sample_name=sample_name,
+        case_index=case_index,
+        sample_index=sample_index,
         field=field_name,
         message=message,
     )
@@ -150,13 +148,13 @@ def get_order_field_name(error: ErrorDetails) -> str:
     return error["loc"][0]
 
 
-def get_sample_name(error: ErrorDetails, order: dict) -> str:
-    return order["samples"][error["loc"][1]]["name"]
+def get_sample_index(error: ErrorDetails) -> int:
+    return error["loc"][1]
 
 
-def get_case_name(error: ErrorDetails, order: dict) -> str:
-    return order["cases"][error["loc"][1]]["name"]
+def get_case_index(error: ErrorDetails) -> int:
+    return error["loc"][1]
 
 
-def get_case_sample_name(error: ErrorDetails, order: dict) -> str:
-    return order["cases"][error["loc"][1]]["samples"][error["loc"][3]]["name"]
+def get_case_sample_index(error: ErrorDetails) -> int:
+    return error["loc"][3]

--- a/cg/services/order_validation_service/workflows/tomte/validation/field/utils.py
+++ b/cg/services/order_validation_service/workflows/tomte/validation/field/utils.py
@@ -36,7 +36,7 @@ def convert_case_errors(error_details: list[ErrorDetails]) -> list[CaseError]:
     errors: list[CaseError] = []
     case_details = get_case_error_details(error_details)
     for error in case_details:
-        error = create_case_error(error=error)
+        error = create_case_error(error)
         errors.append(error)
     return errors
 
@@ -45,7 +45,7 @@ def convert_sample_errors(error_details: list[ErrorDetails]) -> list[SampleError
     errors: list[SampleError] = []
     sample_details = get_sample_error_details(error_details)
     for error in sample_details:
-        error = create_sample_error(error=error)
+        error = create_sample_error(error)
         errors.append(error)
     return errors
 

--- a/cg/services/order_validation_service/workflows/tomte/validation/inter_field/pedigree/models.py
+++ b/cg/services/order_validation_service/workflows/tomte/validation/inter_field/pedigree/models.py
@@ -1,11 +1,14 @@
 from cg.services.order_validation_service.workflows.tomte.models.case import TomteCase
-from cg.services.order_validation_service.workflows.tomte.models.sample import TomteSample
+from cg.services.order_validation_service.workflows.tomte.models.sample import (
+    TomteSample,
+)
 
 
 class Node:
-    def __init__(self, sample: TomteSample, case_name: str):
+    def __init__(self, sample: TomteSample, case_index: int, sample_index: int):
         self.sample = sample
-        self.case_name = case_name
+        self.sample_index = sample_index
+        self.case_index = case_index
         self.father: Node | None = None
         self.mother: Node | None = None
         self.visited = False
@@ -13,15 +16,16 @@ class Node:
 
 
 class FamilyTree:
-    def __init__(self, case: TomteCase):
+    def __init__(self, case: TomteCase, case_index: int):
         self.graph: dict[str, Node] = {}
         self.case = case
+        self.case_index = case_index
         self._add_nodes()
         self.add_edges()
 
     def _add_nodes(self) -> None:
-        for sample in self.case.samples:
-            node = Node(sample=sample, case_name=self.case.name)
+        for sample_index, sample in self.case.enumerated_samples:
+            node = Node(sample=sample, sample_index=sample_index, case_index=self.case_index)
             self.graph[sample.name] = node
 
     def add_edges(self) -> None:

--- a/cg/services/order_validation_service/workflows/tomte/validation/inter_field/pedigree/utils.py
+++ b/cg/services/order_validation_service/workflows/tomte/validation/inter_field/pedigree/utils.py
@@ -47,12 +47,12 @@ def get_error(node: Node, parent_type: str) -> PedigreeError:
 def get_mother_error(node: Node) -> PedigreeError:
     sample = node.sample
     if sample.name == sample.mother:
-        return SampleIsOwnMotherError(sample_name=sample.name, case_name=node.case_name)
-    return DescendantAsMotherError(sample_name=sample.name, case_name=node.case_name)
+        return SampleIsOwnMotherError(sample_index=node.sample_index, case_index=node.case_index)
+    return DescendantAsMotherError(sample_index=node.sample_index, case_index=node.case_index)
 
 
 def get_father_error(node: Node) -> PedigreeError:
     sample = node.sample
     if sample.name == sample.father:
-        return SampleIsOwnFatherError(sample_name=sample.name, case_name=node.case_name)
-    return DescendantAsFatherError(sample_name=sample.name, case_name=node.case_name)
+        return SampleIsOwnFatherError(sample_index=node.sample_index, case_index=node.case_index)
+    return DescendantAsFatherError(sample_index=node.sample_index, case_index=node.case_index)

--- a/cg/services/order_validation_service/workflows/tomte/validation/inter_field/pedigree/validate_pedigree.py
+++ b/cg/services/order_validation_service/workflows/tomte/validation/inter_field/pedigree/validate_pedigree.py
@@ -8,6 +8,6 @@ from cg.services.order_validation_service.workflows.tomte.validation.inter_field
 )
 
 
-def get_pedigree_errors(case: TomteCase) -> list[PedigreeError]:
-    pedigree = FamilyTree(case)
+def get_pedigree_errors(case: TomteCase, case_index: int) -> list[PedigreeError]:
+    pedigree = FamilyTree(case=case, case_index=case_index)
     return validate_tree(pedigree)

--- a/cg/services/order_validation_service/workflows/tomte/validation/inter_field/rules.py
+++ b/cg/services/order_validation_service/workflows/tomte/validation/inter_field/rules.py
@@ -51,13 +51,11 @@ def create_well_position_to_sample_map(
     for case_index, case in order.enumerated_cases:
         for sample_index, sample in case.enumerated_samples:
             if _is_sample_on_plate(sample):
-                if not well_position_to_sample_map.get(
-                    (sample.container_name, sample.well_position)
-                ):
-                    well_position_to_sample_map[(sample.container_name, sample.well_position)] = []
-                well_position_to_sample_map[(sample.container_name, sample.well_position)].append(
-                    (case_index, sample_index)
-                )
+                key: tuple[str, str] = (sample.container_name, sample.well_position)
+                value: tuple[int, int] = (case_index, sample_index)
+                if not well_position_to_sample_map.get(key):
+                    well_position_to_sample_map[key] = []
+                well_position_to_sample_map[key].append(value)
     return well_position_to_sample_map
 
 

--- a/cg/services/order_validation_service/workflows/tomte/validation/inter_field/rules.py
+++ b/cg/services/order_validation_service/workflows/tomte/validation/inter_field/rules.py
@@ -15,13 +15,12 @@ from cg.services.order_validation_service.workflows.tomte.validation.inter_field
     get_pedigree_errors,
 )
 from cg.services.order_validation_service.workflows.tomte.validation.inter_field.utils import (
-    _get_errors,
-    _get_excess_samples,
-    _get_plate_samples,
+    _is_sample_on_plate,
     get_father_case_errors,
     get_father_sex_errors,
     get_mother_case_errors,
     get_mother_sex_errors,
+    get_occupied_well_errors,
     get_repeated_case_name_errors,
     get_repeated_sample_name_errors,
     validate_concentration_in_case,
@@ -31,9 +30,35 @@ from cg.store.store import Store
 
 
 def validate_wells_contain_at_most_one_sample(order: TomteOrder) -> list[OccupiedWellError]:
-    samples_with_cases = _get_plate_samples(order)
-    samples = _get_excess_samples(samples_with_cases)
-    return _get_errors(samples)
+    errors = []
+    well_position_to_sample_map = create_well_position_to_sample_map(order)
+    for indices in well_position_to_sample_map.values():
+        if len(indices) > 1:
+            well_errors = get_occupied_well_errors(indices[1:])
+            errors.extend(well_errors)
+    return errors
+
+
+def create_well_position_to_sample_map(
+    order: TomteOrder,
+) -> dict[tuple[str, str], list[tuple[int, int]]]:
+    """
+    Constructs a dict with keys being a (container_name, well_position) pair. For each such pair, the value will be
+    a list of (case index, sample index) pairs corresponding to all samples with matching container_name and
+    well_position, provided the sample is on a plate.
+    """
+    well_position_to_sample_map = {}
+    for case_index, case in order.enumerated_cases:
+        for sample_index, sample in case.enumerated_samples:
+            if _is_sample_on_plate(sample):
+                if not well_position_to_sample_map.get(
+                    (sample.container_name, sample.well_position)
+                ):
+                    well_position_to_sample_map[(sample.container_name, sample.well_position)] = []
+                well_position_to_sample_map[(sample.container_name, sample.well_position)].append(
+                    (case_index, sample_index)
+                )
+    return well_position_to_sample_map
 
 
 def validate_case_names_not_repeated(order: TomteOrder) -> list[RepeatedCaseNameError]:
@@ -42,48 +67,48 @@ def validate_case_names_not_repeated(order: TomteOrder) -> list[RepeatedCaseName
 
 def validate_sample_names_not_repeated(order: TomteOrder) -> list[RepeatedSampleNameError]:
     errors: list[RepeatedSampleNameError] = []
-    for case in order.cases:
-        case_errors = get_repeated_sample_name_errors(case)
+    for index, case in order.enumerated_cases:
+        case_errors = get_repeated_sample_name_errors(case=case, case_index=index)
         errors.extend(case_errors)
     return errors
 
 
 def validate_fathers_are_male(order: TomteOrder) -> list[InvalidFatherSexError]:
     errors: list[InvalidFatherSexError] = []
-    for case in order.cases:
-        case_errors = get_father_sex_errors(case)
+    for index, case in order.enumerated_cases:
+        case_errors = get_father_sex_errors(case=case, case_index=index)
         errors.extend(case_errors)
     return errors
 
 
 def validate_fathers_in_same_case_as_children(order: TomteOrder) -> list[FatherNotInCaseError]:
     errors = []
-    for case in order.cases:
-        case_errors = get_father_case_errors(case)
+    for index, case in order.enumerated_cases:
+        case_errors = get_father_case_errors(case=case, case_index=index)
         errors.extend(case_errors)
     return errors
 
 
 def validate_mothers_are_female(order: TomteOrder) -> list[InvalidMotherSexError]:
     errors: list[InvalidMotherSexError] = []
-    for case in order.cases:
-        case_errors = get_mother_sex_errors(case)
+    for index, case in order.enumerated_cases:
+        case_errors = get_mother_sex_errors(case=case, case_index=index)
         errors.extend(case_errors)
     return errors
 
 
 def validate_pedigree(order: TomteOrder) -> list[PedigreeError]:
     errors = []
-    for case in order.cases:
-        case_errors = get_pedigree_errors(case)
+    for case_index, case in order.enumerated_cases:
+        case_errors = get_pedigree_errors(case=case, case_index=case_index)
         errors.extend(case_errors)
     return errors
 
 
 def validate_mothers_in_same_case_as_children(order: TomteOrder) -> list[MotherNotInCaseError]:
     errors = []
-    for case in order.cases:
-        case_errors = get_mother_case_errors(case)
+    for index, case in order.enumerated_cases:
+        case_errors = get_mother_case_errors(case=case, case_index=index)
         errors.extend(case_errors)
     return errors
 
@@ -92,8 +117,8 @@ def validate_subject_ids_different_from_case_names(
     order: TomteOrder,
 ) -> list[SubjectIdSameAsCaseNameError]:
     errors = []
-    for case in order.cases:
-        case_errors = validate_subject_ids_in_case(case)
+    for index, case in order.enumerated_cases:
+        case_errors = validate_subject_ids_in_case(case=case, case_index=index)
         errors.extend(case_errors)
     return errors
 
@@ -104,7 +129,7 @@ def validate_concentration_interval_if_skip_rc(
     if not order.skip_reception_control:
         return []
     errors = []
-    for case in order.cases:
-        case_errors = validate_concentration_in_case(case=case, store=store)
+    for index, case in order.enumerated_cases:
+        case_errors = validate_concentration_in_case(case=case, case_index=index, store=store)
         errors.extend(case_errors)
     return errors

--- a/tests/services/order_validation_service/test_inter_field_validators.py
+++ b/tests/services/order_validation_service/test_inter_field_validators.py
@@ -74,7 +74,7 @@ def test_application_is_incompatible(
     # THEN an error should be returned
     assert errors
 
-    # THEN the error should be about the application compatiblity
+    # THEN the error should be about the application compatability
     assert isinstance(errors[0], ApplicationNotCompatibleError)
 
 


### PR DESCRIPTION
## Description

When locating which sample caused a certain error we wanted to use the case name and sample name provided by the customer. This will cause issues if those two parameters are not filled out correctly, though. Say, when a case name is repeated. This PR refactors the errors to instead keep track of the list indices of the cases and names. Closes https://github.com/Clinical-Genomics/improve-order-flow/issues/57.

### Changed

- Errors are instantiated with case and sample indices instead of names.

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
