### PR TITLE
Change file filter to not manipulate indices

### DIFF
--- a/cg/services/deliver_files/file_filter/sample_service.py
+++ b/cg/services/deliver_files/file_filter/sample_service.py
@@ -5,7 +5,9 @@ from cg.services.deliver_files.file_filter.abstract import FilterDeliveryFilesSe
 class SampleFileFilter(FilterDeliveryFilesService):
 
     def filter_delivery_files(self, delivery_files: DeliveryFiles, sample_id: str) -> DeliveryFiles:
-        for index in range(len(delivery_files.sample_files)):
-            if delivery_files.sample_files[index].sample_id != sample_id:
-                delivery_files.sample_files.pop(index)
+        delivery_files.sample_files = [
+            sample_file
+            for sample_file in delivery_files.sample_files
+            if sample_file.sample_id == sample_id
+        ]
         return delivery_files


### PR DESCRIPTION
## Description

The `filter_delivery_files` changes the length of a list which it is still looping through, causing a list index out of range error. This PR reworks the filter.

### Added

-

### Changed

-

### Fixed

- The filter_delivery_files method does not manipulate the list indices


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
