### PR TITLE
(Improve order flow) Ensure buffer is set for new samples

### DIFF
--- a/cg/services/order_validation_service/errors/sample_errors.py
+++ b/cg/services/order_validation_service/errors/sample_errors.py
@@ -52,3 +52,8 @@ class InvalidVolumeError(SampleError):
 class OrganismDoesNotExistError(SampleError):
     field: str = "organism"
     message: str = "Organism does not exist"
+
+
+class ElutionBufferMissingError(SampleError):
+    field: str = "elution_buffer"
+    message: str = "Buffer is required"

--- a/cg/services/order_validation_service/workflows/microsalt/validation/data/rules.py
+++ b/cg/services/order_validation_service/workflows/microsalt/validation/data/rules.py
@@ -1,6 +1,7 @@
 from cg.services.order_validation_service.errors.sample_errors import (
     ApplicationArchivedError,
     ApplicationNotValidError,
+    ElutionBufferMissingError,
     InvalidVolumeError,
     OrganismDoesNotExistError,
     SampleDoesNotExistError,
@@ -63,5 +64,14 @@ def validate_organism_exists(
     for sample_index, sample in order.enumerated_new_samples:
         if not store.get_organism_by_internal_id(sample.organism):
             error = OrganismDoesNotExistError(sample_index=sample_index)
+            errors.append(error)
+    return errors
+
+
+def validate_buffer_required(order: MicrosaltOrder, **kwargs) -> list[ElutionBufferMissingError]:
+    errors: list[ElutionBufferMissingError] = []
+    for sample_index, sample in order.enumerated_new_samples:
+        if not sample.elution_buffer:
+            error = ElutionBufferMissingError(sample_index=sample_index)
             errors.append(error)
     return errors

--- a/cg/services/order_validation_service/workflows/microsalt/validation_rules.py
+++ b/cg/services/order_validation_service/workflows/microsalt/validation_rules.py
@@ -9,6 +9,7 @@ from cg.services.order_validation_service.validators.inter_field.rules import (
 from cg.services.order_validation_service.workflows.microsalt.validation.data.rules import (
     validate_application_exists,
     validate_applications_not_archived,
+    validate_buffer_required,
     validate_organism_exists,
     validate_samples_exist,
     validate_volume_interval,
@@ -30,6 +31,7 @@ SAMPLE_RULES: list[callable] = [
     validate_application_compatibility,
     validate_application_exists,
     validate_applications_not_archived,
+    validate_buffer_required,
     validate_organism_exists,
     validate_sample_names_unique,
     validate_samples_exist,

--- a/tests/services/order_validation_service/microsalt/test_data_validators.py
+++ b/tests/services/order_validation_service/microsalt/test_data_validators.py
@@ -3,6 +3,7 @@ from cg.services.order_validation_service.errors.sample_errors import (
     ApplicationArchivedError,
     ApplicationNotCompatibleError,
     ApplicationNotValidError,
+    ElutionBufferMissingError,
     InvalidVolumeError,
     OrganismDoesNotExistError,
     SampleDoesNotExistError,
@@ -16,6 +17,7 @@ from cg.services.order_validation_service.workflows.microsalt.models.sample impo
 from cg.services.order_validation_service.workflows.microsalt.validation.data.rules import (
     validate_application_exists,
     validate_applications_not_archived,
+    validate_buffer_required,
     validate_organism_exists,
     validate_samples_exist,
     validate_volume_interval,
@@ -144,3 +146,18 @@ def test_valid_organisms(valid_order: MicrosaltOrder, base_store: Store):
 
     # THEN no error should be returned
     assert not errors
+
+
+def test_buffer_required(valid_order: MicrosaltOrder):
+
+    # GIVEN an order containing a sample with missing buffer
+    valid_order.samples[0].elution_buffer = None
+
+    # WHEN validating that buffers are set for new samples
+    errors = validate_buffer_required(order=valid_order)
+
+    # THEN an error should be returned
+    assert errors
+
+    # THEN the error should concern the missing buffer
+    assert isinstance(errors[0], ElutionBufferMissingError)


### PR DESCRIPTION
## Description

### Added

- Validation that buffers are set for new microSALT samples

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
