### PR TITLE
(Improve order flow) Patch validate fathers are male

### DIFF
--- a/cg/services/order_validation_service/workflows/tomte/validation/inter_field/rules.py
+++ b/cg/services/order_validation_service/workflows/tomte/validation/inter_field/rules.py
@@ -78,7 +78,7 @@ def validate_sample_names_not_repeated(order: TomteOrder) -> list[RepeatedSample
 
 def validate_fathers_are_male(order: TomteOrder) -> list[InvalidFatherSexError]:
     errors: list[InvalidFatherSexError] = []
-    for index, case in order.enumerated_new_cases:
+    for index, case in order.enumerated_cases:
         case_errors: list[InvalidFatherSexError] = get_father_sex_errors(
             case=case, case_index=index
         )


### PR DESCRIPTION
## Description

Since fatherhoods can be rerouted for existing cases, we need to validate the the father's sex there too.

### Fixed

- Fathers' sex is validated even in existing cases and samples.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
