### PR TITLE
Make Pacbio model attributes non-nullable (#3858)(patch)

### DIFF
--- a/alembic/versions/2024_10_17_3503b53a9bc3_make_pacbio_attributes_non_nullable_.py
+++ b/alembic/versions/2024_10_17_3503b53a9bc3_make_pacbio_attributes_non_nullable_.py
@@ -1,4 +1,4 @@
-"""make all Pacbio model attributes non-nullable
+"""Make all Pacbio model attributes non-nullable
 
 Revision ID: 3503b53a9bc3
 Revises: fd7c9d246255

--- a/alembic/versions/2024_10_17_3503b53a9bc3_make_pacbio_attributes_non_nullable_.py
+++ b/alembic/versions/2024_10_17_3503b53a9bc3_make_pacbio_attributes_non_nullable_.py
@@ -1,0 +1,180 @@
+"""make all Pacbio model attributes non-nullable
+
+Revision ID: 3503b53a9bc3
+Revises: fd7c9d246255
+Create Date: 2024-10-17 10:24:44.124036
+
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "3503b53a9bc3"
+down_revision = "fd7c9d246255"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        table_name="pacbio_sequencing_run",
+        column_name="run_name",
+        existing_type=mysql.VARCHAR(length=64),
+        type_=sa.String(length=32),
+        existing_nullable=True,
+        nullable=False,
+    )
+    op.alter_column(
+        table_name="pacbio_sequencing_run",
+        column_name="started_at",
+        existing_type=sa.DateTime(),
+        existing_nullable=True,
+        nullable=False,
+    )
+    op.alter_column(
+        table_name="pacbio_sequencing_run",
+        column_name="completed_at",
+        existing_type=sa.DateTime(),
+        existing_nullable=True,
+        nullable=False,
+    )
+    op.alter_column(
+        table_name="pacbio_sequencing_run",
+        column_name="barcoded_hifi_reads",
+        existing_type=mysql.BIGINT(),
+        nullable=False,
+    )
+    op.alter_column(
+        table_name="pacbio_sequencing_run",
+        column_name="barcoded_hifi_reads_percentage",
+        existing_type=mysql.FLOAT(),
+        type_=sa.Numeric(precision=6, scale=2),
+        existing_nullable=True,
+        nullable=False,
+    )
+    op.alter_column(
+        table_name="pacbio_sequencing_run",
+        column_name="barcoded_hifi_yield",
+        existing_type=mysql.BIGINT(),
+        nullable=False,
+    )
+    op.alter_column(
+        table_name="pacbio_sequencing_run",
+        column_name="barcoded_hifi_yield_percentage",
+        existing_type=mysql.FLOAT(),
+        type_=sa.Numeric(precision=6, scale=2),
+        existing_nullable=True,
+        nullable=False,
+    )
+    op.alter_column(
+        table_name="pacbio_sequencing_run",
+        column_name="barcoded_hifi_mean_read_length",
+        existing_type=mysql.BIGINT(),
+        nullable=False,
+    )
+    op.alter_column(
+        table_name="pacbio_sequencing_run",
+        column_name="unbarcoded_hifi_reads",
+        existing_type=mysql.BIGINT(),
+        nullable=False,
+    )
+    op.alter_column(
+        table_name="pacbio_sequencing_run",
+        column_name="unbarcoded_hifi_yield",
+        existing_type=mysql.BIGINT(),
+        nullable=False,
+    )
+    op.alter_column(
+        table_name="pacbio_sequencing_run",
+        column_name="unbarcoded_hifi_mean_read_length",
+        existing_type=mysql.BIGINT(),
+        nullable=False,
+    )
+    op.alter_column(
+        table_name="pacbio_sample_run_metrics",
+        column_name="polymerase_mean_read_length",
+        existing_type=sa.BIGINT,
+        existing_nullable=True,
+        nullable=False,
+    )
+
+
+def downgrade():
+    op.alter_column(
+        table_name="pacbio_sequencing_run",
+        column_name="run_name",
+        existing_type=sa.String(length=32),
+        type_=mysql.VARCHAR(length=64),
+        nullable=True,
+    )
+    op.alter_column(
+        table_name="pacbio_sequencing_run",
+        column_name="started_at",
+        existing_type=sa.DateTime(),
+        nullable=True,
+    )
+    op.alter_column(
+        table_name="pacbio_sequencing_run",
+        column_name="completed_at",
+        existing_type=sa.DateTime(),
+        nullable=True,
+    )
+    op.alter_column(
+        table_name="pacbio_sequencing_run",
+        column_name="barcoded_hifi_reads",
+        existing_type=mysql.BIGINT(),
+        nullable=True,
+    )
+    op.alter_column(
+        table_name="pacbio_sequencing_run",
+        column_name="barcoded_hifi_reads_percentage",
+        existing_type=sa.Numeric(precision=6, scale=2),
+        type_=mysql.FLOAT(),
+        nullable=True,
+    )
+    op.alter_column(
+        table_name="pacbio_sequencing_run",
+        column_name="barcoded_hifi_yield",
+        existing_type=mysql.BIGINT(),
+        nullable=True,
+    )
+    op.alter_column(
+        table_name="pacbio_sequencing_run",
+        column_name="barcoded_hifi_yield_percentage",
+        existing_type=sa.Numeric(precision=6, scale=2),
+        type_=mysql.FLOAT(),
+        nullable=True,
+    )
+    op.alter_column(
+        table_name="pacbio_sequencing_run",
+        column_name="barcoded_hifi_mean_read_length",
+        existing_type=mysql.BIGINT(),
+        nullable=True,
+    )
+    op.alter_column(
+        table_name="pacbio_sequencing_run",
+        column_name="unbarcoded_hifi_reads",
+        existing_type=mysql.BIGINT(),
+        nullable=True,
+    )
+    op.alter_column(
+        table_name="pacbio_sequencing_run",
+        column_name="unbarcoded_hifi_yield",
+        existing_type=mysql.BIGINT(),
+        nullable=True,
+    )
+    op.alter_column(
+        table_name="pacbio_sequencing_run",
+        column_name="unbarcoded_hifi_mean_read_length",
+        existing_type=mysql.BIGINT(),
+        nullable=True,
+    )
+    op.alter_column(
+        table_name="pacbio_sample_run_metrics",
+        column_name="polymerase_mean_read_length",
+        existing_type=sa.BIGINT,
+        nullable=True,
+    )

--- a/alembic/versions/2024_10_17_3503b53a9bc3_make_pacbio_attributes_non_nullable_.py
+++ b/alembic/versions/2024_10_17_3503b53a9bc3_make_pacbio_attributes_non_nullable_.py
@@ -96,7 +96,7 @@ def upgrade():
     op.alter_column(
         table_name="pacbio_sample_run_metrics",
         column_name="polymerase_mean_read_length",
-        existing_type=sa.BIGINT,
+        existing_type=sa.BIGINT(),
         existing_nullable=True,
         nullable=False,
     )

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -1103,10 +1103,10 @@ class PacbioSequencingRun(InstrumentRun):
     )
     well: Mapped[Str32]
     plate: Mapped[int]
-    run_name: Mapped[Str32 | None]
+    run_name: Mapped[Str32]
     movie_name: Mapped[Str32]
-    started_at: Mapped[datetime | None]
-    completed_at: Mapped[datetime | None]
+    started_at: Mapped[datetime]
+    completed_at: Mapped[datetime]
     hifi_reads: Mapped[BigInt]
     hifi_yield: Mapped[BigInt]
     hifi_mean_read_length: Mapped[BigInt]
@@ -1127,14 +1127,14 @@ class PacbioSequencingRun(InstrumentRun):
     failed_reads: Mapped[BigInt]
     failed_yield: Mapped[BigInt]
     failed_mean_read_length: Mapped[BigInt]
-    barcoded_hifi_reads: Mapped[BigInt | None]
-    barcoded_hifi_reads_percentage: Mapped[Num_6_2 | None]
-    barcoded_hifi_yield: Mapped[BigInt | None]
-    barcoded_hifi_yield_percentage: Mapped[Num_6_2 | None]
-    barcoded_hifi_mean_read_length: Mapped[BigInt | None]
-    unbarcoded_hifi_reads: Mapped[BigInt | None]
-    unbarcoded_hifi_yield: Mapped[BigInt | None]
-    unbarcoded_hifi_mean_read_length: Mapped[BigInt | None]
+    barcoded_hifi_reads: Mapped[BigInt]
+    barcoded_hifi_reads_percentage: Mapped[Num_6_2]
+    barcoded_hifi_yield: Mapped[BigInt]
+    barcoded_hifi_yield_percentage: Mapped[Num_6_2]
+    barcoded_hifi_mean_read_length: Mapped[BigInt]
+    unbarcoded_hifi_reads: Mapped[BigInt]
+    unbarcoded_hifi_yield: Mapped[BigInt]
+    unbarcoded_hifi_mean_read_length: Mapped[BigInt]
 
     __mapper_args__ = {"polymorphic_identity": DeviceType.PACBIO}
 
@@ -1188,7 +1188,7 @@ class PacbioSampleSequencingMetrics(SampleRunMetrics):
     hifi_yield: Mapped[BigInt]
     hifi_mean_read_length: Mapped[BigInt]
     hifi_median_read_quality: Mapped[Str32]
-    polymerase_mean_read_length: Mapped[BigInt | None]
+    polymerase_mean_read_length: Mapped[BigInt]
 
     __mapper_args__ = {"polymorphic_identity": DeviceType.PACBIO}
 


### PR DESCRIPTION
## Description

Close https://github.com/Clinical-Genomics/add-new-tech/issues/124
Make all Pacbio database columns non-nullable and required

### Added

- Alembic migration script

### Changed

- Type of attributes of `PacbioSampleSequencingMetrics` and `PacbioSequencingRun` removing `None` from datatypes


### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`

### How to test

- [x] Do the migration `alembic -c $ALEMBIC_CG_STAGE upgrade head`
- [x] Try to add an entry without the newly required attributes
- [x] Do the downgrade

### Expected test outcome

- [x] Check that the upgrade and downgrade work
- [x] You can't add a sample with null in the non-nullable attributes

## Review

- [x] Tests executed by SD
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a


- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Deployed to stage:
```shell

```
- [ ] Deployed to production:
```shell

```