### PR TITLE
(Improve order flow) Make sure internal_id None is disregarded

### DIFF
--- a/cg/services/order_validation_service/models/discriminators.py
+++ b/cg/services/order_validation_service/models/discriminators.py
@@ -3,5 +3,5 @@ from typing import Any
 
 def has_internal_id(v: Any) -> str:
     if isinstance(v, dict):
-        return "existing" if "internal_id" in v.keys() else "new"
+        return "existing" if v.get("internal_id") else "new"
     return "existing" if getattr(v, "internal_id", None) else "new"


### PR DESCRIPTION
## Description

The FE sends internal_id == None for new samples, making our discriminator fail.

### Added

-

### Changed

-

### Fixed

- Discriminator can handle None


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
