### PR TITLE
reduce-log-level-compress

### DIFF
--- a/cg/apps/crunchy/crunchy.py
+++ b/cg/apps/crunchy/crunchy.py
@@ -45,8 +45,6 @@ class CrunchyAPI:
 
     def set_dry_run(self, dry_run: bool) -> None:
         """Update dry run."""
-        LOG.info("Updating compress api")
-        LOG.info(f"Set dry run to {dry_run}")
         self.dry_run = dry_run
         self.slurm_api.set_dry_run(dry_run=dry_run)
 

--- a/cg/apps/housekeeper/hk.py
+++ b/cg/apps/housekeeper/hk.py
@@ -7,7 +7,11 @@ from pathlib import Path
 
 from housekeeper.include import checksum as hk_checksum
 from housekeeper.include import include_version
-from housekeeper.store.database import create_all_tables, drop_all_tables, initialize_database
+from housekeeper.store.database import (
+    create_all_tables,
+    drop_all_tables,
+    initialize_database,
+)
 from housekeeper.store.models import Archive, Bundle, File, Tag, Version
 from housekeeper.store.store import Store
 from sqlalchemy.orm import Query
@@ -273,7 +277,7 @@ class HousekeeperAPI:
         """Get the latest version of a Housekeeper bundle."""
         last_version: Version = self.last_version(bundle_name)
         if not last_version:
-            LOG.warning(f"No bundle found for {bundle_name} in Housekeeper")
+            LOG.debug(f"No bundle found for {bundle_name} in Housekeeper")
             return None
         LOG.debug(f"Found Housekeeper version object for {bundle_name}: {repr(last_version)}")
         return last_version

--- a/cg/cli/compress/fastq.py
+++ b/cg/cli/compress/fastq.py
@@ -97,7 +97,7 @@ def clean_fastq(context: CGConfig, case_id: str | None, days_back: int, dry_run:
                 sample_id=sample_id, archive_location=archive_location
             )
             if not was_cleaned:
-                LOG.info(f"Skipping individual {sample_id}")
+                LOG.debug(f"Skipping individual {sample_id}")
                 continue
             cleaned_inds += 1
 

--- a/cg/cli/compress/helpers.py
+++ b/cg/cli/compress/helpers.py
@@ -73,13 +73,13 @@ def update_compress_api(
 
     compress_api.set_dry_run(dry_run=dry_run)
     if mem:
-        LOG.info(f"Set Crunchy API SLURM mem to {mem}")
+        LOG.debug(f"Set Crunchy API SLURM mem to {mem}")
         compress_api.crunchy_api.slurm_memory = mem
     if hours:
-        LOG.info(f"Set Crunchy API SLURM hours to {hours}")
+        LOG.debug(f"Set Crunchy API SLURM hours to {hours}")
         compress_api.crunchy_api.slurm_hours = hours
     if ntasks:
-        LOG.info(f"Set Crunchy API SLURM number of tasks to {ntasks}")
+        LOG.debug(f"Set Crunchy API SLURM number of tasks to {ntasks}")
         compress_api.crunchy_api.slurm_number_tasks = ntasks
 
 
@@ -139,7 +139,7 @@ def compress_sample_fastqs_in_cases(
         if case_conversion_count >= number_of_conversions:
             break
 
-        LOG.info(f"Searching for FASTQ files in case {case.internal_id}")
+        LOG.debug(f"Searching for FASTQ files in case {case.internal_id}")
         if not case.links:
             continue
         for case_link in case.links:
@@ -159,7 +159,7 @@ def compress_sample_fastqs_in_cases(
                 sample_id=case_link.sample.internal_id
             )
             if not case_converted:
-                LOG.info(f"skipping individual {case_link.sample.internal_id}")
+                LOG.debug(f"skipping individual {case_link.sample.internal_id}")
                 continue
             individuals_conversion_count += 1
         if case_converted:

--- a/cg/meta/compress/compress.py
+++ b/cg/meta/compress/compress.py
@@ -58,7 +58,7 @@ class CompressAPI:
 
     def compress_fastq(self, sample_id: str) -> bool:
         """Compress the FASTQ files for an individual."""
-        LOG.info(f"Check if FASTQ compression is possible for {sample_id}")
+        LOG.debug(f"Check if FASTQ compression is possible for {sample_id}")
         version: Version = self.hk_api.get_latest_bundle_version(bundle_name=sample_id)
         if not version:
             return False
@@ -152,7 +152,7 @@ class CompressAPI:
         This means removing compressed FASTQ files and update housekeeper to point to the new SPRING
         file and its metadata file.
         """
-        LOG.info(f"Clean FASTQ files for {sample_id}")
+        LOG.debug(f"Clean FASTQ files for {sample_id}")
         version: Version = self.hk_api.get_latest_bundle_version(bundle_name=sample_id)
         if not version:
             return False

--- a/cg/meta/compress/files.py
+++ b/cg/meta/compress/files.py
@@ -27,7 +27,7 @@ def get_hk_files_dict(tags: list[str], version_obj: Version) -> dict[Path, File]
         file_tags: set[str] = {tag.name for tag in version_file.tags}
         if not file_tags.intersection(tags):
             continue
-        LOG.info(f"Found file {version_file.path}")
+        LOG.debug(f"Found file {version_file.path}")
         path_obj: Path = Path(version_file.full_path)
         hk_file[path_obj] = version_file
     return hk_file

--- a/tests/apps/hk/test_version.py
+++ b/tests/apps/hk/test_version.py
@@ -117,9 +117,6 @@ def test_get_latest_bundle_version_no_housekeeper_bundle(
     # THEN assert that None was returned since there is no such case bundle in Housekeeper
     assert res is None
 
-    # THEN assert that no bundle is found
-    assert f"No bundle found for {case_id} in Housekeeper" in caplog.text
-
 
 def test_get_create_version(
     another_case_id: str,


### PR DESCRIPTION
## Description
The compress and clean commands for FASTQ are some of the most bloated logs at CG. This PR aims to reduce the spam in this log.


### Changed

- Reduced the log level of several compress related commands
