### PR TITLE
add application ordertype endpoint (#3864)(minor)

### DIFF
--- a/cg/server/endpoints/applications.py
+++ b/cg/server/endpoints/applications.py
@@ -20,7 +20,7 @@ def get_applications():
         message: str = "No applications found for the given order type"
         return abort(make_response(jsonify(message=message), HTTPStatus.NOT_FOUND))
     app_tags: list[str] = [application.tag for application in applications]
-    return jsonify(applications=parsed_applications)
+    return jsonify(applications=app_tags)
 
 
 @APPLICATIONS_BLUEPRINT.route("/applications/<order_type>")

--- a/cg/server/endpoints/applications.py
+++ b/cg/server/endpoints/applications.py
@@ -5,10 +5,7 @@ from flask import Blueprint, abort, jsonify, make_response
 
 from cg.server.endpoints.utils import before_request, is_public
 from cg.server.ext import db
-from cg.store.models import (
-    Application,
-    ApplicationLimitations,
-)
+from cg.store.models import Application, ApplicationLimitations
 
 APPLICATIONS_BLUEPRINT = Blueprint("applications", __name__, url_prefix="/api/v1")
 APPLICATIONS_BLUEPRINT.before_request(before_request)
@@ -19,6 +16,14 @@ APPLICATIONS_BLUEPRINT.before_request(before_request)
 def get_applications():
     """Return application tags."""
     applications: list[Application] = db.get_applications_is_not_archived()
+    parsed_applications: list[dict] = [application.to_dict() for application in applications]
+    return jsonify(applications=parsed_applications)
+
+
+@APPLICATIONS_BLUEPRINT.route("/applications/<order_type>")
+def get_application_order_types(order_type: str):
+    """Return application order types.."""
+    applications: list[Application] = db.get_applications_by_ordertype(order_type)
     parsed_applications: list[dict] = [application.to_dict() for application in applications]
     return jsonify(applications=parsed_applications)
 

--- a/cg/server/endpoints/applications.py
+++ b/cg/server/endpoints/applications.py
@@ -3,7 +3,8 @@ from typing import Any
 
 from flask import Blueprint, abort, jsonify, make_response
 
-from cg.server.endpoints.error_handler import handle_endpoint_errors
+from cg.models.orders.constants import OrderType
+from cg.server.endpoints.error_handler import handle_missing_entries
 from cg.server.endpoints.utils import before_request, is_public
 from cg.server.ext import applications_service, db
 from cg.services.application.models import ApplicationResponse
@@ -23,8 +24,8 @@ def get_applications():
 
 
 @APPLICATIONS_BLUEPRINT.route("/applications/<order_type>")
-@handle_endpoint_errors
-def get_application_order_types(order_type: str):
+@handle_missing_entries
+def get_application_order_types(order_type: OrderType):
     """Return application order types."""
     applications: ApplicationResponse = applications_service.get_valid_applications(order_type)
     return jsonify(applications.model_dump())

--- a/cg/server/endpoints/applications.py
+++ b/cg/server/endpoints/applications.py
@@ -16,19 +16,16 @@ APPLICATIONS_BLUEPRINT.before_request(before_request)
 def get_applications():
     """Return application tags."""
     applications: list[Application] = db.get_applications_is_not_archived()
-    if not applications:
-        message: str = "No applications found for the given order type"
-        return abort(make_response(jsonify(message=message), HTTPStatus.NOT_FOUND))
-    app_tags: list[str] = [application.tag for application in applications]
-    return jsonify(applications=app_tags)
+    parsed_applications: list[dict] = [application.to_dict() for application in applications]
+    return jsonify(applications=parsed_applications)
 
 
 @APPLICATIONS_BLUEPRINT.route("/applications/<order_type>")
 def get_application_order_types(order_type: str):
     """Return application order types.."""
     applications: list[Application] = db.get_active_applications_by_order_type(order_type)
-    parsed_applications: list[dict] = [application.to_dict() for application in applications]
-    return jsonify(applications=parsed_applications)
+    app_tags: list[str] = [application.tag for application in applications]
+    return jsonify(applications=app_tags)
 
 
 @APPLICATIONS_BLUEPRINT.route("/applications/<tag>")

--- a/cg/server/endpoints/applications.py
+++ b/cg/server/endpoints/applications.py
@@ -16,14 +16,17 @@ APPLICATIONS_BLUEPRINT.before_request(before_request)
 def get_applications():
     """Return application tags."""
     applications: list[Application] = db.get_applications_is_not_archived()
-    parsed_applications: list[dict] = [application.to_dict() for application in applications]
+    if not applications:
+        message: str = "No applications found for the given order type"
+        return abort(make_response(jsonify(message=message), HTTPStatus.NOT_FOUND))
+    app_tags: list[str] = [application.tag for application in applications]
     return jsonify(applications=parsed_applications)
 
 
 @APPLICATIONS_BLUEPRINT.route("/applications/<order_type>")
 def get_application_order_types(order_type: str):
     """Return application order types.."""
-    applications: list[Application] = db.get_applications_by_ordertype(order_type)
+    applications: list[Application] = db.get_active_applications_by_order_type(order_type)
     parsed_applications: list[dict] = [application.to_dict() for application in applications]
     return jsonify(applications=parsed_applications)
 

--- a/cg/server/endpoints/applications.py
+++ b/cg/server/endpoints/applications.py
@@ -25,7 +25,7 @@ def get_applications():
 @APPLICATIONS_BLUEPRINT.route("/applications/<order_type>")
 @handle_endpoint_errors
 def get_application_order_types(order_type: str):
-    """Return application order types.."""
+    """Return application order types."""
     applications: ApplicationResponse = applications_service.get_applications_by_order_type(
         order_type
     )

--- a/cg/server/endpoints/applications.py
+++ b/cg/server/endpoints/applications.py
@@ -26,9 +26,7 @@ def get_applications():
 @handle_endpoint_errors
 def get_application_order_types(order_type: str):
     """Return application order types."""
-    applications: ApplicationResponse = applications_service.get_applications_by_order_type(
-        order_type
-    )
+    applications: ApplicationResponse = applications_service.get_valid_applications(order_type)
     return jsonify(applications.model_dump())
 
 

--- a/cg/server/endpoints/applications.py
+++ b/cg/server/endpoints/applications.py
@@ -24,6 +24,9 @@ def get_applications():
 def get_application_order_types(order_type: str):
     """Return application order types.."""
     applications: list[Application] = db.get_active_applications_by_order_type(order_type)
+    if not applications:
+        message: str = "No applications found for the given order type"
+        return abort(make_response(jsonify(message=message), HTTPStatus.NOT_FOUND))
     app_tags: list[str] = [application.tag for application in applications]
     return jsonify(applications=app_tags)
 

--- a/cg/server/endpoints/error_handler.py
+++ b/cg/server/endpoints/error_handler.py
@@ -1,0 +1,27 @@
+import logging
+from functools import wraps
+from http import HTTPStatus
+
+from flask import jsonify
+
+from cg.store.exc import EntryNotFoundError
+
+LOG = logging.getLogger(__name__)
+
+
+def handle_endpoint_errors(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except EntryNotFoundError as error:
+            LOG.error(error)
+            return jsonify(error=str(error)), HTTPStatus.NOT_FOUND
+        except Exception as error:
+            LOG.error(f"Unexpected error in endpoint: {error}")
+            return (
+                jsonify(error="An error occurred while processing your request."),
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+            )
+
+    return wrapper

--- a/cg/server/endpoints/error_handler.py
+++ b/cg/server/endpoints/error_handler.py
@@ -9,7 +9,7 @@ from cg.store.exc import EntryNotFoundError
 LOG = logging.getLogger(__name__)
 
 
-def handle_endpoint_errors(func):
+def handle_missing_entries(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
         try:

--- a/cg/server/ext.py
+++ b/cg/server/ext.py
@@ -10,7 +10,7 @@ from cg.apps.tb.api import TrailblazerAPI
 from cg.clients.freshdesk.freshdesk_client import FreshdeskClient
 from cg.meta.orders.ticket_handler import TicketHandler
 from cg.server.app_config import app_config
-from cg.services.application.service import ApplicationsService
+from cg.services.application.service import ApplicationsWebService
 from cg.services.delivery_message.delivery_message_service import DeliveryMessageService
 from cg.services.orders.order_service.order_service import OrderService
 from cg.services.orders.order_summary_service.order_summary_service import OrderSummaryService
@@ -85,7 +85,7 @@ db = FlaskStore()
 
 admin = Admin(name="Clinical Genomics")
 lims = FlaskLims()
-applications_service = ApplicationsService(store=db)
+applications_service = ApplicationsWebService(store=db)
 analysis_client = AnalysisClient()
 delivery_message_service = DeliveryMessageService(store=db, trailblazer_api=analysis_client)
 summary_service = OrderSummaryService(store=db, analysis_client=analysis_client)

--- a/cg/server/ext.py
+++ b/cg/server/ext.py
@@ -10,11 +10,10 @@ from cg.apps.tb.api import TrailblazerAPI
 from cg.clients.freshdesk.freshdesk_client import FreshdeskClient
 from cg.meta.orders.ticket_handler import TicketHandler
 from cg.server.app_config import app_config
+from cg.services.application.service import ApplicationsService
 from cg.services.delivery_message.delivery_message_service import DeliveryMessageService
 from cg.services.orders.order_service.order_service import OrderService
-from cg.services.orders.order_summary_service.order_summary_service import (
-    OrderSummaryService,
-)
+from cg.services.orders.order_summary_service.order_summary_service import OrderSummaryService
 from cg.services.orders.submitters.order_submitter_registry import (
     OrderSubmitterRegistry,
     setup_order_submitter_registry,
@@ -86,6 +85,7 @@ db = FlaskStore()
 
 admin = Admin(name="Clinical Genomics")
 lims = FlaskLims()
+applications_service = ApplicationsService(store=db)
 analysis_client = AnalysisClient()
 delivery_message_service = DeliveryMessageService(store=db, trailblazer_api=analysis_client)
 summary_service = OrderSummaryService(store=db, analysis_client=analysis_client)

--- a/cg/services/application/models.py
+++ b/cg/services/application/models.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+
+
+class ApplicationResponse(BaseModel):
+    applications: list[str]

--- a/cg/services/application/service.py
+++ b/cg/services/application/service.py
@@ -1,3 +1,4 @@
+from cg.models.orders.constants import OrderType
 from cg.services.application.models import ApplicationResponse
 from cg.store.models import Application
 from cg.store.store import Store
@@ -12,7 +13,7 @@ class ApplicationsService:
     def __init__(self, store: Store):
         self.store = store
 
-    def get_valid_applications(self, order_type: str) -> ApplicationResponse:
+    def get_valid_applications(self, order_type: OrderType) -> ApplicationResponse:
         applications: list[Application] = self.store.get_active_applications_by_order_type(
             order_type
         )

--- a/cg/services/application/service.py
+++ b/cg/services/application/service.py
@@ -12,7 +12,7 @@ class ApplicationsService:
     def __init__(self, store: Store):
         self.store = store
 
-    def get_applications_by_order_type(self, order_type: str) -> ApplicationResponse:
+    def get_valid_applications(self, order_type: str) -> ApplicationResponse:
         applications: list[Application] = self.store.get_active_applications_by_order_type(
             order_type
         )

--- a/cg/services/application/service.py
+++ b/cg/services/application/service.py
@@ -8,7 +8,7 @@ def create_application_response(app_tags: list[str]) -> ApplicationResponse:
     return ApplicationResponse(applications=app_tags)
 
 
-class ApplicationsService:
+class ApplicationsWebService:
 
     def __init__(self, store: Store):
         self.store = store

--- a/cg/services/application/service.py
+++ b/cg/services/application/service.py
@@ -1,0 +1,20 @@
+from cg.services.application.models import ApplicationResponse
+from cg.store.models import Application
+from cg.store.store import Store
+
+
+def create_application_response(app_tags: list[str]) -> ApplicationResponse:
+    return ApplicationResponse(applications=app_tags)
+
+
+class ApplicationsService:
+
+    def __init__(self, store: Store):
+        self.store = store
+
+    def get_applications_by_order_type(self, order_type: str) -> ApplicationResponse:
+        applications: list[Application] = self.store.get_active_applications_by_order_type(
+            order_type
+        )
+        app_tags: list[str] = [application.tag for application in applications]
+        return create_application_response(app_tags)

--- a/cg/store/base.py
+++ b/cg/store/base.py
@@ -15,7 +15,6 @@ from cg.store.models import (
     IlluminaFlowCell,
     IlluminaSampleSequencingMetrics,
     IlluminaSequencingRun,
-    OrderTypeApplication,
     Sample,
 )
 

--- a/cg/store/base.py
+++ b/cg/store/base.py
@@ -6,12 +6,7 @@ from typing import Type
 from sqlalchemy import and_, func
 from sqlalchemy.orm import Query, Session
 
-from cg.store.models import (
-    Analysis,
-    Application,
-    ApplicationLimitations,
-    ApplicationVersion,
-)
+from cg.store.models import Analysis, Application, ApplicationLimitations, ApplicationVersion
 from cg.store.models import Base as ModelBase
 from cg.store.models import (
     Case,
@@ -20,6 +15,7 @@ from cg.store.models import (
     IlluminaFlowCell,
     IlluminaSampleSequencingMetrics,
     IlluminaSequencingRun,
+    OrderTypeApplication,
     Sample,
 )
 
@@ -84,6 +80,10 @@ class BaseHandler:
         return (
             self._get_query(table=Sample).join(Case.links).join(CaseSample.sample).join(Case.orders)
         )
+
+    def _get_join_application_ordertype_query(self) -> Query:
+        """Return join application to ordertype query."""
+        return self._get_query(table=Application).join(Application.order_types)
 
     def _get_join_sample_application_version_query(self) -> Query:
         """Return join sample to application version query."""

--- a/cg/store/base.py
+++ b/cg/store/base.py
@@ -81,7 +81,7 @@ class BaseHandler:
         )
 
     def _get_join_application_ordertype_query(self) -> Query:
-        """Return join application to ordertype query."""
+        """Return join application to order type query."""
         return self._get_query(table=Application).join(Application.order_types)
 
     def _get_join_sample_application_version_query(self) -> Query:

--- a/cg/store/crud/create.py
+++ b/cg/store/crud/create.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 
 from cg.constants import DataDelivery, Priority, Workflow
 from cg.constants.archiving import PDC_ARCHIVE_LOCATION
+from cg.models.orders.constants import OrderType
 from cg.models.orders.order import OrderIn
 from cg.services.illumina.data_transfer.models import (
     IlluminaFlowCellDTO,
@@ -130,13 +131,11 @@ class CreateHandler(BaseHandler):
         )
 
     def link_order_types_to_application(
-        self, application: Application, order_types: list[str]
+        self, application: Application, order_types: list[OrderType]
     ) -> list[OrderTypeApplication]:
         new_orders: list = []
         for order_type in order_types:
-            new_record = OrderTypeApplication()
-            new_record.order_type = order_type
-            new_record.application = application
+            new_record = OrderTypeApplication(application=application, order_type=order_type)
             new_orders.append(new_record)
         return new_orders
 

--- a/cg/store/crud/create.py
+++ b/cg/store/crud/create.py
@@ -37,6 +37,7 @@ from cg.store.models import (
     IlluminaSequencingRun,
     Invoice,
     Order,
+    OrderTypeApplication,
     Organism,
     PacbioSampleSequencingMetrics,
     PacbioSequencingRun,
@@ -127,6 +128,17 @@ class CreateHandler(BaseHandler):
             percent_reads_guaranteed=percent_reads_guaranteed,
             **kwargs,
         )
+
+    def link_order_types_to_application(
+        self, application: Application, order_types: list[str]
+    ) -> list[OrderTypeApplication]:
+        new_orders: list = []
+        for order_type in order_types:
+            new_record = OrderTypeApplication()
+            new_record.order_type = order_type
+            new_record.application = application
+            new_orders.append(new_record)
+        return new_orders
 
     def add_application_version(
         self,

--- a/cg/store/crud/read.py
+++ b/cg/store/crud/read.py
@@ -833,7 +833,7 @@ class ReadHandler(BaseHandler):
             filter_functions=[ApplicationFilter.IS_NOT_ARCHIVED],
         )
         applications: list[Application] = apply_order_type_application_filter(
-            ordertype_applications=non_archived_applications,
+            order_type_applications=non_archived_applications,
             filter_functions=[OrderTypeApplicationFilter.BY_ORDER_TYPE],
             order_type=order_type,
         ).all()

--- a/cg/store/crud/read.py
+++ b/cg/store/crud/read.py
@@ -11,19 +11,11 @@ from cg.constants import SequencingRunDataAvailability, Workflow
 from cg.constants.constants import CaseActions, CustomerId, PrepCategory, SampleType
 from cg.exc import CaseNotFoundError, CgError, OrderNotFoundError, SampleNotFoundError
 from cg.server.dto.orders.orders_request import OrdersRequest
-from cg.server.dto.samples.collaborator_samples_request import (
-    CollaboratorSamplesRequest,
-)
+from cg.server.dto.samples.collaborator_samples_request import CollaboratorSamplesRequest
 from cg.store.base import BaseHandler
 from cg.store.exc import EntryNotFoundError
-from cg.store.filters.status_analysis_filters import (
-    AnalysisFilter,
-    apply_analysis_filter,
-)
-from cg.store.filters.status_application_filters import (
-    ApplicationFilter,
-    apply_application_filter,
-)
+from cg.store.filters.status_analysis_filters import AnalysisFilter, apply_analysis_filter
+from cg.store.filters.status_application_filters import ApplicationFilter, apply_application_filter
 from cg.store.filters.status_application_limitations_filters import (
     ApplicationLimitationsFilter,
     apply_application_limitations_filter,
@@ -33,23 +25,14 @@ from cg.store.filters.status_application_version_filters import (
     apply_application_versions_filter,
 )
 from cg.store.filters.status_bed_filters import BedFilter, apply_bed_filter
-from cg.store.filters.status_bed_version_filters import (
-    BedVersionFilter,
-    apply_bed_version_filter,
-)
+from cg.store.filters.status_bed_version_filters import BedVersionFilter, apply_bed_version_filter
 from cg.store.filters.status_case_filters import CaseFilter, apply_case_filter
-from cg.store.filters.status_case_sample_filters import (
-    CaseSampleFilter,
-    apply_case_sample_filter,
-)
+from cg.store.filters.status_case_sample_filters import CaseSampleFilter, apply_case_sample_filter
 from cg.store.filters.status_collaboration_filters import (
     CollaborationFilter,
     apply_collaboration_filter,
 )
-from cg.store.filters.status_customer_filters import (
-    CustomerFilter,
-    apply_customer_filter,
-)
+from cg.store.filters.status_customer_filters import CustomerFilter, apply_customer_filter
 from cg.store.filters.status_illumina_flow_cell_filters import (
     IlluminaFlowCellFilter,
     apply_illumina_flow_cell_filters,
@@ -64,10 +47,11 @@ from cg.store.filters.status_illumina_sequencing_run_filters import (
 )
 from cg.store.filters.status_invoice_filters import InvoiceFilter, apply_invoice_filter
 from cg.store.filters.status_order_filters import OrderFilter, apply_order_filters
-from cg.store.filters.status_organism_filters import (
-    OrganismFilter,
-    apply_organism_filter,
+from cg.store.filters.status_ordertype_application_filters import (
+    OrderTypeApplicationFilter,
+    apply_ordertype_application_filter,
 )
+from cg.store.filters.status_organism_filters import OrganismFilter, apply_organism_filter
 from cg.store.filters.status_pacbio_smrt_cell_filters import (
     PacBioSMRTCellFilter,
     apply_pac_bio_smrt_cell_filters,
@@ -837,6 +821,18 @@ class ReadHandler(BaseHandler):
             .order_by(Application.prep_category, Application.tag)
             .all()
         )
+
+    def get_applications_by_ordertype(self, order_type: str) -> list[Application]:
+        """Return all possible not archived applications for an order type."""
+        non_archived_applications: Query = apply_application_filter(
+            applications=self._get_join_application_ordertype_query(),
+            filter_functions=[ApplicationFilter.IS_NOT_ARCHIVED],
+        )
+        return apply_ordertype_application_filter(
+            ordertype_applications=non_archived_applications,
+            filter_functions=[OrderTypeApplicationFilter.BY_ORDER_TYPE],
+            order_type=order_type,
+        ).all()
 
     def get_current_application_version_by_tag(self, tag: str) -> ApplicationVersion | None:
         """Return the current application version for an application tag."""

--- a/cg/store/crud/read.py
+++ b/cg/store/crud/read.py
@@ -823,16 +823,23 @@ class ReadHandler(BaseHandler):
         )
 
     def get_active_applications_by_order_type(self, order_type: str) -> list[Application]:
-        """Return all possible not archived applications for an order type."""
+        """
+        Return all possible non-archived applications for an order type.
+        Raises:
+            EntryNotFoundError: If no applications are found for the order type.
+        """
         non_archived_applications: Query = apply_application_filter(
             applications=self._get_join_application_ordertype_query(),
             filter_functions=[ApplicationFilter.IS_NOT_ARCHIVED],
         )
-        return apply_order_type_application_filter(
+        applications: list[Application] = apply_order_type_application_filter(
             ordertype_applications=non_archived_applications,
             filter_functions=[OrderTypeApplicationFilter.BY_ORDER_TYPE],
             order_type=order_type,
         ).all()
+        if not applications:
+            raise EntryNotFoundError(f"No applications found for order type {order_type}")
+        return applications
 
     def get_current_application_version_by_tag(self, tag: str) -> ApplicationVersion | None:
         """Return the current application version for an application tag."""

--- a/cg/store/crud/read.py
+++ b/cg/store/crud/read.py
@@ -49,7 +49,7 @@ from cg.store.filters.status_invoice_filters import InvoiceFilter, apply_invoice
 from cg.store.filters.status_order_filters import OrderFilter, apply_order_filters
 from cg.store.filters.status_ordertype_application_filters import (
     OrderTypeApplicationFilter,
-    apply_ordertype_application_filter,
+    apply_order_type_application_filter,
 )
 from cg.store.filters.status_organism_filters import OrganismFilter, apply_organism_filter
 from cg.store.filters.status_pacbio_smrt_cell_filters import (
@@ -822,13 +822,13 @@ class ReadHandler(BaseHandler):
             .all()
         )
 
-    def get_applications_by_ordertype(self, order_type: str) -> list[Application]:
+    def get_active_applications_by_order_type(self, order_type: str) -> list[Application]:
         """Return all possible not archived applications for an order type."""
         non_archived_applications: Query = apply_application_filter(
             applications=self._get_join_application_ordertype_query(),
             filter_functions=[ApplicationFilter.IS_NOT_ARCHIVED],
         )
-        return apply_ordertype_application_filter(
+        return apply_order_type_application_filter(
             ordertype_applications=non_archived_applications,
             filter_functions=[OrderTypeApplicationFilter.BY_ORDER_TYPE],
             order_type=order_type,

--- a/cg/store/filters/status_ordertype_application_filters.py
+++ b/cg/store/filters/status_ordertype_application_filters.py
@@ -10,7 +10,7 @@ def filter_applications_by_order_type(
     order_type_applications: Query, order_type: OrderType, **kwargs
 ) -> Query:
     """Return application by order type."""
-    return order_type_applications.filter(OrderTypeApplication.order_type.is_(order_type))
+    return order_type_applications.filter(OrderTypeApplication.order_type == order_type)
 
 
 def apply_order_type_application_filter(

--- a/cg/store/filters/status_ordertype_application_filters.py
+++ b/cg/store/filters/status_ordertype_application_filters.py
@@ -2,20 +2,21 @@ from enum import Enum
 
 from sqlalchemy.orm import Query
 
+from cg.models.orders.constants import OrderType
 from cg.store.models import OrderTypeApplication
 
 
 def filter_applications_by_order_type(
-    ordertype_applications: Query, order_type: str, **kwargs
+    ordertype_applications: Query, order_type: OrderType, **kwargs
 ) -> Query:
     """Return application by order type."""
     return ordertype_applications.filter(OrderTypeApplication.order_type.is_(order_type))
 
 
-def apply_ordertype_application_filter(
+def apply_order_type_application_filter(
     filter_functions: list[callable],
     ordertype_applications: Query,
-    order_type: str = None,
+    order_type: OrderType = None,
 ) -> Query:
     """Apply filtering functions to the ordertype_applications query and return filtered results."""
 
@@ -28,6 +29,6 @@ def apply_ordertype_application_filter(
 
 
 class OrderTypeApplicationFilter(Enum):
-    """Define OrdertypeApplication filter functions."""
+    """Define OrderTypeApplication filter functions."""
 
     BY_ORDER_TYPE = filter_applications_by_order_type

--- a/cg/store/filters/status_ordertype_application_filters.py
+++ b/cg/store/filters/status_ordertype_application_filters.py
@@ -1,0 +1,33 @@
+from enum import Enum
+
+from sqlalchemy.orm import Query
+
+from cg.store.models import OrderTypeApplication
+
+
+def filter_applications_by_order_type(
+    ordertype_applications: Query, order_type: str, **kwargs
+) -> Query:
+    """Return application by order type."""
+    return ordertype_applications.filter(OrderTypeApplication.order_type.is_(order_type))
+
+
+def apply_ordertype_application_filter(
+    filter_functions: list[callable],
+    ordertype_applications: Query,
+    order_type: str = None,
+) -> Query:
+    """Apply filtering functions to the ordertype_applications query and return filtered results."""
+
+    for filter_function in filter_functions:
+        ordertype_applications: Query = filter_function(
+            applications_orders=ordertype_applications,
+            order_type=order_type,
+        )
+    return ordertype_applications
+
+
+class OrderTypeApplicationFilter(Enum):
+    """Define OrdertypeApplication filter functions."""
+
+    BY_ORDER_TYPE = filter_applications_by_order_type

--- a/cg/store/filters/status_ordertype_application_filters.py
+++ b/cg/store/filters/status_ordertype_application_filters.py
@@ -7,25 +7,25 @@ from cg.store.models import OrderTypeApplication
 
 
 def filter_applications_by_order_type(
-    ordertype_applications: Query, order_type: OrderType, **kwargs
+    order_type_applications: Query, order_type: OrderType, **kwargs
 ) -> Query:
     """Return application by order type."""
-    return ordertype_applications.filter(OrderTypeApplication.order_type.is_(order_type))
+    return order_type_applications.filter(OrderTypeApplication.order_type.is_(order_type))
 
 
 def apply_order_type_application_filter(
     filter_functions: list[callable],
-    ordertype_applications: Query,
+    order_type_applications: Query,
     order_type: OrderType = None,
 ) -> Query:
     """Apply filtering functions to the ordertype_applications query and return filtered results."""
 
     for filter_function in filter_functions:
-        ordertype_applications: Query = filter_function(
-            applications_orders=ordertype_applications,
+        order_type_applications: Query = filter_function(
+            order_type_applications=order_type_applications,
             order_type=order_type,
         )
-    return ordertype_applications
+    return order_type_applications
 
 
 class OrderTypeApplicationFilter(Enum):

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -181,6 +181,7 @@ class Application(Base):
     pipeline_limitations: Mapped[list["ApplicationLimitations"]] = orm.relationship(
         back_populates="application"
     )
+    order_types = orm.relationship("OrderTypeApplication", back_populates="application")
 
     def __str__(self) -> str:
         return self.tag
@@ -1202,4 +1203,4 @@ class OrderTypeApplication(Base):
     application_id: Mapped[int] = mapped_column(
         ForeignKey("application.id", ondelete="CASCADE"), primary_key=True
     )
-    application: Mapped[Application] = orm.relationship("Application")
+    application: Mapped[Application] = orm.relationship("Application", back_populates="order_types")

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -181,7 +181,9 @@ class Application(Base):
     pipeline_limitations: Mapped[list["ApplicationLimitations"]] = orm.relationship(
         back_populates="application"
     )
-    order_types: Mapped[list["OrderTypeApplication"]] = orm.relationship("OrderTypeApplication", back_populates="application")
+    order_types: Mapped[list["OrderTypeApplication"]] = orm.relationship(
+        "OrderTypeApplication", back_populates="application"
+    )
 
     def __str__(self) -> str:
         return self.tag

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -181,7 +181,7 @@ class Application(Base):
     pipeline_limitations: Mapped[list["ApplicationLimitations"]] = orm.relationship(
         back_populates="application"
     )
-    order_types = orm.relationship("OrderTypeApplication", back_populates="application")
+    order_types: Mapped[list["OrderTypeApplication"]] = orm.relationship("OrderTypeApplication", back_populates="application")
 
     def __str__(self) -> str:
         return self.tag

--- a/tests/store/conftest.py
+++ b/tests/store/conftest.py
@@ -11,6 +11,7 @@ from cg.constants import Workflow
 from cg.constants.devices import DeviceType
 from cg.constants.priority import PriorityTerms
 from cg.constants.subject import PhenotypeStatus, Sex
+from cg.models.orders.constants import OrderType
 from cg.services.illumina.data_transfer.models import IlluminaFlowCellDTO
 from cg.services.orders.store_order_services.store_pool_order import StorePoolOrderService
 from cg.store.models import (
@@ -341,7 +342,7 @@ def store_with_application_limitations(
 
 @pytest.fixture(name="applications_store")
 def applications_store(store: Store, helpers: StoreHelpers) -> Store:
-    """Return a store populated with applications from excel file"""
+    """Return a store populated with applications from excel file."""
     app_tags: list[str] = ["PGOTTTR020", "PGOTTTR030", "PGOTTTR040"]
     for app_tag in app_tags:
         helpers.ensure_application(store=store, tag=app_tag)
@@ -368,6 +369,24 @@ def store_with_different_application_versions(
             application_tag=application.tag,
             valid_from=dt.datetime(year, 1, 1, 1, 1, 1),
             version=version,
+        )
+    return applications_store
+
+
+@pytest.fixture
+def store_with_applications_with_order_types(
+    applications_store: Store, helpers: StoreHelpers
+) -> Store:
+    """Return a store with applications that have entries in the OrderTypeApplication table."""
+    order_types_per_application: list[list[str]] = [
+        [OrderType.BALSAMIC, OrderType.MIP_DNA, OrderType.MIP_RNA],
+        [OrderType.RNAFUSION, OrderType.TAXPROFILER, OrderType.TOMTE],
+        [OrderType.FASTQ, OrderType.PACBIO_LONG_READ, OrderType.RML],
+    ]
+    applications: list[Application] = applications_store.get_applications()
+    for application, order_types in zip(applications, order_types_per_application):
+        helpers.add_application_order_type(
+            store=applications_store, application=application, order_types=order_types
         )
     return applications_store
 

--- a/tests/store/conftest.py
+++ b/tests/store/conftest.py
@@ -11,7 +11,6 @@ from cg.constants import Workflow
 from cg.constants.devices import DeviceType
 from cg.constants.priority import PriorityTerms
 from cg.constants.subject import PhenotypeStatus, Sex
-from cg.models.orders.constants import OrderType
 from cg.services.illumina.data_transfer.models import IlluminaFlowCellDTO
 from cg.services.orders.store_order_services.store_pool_order import StorePoolOrderService
 from cg.store.models import (
@@ -342,7 +341,7 @@ def store_with_application_limitations(
 
 @pytest.fixture(name="applications_store")
 def applications_store(store: Store, helpers: StoreHelpers) -> Store:
-    """Return a store populated with applications from excel file."""
+    """Return a store populated with applications from excel file"""
     app_tags: list[str] = ["PGOTTTR020", "PGOTTTR030", "PGOTTTR040"]
     for app_tag in app_tags:
         helpers.ensure_application(store=store, tag=app_tag)
@@ -369,24 +368,6 @@ def store_with_different_application_versions(
             application_tag=application.tag,
             valid_from=dt.datetime(year, 1, 1, 1, 1, 1),
             version=version,
-        )
-    return applications_store
-
-
-@pytest.fixture
-def store_with_applications_with_order_types(
-    applications_store: Store, helpers: StoreHelpers
-) -> Store:
-    """Return a store with applications that have entries in the OrderTypeApplication table."""
-    order_types_per_application: list[list[str]] = [
-        [OrderType.BALSAMIC, OrderType.MIP_DNA, OrderType.MIP_RNA],
-        [OrderType.RNAFUSION, OrderType.TAXPROFILER, OrderType.TOMTE],
-        [OrderType.FASTQ, OrderType.PACBIO_LONG_READ, OrderType.RML],
-    ]
-    applications: list[Application] = applications_store.get_applications()
-    for application, order_types in zip(applications, order_types_per_application):
-        helpers.add_application_order_type(
-            store=applications_store, application=application, order_types=order_types
         )
     return applications_store
 

--- a/tests/store/crud/read/test_read_application.py
+++ b/tests/store/crud/read/test_read_application.py
@@ -1,0 +1,43 @@
+import pytest
+
+from cg.models.orders.constants import OrderType
+from cg.store.exc import EntryNotFoundError
+from cg.store.models import Application
+from cg.store.store import Store
+
+
+def test_get_active_applications_by_order_type(store_with_applications_with_order_types: Store):
+    """Test that getting non-archived applications by order type works."""
+    # GIVEN a store with applications with different order types
+    store: Store = store_with_applications_with_order_types
+    number_applications: int = len(store.get_applications())
+    assert number_applications > 0
+
+    # GIVEN an order type
+    order_type: OrderType = OrderType.PACBIO_LONG_READ
+
+    # WHEN getting active applications by order type
+    applications: list[Application] = store.get_active_applications_by_order_type(order_type)
+
+    # THEN assert that only the applications with the given order type are returned
+    assert number_applications > len(applications) > 0
+    for application in applications:
+        app_order_types: list[OrderType] = [link.order_type for link in application.order_types]
+        assert order_type in app_order_types
+
+
+def test_get_active_applications_by_order_type_no_application(store):
+    """Test that if there are not applications for a given type an error is raised."""
+    # GIVEN a store with applications without order types
+    applications: list[Application] = store.get_applications()
+    for application in applications:
+        assert not application.order_types
+
+    # GIVEN an order type
+    order_type: OrderType = OrderType.PACBIO_LONG_READ
+
+    # WHEN getting active applications by order type
+    with pytest.raises(EntryNotFoundError):
+        store.get_active_applications_by_order_type(order_type)
+
+    # THEN an EntryNotFoundError is raised

--- a/tests/store/crud/read/test_read_application.py
+++ b/tests/store/crud/read/test_read_application.py
@@ -6,27 +6,7 @@ from cg.store.models import Application
 from cg.store.store import Store
 
 
-def test_get_active_applications_by_order_type(store_with_applications_with_order_types: Store):
-    """Test that getting non-archived applications by order type works."""
-    # GIVEN a store with applications with different order types
-    store: Store = store_with_applications_with_order_types
-    number_applications: int = len(store.get_applications())
-    assert number_applications > 0
-
-    # GIVEN an order type
-    order_type: OrderType = OrderType.PACBIO_LONG_READ
-
-    # WHEN getting active applications by order type
-    applications: list[Application] = store.get_active_applications_by_order_type(order_type)
-
-    # THEN assert that only the applications with the given order type are returned
-    assert number_applications > len(applications) > 0
-    for application in applications:
-        app_order_types: list[OrderType] = [link.order_type for link in application.order_types]
-        assert order_type in app_order_types
-
-
-def test_get_active_applications_by_order_type_no_application(store):
+def test_get_active_applications_by_order_type_no_application(store: Store):
     """Test that if there are not applications for a given type an error is raised."""
     # GIVEN a store with applications without order types
     applications: list[Application] = store.get_applications()

--- a/tests/store/filters/test_status_order_type_application_filters.py
+++ b/tests/store/filters/test_status_order_type_application_filters.py
@@ -1,0 +1,36 @@
+from sqlalchemy.orm import Query
+
+from cg.models.orders.constants import OrderType
+from cg.store.filters.status_ordertype_application_filters import filter_applications_by_order_type
+from cg.store.models import Application, OrderTypeApplication
+from cg.store.store import Store
+from tests.store_helpers import StoreHelpers
+
+
+def test_filter_applications_by_order_type(applications_store: Store, helpers: StoreHelpers):
+    # GIVEN a store with applications
+    applications: list[Application] = applications_store.get_applications()
+    assert applications
+
+    # GIVEN an order type
+    order_type = OrderType.PACBIO_LONG_READ
+
+    # GIVEN that one application has the given order type
+    helpers.add_application_order_type(
+        store=applications_store, application=applications[0], order_types=[order_type]
+    )
+
+    # GIVEN that another application has a different order type
+    helpers.add_application_order_type(
+        store=applications_store, application=applications[1], order_types=[OrderType.BALSAMIC]
+    )
+
+    # WHEN filtering applications by order type
+    order_type_applications: Query = applications_store._get_query(table=OrderTypeApplication)
+    filtered_order_type_applications: Query = filter_applications_by_order_type(
+        order_type_applications=order_type_applications, order_type=order_type
+    )
+
+    # THEN assert that only the applications with the given order type are returned
+    assert filtered_order_type_applications.count() == 1
+    assert filtered_order_type_applications.first().order_type == order_type

--- a/tests/store_helpers.py
+++ b/tests/store_helpers.py
@@ -36,6 +36,7 @@ from cg.store.models import (
     IlluminaSequencingRun,
     Invoice,
     Order,
+    OrderTypeApplication,
     Organism,
     Panel,
     Pool,
@@ -250,6 +251,18 @@ class StoreHelpers:
         store.session.add(application)
         store.session.commit()
         return application
+
+    def add_application_order_type(
+        self, store: Store, application: Application, order_types: list[str]
+    ):
+        """Add an order type to an application."""
+        order_app_links: list[OrderTypeApplication] = store.link_order_types_to_application(
+            application=application, order_types=order_types
+        )
+        for link in order_app_links:
+            store.session.add(link)
+        store.session.commit()
+        return order_app_links
 
     @staticmethod
     def ensure_application_limitation(


### PR DESCRIPTION
## Description
Closes https://github.com/Clinical-Genomics/add-new-tech/issues/130
Adds the endpoint requesting applications given the order types

### Added

- Endpoint function `get_application_order_types` in `cg/server/endpoints/applications.py`
- Error handler for endpoint in `cg/server/endpoints/error_handler.py`
- Aplication web service that returns the response to the endpoint in `cg/services/application/service.py`
- ApplicationResponse model
- Join application order query function `_get_join_application_ordertype_query` in `cg/store/base.py`
- CRUD function `link_order_types_to_application`. to create `OrderTypeApplication` entries (create)
- CRUF function `get_active_applications_by_order_type` (read)
- Status filter module `cg/store/filters/status_ordertype_application_filters.py` for OrderTypeApplication table and one filter function
- Attribute `order_types` to the `Appliacation` model in the database
- Attribute `application` to the `OrderTypeApplication` model in the database
- Tests for the filter function
- Test for the CRUD (read) function
- Fixtures
- Store helpers function


### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] See below

### Expected test outcome

- [ ] Check that fetching an application with an existing order type returns an application
- [ ] Chack that fetching an application with a non-existing order type raises an informative error

## Review

- [ ] Tests executed by SD, IO
- [ ] "Merge and deploy" approved by VJ, IO, CO
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MINOR** - when you add functionality in a backwards compatible manner

## Implementation Plan

- [ ] Deployed to stage:
```shell

```
- [ ] Deployed to production:
```shell

```