### PR TITLE
(Improve order flow) Type panels as string

### DIFF
--- a/cg/services/order_validation_service/workflows/tomte/models/case.py
+++ b/cg/services/order_validation_service/workflows/tomte/models/case.py
@@ -1,4 +1,3 @@
-from cg.constants import GenePanelMasterList
 from cg.services.order_validation_service.models.case import Case
 from cg.services.order_validation_service.workflows.tomte.models.sample import (
     TomteSample,
@@ -7,7 +6,7 @@ from cg.services.order_validation_service.workflows.tomte.models.sample import (
 
 class TomteCase(Case):
     cohorts: list[str] | None = None
-    panels: list[GenePanelMasterList]
+    panels: list[str]
     synopsis: str | None = None
     samples: list[TomteSample]
 


### PR DESCRIPTION
## Description

The gene panels are now typed as strings as the master list does not cover all.

### Added

-

### Changed

-

### Fixed

- Gene panels typed as strings


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
