### PR TITLE
Raredisease: add genepanel path to params file

### DIFF
--- a/cg/meta/workflow/raredisease.py
+++ b/cg/meta/workflow/raredisease.py
@@ -124,6 +124,7 @@ class RarediseaseAnalysisAPI(NfAnalysisAPI):
             save_mapped_as_cram=True,
             skip_germlinecnvcaller=skip_germlinecnvcaller,
             vcfanno_extra_resources=f"{outdir}/{ScoutExportFileName.MANAGED_VARIANTS}",
+            vep_filters_scout_fmt=f"{outdir}/{ScoutExportFileName.PANELS}",
         )
 
     @staticmethod

--- a/cg/models/raredisease/raredisease.py
+++ b/cg/models/raredisease/raredisease.py
@@ -70,3 +70,4 @@ class RarediseaseParameters(WorkflowParameters):
     skip_germlinecnvcaller: bool
     vcfanno_extra_resources: str
     local_genomes: str
+    vep_filters_scout_fmt: str

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2581,6 +2581,9 @@ def raredisease_parameters_default(
             Path(raredisease_dir, raredisease_case_id + ScoutExportFileName.MANAGED_VARIANTS)
         ),
         local_genomes=Path(raredisease_dir, "references").as_posix(),
+        vep_filters_scout_fmt=str(
+            Path(raredisease_dir, raredisease_case_id + ScoutExportFileName.PANELS)
+        ),
     )
 
 


### PR DESCRIPTION
## Description
This PR adds the path of the gene_panels.bed file to the params.yaml file, as Nextflow requires its location as input parameter `vep_filters_scout_fmt`. This is triggered as part of the `cg workflow raredisease config-case` command.

### Added

- Scout gene panel file path into Raredisease params.yaml

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [x] Do `cg workflow raredisease config-case evolvedsalmon`

### Expected test outcome

- [x] Check that in evolvedsalmon_params_file.yaml **vep_filters_scout_fmt** exists as /path/to/case/gene_panels.bed 
- [x] Take a screenshot and attach or copy/paste the output.
<img width="1305" alt="image" src="https://github.com/user-attachments/assets/32eeb2cc-dfe5-4c73-b26d-cd4ea1c890ef">

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
