### PR TITLE
Add organism exists validation for microSALT

### DIFF
--- a/cg/services/order_validation_service/errors/sample_errors.py
+++ b/cg/services/order_validation_service/errors/sample_errors.py
@@ -47,3 +47,8 @@ class SampleDoesNotExistError(SampleError):
 class InvalidVolumeError(SampleError):
     field: str = "volume"
     message: str = f"Volume must be between {MINIMUM_VOLUME}-{MAXIMUM_VOLUME} μL"
+
+
+class OrganismDoesNotExistError(SampleError):
+    field: str = "organism"
+    message: str = "Organism does not exist"

--- a/cg/services/order_validation_service/workflows/microsalt/validation/data/rules.py
+++ b/cg/services/order_validation_service/workflows/microsalt/validation/data/rules.py
@@ -2,6 +2,7 @@ from cg.services.order_validation_service.errors.sample_errors import (
     ApplicationArchivedError,
     ApplicationNotValidError,
     InvalidVolumeError,
+    OrganismDoesNotExistError,
     SampleDoesNotExistError,
 )
 from cg.services.order_validation_service.validators.data.utils import is_volume_invalid
@@ -51,5 +52,16 @@ def validate_volume_interval(order: MicrosaltOrder, **kwargs) -> list[InvalidVol
     for sample_index, sample in order.enumerated_new_samples:
         if is_volume_invalid(sample):
             error = InvalidVolumeError(sample_index=sample_index)
+            errors.append(error)
+    return errors
+
+
+def validate_organism_exists(
+    order: MicrosaltOrder, store: Store, **kwargs
+) -> list[OrganismDoesNotExistError]:
+    errors: list[OrganismDoesNotExistError] = []
+    for sample_index, sample in order.enumerated_new_samples:
+        if not store.get_organism_by_internal_id(sample.organism):
+            error = OrganismDoesNotExistError(sample_index=sample_index)
             errors.append(error)
     return errors

--- a/cg/services/order_validation_service/workflows/microsalt/validation_rules.py
+++ b/cg/services/order_validation_service/workflows/microsalt/validation_rules.py
@@ -9,6 +9,7 @@ from cg.services.order_validation_service.validators.inter_field.rules import (
 from cg.services.order_validation_service.workflows.microsalt.validation.data.rules import (
     validate_application_exists,
     validate_applications_not_archived,
+    validate_organism_exists,
     validate_samples_exist,
     validate_volume_interval,
 )
@@ -29,6 +30,7 @@ SAMPLE_RULES: list[callable] = [
     validate_application_compatibility,
     validate_application_exists,
     validate_applications_not_archived,
+    validate_organism_exists,
     validate_sample_names_unique,
     validate_samples_exist,
     validate_volume_interval,

--- a/tests/services/order_validation_service/microsalt/conftest.py
+++ b/tests/services/order_validation_service/microsalt/conftest.py
@@ -22,6 +22,7 @@ def create_microsalt_sample(id: int) -> MicrosaltSample:
         application="MWRNXTR003",
         container=ContainerEnum.plate,
         container_name="ContainerName",
+        organism="C. jejuni",
         require_qc_ok=True,
         reference_genome="NC_00001",
         well_position=f"A:{id}",

--- a/tests/services/order_validation_service/microsalt/test_data_validators.py
+++ b/tests/services/order_validation_service/microsalt/test_data_validators.py
@@ -133,3 +133,14 @@ def test_invalid_organism(valid_order: MicrosaltOrder, base_store: Store):
 
     # THEN the error should concern the invalid organism
     assert isinstance(errors[0], OrganismDoesNotExistError)
+
+
+def test_valid_organisms(valid_order: MicrosaltOrder, base_store: Store):
+
+    # GIVEN a valid order
+
+    # WHEN validating that all organisms exist
+    errors = validate_organism_exists(order=valid_order, store=base_store)
+
+    # THEN no error should be returned
+    assert not errors

--- a/tests/services/order_validation_service/microsalt/test_data_validators.py
+++ b/tests/services/order_validation_service/microsalt/test_data_validators.py
@@ -4,6 +4,7 @@ from cg.services.order_validation_service.errors.sample_errors import (
     ApplicationNotCompatibleError,
     ApplicationNotValidError,
     InvalidVolumeError,
+    OrganismDoesNotExistError,
     SampleDoesNotExistError,
 )
 from cg.services.order_validation_service.workflows.microsalt.models.order import (
@@ -15,6 +16,7 @@ from cg.services.order_validation_service.workflows.microsalt.models.sample impo
 from cg.services.order_validation_service.workflows.microsalt.validation.data.rules import (
     validate_application_exists,
     validate_applications_not_archived,
+    validate_organism_exists,
     validate_samples_exist,
     validate_volume_interval,
 )
@@ -116,3 +118,18 @@ def test_invalid_volume(valid_order: MicrosaltOrder, base_store: Store):
 
     # THEN the error should concern the invalid volume
     assert isinstance(errors[0], InvalidVolumeError)
+
+
+def test_invalid_organism(valid_order: MicrosaltOrder, base_store: Store):
+
+    # GIVEN an order with a sample specifying a non-existent organism
+    valid_order.samples[0].organism = "Non-existent organism"
+
+    # WHEN validating that all organisms exist
+    errors = validate_organism_exists(order=valid_order, store=base_store)
+
+    # THEN an error should be returned
+    assert errors
+
+    # THEN the error should concern the invalid organism
+    assert isinstance(errors[0], OrganismDoesNotExistError)


### PR DESCRIPTION
## Description

### Added

- Validation ensuring that the provided organisms in a microSALT order exists in StatusDB.

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
