### PR TITLE
fix PacBio sequencing run column names

### DIFF
--- a/alembic/versions/2024_08_14_bb4c6dbad991_fix_pacbio_column_names.py
+++ b/alembic/versions/2024_08_14_bb4c6dbad991_fix_pacbio_column_names.py
@@ -1,0 +1,31 @@
+"""Fix PacBio column names
+
+Revision ID: bb4c6dbad991
+Revises: 817cf7fea40d
+Create Date: 2024-08-14 14:03:37.122506
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "bb4c6dbad991"
+down_revision = "817cf7fea40d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column("pacbio_sequencing_run", "hi_fi_reads", new_column_name="hifi_reads")
+    op.alter_column("pacbio_sequencing_run", "hi_fi_yield", new_column_name="hifi_yield")
+    op.alter_column("pacbio_sequencing_run", "run_started_at", new_column_name="started_at")
+    op.alter_column("pacbio_sequencing_run", "run_completed_at", new_column_name="completed_at")
+    op.alter_column("pacbio_sequencing_run", "Productive_ZMWS", new_column_name="productive_zmws")
+
+
+def downgrade():
+    op.alter_column("pacbio_sequencing_run", "productive_zmws", new_column_name="Productive_ZMWS")
+    op.alter_column("pacbio_sequencing_run", "completed_at", new_column_name="run_completed_at")
+    op.alter_column("pacbio_sequencing_run", "started_at", new_column_name="run_started_at")
+    op.alter_column("pacbio_sequencing_run", "hifi_yield", new_column_name="hi_fi_yield")
+    op.alter_column("pacbio_sequencing_run", "hifi_reads", new_column_name="hi_fi_reads")

--- a/alembic/versions/2024_08_14_bb4c6dbad991_fix_pacbio_column_names.py
+++ b/alembic/versions/2024_08_14_bb4c6dbad991_fix_pacbio_column_names.py
@@ -6,6 +6,8 @@ Create Date: 2024-08-14 14:03:37.122506
 
 """
 
+import sqlalchemy as sa
+
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -16,16 +18,66 @@ depends_on = None
 
 
 def upgrade():
-    op.alter_column("pacbio_sequencing_run", "hi_fi_reads", new_column_name="hifi_reads")
-    op.alter_column("pacbio_sequencing_run", "hi_fi_yield", new_column_name="hifi_yield")
-    op.alter_column("pacbio_sequencing_run", "run_started_at", new_column_name="started_at")
-    op.alter_column("pacbio_sequencing_run", "run_completed_at", new_column_name="completed_at")
-    op.alter_column("pacbio_sequencing_run", "Productive_ZMWS", new_column_name="productive_zmws")
+    op.alter_column(
+        "pacbio_sequencing_run",
+        "hi_fi_reads",
+        new_column_name="hifi_reads",
+        existing_type=sa.BigInteger(),
+    )
+    op.alter_column(
+        "pacbio_sequencing_run",
+        "hi_fi_yield",
+        new_column_name="hifi_yield",
+        existing_type=sa.BigInteger(),
+    )
+    op.alter_column(
+        "pacbio_sequencing_run",
+        "run_started_at",
+        new_column_name="started_at",
+        existing_type=sa.DateTime(),
+    )
+    op.alter_column(
+        "pacbio_sequencing_run",
+        "run_completed_at",
+        new_column_name="completed_at",
+        existing_type=sa.DateTime(),
+    )
+    op.alter_column(
+        "pacbio_sequencing_run",
+        "Productive_ZMWS",
+        new_column_name="productive_zmws",
+        existing_type=sa.BigInteger(),
+    )
 
 
 def downgrade():
-    op.alter_column("pacbio_sequencing_run", "productive_zmws", new_column_name="Productive_ZMWS")
-    op.alter_column("pacbio_sequencing_run", "completed_at", new_column_name="run_completed_at")
-    op.alter_column("pacbio_sequencing_run", "started_at", new_column_name="run_started_at")
-    op.alter_column("pacbio_sequencing_run", "hifi_yield", new_column_name="hi_fi_yield")
-    op.alter_column("pacbio_sequencing_run", "hifi_reads", new_column_name="hi_fi_reads")
+    op.alter_column(
+        "pacbio_sequencing_run",
+        "productive_zmws",
+        new_column_name="Productive_ZMWS",
+        existing_type=sa.BigInteger(),
+    )
+    op.alter_column(
+        "pacbio_sequencing_run",
+        "completed_at",
+        new_column_name="run_completed_at",
+        existing_type=sa.BigInteger(),
+    )
+    op.alter_column(
+        "pacbio_sequencing_run",
+        "started_at",
+        new_column_name="run_started_at",
+        existing_type=sa.DateTime(),
+    )
+    op.alter_column(
+        "pacbio_sequencing_run",
+        "hifi_yield",
+        new_column_name="hi_fi_yield",
+        existing_type=sa.DateTime(),
+    )
+    op.alter_column(
+        "pacbio_sequencing_run",
+        "hifi_reads",
+        new_column_name="hi_fi_reads",
+        existing_type=sa.BigInteger(),
+    )


### PR DESCRIPTION
## Description
Some names in the database were misspelt with respect to the definition of the models. This PR makes and alembic migration fixing those names in the db.

### Fixed

- Renamed `hi_fi_reads` to `hifi_reads`
- Renamed `hi_fi_yield` to `hifi_yield`
- Renamed `run_started_at` to `started_at`
- Renamed `run_completed_at` to `completed_at`
- Renamed `Productive_ZMWS` to `productive_zmws`


### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [x] Do the alembic upgrade and verify that the column names are updated successfully
- [x] Do the downgrade

## Review

- [x] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
