### PR TITLE
Feat(rsync) Remove -t flag for sars-cov

### DIFF
--- a/cg/meta/rsync/sbatch.py
+++ b/cg/meta/rsync/sbatch.py
@@ -9,8 +9,8 @@ rsync -rvL {source_path}/ {destination_path}
 """
 
 COVID_RSYNC = """
-rsync -rvtL {source_path} {destination_path}
-rsync -rvtL --chmod=777 {covid_report_path} {covid_destination_path}
+rsync -rvL {source_path} {destination_path}
+rsync -rvL --chmod=777 {covid_report_path} {covid_destination_path}
 """
 
 ERROR_RSYNC_FUNCTION = """


### PR DESCRIPTION
### Description
For some reason the rsync command used for covid samples contains the `-t` flag which preserves the timestamp on the files. This however seems to have the side effect of setting the the group owning the file to users.

There is no documentation in the PR or anywhere else on why the -t flag was added, so I'm removing it so that our rsyncs behave the same way.

### Fixes
- Files delivered now correctly belongs to the customers group