### PR TITLE
(improve-order-flow) Add case internal id existence check

### DIFF
--- a/cg/services/order_validation_service/models/errors.py
+++ b/cg/services/order_validation_service/models/errors.py
@@ -189,3 +189,8 @@ class InvalidVolumeError(CaseSampleError):
 class CaseNameNotAvailableError(CaseError):
     field: str = "name"
     message: str = "Case name already used in a previous order"
+
+
+class ExistingCaseDoesNotExistError(CaseError):
+    field: str = "internal_id"
+    message: str = "The existing case is not found"

--- a/cg/services/order_validation_service/workflows/tomte/models/order.py
+++ b/cg/services/order_validation_service/workflows/tomte/models/order.py
@@ -10,9 +10,17 @@ class TomteOrder(Order):
         return enumerate(self.cases)
 
     @property
-    def enumerated_new_cases(self) -> enumerate[TomteCase]:
+    def enumerated_new_cases(self) -> list[tuple[int, TomteCase]]:
         cases: list[tuple[int, TomteCase]] = []
         for case_index, case in self.enumerated_cases:
             if case.is_new:
+                cases.append((case_index, case))
+        return cases
+
+    @property
+    def enumerated_existing_cases(self) -> list[tuple[int, TomteCase]]:
+        cases: list[tuple[int, TomteCase]] = []
+        for case_index, case in self.enumerated_cases:
+            if not case.is_new:
                 cases.append((case_index, case))
         return cases

--- a/cg/services/order_validation_service/workflows/tomte/validation_rules.py
+++ b/cg/services/order_validation_service/workflows/tomte/validation_rules.py
@@ -1,6 +1,7 @@
 from cg.services.order_validation_service.validators.data.rules import (
     validate_application_exists,
     validate_application_not_archived,
+    validate_case_internal_ids_exist,
     validate_case_names_available,
     validate_customer_can_skip_reception_control,
     validate_customer_exists,
@@ -36,9 +37,10 @@ TOMTE_ORDER_RULES: list[callable] = [
 ]
 
 TOMTE_CASE_RULES: list[callable] = [
+    validate_case_internal_ids_exist,
+    validate_case_names_available,
     validate_gene_panels_exist,
     validate_gene_panels_unique,
-    validate_case_names_available,
 ]
 
 TOMTE_CASE_SAMPLE_RULES: list[callable] = [


### PR DESCRIPTION
## Description

Existing cases are marked with their internal_id. We should make sure that these match entries in our database.

### Added

- Validation that any provided internal_id for a case exists in StatusDB.

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
