### PR TITLE
(Improve order flow) Validate volume interval for microSALT

### DIFF
--- a/cg/services/order_validation_service/errors/sample_errors.py
+++ b/cg/services/order_validation_service/errors/sample_errors.py
@@ -1,3 +1,7 @@
+from cg.services.order_validation_service.constants import (
+    MAXIMUM_VOLUME,
+    MINIMUM_VOLUME,
+)
 from cg.services.order_validation_service.errors.order_errors import OrderError
 
 
@@ -38,3 +42,8 @@ class SampleNameRepeatedError(SampleError):
 class SampleDoesNotExistError(SampleError):
     field: str = "internal_id"
     message: str = "The sample does not exist"
+
+
+class InvalidVolumeError(SampleError):
+    field: str = "volume"
+    message: str = f"Volume must be between {MINIMUM_VOLUME}-{MAXIMUM_VOLUME} μL"

--- a/cg/services/order_validation_service/workflows/microsalt/validation/data/rules.py
+++ b/cg/services/order_validation_service/workflows/microsalt/validation/data/rules.py
@@ -1,8 +1,10 @@
 from cg.services.order_validation_service.errors.sample_errors import (
     ApplicationArchivedError,
     ApplicationNotValidError,
+    InvalidVolumeError,
     SampleDoesNotExistError,
 )
+from cg.services.order_validation_service.validators.data.utils import is_volume_invalid
 from cg.services.order_validation_service.workflows.microsalt.models.order import (
     MicrosaltOrder,
 )
@@ -40,5 +42,14 @@ def validate_samples_exist(
         sample: Sample | None = store.get_sample_by_internal_id(sample.internal_id)
         if not sample:
             error = SampleDoesNotExistError(sample_index=sample_index)
+            errors.append(error)
+    return errors
+
+
+def validate_volume_interval(order: MicrosaltOrder, **kwargs) -> list[InvalidVolumeError]:
+    errors: list[InvalidVolumeError] = []
+    for sample_index, sample in order.enumerated_new_samples:
+        if is_volume_invalid(sample):
+            error = InvalidVolumeError(sample_index=sample_index)
             errors.append(error)
     return errors

--- a/cg/services/order_validation_service/workflows/microsalt/validation_rules.py
+++ b/cg/services/order_validation_service/workflows/microsalt/validation_rules.py
@@ -10,6 +10,7 @@ from cg.services.order_validation_service.workflows.microsalt.validation.data.ru
     validate_application_exists,
     validate_applications_not_archived,
     validate_samples_exist,
+    validate_volume_interval,
 )
 from cg.services.order_validation_service.workflows.microsalt.validation.inter_field.rules import (
     validate_application_compatibility,
@@ -30,6 +31,7 @@ SAMPLE_RULES: list[callable] = [
     validate_applications_not_archived,
     validate_sample_names_unique,
     validate_samples_exist,
+    validate_volume_interval,
     validate_well_positions_required,
     validate_wells_contain_at_most_one_sample,
 ]

--- a/tests/services/order_validation_service/microsalt/test_data_validators.py
+++ b/tests/services/order_validation_service/microsalt/test_data_validators.py
@@ -1,7 +1,9 @@
+from cg.services.order_validation_service.constants import MAXIMUM_VOLUME
 from cg.services.order_validation_service.errors.sample_errors import (
     ApplicationArchivedError,
     ApplicationNotCompatibleError,
     ApplicationNotValidError,
+    InvalidVolumeError,
     SampleDoesNotExistError,
 )
 from cg.services.order_validation_service.workflows.microsalt.models.order import (
@@ -14,6 +16,7 @@ from cg.services.order_validation_service.workflows.microsalt.validation.data.ru
     validate_application_exists,
     validate_applications_not_archived,
     validate_samples_exist,
+    validate_volume_interval,
 )
 from cg.services.order_validation_service.workflows.microsalt.validation.inter_field.rules import (
     validate_application_compatibility,
@@ -98,3 +101,18 @@ def test_samples_do_exist(valid_order: MicrosaltOrder, base_store: Store):
 
     # THEN no error should be returned
     assert not errors
+
+
+def test_invalid_volume(valid_order: MicrosaltOrder, base_store: Store):
+
+    # GIVEN an order with a sample with an invalid volume
+    valid_order.samples[0].volume = MAXIMUM_VOLUME + 10
+
+    # WHEN validating the volume interval
+    errors = validate_volume_interval(order=valid_order)
+
+    # THEN an error should be returned
+    assert errors
+
+    # THEN the error should concern the invalid volume
+    assert isinstance(errors[0], InvalidVolumeError)


### PR DESCRIPTION
## Description

This PR adds validation of the volumes for submitted microSALT samples.

### Added

- Volumes are validated for microSALT orders

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
