### PR TITLE
(Improve order flow) Fix placement of Tomte rule

### DIFF
--- a/cg/services/order_validation_service/workflows/tomte/validation_rules.py
+++ b/cg/services/order_validation_service/workflows/tomte/validation_rules.py
@@ -44,6 +44,7 @@ TOMTE_ORDER_RULES: list[callable] = [
 TOMTE_CASE_RULES: list[callable] = [
     validate_case_internal_ids_exist,
     validate_case_names_available,
+    validate_case_names_not_repeated,
     validate_gene_panels_exist,
     validate_gene_panels_unique,
 ]
@@ -53,7 +54,6 @@ TOMTE_CASE_SAMPLE_RULES: list[callable] = [
     validate_application_exists,
     validate_application_not_archived,
     validate_buffer_skip_rc_condition,
-    validate_case_names_not_repeated,
     validate_concentration_interval_if_skip_rc,
     validate_concentration_required_if_skip_rc,
     validate_fathers_are_male,


### PR DESCRIPTION
## Description

The repeated case names validation was wrongly placed.

### Fixed

- The Tomte repeated case names validation rule is put as a Case rule.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
