### PR TITLE
Add handling of unassigned reads

### DIFF
--- a/cg/constants/pacbio.py
+++ b/cg/constants/pacbio.py
@@ -103,7 +103,7 @@ class SampleMetricsAliases:
     HIFI_READS: str = "barcode.barcode_table.number_of_reads"
     HIFI_YIELD: str = "barcode.barcode_table.number_of_bases"
     POLYMERASE_READ_LENGTH: str = "barcode.barcode_table.mean_polymerase_read_length"
-    SAMPLE_NAME: str = "barcode.barcode_table.biosample"
+    SAMPLE_INTERNAL_ID: str = "barcode.barcode_table.biosample"
 
 
 file_pattern_to_bundle_type: dict[str, str] = {

--- a/cg/services/run_devices/pacbio/data_transfer_service/utils.py
+++ b/cg/services/run_devices/pacbio/data_transfer_service/utils.py
@@ -4,7 +4,10 @@ from cg.services.run_devices.pacbio.data_transfer_service.dto import (
     PacBioSequencingRunDTO,
     PacBioSMRTCellDTO,
 )
-from cg.services.run_devices.pacbio.metrics_parser.models import PacBioMetrics, SampleMetrics
+from cg.services.run_devices.pacbio.metrics_parser.models import (
+    PacBioMetrics,
+    SampleMetrics,
+)
 from cg.services.run_devices.pacbio.run_data_generator.run_data import PacBioRunData
 
 
@@ -64,7 +67,7 @@ def get_sample_sequencing_metrics_dtos(
     sample_metrics_dtos: list[PacBioSampleSequencingMetricsDTO] = []
     for sample in sample_metrics:
         sample_sequencing_metrics_dto = PacBioSampleSequencingMetricsDTO(
-            sample_internal_id=sample.sample_name,
+            sample_internal_id=sample.sample_internal_id,
             hifi_reads=sample.hifi_reads,
             hifi_yield=sample.hifi_yield,
             hifi_mean_read_length=sample.hifi_mean_read_length,

--- a/cg/services/run_devices/pacbio/housekeeper_service/pacbio_houskeeper_service.py
+++ b/cg/services/run_devices/pacbio/housekeeper_service/pacbio_houskeeper_service.py
@@ -20,10 +20,14 @@ from cg.services.run_devices.exc import (
     PostProcessingStoreFileError,
 )
 from cg.services.run_devices.pacbio.housekeeper_service.models import PacBioFileData
-from cg.services.run_devices.pacbio.metrics_parser.metrics_parser import PacBioMetricsParser
+from cg.services.run_devices.pacbio.metrics_parser.metrics_parser import (
+    PacBioMetricsParser,
+)
 from cg.services.run_devices.pacbio.metrics_parser.models import PacBioMetrics
 from cg.services.run_devices.pacbio.run_data_generator.run_data import PacBioRunData
-from cg.services.run_devices.pacbio.run_file_manager.run_file_manager import PacBioRunFileManager
+from cg.services.run_devices.pacbio.run_file_manager.run_file_manager import (
+    PacBioRunFileManager,
+)
 from cg.utils.mapping import get_item_by_pattern_in_source
 
 LOG = logging.getLogger(__name__)
@@ -72,7 +76,7 @@ class PacBioHousekeeperService(PostProcessingHKService):
         full_barcode: str = f"{barcode}--{barcode}"
         for sample in metrics.samples:
             if sample.barcode_name == full_barcode:
-                return sample.sample_name
+                return sample.sample_internal_id
         raise PostProcessingStoreFileError(f"Sample not found for barcode: {barcode}")
 
     @staticmethod

--- a/cg/services/run_devices/pacbio/metrics_parser/models.py
+++ b/cg/services/run_devices/pacbio/metrics_parser/models.py
@@ -152,7 +152,7 @@ class SampleMetrics(RunMetrics):
     hifi_reads: int = Field(..., alias=SampleMetricsAliases.HIFI_READS)
     hifi_yield: int = Field(..., alias=SampleMetricsAliases.HIFI_YIELD)
     polymerase_read_length: int = Field(..., alias=SampleMetricsAliases.POLYMERASE_READ_LENGTH)
-    sample_name: str = Field(..., alias=SampleMetricsAliases.SAMPLE_NAME)
+    sample_internal_id: str = Field(..., alias=SampleMetricsAliases.SAMPLE_INTERNAL_ID)
 
 
 class PacBioMetrics(RunMetrics):

--- a/cg/services/run_devices/pacbio/metrics_parser/utils.py
+++ b/cg/services/run_devices/pacbio/metrics_parser/utils.py
@@ -50,7 +50,7 @@ def get_parsed_metrics_from_file_name(metrics_files: list[Path], file_name: str)
 
 
 def _is_unassigned_reads_entry(sample_metric: SampleMetrics) -> bool:
-    return sample_metric.sample_name == "No Name"
+    return sample_metric.sample_internal_id == "No Name"
 
 
 def _parse_sample_data(sample_data: list[dict[str, Any]]) -> list[SampleMetrics]:

--- a/cg/services/run_devices/pacbio/metrics_parser/utils.py
+++ b/cg/services/run_devices/pacbio/metrics_parser/utils.py
@@ -49,6 +49,10 @@ def get_parsed_metrics_from_file_name(metrics_files: list[Path], file_name: str)
     return _parse_report_to_model(report_file=report_file, data_model=data_model)
 
 
+def _is_unassigned_reads_entry(sample_metric: SampleMetrics) -> bool:
+    return sample_metric.sample_name == "No Name"
+
+
 def _parse_sample_data(sample_data: list[dict[str, Any]]) -> list[SampleMetrics]:
     """Parse all samples data into SampleMetrics given the sample section of the barcodes report."""
     sample_metrics: list[SampleMetrics] = []
@@ -58,7 +62,9 @@ def _parse_sample_data(sample_data: list[dict[str, Any]]) -> list[SampleMetrics]
         for data_field in sample_data:
             field_id: str = data_field.get(MetricsFileFields.ID)
             sample[field_id] = data_field.get(MetricsFileFields.VALUES)[sample_idx]
-        sample_metrics.append(SampleMetrics.model_validate(sample))
+        sample_metric = SampleMetrics.model_validate(sample)
+        if not _is_unassigned_reads_entry(sample_metric):
+            sample_metrics.append(sample_metric)
     return sample_metrics
 
 

--- a/cg/store/crud/create.py
+++ b/cg/store/crud/create.py
@@ -534,7 +534,9 @@ class CreateHandler(BaseHandler):
         sample_run_metrics_dto: PacBioSampleSequencingMetricsDTO,
         sequencing_run: PacBioSequencingRun,
     ) -> PacBioSampleSequencingMetrics:
-        sample: Sample = self.get_sample_by_internal_id(sample_run_metrics_dto.sample_internal_id)
+        sample_id: str = sample_run_metrics_dto.sample_internal_id
+        LOG.debug(f"Creating Pacbio sample sequencing metric for sample {sample_id}")
+        sample: Sample = self.get_sample_by_internal_id(sample_id)
         new_sample_sequencing_run = PacBioSampleSequencingMetrics(
             sample=sample,
             hifi_reads=sample_run_metrics_dto.hifi_reads,

--- a/tests/fixture_plugins/pacbio_fixtures/metrics_fixtures.py
+++ b/tests/fixture_plugins/pacbio_fixtures/metrics_fixtures.py
@@ -122,7 +122,7 @@ def pacbio_barcoded_sample_metrics(
         SampleMetricsAliases.HIFI_READS: 7785983,
         SampleMetricsAliases.HIFI_YIELD: 114676808325,
         SampleMetricsAliases.POLYMERASE_READ_LENGTH: 163451,
-        SampleMetricsAliases.SAMPLE_NAME: pacbio_barcoded_sample_internal_id,
+        SampleMetricsAliases.SAMPLE_INTERNAL_ID: pacbio_barcoded_sample_internal_id,
     }
     return SampleMetrics.model_validate(data)
 
@@ -140,7 +140,7 @@ def pacbio_unassigned_sample_metrics(
         SampleMetricsAliases.HIFI_READS: 29318,
         SampleMetricsAliases.HIFI_YIELD: 424465869,
         SampleMetricsAliases.POLYMERASE_READ_LENGTH: 142228,
-        SampleMetricsAliases.SAMPLE_NAME: pacbio_unassigned_sample_internal_id,
+        SampleMetricsAliases.SAMPLE_INTERNAL_ID: pacbio_unassigned_sample_internal_id,
     }
     return SampleMetrics.model_validate(data)
 


### PR DESCRIPTION
## Description

We should disregard the sample metric pertaining to unassigned reads. 

### Added

-

### Changed

- sample_name to sample_internal_id
- Unassigned reads are disregarded.

### Fixed

- Unassigned reads are discarded


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b handle-unassigned-reads -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
