### PR TITLE
(Improve order flow) Patch min string length

### DIFF
--- a/cg/services/order_validation_service/models/case.py
+++ b/cg/services/order_validation_service/models/case.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, Field
 
 from cg.constants.priority import PriorityTerms
 from cg.models.orders.sample_base import NAME_PATTERN
@@ -10,8 +10,6 @@ class Case(BaseModel):
     name: str = Field(pattern=NAME_PATTERN, min_length=2, max_length=128)
     priority: PriorityTerms = PriorityTerms.STANDARD
     samples: list[Sample]
-
-    model_config = ConfigDict(str_min_length=1)
 
     @property
     def enumerated_samples(self):

--- a/cg/services/order_validation_service/models/order.py
+++ b/cg/services/order_validation_service/models/order.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, Field
 
 from cg.constants import DataDelivery
 from cg.constants.constants import Workflow
@@ -9,12 +9,10 @@ TICKET_PATTERN = r"^#\d{4,}"
 class Order(BaseModel):
     comment: str | None = None
     connect_to_ticket: bool = False
-    customer: str
+    customer: str = Field(min_length=1)
     delivery_type: DataDelivery
-    name: str
+    name: str = Field(min_length=1)
     skip_reception_control: bool = False
     ticket_number: str | None = Field(None, pattern=TICKET_PATTERN)
     user_id: int
     workflow: Workflow
-
-    model_config = ConfigDict(str_min_length=1)

--- a/cg/services/order_validation_service/models/sample.py
+++ b/cg/services/order_validation_service/models/sample.py
@@ -1,10 +1,10 @@
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, Field
 
 from cg.models.orders.sample_base import NAME_PATTERN, ContainerEnum
 
 
 class Sample(BaseModel):
-    application: str
+    application: str = Field(min_length=1)
     comment: str | None = None
     container: ContainerEnum
     container_name: str | None = None
@@ -13,8 +13,6 @@ class Sample(BaseModel):
     require_qc_ok: bool
     volume: int | None = None
     well_position: str | None = None
-
-    model_config = ConfigDict(str_min_length=1)
 
     @property
     def is_new(self) -> bool:

--- a/cg/services/order_validation_service/workflows/tomte/models/sample.py
+++ b/cg/services/order_validation_service/workflows/tomte/models/sample.py
@@ -20,6 +20,6 @@ class TomteSample(Sample):
     sex: SexEnum | None = None
     source: str | None = None
     status: StatusEnum | None = None
-    subject_id: str = Field(pattern=NAME_PATTERN, max_length=128)
+    subject_id: str = Field(pattern=NAME_PATTERN, min_length=1, max_length=128)
     tissue_block_size: TissueBlockEnum | None = None
     concentration_ng_ul: float | None = None


### PR DESCRIPTION
## Description

The FE sends both null and empty strings for fields which are not set. Hence we can not set a global min length on strings.

### Added

-

### Changed

-

### Fixed

- Min string length is set on field level.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
