### PR TITLE
(Improve order flow) Add validation of repeated sample names for Microsalt

### DIFF
--- a/cg/services/order_validation_service/errors/case_sample_errors.py
+++ b/cg/services/order_validation_service/errors/case_sample_errors.py
@@ -1,5 +1,3 @@
-from pydantic import BaseModel
-
 from cg.services.order_validation_service.constants import (
     MAXIMUM_VOLUME,
     MINIMUM_VOLUME,
@@ -32,7 +30,7 @@ class ApplicationNotCompatibleError(CaseSampleError):
     message: str = "Application is not allowed for the chosen workflow"
 
 
-class RepeatedSampleNameError(CaseSampleError):
+class SampleNameRepeatedError(CaseSampleError):
     field: str = "name"
     message: str = "Sample name already used"
 

--- a/cg/services/order_validation_service/errors/sample_errors.py
+++ b/cg/services/order_validation_service/errors/sample_errors.py
@@ -28,3 +28,8 @@ class OccupiedWellError(SampleError):
 class WellPositionMissingError(SampleError):
     field: str = "well_position"
     message: str = "Well position is required for well plates"
+
+
+class SampleNameRepeatedError(SampleError):
+    field: str = "name"
+    message: str = "Sample name repeated"

--- a/cg/services/order_validation_service/workflows/microsalt/validation/inter_field/rules.py
+++ b/cg/services/order_validation_service/workflows/microsalt/validation/inter_field/rules.py
@@ -1,13 +1,18 @@
+from collections import Counter
+
 from cg.constants.constants import PrepCategory, Workflow
 from cg.services.order_validation_service.constants import WORKFLOW_PREP_CATEGORIES
 from cg.services.order_validation_service.errors.sample_errors import (
     ApplicationNotCompatibleError,
     OccupiedWellError,
+    SampleNameRepeatedError,
 )
 from cg.services.order_validation_service.validators.inter_field.utils import (
     _is_application_not_compatible,
 )
-from cg.services.order_validation_service.workflows.microsalt.models.order import MicrosaltOrder
+from cg.services.order_validation_service.workflows.microsalt.models.order import (
+    MicrosaltOrder,
+)
 from cg.services.order_validation_service.workflows.microsalt.validation.inter_field.utils import (
     PlateSamplesValidator,
 )
@@ -48,3 +53,17 @@ def validate_well_positions_required(
 ) -> list[OccupiedWellError]:
     plate_samples = PlateSamplesValidator(order)
     return plate_samples.get_well_position_missing_errors()
+
+
+def validate_sample_names_unique(order: MicrosaltOrder, **kwargs) -> list[SampleNameRepeatedError]:
+    sample_indices: list[int] = get_indices_for_repeated_sample_names(order)
+    return [SampleNameRepeatedError(sample_index=sample_index) for sample_index in sample_indices]
+
+
+def get_indices_for_repeated_sample_names(order: MicrosaltOrder) -> list[int]:
+    counter = Counter([sample.name for sample in order.samples])
+    indices: list[int] = []
+    for index, sample in order.enumerated_new_samples:
+        if counter.get(sample.name) > 1:
+            indices.append(index)
+    return indices

--- a/cg/services/order_validation_service/workflows/microsalt/validation_rules.py
+++ b/cg/services/order_validation_service/workflows/microsalt/validation_rules.py
@@ -12,6 +12,7 @@ from cg.services.order_validation_service.workflows.microsalt.validation.data.ru
 )
 from cg.services.order_validation_service.workflows.microsalt.validation.inter_field.rules import (
     validate_application_compatibility,
+    validate_sample_names_unique,
     validate_well_positions_required,
     validate_wells_contain_at_most_one_sample,
 )
@@ -26,6 +27,7 @@ SAMPLE_RULES: list[callable] = [
     validate_application_compatibility,
     validate_application_exists,
     validate_applications_not_archived,
+    validate_sample_names_unique,
     validate_well_positions_required,
     validate_wells_contain_at_most_one_sample,
 ]

--- a/cg/services/order_validation_service/workflows/tomte/validation/inter_field/rules.py
+++ b/cg/services/order_validation_service/workflows/tomte/validation/inter_field/rules.py
@@ -1,4 +1,6 @@
-from cg.services.order_validation_service.errors.case_errors import RepeatedCaseNameError
+from cg.services.order_validation_service.errors.case_errors import (
+    RepeatedCaseNameError,
+)
 from cg.services.order_validation_service.errors.case_sample_errors import (
     FatherNotInCaseError,
     InvalidConcentrationIfSkipRCError,
@@ -7,7 +9,7 @@ from cg.services.order_validation_service.errors.case_sample_errors import (
     MotherNotInCaseError,
     OccupiedWellError,
     PedigreeError,
-    RepeatedSampleNameError,
+    SampleNameRepeatedError,
     StatusMissingError,
     SubjectIdSameAsCaseNameError,
 )
@@ -16,7 +18,6 @@ from cg.services.order_validation_service.workflows.tomte.validation.inter_field
     get_pedigree_errors,
 )
 from cg.services.order_validation_service.workflows.tomte.validation.inter_field.utils import (
-    get_well_sample_map,
     get_father_case_errors,
     get_father_sex_errors,
     get_mother_case_errors,
@@ -24,7 +25,7 @@ from cg.services.order_validation_service.workflows.tomte.validation.inter_field
     get_occupied_well_errors,
     get_repeated_case_name_errors,
     get_repeated_sample_name_errors,
-    is_sample_on_plate,
+    get_well_sample_map,
     validate_concentration_in_case,
     validate_subject_ids_in_case,
 )
@@ -51,10 +52,10 @@ def validate_case_names_not_repeated(order: TomteOrder, **kwargs) -> list[Repeat
 
 def validate_sample_names_not_repeated(
     order: TomteOrder, **kwargs
-) -> list[RepeatedSampleNameError]:
-    errors: list[RepeatedSampleNameError] = []
+) -> list[SampleNameRepeatedError]:
+    errors: list[SampleNameRepeatedError] = []
     for index, case in order.enumerated_new_cases:
-        case_errors: list[RepeatedSampleNameError] = get_repeated_sample_name_errors(
+        case_errors: list[SampleNameRepeatedError] = get_repeated_sample_name_errors(
             case=case, case_index=index
         )
         errors.extend(case_errors)

--- a/cg/services/order_validation_service/workflows/tomte/validation/inter_field/utils.py
+++ b/cg/services/order_validation_service/workflows/tomte/validation/inter_field/utils.py
@@ -3,7 +3,9 @@ from collections import Counter
 from cg.constants.sample_sources import SourceType
 from cg.constants.subject import Sex
 from cg.models.orders.sample_base import ContainerEnum
-from cg.services.order_validation_service.errors.case_errors import RepeatedCaseNameError
+from cg.services.order_validation_service.errors.case_errors import (
+    RepeatedCaseNameError,
+)
 from cg.services.order_validation_service.errors.case_sample_errors import (
     FatherNotInCaseError,
     InvalidConcentrationIfSkipRCError,
@@ -11,7 +13,7 @@ from cg.services.order_validation_service.errors.case_sample_errors import (
     InvalidMotherSexError,
     MotherNotInCaseError,
     OccupiedWellError,
-    RepeatedSampleNameError,
+    SampleNameRepeatedError,
     SubjectIdSameAsCaseNameError,
 )
 from cg.services.order_validation_service.workflows.tomte.models.case import TomteCase
@@ -84,10 +86,10 @@ def get_indices_for_repeated_sample_names(case: TomteCase) -> list[int]:
 
 def get_repeated_sample_name_errors(
     case: TomteCase, case_index: int
-) -> list[RepeatedSampleNameError]:
+) -> list[SampleNameRepeatedError]:
     sample_indices: list[int] = get_indices_for_repeated_sample_names(case)
     return [
-        RepeatedSampleNameError(sample_index=sample_index, case_index=case_index)
+        SampleNameRepeatedError(sample_index=sample_index, case_index=case_index)
         for sample_index in sample_indices
     ]
 

--- a/tests/services/order_validation_service/microsalt/test_inter_field_validators.py
+++ b/tests/services/order_validation_service/microsalt/test_inter_field_validators.py
@@ -1,6 +1,12 @@
-from cg.services.order_validation_service.errors.sample_errors import OccupiedWellError
-from cg.services.order_validation_service.workflows.microsalt.models.order import MicrosaltOrder
+from cg.services.order_validation_service.errors.sample_errors import (
+    OccupiedWellError,
+    SampleNameRepeatedError,
+)
+from cg.services.order_validation_service.workflows.microsalt.models.order import (
+    MicrosaltOrder,
+)
 from cg.services.order_validation_service.workflows.microsalt.validation.inter_field.rules import (
+    validate_sample_names_unique,
     validate_wells_contain_at_most_one_sample,
 )
 
@@ -28,3 +34,19 @@ def test_order_without_multiple_samples_in_well(valid_order: MicrosaltOrder):
 
     # THEN no errors should be returned
     assert not errors
+
+
+def test_sample_name_repeated(valid_order: MicrosaltOrder):
+
+    # GIVEN a valid order within sample names are repeated
+    sample_name_1 = valid_order.samples[0].name
+    valid_order.samples[1].name = sample_name_1
+
+    # WHEN validating that the sample names are unique
+    errors = validate_sample_names_unique(valid_order)
+
+    # THEN an error should be returned
+    assert errors
+
+    # THEN the error should concern the repeated sample name
+    assert isinstance(errors[0], SampleNameRepeatedError)

--- a/tests/services/order_validation_service/test_tomte_inter_field_validators.py
+++ b/tests/services/order_validation_service/test_tomte_inter_field_validators.py
@@ -1,4 +1,6 @@
-from cg.services.order_validation_service.errors.case_errors import RepeatedCaseNameError
+from cg.services.order_validation_service.errors.case_errors import (
+    RepeatedCaseNameError,
+)
 from cg.services.order_validation_service.errors.case_sample_errors import (
     ConcentrationRequiredIfSkipRCError,
     DescendantAsFatherError,
@@ -7,8 +9,8 @@ from cg.services.order_validation_service.errors.case_sample_errors import (
     InvalidConcentrationIfSkipRCError,
     InvalidFatherSexError,
     OccupiedWellError,
-    RepeatedSampleNameError,
     SampleIsOwnFatherError,
+    SampleNameRepeatedError,
     StatusMissingError,
     SubjectIdSameAsSampleNameError,
 )
@@ -70,7 +72,7 @@ def test_repeated_sample_names_not_allowed(order_with_repeated_sample_names: Tom
     assert errors
 
     # THEN the errors are about the sample names
-    assert isinstance(errors[0], RepeatedSampleNameError)
+    assert isinstance(errors[0], SampleNameRepeatedError)
 
 
 def test_repeated_case_names_not_allowed(order_with_repeated_case_names: TomteOrder):


### PR DESCRIPTION
## Description

This PR adds validation that sample names are not reused within a microSALT order.

### Added

- Validation ensuring unique sample names within a microSALT order.

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
