### PR TITLE
Add sample error mapping

### DIFF
--- a/cg/services/order_validation_service/models/sample.py
+++ b/cg/services/order_validation_service/models/sample.py
@@ -9,7 +9,6 @@ class Sample(BaseModel):
     container: ContainerEnum
     container_name: str | None = None
     name: str = Field(pattern=NAME_PATTERN, min_length=2, max_length=128)
-    require_qc_ok: bool
     volume: int | None = None
     well_position: str | None = None
 

--- a/cg/services/order_validation_service/response_mapper.py
+++ b/cg/services/order_validation_service/response_mapper.py
@@ -72,7 +72,7 @@ def wrap_fields(raw_order: dict) -> None:
     if raw_order.get("cases"):
         wrap_case_and_sample_fields(raw_order)
     else:
-        wrap_sample_fields(raw_order)
+        wrap_sample_fields(raw_order["samples"])
 
 
 def wrap_order_fields(raw_order: dict) -> None:
@@ -84,7 +84,7 @@ def wrap_order_fields(raw_order: dict) -> None:
 def wrap_case_and_sample_fields(raw_order: dict) -> None:
     for case in raw_order["cases"]:
         wrap_case_fields(case)
-        wrap_sample_fields(case)
+        wrap_sample_fields(case["samples"])
 
 
 def wrap_case_fields(case: dict) -> None:
@@ -93,8 +93,7 @@ def wrap_case_fields(case: dict) -> None:
             set_field(entity=case, field=field, value=value)
 
 
-def wrap_sample_fields(dict_containing_samples: dict) -> None:
-    samples: list[dict] = dict_containing_samples.get("samples", [])
+def wrap_sample_fields(samples: list[dict]) -> None:
     for sample in samples:
         for field, value in sample.items():
             set_field(entity=sample, field=field, value=value)

--- a/cg/services/order_validation_service/response_mapper.py
+++ b/cg/services/order_validation_service/response_mapper.py
@@ -1,9 +1,14 @@
 from typing import Any
 
 from cg.services.order_validation_service.errors.case_errors import CaseError
-from cg.services.order_validation_service.errors.case_sample_errors import CaseSampleError
+from cg.services.order_validation_service.errors.case_sample_errors import (
+    CaseSampleError,
+)
 from cg.services.order_validation_service.errors.order_errors import OrderError
-from cg.services.order_validation_service.errors.validation_errors import ValidationErrors
+from cg.services.order_validation_service.errors.sample_errors import SampleError
+from cg.services.order_validation_service.errors.validation_errors import (
+    ValidationErrors,
+)
 
 
 def create_order_validation_response(raw_order: dict, errors: ValidationErrors) -> dict:
@@ -17,6 +22,7 @@ def map_errors_to_order(order: dict, errors: ValidationErrors) -> None:
     map_order_errors(order=order, errors=errors.order_errors)
     map_case_errors(order=order, errors=errors.case_errors)
     map_case_sample_errors(order=order, errors=errors.case_sample_errors)
+    map_sample_errors(order=order, errors=errors.sample_errors)
 
 
 def map_order_errors(order: dict, errors: list[OrderError]) -> None:
@@ -33,7 +39,13 @@ def map_case_errors(order: dict, errors: list[CaseError]) -> None:
 def map_case_sample_errors(order: dict, errors: list[CaseSampleError]) -> None:
     for error in errors:
         case: dict = get_case(order=order, index=error.case_index)
-        sample: dict = get_sample(case=case, index=error.sample_index)
+        sample: dict = get_case_sample(case=case, index=error.sample_index)
+        add_error(entity=sample, field=error.field, message=error.message)
+
+
+def map_sample_errors(order: dict, errors: list[SampleError]) -> None:
+    for error in errors:
+        sample: dict = get_sample(order=order, index=error.sample_index)
         add_error(entity=sample, field=error.field, message=error.message)
 
 
@@ -47,13 +59,20 @@ def get_case(order: dict, index: int) -> dict:
     return order["cases"][index]
 
 
-def get_sample(case: dict, index: int) -> dict:
+def get_case_sample(case: dict, index: int) -> dict:
     return case["samples"][index]
+
+
+def get_sample(order: dict, index: int) -> dict:
+    return order["samples"][index]
 
 
 def wrap_fields(raw_order: dict) -> None:
     wrap_order_fields(raw_order)
-    wrap_case_and_sample_fields(raw_order)
+    if raw_order.get("cases"):
+        wrap_case_and_sample_fields(raw_order)
+    else:
+        wrap_sample_fields(raw_order)
 
 
 def wrap_order_fields(raw_order: dict) -> None:
@@ -74,8 +93,8 @@ def wrap_case_fields(case: dict) -> None:
             set_field(entity=case, field=field, value=value)
 
 
-def wrap_sample_fields(case: dict) -> None:
-    samples: list[dict] = case.get("samples", [])
+def wrap_sample_fields(dict_containing_samples: dict) -> None:
+    samples: list[dict] = dict_containing_samples.get("samples", [])
     for sample in samples:
         for field, value in sample.items():
             set_field(entity=sample, field=field, value=value)

--- a/cg/services/order_validation_service/rules/case_sample/utils.py
+++ b/cg/services/order_validation_service/rules/case_sample/utils.py
@@ -136,7 +136,7 @@ def get_father_sex_errors(
 
 
 def is_father_sex_invalid(child: SampleWithRelatives, case: CaseContainingRelatives) -> bool:
-    father: SampleWithRelatives | None = case.get_case_sample(child.father)
+    father: SampleWithRelatives | None = case.get_sample(child.father)
     return father and father.sex != Sex.MALE
 
 
@@ -151,7 +151,7 @@ def get_father_case_errors(
     errors: list[FatherNotInCaseError] = []
     children: list[tuple[SampleWithRelatives, int]] = case.get_samples_with_father()
     for child, child_index in children:
-        father: SampleWithRelatives | None = case.get_case_sample(child.father)
+        father: SampleWithRelatives | None = case.get_sample(child.father)
         if not father:
             error: FatherNotInCaseError = create_father_case_error(
                 case_index=case_index,
@@ -184,7 +184,7 @@ def get_mother_case_errors(
     errors: list[MotherNotInCaseError] = []
     children: list[tuple[SampleWithRelatives, int]] = case.get_samples_with_mother()
     for child, child_index in children:
-        mother: SampleWithRelatives | None = case.get_case_sample(child.mother)
+        mother: SampleWithRelatives | None = case.get_sample(child.mother)
         if not mother:
             error: MotherNotInCaseError = create_mother_case_error(
                 case_index=case_index, sample_index=child_index
@@ -202,7 +202,7 @@ def create_mother_case_error(case_index: int, sample_index: int) -> MotherNotInC
 
 
 def is_mother_sex_invalid(child: SampleWithRelatives, case: CaseContainingRelatives) -> bool:
-    mother: SampleWithRelatives | None = case.get_case_sample(child.mother)
+    mother: SampleWithRelatives | None = case.get_sample(child.mother)
     return mother and mother.sex != Sex.FEMALE
 
 

--- a/cg/services/order_validation_service/rules/case_sample/utils.py
+++ b/cg/services/order_validation_service/rules/case_sample/utils.py
@@ -136,7 +136,7 @@ def get_father_sex_errors(
 
 
 def is_father_sex_invalid(child: SampleWithRelatives, case: CaseContainingRelatives) -> bool:
-    father: SampleWithRelatives | None = case.get_sample(child.father)
+    father: SampleWithRelatives | None = case.get_case_sample(child.father)
     return father and father.sex != Sex.MALE
 
 
@@ -151,7 +151,7 @@ def get_father_case_errors(
     errors: list[FatherNotInCaseError] = []
     children: list[tuple[SampleWithRelatives, int]] = case.get_samples_with_father()
     for child, child_index in children:
-        father: SampleWithRelatives | None = case.get_sample(child.father)
+        father: SampleWithRelatives | None = case.get_case_sample(child.father)
         if not father:
             error: FatherNotInCaseError = create_father_case_error(
                 case_index=case_index,
@@ -184,7 +184,7 @@ def get_mother_case_errors(
     errors: list[MotherNotInCaseError] = []
     children: list[tuple[SampleWithRelatives, int]] = case.get_samples_with_mother()
     for child, child_index in children:
-        mother: SampleWithRelatives | None = case.get_sample(child.mother)
+        mother: SampleWithRelatives | None = case.get_case_sample(child.mother)
         if not mother:
             error: MotherNotInCaseError = create_mother_case_error(
                 case_index=case_index, sample_index=child_index
@@ -202,7 +202,7 @@ def create_mother_case_error(case_index: int, sample_index: int) -> MotherNotInC
 
 
 def is_mother_sex_invalid(child: SampleWithRelatives, case: CaseContainingRelatives) -> bool:
-    mother: SampleWithRelatives | None = case.get_sample(child.mother)
+    mother: SampleWithRelatives | None = case.get_case_sample(child.mother)
     return mother and mother.sex != Sex.FEMALE
 
 

--- a/cg/services/order_validation_service/workflows/balsamic/models/sample.py
+++ b/cg/services/order_validation_service/workflows/balsamic/models/sample.py
@@ -1,7 +1,11 @@
 from pydantic import Field
+
 from cg.constants.constants import GenomeVersion
 from cg.models.orders.sample_base import NAME_PATTERN, ControlEnum, SexEnum, StatusEnum
-from cg.services.order_validation_service.constants import ElutionBuffer, TissueBlockEnum
+from cg.services.order_validation_service.constants import (
+    ElutionBuffer,
+    TissueBlockEnum,
+)
 from cg.services.order_validation_service.models.sample import Sample
 
 
@@ -18,6 +22,7 @@ class BalsamicSample(Sample):
     phenotype_terms: list[str] | None = None
     post_formalin_fixation_time: int | None = None
     reference_genome: GenomeVersion
+    require_qc_ok: bool
     sex: SexEnum
     source: str
     status: StatusEnum | None = None

--- a/cg/services/order_validation_service/workflows/microsalt/validation_service.py
+++ b/cg/services/order_validation_service/workflows/microsalt/validation_service.py
@@ -1,16 +1,30 @@
 from cg.services.order_validation_service.errors.order_errors import OrderError
 from cg.services.order_validation_service.errors.sample_errors import SampleError
-from cg.services.order_validation_service.errors.validation_errors import ValidationErrors
-from cg.services.order_validation_service.model_validator.model_validator import ModelValidator
-from cg.services.order_validation_service.order_validation_service import OrderValidationService
+from cg.services.order_validation_service.errors.validation_errors import (
+    ValidationErrors,
+)
+from cg.services.order_validation_service.model_validator.model_validator import (
+    ModelValidator,
+)
+from cg.services.order_validation_service.order_validation_service import (
+    OrderValidationService,
+)
+from cg.services.order_validation_service.response_mapper import (
+    create_order_validation_response,
+)
 from cg.services.order_validation_service.utils import (
     apply_order_validation,
     apply_sample_validation,
 )
-from cg.services.order_validation_service.workflows.microsalt.models.order import MicrosaltOrder
-from cg.services.order_validation_service.workflows.microsalt.validation_rules import SAMPLE_RULES
-from cg.services.order_validation_service.response_mapper import create_order_validation_response
-from cg.services.order_validation_service.workflows.order_validation_rules import ORDER_RULES
+from cg.services.order_validation_service.workflows.microsalt.models.order import (
+    MicrosaltOrder,
+)
+from cg.services.order_validation_service.workflows.microsalt.validation_rules import (
+    SAMPLE_RULES,
+)
+from cg.services.order_validation_service.workflows.order_validation_rules import (
+    ORDER_RULES,
+)
 from cg.store.store import Store
 
 
@@ -26,7 +40,7 @@ class MicroSaltValidationService(OrderValidationService):
     def _get_errors(self, raw_order: dict) -> ValidationErrors:
         order, field_errors = ModelValidator.validate(order=raw_order, model=MicrosaltOrder)
 
-        if field_errors:
+        if not order:
             return field_errors
 
         order_errors: list[OrderError] = apply_order_validation(

--- a/cg/services/order_validation_service/workflows/mip_dna/models/sample.py
+++ b/cg/services/order_validation_service/workflows/mip_dna/models/sample.py
@@ -15,6 +15,7 @@ class MipDnaSample(Sample):
     phenotype_groups: list[str] | None = None
     phenotype_terms: list[str] | None = None
     post_formalin_fixation_time: int | None = None
+    require_qc_ok: bool
     sex: SexEnum
     source: str
     status: StatusEnum

--- a/cg/services/order_validation_service/workflows/tomte/models/sample.py
+++ b/cg/services/order_validation_service/workflows/tomte/models/sample.py
@@ -17,6 +17,7 @@ class TomteSample(Sample):
     phenotype_terms: list[str] | None = None
     post_formalin_fixation_time: int | None = None
     reference_genome: GenomeVersion
+    require_qc_ok: bool
     sex: SexEnum
     source: str
     status: StatusEnum


### PR DESCRIPTION
## Description

We are not mapping errors found in standalone sample orders properly.

### Added

-

### Changed

- Sample errors are mapped to their field in the response

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
