### PR TITLE
(Improve order flow) Validate sex required for new samples

### DIFF
--- a/cg/services/order_validation_service/models/errors.py
+++ b/cg/services/order_validation_service/models/errors.py
@@ -204,3 +204,8 @@ class StatusMissingError(CaseSampleError):
 class SampleDoesNotExistError(CaseSampleError):
     field: str = "internal_id"
     message: str = "The sample does not exist"
+
+
+class SexMissingError(CaseSampleError):
+    field: str = "sex"
+    message: str = "Sex is required"

--- a/cg/services/order_validation_service/validators/data/rules.py
+++ b/cg/services/order_validation_service/validators/data/rules.py
@@ -1,15 +1,16 @@
 from cg.services.order_validation_service.models.errors import (
     ApplicationArchivedError,
     ApplicationNotValidError,
+    CaseDoesNotExistError,
     CaseNameNotAvailableError,
     CustomerCannotSkipReceptionControlError,
     CustomerDoesNotExistError,
-    CaseDoesNotExistError,
     InvalidGenePanelsError,
     InvalidVolumeError,
     OrderError,
     RepeatedGenePanelsError,
     SampleDoesNotExistError,
+    SexMissingError,
     UserNotAssociatedWithCustomerError,
 )
 from cg.services.order_validation_service.models.order import Order
@@ -147,5 +148,15 @@ def validate_samples_exist(
             sample: Sample | None = store.get_sample_by_internal_id(sample.internal_id)
             if not sample:
                 error = SampleDoesNotExistError(case_index=case_index, sample_index=sample_index)
+                errors.append(error)
+    return errors
+
+
+def validate_sex_required_for_new_samples(order: TomteOrder) -> list[SexMissingError]:
+    errors: list[SexMissingError] = []
+    for case_index, case in order.enumerated_new_cases:
+        for sample_index, sample in case.enumerated_new_samples:
+            if not sample.sex:
+                error = SexMissingError(case_index=case_index, sample_index=sample_index)
                 errors.append(error)
     return errors

--- a/cg/services/order_validation_service/workflows/tomte/validation_rules.py
+++ b/cg/services/order_validation_service/workflows/tomte/validation_rules.py
@@ -8,6 +8,7 @@ from cg.services.order_validation_service.validators.data.rules import (
     validate_gene_panels_exist,
     validate_gene_panels_unique,
     validate_samples_exist,
+    validate_sex_required_for_new_samples,
     validate_user_belongs_to_customer,
 )
 from cg.services.order_validation_service.validators.inter_field.rules import (
@@ -60,6 +61,7 @@ TOMTE_CASE_SAMPLE_RULES: list[callable] = [
     validate_pedigree,
     validate_samples_exist,
     validate_sample_names_not_repeated,
+    validate_sex_required_for_new_samples,
     validate_status_required_if_new,
     validate_subject_ids_different_from_case_names,
     validate_subject_ids_different_from_sample_names,

--- a/tests/services/order_validation_service/test_data_validators.py
+++ b/tests/services/order_validation_service/test_data_validators.py
@@ -1,11 +1,12 @@
 from cg.services.order_validation_service.models.errors import (
     ApplicationArchivedError,
     ApplicationNotValidError,
-    CaseNameNotAvailableError,
     CaseDoesNotExistError,
+    CaseNameNotAvailableError,
     InvalidGenePanelsError,
     RepeatedGenePanelsError,
     SampleDoesNotExistError,
+    SexMissingError,
 )
 from cg.services.order_validation_service.validators.data.rules import (
     validate_application_exists,
@@ -15,6 +16,7 @@ from cg.services.order_validation_service.validators.data.rules import (
     validate_gene_panels_exist,
     validate_gene_panels_unique,
     validate_samples_exist,
+    validate_sex_required_for_new_samples,
 )
 from cg.services.order_validation_service.workflows.tomte.models.order import TomteOrder
 from cg.store.models import Application
@@ -142,3 +144,18 @@ def test_sample_internal_ids_does_not_exist(
 
     # THEN the error should concern the non-existent sample
     assert isinstance(errors[0], SampleDoesNotExistError)
+
+
+def test_sex_missing_for_new_sample(valid_order: TomteOrder):
+
+    # GIVEN an order with a new sample without 'sex' set
+    valid_order.cases[0].samples[0].sex = None
+
+    # WHEN validating that all new samples have a provided sex
+    errors = validate_sex_required_for_new_samples(order=valid_order)
+
+    # THEN an error should be returned
+    assert errors
+
+    # THEN the error should concern the missing sex
+    assert isinstance(errors[0], SexMissingError)


### PR DESCRIPTION
## Description

Sex is required for new samples

### Added

- Validation ensuring that a sex is provided for new Tomte samples.

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
