### PR TITLE
fix(rsync name to tb api)

### DIFF
--- a/cg/services/deliver_files/deliver_files_service/deliver_files_service.py
+++ b/cg/services/deliver_files/deliver_files_service/deliver_files_service.py
@@ -104,7 +104,7 @@ class DeliverFilesService:
             LOG.info(f"Would have added the analysis for case {case.internal_id} to Trailblazer")
         else:
             analysis: TrailblazerAnalysis = self.tb_service.add_pending_analysis(
-                case_id=case.internal_id,
+                case_id=f"{case.internal_id}_rsync",
                 analysis_type=AnalysisTypes.OTHER,
                 config_path=self.rsync_service.trailblazer_config_path.as_posix(),
                 order_id=case.latest_order.id,

--- a/cg/services/deliver_files/deliver_files_service/deliver_files_service_factory.py
+++ b/cg/services/deliver_files/deliver_files_service/deliver_files_service_factory.py
@@ -147,7 +147,7 @@ class DeliveryServiceFactory:
         if delivery_type in [DataDelivery.FASTQ_QC, DataDelivery.FASTQ_SCOUT]:
             return DataDelivery.FASTQ
         if delivery_type in [DataDelivery.ANALYSIS_SCOUT]:
-            return DataDelivery.FASTQ_ANALYSIS
+            return DataDelivery.ANALYSIS_FILES
         if delivery_type in [
             DataDelivery.FASTQ_ANALYSIS_SCOUT,
             DataDelivery.FASTQ_QC_ANALYSIS,


### PR DESCRIPTION
## Description

Fixes a bug caused in trailblazer by adding an analysis to workflow with a casename that exists for a different workflow. This caused bugs where the uploaded_at was set on the rsync instead of the actual case under the rna fusion worfklow.

The logic around getting analysis based on case names seems very fragile to me...

### Added

-

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
