### PR TITLE
Patch(clinical-delivery) Remove -p flag for rsync

### DIFF
--- a/cg/meta/rsync/sbatch.py
+++ b/cg/meta/rsync/sbatch.py
@@ -1,16 +1,16 @@
 """Sbatch templates for the rsync function"""
 
 RSYNC_COMMAND = """
-rsync -rvpL {source_path} {destination_path}
+rsync -rvL {source_path} {destination_path}
 """
 
 RSYNC_CONTENTS_COMMAND = """
-rsync -rvpL {source_path}/ {destination_path}
+rsync -rvL {source_path}/ {destination_path}
 """
 
 COVID_RSYNC = """
-rsync -rvptL {source_path} {destination_path}
-rsync -rvptL --chmod=777 {covid_report_path} {covid_destination_path}
+rsync -rvtL {source_path} {destination_path}
+rsync -rvtL --chmod=777 {covid_report_path} {covid_destination_path}
 """
 
 ERROR_RSYNC_FUNCTION = """


### PR DESCRIPTION
## Description
Currently the permissions set when using rsync to transfer files to the delivery server are wrong (see [this issue](https://github.com/Clinical-Genomics/servers/issues/1430)).

This PR removes the permission flags when used for rsync. This together with changing the umask in the bashrc creates files with the correct permissions.

### Changed

- Removed -p flag for rsync
