### PR TITLE
Patch scout uploads 

### DIFF
--- a/cg/meta/upload/scout/raredisease_config_builder.py
+++ b/cg/meta/upload/scout/raredisease_config_builder.py
@@ -61,13 +61,11 @@ class RarediseaseConfigBuilder(ScoutConfigBuilder):
         self.include_case_files(load_config)
         self.get_sample_information(load_config)
         self.include_pedigree_picture(load_config)
-        custom_images = self.load_custom_image_sample()
-        if custom_images:
-            load_config.custom_images = custom_images
+        load_config.custom_images = self.load_custom_image_sample()
         load_config.human_genome_build = GenomeBuild.hg19
         return load_config
 
-    def load_custom_image_sample(self) -> CustomImages | None:
+    def load_custom_image_sample(self) -> CustomImages:
         """Build custom images config."""
         LOG.info("Adding custom images")
         eklipse_images: list = []

--- a/cg/meta/upload/scout/raredisease_config_builder.py
+++ b/cg/meta/upload/scout/raredisease_config_builder.py
@@ -6,9 +6,9 @@ from cg.apps.lims import LimsAPI
 from cg.apps.madeline.api import MadelineAPI
 from cg.constants.housekeeper_tags import HK_DELIVERY_REPORT_TAG
 from cg.constants.scout import (
-    GenomeBuild,
     RAREDISEASE_CASE_TAGS,
     RAREDISEASE_SAMPLE_TAGS,
+    GenomeBuild,
     UploadTrack,
 )
 from cg.meta.upload.scout.hk_tags import CaseTags, SampleTags
@@ -61,11 +61,13 @@ class RarediseaseConfigBuilder(ScoutConfigBuilder):
         self.include_case_files(load_config)
         self.get_sample_information(load_config)
         self.include_pedigree_picture(load_config)
-        load_config.custom_images = self.load_custom_image_sample()
+        custom_images = self.load_custom_image_sample()
+        if custom_images:
+            load_config.custom_images = custom_images
         load_config.human_genome_build = GenomeBuild.hg19
         return load_config
 
-    def load_custom_image_sample(self) -> CustomImages:
+    def load_custom_image_sample(self) -> CustomImages | None:
         """Build custom images config."""
         LOG.info("Adding custom images")
         eklipse_images: list = []

--- a/cg/models/scout/scout_load_config.py
+++ b/cg/models/scout/scout_load_config.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 from pydantic import BaseModel, BeforeValidator, ConfigDict
 from typing_extensions import Annotated, Literal
+
 from cg.constants.scout import UploadTrack
 from cg.models.scout.validators import field_not_none
 
@@ -118,7 +119,7 @@ class ScoutLoadConfig(BaseModel):
     sv_rank_model_version: str | None = None
     analysis_date: datetime | None = None
     samples: list[ScoutIndividual] = []
-    custom_images: CustomImages = CustomImages()
+    customer_images: CustomImages | None = None
     delivery_report: str | None = None
     coverage_qc_report: str | None = None
     cnv_report: str | None = None


### PR DESCRIPTION
## Description


The new customer_images attribute of ScoutLoadConfig is empty for all workflows (and will be empty at first also for raredisease workflow). Scout does not handle the field being defined but empty. Only add custom_images when field is filled.

### Added

- Declare None instead of empty custom images

### Changed

-

### Fixed

-

Tested:
cg upload scout CASE
Uploads to scout-stage successfully, custom_images: {} is not in scout-load.yaml


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
