### PR TITLE
feat(test for counting reads of negative controls)

### DIFF
--- a/tests/store/crud/update/test_update.py
+++ b/tests/store/crud/update/test_update.py
@@ -97,7 +97,6 @@ def test_update_sample_reads_illumina_negative_control(
     assert sample.reads == 0
     # GIVEN that the sample is a negative control sample
     sample.control = ControlOptions.NEGATIVE
-    assert sample.is_negative_control is True
 
     # WHEN updating the sample reads for a sequencing run
     store_with_illumina_sequencing_data.update_sample_reads_illumina(


### PR DESCRIPTION
## Description

Closes https://github.com/Clinical-Genomics/cg/issues/2871

### Added

-  Test for counting reads of negative controls.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [X] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
