### PR TITLE
Rename applications endpoint

### DIFF
--- a/cg/server/endpoints/applications.py
+++ b/cg/server/endpoints/applications.py
@@ -1,7 +1,7 @@
 from http import HTTPStatus
 from typing import Any
 
-from flask import Blueprint, abort, jsonify, make_response
+from flask import Blueprint, abort, jsonify, make_response, request
 
 from cg.models.orders.constants import OrderType
 from cg.server.endpoints.error_handler import handle_missing_entries
@@ -23,10 +23,11 @@ def get_applications():
     return jsonify(applications=parsed_applications)
 
 
-@APPLICATIONS_BLUEPRINT.route("/applications/<order_type>")
+@APPLICATIONS_BLUEPRINT.route("/applications/order_type")
 @handle_missing_entries
-def get_application_order_types(order_type: OrderType):
+def get_application_order_types():
     """Return application order types."""
+    order_type: OrderType = OrderType(request.args.get("order_type"))
     applications: ApplicationResponse = applications_service.get_valid_applications(order_type)
     return jsonify(applications.model_dump())
 

--- a/cg/server/endpoints/applications.py
+++ b/cg/server/endpoints/applications.py
@@ -27,7 +27,7 @@ def get_applications():
 @handle_missing_entries
 def get_application_order_types():
     """Return application order types."""
-    order_type: OrderType = OrderType(request.args.get("order_type"))
+    order_type = OrderType(request.args.get("order_type"))
     applications: ApplicationResponse = applications_service.get_valid_applications(order_type)
     return jsonify(applications.model_dump())
 

--- a/cg/services/application/service.py
+++ b/cg/services/application/service.py
@@ -17,5 +17,5 @@ class ApplicationsWebService:
         applications: list[Application] = self.store.get_active_applications_by_order_type(
             order_type
         )
-        app_tags: list[str] = [application.tag for application in applications]
+        app_tags: list[str] = sorted([application.tag for application in applications])
         return create_application_response(app_tags)


### PR DESCRIPTION
## Description

The applications/<order_type> endpoint is not different to applications/<order_type> which could cause issues. This PR reworks it to be a GET applications/order_type where the <order_type> is specified as a parameter

### Added

-

### Changed

-

### Fixed

- applications/order_type endpoint renamed


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
