### PR TITLE
fix - Suppress warnings raised in docker build

### DIFF
--- a/.github/workflows/build_dockerfile_on_push.yml
+++ b/.github/workflows/build_dockerfile_on_push.yml
@@ -24,6 +24,9 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Suppress annotations during build
+        run: echo "::stop-commands::suppress-annotations"
+
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v6
@@ -32,3 +35,6 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: "clinicalgenomics/cg-stage:${{steps.get_branch_name.outputs.branch}}, clinicalgenomics/cg-stage:latest"
+
+      - name: Resume annotations
+        run: echo "::suppress-annotations::"

--- a/.github/workflows/build_dockerfile_on_push.yml
+++ b/.github/workflows/build_dockerfile_on_push.yml
@@ -25,7 +25,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Suppress annotations during build
-        run: echo "::stop-commands::suppress-annotations"
+        run: echo "::stop-commands::no-annotations"
 
       - name: Build and push
         id: docker_build
@@ -37,4 +37,4 @@ jobs:
           tags: "clinicalgenomics/cg-stage:${{steps.get_branch_name.outputs.branch}}, clinicalgenomics/cg-stage:latest"
 
       - name: Resume annotations
-        run: echo "::suppress-annotations::"
+        run: echo "::no-annotations::"


### PR DESCRIPTION
## Description

### Added

- Run statements to stop annotations before running docker build and resume them afterwards

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
