### PR TITLE
Prevent GENS files being provided to Balsamic CLI for hg38

### DIFF
--- a/cg/meta/workflow/balsamic.py
+++ b/cg/meta/workflow/balsamic.py
@@ -7,7 +7,7 @@ from housekeeper.store.models import File, Version
 from pydantic.v1 import EmailStr, ValidationError
 
 from cg.constants import Workflow
-from cg.constants.constants import FileFormat, SampleType
+from cg.constants.constants import FileFormat, SampleType, GenomeVersion
 from cg.constants.housekeeper_tags import BalsamicAnalysisTag
 from cg.constants.observations import ObservationsFileWildcards
 from cg.constants.priority import SlurmQos
@@ -461,7 +461,7 @@ class BalsamicAnalysisAPI(AnalysisAPI):
         config_case.update(self.get_parsed_observation_file_paths(observations))
         (
             config_case.update(self.get_verified_gens_file_paths(sex=verified_sex))
-            if not verified_panel_bed
+            if not verified_panel_bed and genome_version == GenomeVersion.HG19
             else None
         )
 


### PR DESCRIPTION
## Description

### Changed
- Prevent GENS files being provided to Balsamic CLI for hg38

### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [x] `cg workflow balsamic config-case <wgs-hg19-case> --dry-run`
- [x] `cg workflow balsamic config-case <wgs-hg38-case> --genome-version hg38 --dry-run`

### Expected test outcome

- [x] Check that gens files are fed into the Balsamic CLI for hg19
- [x] Check that gens files are not provided to Balsamic CLI for hg38

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
