### PR TITLE
feat/connect order to Freshdesk ticket

### DIFF
--- a/cg/clients/freshdesk/models.py
+++ b/cg/clients/freshdesk/models.py
@@ -8,7 +8,6 @@ class TicketCreate(BaseModel):
     """Freshdesk ticket."""
 
     attachments: List[Union[str, bytes]] = Field(default_factory=list)
-    email: str
     email_config_id: int | None = None
     description: str
     name: str

--- a/cg/meta/orders/api.py
+++ b/cg/meta/orders/api.py
@@ -74,13 +74,12 @@ class OrdersAPI:
         ticket_number: str | None = self.ticket_handler.parse_ticket_number(order_in.name)
         if not ticket_number:
             ticket_number = self.ticket_handler.create_ticket(
-                order=order_in, user_name=user_name, user_mail=user_mail, project=project
+                order=order_in, user_name=user_name, project=project
             )
         else:
             self.ticket_handler.connect_to_ticket(
                 order=order_in,
                 user_name=user_name,
-                user_mail=user_mail,
                 project=project,
                 ticket_number=ticket_number,
             )

--- a/cg/meta/orders/ticket_handler.py
+++ b/cg/meta/orders/ticket_handler.py
@@ -4,11 +4,8 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any
 
-from sendmail_container import FormDataRequest
-
 from cg.clients.freshdesk.freshdesk_client import FreshdeskClient
 from cg.clients.freshdesk.models import TicketCreate, TicketResponse
-from cg.clients.freshdesk.utils import create_temp_attachment_file
 from cg.models.orders.order import OrderIn
 from cg.models.orders.samples import Of1508Sample
 from cg.store.models import Customer, Sample
@@ -22,16 +19,17 @@ class TicketHandler:
 
     NEW_LINE = "<br />"
 
-    def __init__(self, status_db: Store, client: FreshdeskClient, env: str):
+    def __init__(self, status_db: Store, client: FreshdeskClient, system_email_id: int, env: str):
         self.client: FreshdeskClient = client
         self.status_db: Store = status_db
+        self.system_email_id: int = system_email_id
         self.env = env
 
     @staticmethod
     def parse_ticket_number(name: str) -> str | None:
         """Try to parse a ticket number from a string"""
         # detect manual ticket assignment
-        ticket_match = re.fullmatch(r"#([0-9]{6})", name)
+        ticket_match = re.fullmatch(r"#([0-9]{6,10})", name)
         if ticket_match:
             ticket_id = ticket_match.group(1)
             LOG.info(f"{ticket_id}: detected ticket in order name")
@@ -39,9 +37,7 @@ class TicketHandler:
         LOG.info(f"Could not detected ticket number in name {name}")
         return None
 
-    def create_ticket(
-        self, order: OrderIn, user_name: str, user_mail: str, project: str
-    ) -> int | None:
+    def create_ticket(self, order: OrderIn, user_name: str, project: str) -> int | None:
         """Create a ticket and return the ticket number"""
         message: str = self.create_new_ticket_header(
             message=self.create_xml_sample_list(order=order, user_name=user_name),
@@ -53,8 +49,8 @@ class TicketHandler:
             attachments: Path = self.create_attachment_file(order=order, temp_dir=temp_dir)
 
             freshdesk_ticket = TicketCreate(
-                email=user_mail,
                 description=message,
+                email_config_id=self.system_email_id,
                 name=user_name,
                 subject=order.name,
                 type="Order",
@@ -193,27 +189,27 @@ class TicketHandler:
         return obj
 
     def connect_to_ticket(
-        self, order: OrderIn, user_name: str, user_mail: str, project: str, ticket_number: str
+        self, order: OrderIn, user_name: str, project: str, ticket_number: str
     ) -> None:
         """Appends a new order message to the ticket selected by the customer"""
-        LOG.info(f"Connecting order to ticket {ticket_number}")
+        LOG.info("Connecting order to ticket %s", ticket_number)
+
+        # Create the message content
         message: str = self.add_existing_ticket_header(
             message=self.create_xml_sample_list(order=order, user_name=user_name),
             order=order,
             project=project,
         )
-        sender_prefix, email_server_alias = user_mail.split("@")
-        temp_dir: TemporaryDirectory = create_temp_attachment_file(
-            content=self.replace_empty_string_with_none(obj=order.dict()), file_name="order.json"
-        )
-        email_form = FormDataRequest(
-            sender_prefix=sender_prefix,
-            email_server_alias=email_server_alias,
-            request_uri=self.client.base_url,
-            recipients=user_mail,
-            mail_title=f"[#{ticket_number}]",
-            mail_body=message,
-            attachments=[Path(f"{temp_dir.name}/order.json")],
-        )
-        email_form.submit()
-        temp_dir.cleanup()
+
+        with TemporaryDirectory() as temp_dir:
+            attachments: Path = self.create_attachment_file(order=order, temp_dir=temp_dir)
+
+            reply_payload = {"body": message, "attachments": []}
+
+            LOG.info("Reply payload: %s", reply_payload)
+
+            self.client.reply_to_ticket(
+                ticket_id=ticket_number, reply=reply_payload, attachments=[attachments]
+            )
+
+            LOG.info("Connected order to ticket %s in Freshdesk", ticket_number)

--- a/cg/meta/orders/ticket_handler.py
+++ b/cg/meta/orders/ticket_handler.py
@@ -194,7 +194,6 @@ class TicketHandler:
         """Appends a new order message to the ticket selected by the customer"""
         LOG.info("Connecting order to ticket %s", ticket_number)
 
-        # Create the message content
         message: str = self.add_existing_ticket_header(
             message=self.create_xml_sample_list(order=order, user_name=user_name),
             order=order,

--- a/cg/server/ext.py
+++ b/cg/server/ext.py
@@ -89,12 +89,11 @@ order_service = OrderService(store=db, status_service=summary_service)
 sample_service = SampleService(db)
 freshdesk_client = FreshdeskClient(
     base_url=app_config.freshdesk_url,
-    api_key=app_config.freshdesk_api_key,
-    order_email_id=app_config.freshdesk_order_email_id,
-)
+    api_key=app_config.freshdesk_api_key)
 ticket_handler = TicketHandler(
     client=freshdesk_client,
     status_db=db,
+    system_email_id=app_config.freshdesk_order_email_id,
     env=app_config.freshdesk_environment,
 )
 orders_api = OrdersAPI(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -651,7 +651,7 @@ def osticket(ticket_id: str) -> MockOsTicket:
 def freshdesk_client() -> FreshdeskClient:
     """Return a FreshdeskClient instance with mock parameters."""
     client = FreshdeskClient(
-        base_url="https://mock.freshdesk.com", api_key="mock_api_key", order_email_id=2024
+        base_url="https://mock.freshdesk.com", api_key="mock_api_key"
     )
     return client
 

--- a/tests/meta/orders/conftest.py
+++ b/tests/meta/orders/conftest.py
@@ -133,7 +133,7 @@ def tomte_status_data(tomte_order_to_submit: dict):
 @pytest.fixture
 def freshdesk_client():
     return FreshdeskClient(
-        base_url="https://example.com", api_key="dummy_api_key", order_email_id=12345
+        base_url="https://example.com", api_key="dummy_api_key"
     )
 
 
@@ -144,4 +144,4 @@ def orders_api(base_store: Store, lims_api: MockLimsAPI, ticket_handler: TicketH
 
 @pytest.fixture
 def ticket_handler(store: Store, freshdesk_client: FreshdeskClient):
-    return TicketHandler(status_db=store, client=freshdesk_client, env="test")
+    return TicketHandler(status_db=store, client=freshdesk_client, system_email_id=1, env="test")

--- a/tests/meta/orders/conftest.py
+++ b/tests/meta/orders/conftest.py
@@ -132,9 +132,7 @@ def tomte_status_data(tomte_order_to_submit: dict):
 
 @pytest.fixture
 def freshdesk_client():
-    return FreshdeskClient(
-        base_url="https://example.com", api_key="dummy_api_key"
-    )
+    return FreshdeskClient(base_url="https://example.com", api_key="dummy_api_key")
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
## Description

### Added

-  `reply_to_ticket` method to the Freshdesk client


### Changed
- ` connect_to_ticket` method to handle the order details as a reply in the same ticket
- deleted `user_mail`, which was used by the old ` connect_to_ticket`
- updated tests to accommodate these changes


