### PR TITLE
Handle EntryNotFoundError when retrieving Illumina sequencing run by device internal ID

### DIFF
--- a/cg/services/illumina/post_processing/post_processing_service.py
+++ b/cg/services/illumina/post_processing/post_processing_service.py
@@ -218,7 +218,7 @@ class IlluminaPostProcessingService:
             )
             has_backup: bool = sequencing_run.has_backup
         except EntryNotFoundError as error:
-            LOG.info(f"Run {sequencing_run_name} not found in StatusDB")
+            LOG.info(f"Run {sequencing_run_name} not found in StatusDB: {str(error)}")
         self.delete_sequencing_run_data(flow_cell_id=run_directory_data.id)
         try:
             self.store_sequencing_data_in_status_db(run_directory_data)

--- a/cg/services/illumina/post_processing/post_processing_service.py
+++ b/cg/services/illumina/post_processing/post_processing_service.py
@@ -196,7 +196,9 @@ class IlluminaPostProcessingService:
         run_directory_data = IlluminaRunDirectoryData(demux_run_dir)
         sample_sheet_path: Path = self.hk_api.get_sample_sheet_path(run_directory_data.id)
         run_directory_data.set_sample_sheet_path_hk(hk_path=sample_sheet_path)
-
+        sequencing_run: IlluminaSequencingRun | None = None
+        has_backup: bool = False
+        
         LOG.debug("Set path for Housekeeper sample sheet in run directory")
         try:
             is_flow_cell_ready_for_postprocessing(
@@ -209,7 +211,6 @@ class IlluminaPostProcessingService:
         if self.dry_run:
             LOG.info(f"Dry run: will not post-process Illumina run {sequencing_run_name}")
             return
-        has_backup: bool = False
         try:
             sequencing_run: IlluminaSequencingRun = (
                 self.status_db.get_illumina_sequencing_run_by_device_internal_id(
@@ -232,7 +233,8 @@ class IlluminaPostProcessingService:
         if sequencing_run:
             self.status_db.update_illumina_sequencing_run_has_backup(
                 sequencing_run=sequencing_run, has_backup=has_backup
-            )
+                )
+            
         create_delivery_file_in_flow_cell_directory(demux_run_dir)
 
     def get_all_demultiplexed_runs(self) -> list[Path]:

--- a/cg/services/illumina/post_processing/post_processing_service.py
+++ b/cg/services/illumina/post_processing/post_processing_service.py
@@ -212,7 +212,9 @@ class IlluminaPostProcessingService:
         has_backup: bool = False
         try:
             sequencing_run: IlluminaSequencingRun = (
-                self.status_db.get_illumina_sequencing_run_by_device_internal_id(run_directory_data.id)
+                self.status_db.get_illumina_sequencing_run_by_device_internal_id(
+                    run_directory_data.id
+                )
             )
             has_backup: bool = sequencing_run.has_backup
         except EntryNotFoundError as error:

--- a/cg/services/illumina/post_processing/post_processing_service.py
+++ b/cg/services/illumina/post_processing/post_processing_service.py
@@ -211,11 +211,11 @@ class IlluminaPostProcessingService:
             return
         has_backup: bool = False
         try:
-            sequencing_run: IlluminaSequencingRun | None = (
+            sequencing_run: IlluminaSequencingRun = (
                 self.status_db.get_illumina_sequencing_run_by_device_internal_id(run_directory_data.id)
             )
             has_backup: bool = sequencing_run.has_backup
-        except EntryNotFoundError as e:
+        except EntryNotFoundError as error:
             LOG.info(f"Run {sequencing_run_name} not found in StatusDB")
         self.delete_sequencing_run_data(flow_cell_id=run_directory_data.id)
         try:

--- a/cg/services/illumina/post_processing/post_processing_service.py
+++ b/cg/services/illumina/post_processing/post_processing_service.py
@@ -198,7 +198,7 @@ class IlluminaPostProcessingService:
         run_directory_data.set_sample_sheet_path_hk(hk_path=sample_sheet_path)
         sequencing_run: IlluminaSequencingRun | None = None
         has_backup: bool = False
-        
+
         LOG.debug("Set path for Housekeeper sample sheet in run directory")
         try:
             is_flow_cell_ready_for_postprocessing(
@@ -233,8 +233,8 @@ class IlluminaPostProcessingService:
         if sequencing_run:
             self.status_db.update_illumina_sequencing_run_has_backup(
                 sequencing_run=sequencing_run, has_backup=has_backup
-                )
-            
+            )
+
         create_delivery_file_in_flow_cell_directory(demux_run_dir)
 
     def get_all_demultiplexed_runs(self) -> list[Path]:

--- a/cg/store/crud/read.py
+++ b/cg/store/crud/read.py
@@ -383,7 +383,7 @@ class ReadHandler(BaseHandler):
         self, device_internal_id: str
     ) -> IlluminaSequencingRun:
         """Get Illumina sequencing run entry by device internal id."""
-        sequencing_run: IlluminaSequencingRun = apply_illumina_sequencing_run_filter(
+        sequencing_run: IlluminaSequencingRun | None = apply_illumina_sequencing_run_filter(
             runs=self._get_query(table=IlluminaSequencingRun),
             filter_functions=[IlluminaSequencingRunFilter.BY_DEVICE_INTERNAL_ID],
             device_internal_id=device_internal_id,


### PR DESCRIPTION
## Description

Fixes bug in https://github.com/Clinical-Genomics/cg/issues/3555

### Added

- Error handler when we do not have an entry in statusdb

### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [x] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
