### PR TITLE
(Improve order flow) Remove subject id from tomte

### DIFF
--- a/cg/services/order_validation_service/workflows/tomte/models/case.py
+++ b/cg/services/order_validation_service/workflows/tomte/models/case.py
@@ -1,4 +1,3 @@
-from cg.constants import GenePanelMasterList
 from cg.services.order_validation_service.models.case import Case
 from cg.services.order_validation_service.workflows.tomte.models.sample import (
     TomteSample,
@@ -7,7 +6,7 @@ from cg.services.order_validation_service.workflows.tomte.models.sample import (
 
 class TomteCase(Case):
     cohorts: list[str] | None = None
-    panels: list[GenePanelMasterList]
+    panels: list[str]
     synopsis: str | None = None
     samples: list[TomteSample]
 

--- a/cg/services/order_validation_service/workflows/tomte/models/sample.py
+++ b/cg/services/order_validation_service/workflows/tomte/models/sample.py
@@ -20,6 +20,5 @@ class TomteSample(Sample):
     sex: SexEnum | None = None
     source: str | None = None
     status: StatusEnum | None = None
-    subject_id: str = Field(pattern=NAME_PATTERN, min_length=1, max_length=128)
     tissue_block_size: TissueBlockEnum | None = None
     concentration_ng_ul: float | None = None


### PR DESCRIPTION
## Description

Subject id is not set for tomte, hence it is removed from the TomteSample model. Panels need to be validated against StatusDB instead of an enum.

### Added

-

### Changed

-

### Fixed

- Subject_id removed from TomteSample
- Panels are typed as strings and validated later

### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
