### PR TITLE
add artefact loqusdb argument

### DIFF
--- a/cg/constants/observations.py
+++ b/cg/constants/observations.py
@@ -66,7 +66,7 @@ class MipDNAObservationsAnalysisTag(StrEnum):
 
 class ObservationsFileWildcards(StrEnum):
     """File patterns regarding dump Loqusdb files."""
-
+    ARTEFACT_SNV: str = "artefact_somatic_snv"
     CLINICAL_SNV: str = "clinical_snv"
     CLINICAL_SV: str = "clinical_sv"
     CANCER_GERMLINE_SNV: str = "cancer_germline_snv"

--- a/cg/constants/observations.py
+++ b/cg/constants/observations.py
@@ -66,6 +66,7 @@ class MipDNAObservationsAnalysisTag(StrEnum):
 
 class ObservationsFileWildcards(StrEnum):
     """File patterns regarding dump Loqusdb files."""
+
     ARTEFACT_SNV: str = "artefact_somatic_snv"
     CLINICAL_SNV: str = "clinical_snv"
     CLINICAL_SV: str = "clinical_sv"

--- a/cg/meta/workflow/balsamic.py
+++ b/cg/meta/workflow/balsamic.py
@@ -551,6 +551,7 @@ class BalsamicAnalysisAPI(AnalysisAPI):
                 "--balsamic-cache": self.balsamic_cache,
                 "--cache-version": cache_version,
                 "--cadd-annotations": self.cadd_path,
+                "--artefact-snv-observations": arguments.get("artefact_somatic_snv"),
                 "--cancer-germline-snv-observations": arguments.get("cancer_germline_snv"),
                 "--cancer-germline-sv-observations": arguments.get("cancer_germline_sv"),
                 "--cancer-somatic-snv-observations": arguments.get("cancer_somatic_snv"),


### PR DESCRIPTION
## Description

Added new argument to enable this feature in balsamic: https://github.com/Clinical-Genomics/BALSAMIC/pull/1481

It adds a new annotation of somatic SNVs called in merged WGS normal samples, planned to be used as a list of artefacts with minimal risk of filtering out true relevant somatic events. 

### Added

- new argument for balsamic with new loqusdb vcf for artefact filtering

### Changed

-

### Fixed

-


### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [x] Start an example case after installing  https://github.com/Clinical-Genomics/BALSAMIC/pull/1481 and this PR to stage.


### Expected test outcome

- [x] Ensure that the new loqusdb argument is provided:` --artefact-snv-observations`

<img width="1258" alt="image" src="https://github.com/user-attachments/assets/d5e18a0a-ff44-4780-8575-e2479aab9262">


## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
