### PR TITLE
Fix retrieved fastq cleaning

### DIFF
--- a/cg/meta/compress/compress.py
+++ b/cg/meta/compress/compress.py
@@ -198,7 +198,7 @@ class CompressAPI:
     def _can_fastqs_be_removed(
         self, compression_data: CompressionData, fastq_first: File, fastq_second: File
     ) -> bool:
-        is_fastq_compression_done: bool = self.crunchy_api.is_fastq_compression_possible(
+        is_fastq_compression_done: bool = self.crunchy_api.is_fastq_compression_done(
             compression_data
         )
         spring_file: File | None = self.hk_api.get_file_insensitive_path(

--- a/cg/meta/compress/compress.py
+++ b/cg/meta/compress/compress.py
@@ -202,7 +202,9 @@ class CompressAPI:
         spring_file: File | None = self.hk_api.get_file_insensitive_path(
             compression_data.spring_path
         )
-        return (is_fastq_compression_done) or (spring_file and spring_file.is_archived)
+        return (is_fastq_compression_done) or (
+            spring_file and spring_file.archive and spring_file.archive.archived_at
+        )
 
     def add_decompressed_fastq(self, sample: Sample) -> bool:
         """Adds unpacked FASTQ files to Housekeeper."""

--- a/cg/meta/compress/compress.py
+++ b/cg/meta/compress/compress.py
@@ -195,9 +195,7 @@ class CompressAPI:
             )
         return all_cleaned
 
-    def _can_fastqs_be_removed(
-        self, compression_data: CompressionData, fastq_first: File, fastq_second: File
-    ) -> bool:
+    def _can_fastqs_be_removed(self, compression_data: CompressionData) -> bool:
         is_fastq_compression_done: bool = self.crunchy_api.is_fastq_compression_done(
             compression_data
         )

--- a/cg/meta/compress/compress.py
+++ b/cg/meta/compress/compress.py
@@ -207,9 +207,6 @@ class CompressAPI:
         is_spring_archived: bool = (
             spring_file and spring_file.archive and spring_file.archive.archived_at
         )
-        LOG.info(
-            f"SPRING file {compression_data.spring_path} has been archived? {is_spring_archived}"
-        )
         return is_fastq_compression_done or is_spring_archived
 
     def add_decompressed_fastq(self, sample: Sample) -> bool:

--- a/cg/meta/compress/compress.py
+++ b/cg/meta/compress/compress.py
@@ -169,7 +169,7 @@ class CompressAPI:
             fastq_first: File = sample_fastq[run_name]["hk_first"]
             fastq_second: File = sample_fastq[run_name]["hk_second"]
 
-            if not self._can_fastqs_be_removed(compression_data=compression):
+            if not self._can_fastqs_be_removed(compression):
                 LOG.info(f"FASTQ compression not done for sample {sample_id}, run {run_name}")
                 all_cleaned = False
                 continue

--- a/cg/meta/compress/compress.py
+++ b/cg/meta/compress/compress.py
@@ -202,9 +202,10 @@ class CompressAPI:
         spring_file: File | None = self.hk_api.get_file_insensitive_path(
             compression_data.spring_path
         )
-        return (is_fastq_compression_done) or (
+        is_spring_archived: bool = (
             spring_file and spring_file.archive and spring_file.archive.archived_at
         )
+        return is_fastq_compression_done or is_spring_archived
 
     def add_decompressed_fastq(self, sample: Sample) -> bool:
         """Adds unpacked FASTQ files to Housekeeper."""

--- a/cg/meta/compress/compress.py
+++ b/cg/meta/compress/compress.py
@@ -170,11 +170,13 @@ class CompressAPI:
             fastq_second: File = sample_fastq[run_name]["hk_second"]
 
             if not self._can_fastqs_be_removed(compression):
-                LOG.info(f"FASTQ compression not done for sample {sample_id}, run {run_name}")
+                LOG.info(
+                    f"FASTQ compression not done for sample {sample_id}, run {run_name}, and spring files are not archived."
+                )
                 all_cleaned = False
                 continue
 
-            LOG.info(f"FASTQ compression done for sample {sample_id}, run {run_name}!")
+            LOG.info(f"FASTQs are ready to be removed for sample {sample_id}, run {run_name}!")
 
             self.update_fastq_hk(
                 sample_id=sample_id,
@@ -205,6 +207,7 @@ class CompressAPI:
         is_spring_archived: bool = (
             spring_file and spring_file.archive and spring_file.archive.archived_at
         )
+        LOG.info(f"SPRING file {compression_data.spring_path} has been archived")
         return is_fastq_compression_done or is_spring_archived
 
     def add_decompressed_fastq(self, sample: Sample) -> bool:

--- a/cg/meta/compress/compress.py
+++ b/cg/meta/compress/compress.py
@@ -207,7 +207,9 @@ class CompressAPI:
         is_spring_archived: bool = (
             spring_file and spring_file.archive and spring_file.archive.archived_at
         )
-        LOG.info(f"SPRING file {compression_data.spring_path} has been archived")
+        LOG.info(
+            f"SPRING file {compression_data.spring_path} has been archived? {is_spring_archived}"
+        )
         return is_fastq_compression_done or is_spring_archived
 
     def add_decompressed_fastq(self, sample: Sample) -> bool:

--- a/cg/meta/compress/compress.py
+++ b/cg/meta/compress/compress.py
@@ -169,9 +169,7 @@ class CompressAPI:
             fastq_first: File = sample_fastq[run_name]["hk_first"]
             fastq_second: File = sample_fastq[run_name]["hk_second"]
 
-            if not self._can_fastqs_be_removed(
-                compression_data=compression, fastq_first=fastq_first, fastq_second=fastq_second
-            ):
+            if not self._can_fastqs_be_removed(compression_data=compression):
                 LOG.info(f"FASTQ compression not done for sample {sample_id}, run {run_name}")
                 all_cleaned = False
                 continue
@@ -203,8 +201,10 @@ class CompressAPI:
         is_fastq_compression_done: bool = self.crunchy_api.is_fastq_compression_possible(
             compression_data
         )
-        is_archived = fastq_first.archive.archived_at and fastq_second.archive.archived_at
-        return is_fastq_compression_done or is_archived
+        spring_file: File | None = self.hk_api.get_file_insensitive_path(
+            compression_data.spring_path
+        )
+        return (is_fastq_compression_done) or (spring_file and spring_file.is_archived)
 
     def add_decompressed_fastq(self, sample: Sample) -> bool:
         """Adds unpacked FASTQ files to Housekeeper."""

--- a/tests/mocks/hk_mock.py
+++ b/tests/mocks/hk_mock.py
@@ -67,7 +67,7 @@ class MockFile:
         return str(self.app_root) in self.full_path
 
     @property
-    def is_archived(self):
+    def archive(self):
         return False
 
     def delete(self):

--- a/tests/mocks/hk_mock.py
+++ b/tests/mocks/hk_mock.py
@@ -66,6 +66,10 @@ class MockFile:
         """Check if the file is included in Housekeeper."""
         return str(self.app_root) in self.full_path
 
+    @property
+    def is_archived(self):
+        return False
+
     def delete(self):
         """Mock delete functions"""
         return True


### PR DESCRIPTION
## Description

If the retrieved spring file is removed before the decompressed fastq file, the decompressed fastq file will never be removed with the current logic. This PR adds a check if the spring file is archived.

### Fixed

- Fastqs are removed if the potential spring already exists in the K data lake


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b fix-fastq-cleaning -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
