### PR TITLE
Patch balsamic uploads

### DIFF
--- a/cg/meta/upload/balsamic/balsamic.py
+++ b/cg/meta/upload/balsamic/balsamic.py
@@ -55,7 +55,7 @@ class BalsamicUploadAPI(UploadAPI):
             )
 
         # Genotype specific upload
-        if UploadGenotypesAPI.is_suitable_for_genotype_upload(case_obj=case):
+        if UploadGenotypesAPI.is_suitable_for_genotype_upload(case):
             ctx.invoke(upload_genotypes, family_id=case.internal_id, re_upload=restart)
         else:
             LOG.info(f"Balsamic case {case.internal_id} is not compatible for Genotype upload")

--- a/cg/meta/upload/gt.py
+++ b/cg/meta/upload/gt.py
@@ -68,7 +68,7 @@ class UploadGenotypesAPI(object):
         )
 
     @staticmethod
-    def _is_suitable_for_genotype_upload(case: Case) -> bool:
+    def is_suitable_for_genotype_upload(case: Case) -> bool:
         """Returns True if there are any non-tumor WGS samples in the case."""
         samples: list[Sample] = case.samples
         return any(

--- a/tests/meta/upload/balsamic/test_balsamic.py
+++ b/tests/meta/upload/balsamic/test_balsamic.py
@@ -27,7 +27,7 @@ def test_genotype_check_wgs_normal(balsamic_context: CGConfig):
     case: Case = balsamic_context.status_db.get_case_by_internal_id(internal_id=internal_id)
 
     # WHEN checking if the case is Genotype upload compatible
-    passed_check = UploadGenotypesAPI._is_suitable_for_genotype_upload(case)
+    passed_check = UploadGenotypesAPI.is_suitable_for_genotype_upload(case)
 
     # THEN it should return True
     assert passed_check
@@ -40,7 +40,7 @@ def test_genotype_check_non_wgs_normal(balsamic_context: CGConfig):
     case: Case = balsamic_context.status_db.get_case_by_internal_id(internal_id=internal_id)
 
     # WHEN checking if the case is Genotype upload compatible
-    passed_check = UploadGenotypesAPI._is_suitable_for_genotype_upload(case)
+    passed_check = UploadGenotypesAPI.is_suitable_for_genotype_upload(case)
 
     # THEN it should return False
     assert not passed_check
@@ -53,7 +53,7 @@ def test_genotype_check_only_tumour(balsamic_context: CGConfig):
     case: Case = balsamic_context.status_db.get_case_by_internal_id(internal_id=internal_id)
 
     # WHEN checking if the case is Genotype upload compatible
-    passed_check = UploadGenotypesAPI._is_suitable_for_genotype_upload(case)
+    passed_check = UploadGenotypesAPI.is_suitable_for_genotype_upload(case)
 
     # THEN it should return False
     assert not passed_check


### PR DESCRIPTION
## Description

The new _is_suitable_for_genotype_upload method from #3784 was wrongly called blocking uploaded_at from being set.

### Added

-

### Changed

-

### Fixed

- Correct function call to is_suitable_for_genotype_upload


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
