### PR TITLE
add raredisease ngsbits sex check

### DIFF
--- a/cg/constants/nf_analysis.py
+++ b/cg/constants/nf_analysis.py
@@ -22,6 +22,7 @@ RAREDISEASE_METRIC_CONDITIONS: dict[str, dict[str, Any]] = {
     "PCT_TARGET_BASES_10X": {"norm": "gt", "threshold": 0.95},
     "PCT_EXC_ADAPTER": {"norm": "lt", "threshold": 0.0005},
     "predicted_sex_sex_check": {"norm": "eq", "threshold": None},
+    "gender": {"norm": "eq", "threshold": None},
 }
 
 RAREDISEASE_PARENT_PEDDY_METRIC_CONDITION: dict[str, dict[str, Any]] = {

--- a/cg/meta/workflow/raredisease.py
+++ b/cg/meta/workflow/raredisease.py
@@ -218,6 +218,7 @@ class RarediseaseAnalysisAPI(NfAnalysisAPI):
     @staticmethod
     def set_order_sex_for_sample(sample: Sample, metric_conditions: dict) -> None:
         metric_conditions["predicted_sex_sex_check"]["threshold"] = sample.sex
+        metric_conditions["gender"]["threshold"] = sample.sex
 
     def get_sample_coverage_file_path(self, bundle_name: str, sample_id: str) -> str | None:
         """Return the Raredisease d4 coverage file path."""

--- a/tests/fixtures/analysis/raredisease/multiqc_data.json
+++ b/tests/fixtures/analysis/raredisease/multiqc_data.json
@@ -102,6 +102,14 @@
         },
         {
             "ADM1": {
+                "gender": "female",
+                "reads_chry": 103876,
+                "reads_chrx": 37077016,
+                "ratio_chry_chrx": 0.0028
+            }
+        },
+        {
+            "ADM1": {
                 "GENOME_TERRITORY": 2858674663.0,
                 "MEAN_COVERAGE": 25.002304,
                 "SD_COVERAGE": 7.564118,
@@ -299,6 +307,14 @@
                 "total_pairs": 272728731.0,
                 "summed_mean": 330.957577,
                 "summed_median": 327
+            }
+        },
+        {
+            "ADM2": {
+                "gender": "female",
+                "reads_chry": 103876,
+                "reads_chrx": 37077016,
+                "ratio_chry_chrx": 0.0028
             }
         },
         {

--- a/tests/fixtures/analysis/raredisease/raredisease_case_enough_reads_metrics_deliverables.yaml
+++ b/tests/fixtures/analysis/raredisease/raredisease_case_enough_reads_metrics_deliverables.yaml
@@ -563,6 +563,36 @@ metrics:
   name: summed_median
   step: multiqc
   value: 327
+- condition:
+    norm: eq
+    threshold: female
+  header: null
+  id: ADM1
+  input: multiqc_data.json
+  name: gender
+  step: multiqc
+  value: female
+- condition: null
+  header: null
+  id: ADM1
+  input: multiqc_data.json
+  name: reads_chry
+  step: multiqc
+  value: 103876
+- condition: null
+  header: null
+  id: ADM1
+  input: multiqc_data.json
+  name: reads_chrx
+  step: multiqc
+  value: 37077016
+- condition: null
+  header: null
+  id: ADM1
+  input: multiqc_data.json
+  name: ratio_chry_chrx
+  step: multiqc
+  value: 0.0028
 - condition: null
   header: null
   id: ADM1
@@ -1653,6 +1683,36 @@ metrics:
   name: summed_median
   step: multiqc
   value: 327
+- condition:
+    norm: eq
+    threshold: female
+  header: null
+  id: ADM2
+  input: multiqc_data.json
+  name: gender
+  step: multiqc
+  value: female
+- condition: null
+  header: null
+  id: ADM2
+  input: multiqc_data.json
+  name: reads_chry
+  step: multiqc
+  value: 103876
+- condition: null
+  header: null
+  id: ADM2
+  input: multiqc_data.json
+  name: reads_chrx
+  step: multiqc
+  value: 37077016
+- condition: null
+  header: null
+  id: ADM2
+  input: multiqc_data.json
+  name: ratio_chry_chrx
+  step: multiqc
+  value: 0.0028
 - condition: null
   header: null
   id: ADM2


### PR DESCRIPTION
## Description
This PR adds a sex check to cg workflow raredisease metrics-deliver case, comparing the sex in statusDB against the predicted sex in ngs-bits SampleGender.

### Added

- ngs-bits sex check to raredisease

### Changed

-

### Fixed

-


### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b add-ngsbits-sex-check-raredisease
    ```

### How to test

- [x] `nano multiqc_data.json` and add example output of SampleGender into the multiQC file.
- [x] Do `cg workflow raredisease metrics-deliver funkitten`, it should complete successfully

### Expected test outcome

- [x] Check that the command completes successfully.
- [x] Take a screenshot and attach or copy/paste the output.
<img width="686" alt="image" src="https://github.com/user-attachments/assets/14397244-469a-45cb-b8ba-7d4e5a6134d9">

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
