### PR TITLE
(Improve order flow) Remove delivery type from Case

### DIFF
--- a/cg/services/order_validation_service/models/case.py
+++ b/cg/services/order_validation_service/models/case.py
@@ -1,13 +1,11 @@
 from pydantic import BaseModel, ConfigDict, Field
 
-from cg.constants.constants import DataDelivery
 from cg.constants.priority import PriorityTerms
 from cg.models.orders.sample_base import NAME_PATTERN
 from cg.services.order_validation_service.models.sample import Sample
 
 
 class Case(BaseModel):
-    data_delivery: DataDelivery
     internal_id: str | None = None
     name: str = Field(pattern=NAME_PATTERN, min_length=2, max_length=128)
     priority: PriorityTerms = PriorityTerms.STANDARD

--- a/cg/services/order_validation_service/workflows/tomte/models/case.py
+++ b/cg/services/order_validation_service/workflows/tomte/models/case.py
@@ -1,8 +1,5 @@
 from cg.constants import GenePanelMasterList
 from cg.services.order_validation_service.models.case import Case
-from cg.services.order_validation_service.workflows.tomte.constants import (
-    TomteDeliveryType,
-)
 from cg.services.order_validation_service.workflows.tomte.models.sample import (
     TomteSample,
 )
@@ -10,7 +7,6 @@ from cg.services.order_validation_service.workflows.tomte.models.sample import (
 
 class TomteCase(Case):
     cohorts: list[str] | None = None
-    data_delivery: TomteDeliveryType
     panels: list[GenePanelMasterList]
     synopsis: str | None = None
     samples: list[TomteSample]

--- a/cg/services/order_validation_service/workflows/tomte/models/order.py
+++ b/cg/services/order_validation_service/workflows/tomte/models/order.py
@@ -1,9 +1,13 @@
 from cg.services.order_validation_service.models.order import Order
+from cg.services.order_validation_service.workflows.tomte.constants import (
+    TomteDeliveryType,
+)
 from cg.services.order_validation_service.workflows.tomte.models.case import TomteCase
 
 
 class TomteOrder(Order):
     cases: list[TomteCase]
+    delivery_type: TomteDeliveryType
 
     @property
     def enumerated_cases(self) -> enumerate[TomteCase]:

--- a/tests/services/order_validation_service/test_tomte_field_validator.py
+++ b/tests/services/order_validation_service/test_tomte_field_validator.py
@@ -47,7 +47,7 @@ def test_case_field_error(
     tomte_model_validator: TomteModelValidator,
 ):
     # GIVEN an order with a case field error
-    valid_order.cases[0].data_delivery = None
+    valid_order.cases[0].priority = None
     order = valid_order.model_dump(by_alias=True)
 
     # WHEN validating the order
@@ -57,7 +57,7 @@ def test_case_field_error(
     assert errors.case_errors
 
     # THEN the error should concern the missing name
-    assert errors.case_errors[0].field == "data_delivery"
+    assert errors.case_errors[0].field == "priority"
 
 
 def test_case_sample_field_error(
@@ -84,7 +84,7 @@ def test_order_case_and_case_sample_field_error(
 ):
     # GIVEN an order with an order, case and case sample error
     valid_order.name = None
-    valid_order.cases[0].data_delivery = None
+    valid_order.cases[0].priority = None
     valid_order.cases[0].samples[0].well_position = 1.8
     order = valid_order.model_dump(by_alias=True)
 
@@ -98,5 +98,5 @@ def test_order_case_and_case_sample_field_error(
 
     # THEN the errors should concern the relevant fields
     assert errors.order_errors[0].field == "name"
-    assert errors.case_errors[0].field == "data_delivery"
+    assert errors.case_errors[0].field == "priority"
     assert errors.case_sample_errors[0].field == "well_position"


### PR DESCRIPTION
## Description

The current Case model in the FE does not have delivery type set, it is set on the order.

### Added

-

### Changed

- Delivery type is specified on the order level.

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
