### PR TITLE
fix(set case priority research bug)

### DIFF
--- a/cg/cli/set/case.py
+++ b/cg/cli/set/case.py
@@ -84,7 +84,7 @@ def set_case(
 
 
 def abort_on_empty_options(options: list[str]) -> None:
-    if not any(options):
+    if len(options) > 1:
         LOG.error("Nothing to change")
         raise click.Abort
 


### PR DESCRIPTION
## Description

The Priority enum links the input research to 0.
In the set case there is a check for `if not any(options)` . In the case for priority research the options look like. `[0]` 

According to the following:
```
>>> test = [0]
>>> any(test)
False
```

So setting priority to research would exit here with nothing to change, which is a bug.

Changed the check to evaluate the length of the options, which is a list[str] but can also be a list of int it seems.


### Added

-

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
