### PR TITLE
Add application version filter

### DIFF
--- a/cg/store/crud/read.py
+++ b/cg/store/crud/read.py
@@ -52,7 +52,7 @@ from cg.store.filters.status_ordertype_application_filters import (
     OrderTypeApplicationFilter,
     apply_order_type_application_filter,
 )
-from cg.store.filters.status_organism_filters import OrganismFilter, apply_organism_filter,
+from cg.store.filters.status_organism_filters import OrganismFilter, apply_organism_filter
 from cg.store.filters.status_pacbio_smrt_cell_filters import (
     PacBioSMRTCellFilter,
     apply_pac_bio_smrt_cell_filters,

--- a/cg/store/crud/read.py
+++ b/cg/store/crud/read.py
@@ -10,12 +10,21 @@ from sqlalchemy.orm import Query, Session
 from cg.constants import SequencingRunDataAvailability, Workflow
 from cg.constants.constants import CaseActions, CustomerId, PrepCategory, SampleType
 from cg.exc import CaseNotFoundError, CgError, OrderNotFoundError, SampleNotFoundError
+from cg.models.orders.constants import OrderType
 from cg.server.dto.orders.orders_request import OrdersRequest
-from cg.server.dto.samples.collaborator_samples_request import CollaboratorSamplesRequest
+from cg.server.dto.samples.collaborator_samples_request import (
+    CollaboratorSamplesRequest,
+)
 from cg.store.base import BaseHandler
 from cg.store.exc import EntryNotFoundError
-from cg.store.filters.status_analysis_filters import AnalysisFilter, apply_analysis_filter
-from cg.store.filters.status_application_filters import ApplicationFilter, apply_application_filter
+from cg.store.filters.status_analysis_filters import (
+    AnalysisFilter,
+    apply_analysis_filter,
+)
+from cg.store.filters.status_application_filters import (
+    ApplicationFilter,
+    apply_application_filter,
+)
 from cg.store.filters.status_application_limitations_filters import (
     ApplicationLimitationsFilter,
     apply_application_limitations_filter,
@@ -25,14 +34,23 @@ from cg.store.filters.status_application_version_filters import (
     apply_application_versions_filter,
 )
 from cg.store.filters.status_bed_filters import BedFilter, apply_bed_filter
-from cg.store.filters.status_bed_version_filters import BedVersionFilter, apply_bed_version_filter
+from cg.store.filters.status_bed_version_filters import (
+    BedVersionFilter,
+    apply_bed_version_filter,
+)
 from cg.store.filters.status_case_filters import CaseFilter, apply_case_filter
-from cg.store.filters.status_case_sample_filters import CaseSampleFilter, apply_case_sample_filter
+from cg.store.filters.status_case_sample_filters import (
+    CaseSampleFilter,
+    apply_case_sample_filter,
+)
 from cg.store.filters.status_collaboration_filters import (
     CollaborationFilter,
     apply_collaboration_filter,
 )
-from cg.store.filters.status_customer_filters import CustomerFilter, apply_customer_filter
+from cg.store.filters.status_customer_filters import (
+    CustomerFilter,
+    apply_customer_filter,
+)
 from cg.store.filters.status_illumina_flow_cell_filters import (
     IlluminaFlowCellFilter,
     apply_illumina_flow_cell_filters,
@@ -51,7 +69,10 @@ from cg.store.filters.status_ordertype_application_filters import (
     OrderTypeApplicationFilter,
     apply_order_type_application_filter,
 )
-from cg.store.filters.status_organism_filters import OrganismFilter, apply_organism_filter
+from cg.store.filters.status_organism_filters import (
+    OrganismFilter,
+    apply_organism_filter,
+)
 from cg.store.filters.status_pacbio_smrt_cell_filters import (
     PacBioSMRTCellFilter,
     apply_pac_bio_smrt_cell_filters,
@@ -822,15 +843,19 @@ class ReadHandler(BaseHandler):
             .all()
         )
 
-    def get_active_applications_by_order_type(self, order_type: str) -> list[Application]:
+    def get_active_applications_by_order_type(self, order_type: OrderType) -> list[Application]:
         """
         Return all possible non-archived applications for an order type.
         Raises:
             EntryNotFoundError: If no applications are found for the order type.
         """
+        filters: list[ApplicationFilter] = [
+            ApplicationFilter.IS_NOT_ARCHIVED,
+            ApplicationFilter.HAS_VERSIONS,
+        ]
         non_archived_applications: Query = apply_application_filter(
             applications=self._get_join_application_ordertype_query(),
-            filter_functions=[ApplicationFilter.IS_NOT_ARCHIVED],
+            filter_functions=filters,
         )
         applications: list[Application] = apply_order_type_application_filter(
             order_type_applications=non_archived_applications,

--- a/cg/store/crud/read.py
+++ b/cg/store/crud/read.py
@@ -12,11 +12,19 @@ from cg.constants.constants import CaseActions, CustomerId, PrepCategory, Sample
 from cg.exc import CaseNotFoundError, CgError, OrderNotFoundError, SampleNotFoundError
 from cg.models.orders.constants import OrderType
 from cg.server.dto.orders.orders_request import OrdersRequest
-from cg.server.dto.samples.collaborator_samples_request import CollaboratorSamplesRequest
+from cg.server.dto.samples.collaborator_samples_request import (
+    CollaboratorSamplesRequest,
+)
 from cg.store.base import BaseHandler
 from cg.store.exc import EntryNotFoundError
-from cg.store.filters.status_analysis_filters import AnalysisFilter, apply_analysis_filter
-from cg.store.filters.status_application_filters import ApplicationFilter, apply_application_filter
+from cg.store.filters.status_analysis_filters import (
+    AnalysisFilter,
+    apply_analysis_filter,
+)
+from cg.store.filters.status_application_filters import (
+    ApplicationFilter,
+    apply_application_filter,
+)
 from cg.store.filters.status_application_limitations_filters import (
     ApplicationLimitationsFilter,
     apply_application_limitations_filter,
@@ -26,14 +34,23 @@ from cg.store.filters.status_application_version_filters import (
     apply_application_versions_filter,
 )
 from cg.store.filters.status_bed_filters import BedFilter, apply_bed_filter
-from cg.store.filters.status_bed_version_filters import BedVersionFilter, apply_bed_version_filter
+from cg.store.filters.status_bed_version_filters import (
+    BedVersionFilter,
+    apply_bed_version_filter,
+)
 from cg.store.filters.status_case_filters import CaseFilter, apply_case_filter
-from cg.store.filters.status_case_sample_filters import CaseSampleFilter, apply_case_sample_filter
+from cg.store.filters.status_case_sample_filters import (
+    CaseSampleFilter,
+    apply_case_sample_filter,
+)
 from cg.store.filters.status_collaboration_filters import (
     CollaborationFilter,
     apply_collaboration_filter,
 )
-from cg.store.filters.status_customer_filters import CustomerFilter, apply_customer_filter
+from cg.store.filters.status_customer_filters import (
+    CustomerFilter,
+    apply_customer_filter,
+)
 from cg.store.filters.status_illumina_flow_cell_filters import (
     IlluminaFlowCellFilter,
     apply_illumina_flow_cell_filters,
@@ -52,7 +69,10 @@ from cg.store.filters.status_ordertype_application_filters import (
     OrderTypeApplicationFilter,
     apply_order_type_application_filter,
 )
-from cg.store.filters.status_organism_filters import OrganismFilter, apply_organism_filter
+from cg.store.filters.status_organism_filters import (
+    OrganismFilter,
+    apply_organism_filter,
+)
 from cg.store.filters.status_pacbio_smrt_cell_filters import (
     PacBioSMRTCellFilter,
     apply_pac_bio_smrt_cell_filters,
@@ -825,7 +845,7 @@ class ReadHandler(BaseHandler):
 
     def get_active_applications_by_order_type(self, order_type: OrderType) -> list[Application]:
         """
-        Return all possible non-archived applications for an order type.
+        Return all possible non-archived applications with versions for an order type.
         Raises:
             EntryNotFoundError: If no applications are found for the order type.
         """

--- a/cg/store/crud/read.py
+++ b/cg/store/crud/read.py
@@ -12,19 +12,11 @@ from cg.constants.constants import CaseActions, CustomerId, PrepCategory, Sample
 from cg.exc import CaseNotFoundError, CgError, OrderNotFoundError, SampleNotFoundError
 from cg.models.orders.constants import OrderType
 from cg.server.dto.orders.orders_request import OrdersRequest
-from cg.server.dto.samples.collaborator_samples_request import (
-    CollaboratorSamplesRequest,
-)
+from cg.server.dto.samples.collaborator_samples_request import CollaboratorSamplesRequest
 from cg.store.base import BaseHandler
 from cg.store.exc import EntryNotFoundError
-from cg.store.filters.status_analysis_filters import (
-    AnalysisFilter,
-    apply_analysis_filter,
-)
-from cg.store.filters.status_application_filters import (
-    ApplicationFilter,
-    apply_application_filter,
-)
+from cg.store.filters.status_analysis_filters import AnalysisFilter, apply_analysis_filter
+from cg.store.filters.status_application_filters import ApplicationFilter, apply_application_filter
 from cg.store.filters.status_application_limitations_filters import (
     ApplicationLimitationsFilter,
     apply_application_limitations_filter,
@@ -34,23 +26,14 @@ from cg.store.filters.status_application_version_filters import (
     apply_application_versions_filter,
 )
 from cg.store.filters.status_bed_filters import BedFilter, apply_bed_filter
-from cg.store.filters.status_bed_version_filters import (
-    BedVersionFilter,
-    apply_bed_version_filter,
-)
+from cg.store.filters.status_bed_version_filters import BedVersionFilter, apply_bed_version_filter
 from cg.store.filters.status_case_filters import CaseFilter, apply_case_filter
-from cg.store.filters.status_case_sample_filters import (
-    CaseSampleFilter,
-    apply_case_sample_filter,
-)
+from cg.store.filters.status_case_sample_filters import CaseSampleFilter, apply_case_sample_filter
 from cg.store.filters.status_collaboration_filters import (
     CollaborationFilter,
     apply_collaboration_filter,
 )
-from cg.store.filters.status_customer_filters import (
-    CustomerFilter,
-    apply_customer_filter,
-)
+from cg.store.filters.status_customer_filters import CustomerFilter, apply_customer_filter
 from cg.store.filters.status_illumina_flow_cell_filters import (
     IlluminaFlowCellFilter,
     apply_illumina_flow_cell_filters,
@@ -69,10 +52,7 @@ from cg.store.filters.status_ordertype_application_filters import (
     OrderTypeApplicationFilter,
     apply_order_type_application_filter,
 )
-from cg.store.filters.status_organism_filters import (
-    OrganismFilter,
-    apply_organism_filter,
-)
+from cg.store.filters.status_organism_filters import OrganismFilter, apply_organism_filter
 from cg.store.filters.status_pacbio_smrt_cell_filters import (
     PacBioSMRTCellFilter,
     apply_pac_bio_smrt_cell_filters,

--- a/cg/store/crud/read.py
+++ b/cg/store/crud/read.py
@@ -12,19 +12,11 @@ from cg.constants.constants import CaseActions, CustomerId, PrepCategory, Sample
 from cg.exc import CaseNotFoundError, CgError, OrderNotFoundError, SampleNotFoundError
 from cg.models.orders.constants import OrderType
 from cg.server.dto.orders.orders_request import OrdersRequest
-from cg.server.dto.samples.collaborator_samples_request import (
-    CollaboratorSamplesRequest,
-)
+from cg.server.dto.samples.collaborator_samples_request import CollaboratorSamplesRequest
 from cg.store.base import BaseHandler
 from cg.store.exc import EntryNotFoundError
-from cg.store.filters.status_analysis_filters import (
-    AnalysisFilter,
-    apply_analysis_filter,
-)
-from cg.store.filters.status_application_filters import (
-    ApplicationFilter,
-    apply_application_filter,
-)
+from cg.store.filters.status_analysis_filters import AnalysisFilter, apply_analysis_filter
+from cg.store.filters.status_application_filters import ApplicationFilter, apply_application_filter
 from cg.store.filters.status_application_limitations_filters import (
     ApplicationLimitationsFilter,
     apply_application_limitations_filter,
@@ -34,23 +26,14 @@ from cg.store.filters.status_application_version_filters import (
     apply_application_versions_filter,
 )
 from cg.store.filters.status_bed_filters import BedFilter, apply_bed_filter
-from cg.store.filters.status_bed_version_filters import (
-    BedVersionFilter,
-    apply_bed_version_filter,
-)
+from cg.store.filters.status_bed_version_filters import BedVersionFilter, apply_bed_version_filter
 from cg.store.filters.status_case_filters import CaseFilter, apply_case_filter
-from cg.store.filters.status_case_sample_filters import (
-    CaseSampleFilter,
-    apply_case_sample_filter,
-)
+from cg.store.filters.status_case_sample_filters import CaseSampleFilter, apply_case_sample_filter
 from cg.store.filters.status_collaboration_filters import (
     CollaborationFilter,
     apply_collaboration_filter,
 )
-from cg.store.filters.status_customer_filters import (
-    CustomerFilter,
-    apply_customer_filter,
-)
+from cg.store.filters.status_customer_filters import CustomerFilter, apply_customer_filter
 from cg.store.filters.status_illumina_flow_cell_filters import (
     IlluminaFlowCellFilter,
     apply_illumina_flow_cell_filters,
@@ -69,10 +52,7 @@ from cg.store.filters.status_ordertype_application_filters import (
     OrderTypeApplicationFilter,
     apply_order_type_application_filter,
 )
-from cg.store.filters.status_organism_filters import (
-    OrganismFilter,
-    apply_organism_filter,
-)
+from cg.store.filters.status_organism_filters import OrganismFilter, apply_organism_filter,
 from cg.store.filters.status_pacbio_smrt_cell_filters import (
     PacBioSMRTCellFilter,
     apply_pac_bio_smrt_cell_filters,

--- a/cg/store/filters/status_application_filters.py
+++ b/cg/store/filters/status_application_filters.py
@@ -27,6 +27,10 @@ def filter_applications_is_not_external(applications: Query, **kwargs) -> Query:
     return applications.filter(Application.is_external == False)
 
 
+def filter_applications_has_versions(applications: Query, **kwargs) -> Query:
+    return applications.filter(Application.versions.any())
+
+
 def filter_application_by_prep_categories(
     applications: Query, prep_categories: list[PrepCategory], **kwargs
 ) -> Query:
@@ -58,6 +62,7 @@ def apply_application_filter(
 class ApplicationFilter(Enum):
     """Define Application filter functions."""
 
+    HAS_VERSIONS = filter_applications_has_versions
     IS_EXTERNAL = filter_applications_is_external
     IS_NOT_EXTERNAL = filter_applications_is_not_external
     BY_TAG = filter_applications_by_tag

--- a/tests/store/filters/test_status_application_filters.py
+++ b/tests/store/filters/test_status_application_filters.py
@@ -1,7 +1,11 @@
+from datetime import datetime
+
 from sqlalchemy.orm import Query
 
+from cg.models.orders.sample_base import PriorityEnum
 from cg.store.filters.status_application_filters import (
     filter_applications_by_tag,
+    filter_applications_has_versions,
     filter_applications_is_external,
     filter_applications_is_not_archived,
     filter_applications_is_not_external,
@@ -103,3 +107,58 @@ def test_filter_get_applications_is_not_external(
         and len(application.all()) == 1
         and application.all()[0].is_external is False
     )
+
+
+def test_filter_get_applications_has_no_versions(
+    store_with_an_application_with_and_without_attributes: Store,
+):
+    """Tests that applications without versions are removed by filter_applications_has_versions."""
+    # GIVEN a store where no application has a version
+    applications: Query = filter_applications_is_not_external(
+        applications=store_with_an_application_with_and_without_attributes._get_query(
+            table=Application
+        )
+    )
+    for application in applications.all():
+        assert not application.versions
+
+    # WHEN fetching only applicatications with versions
+    filtered_applications: list[Application] = filter_applications_has_versions(
+        applications=applications
+    ).all()
+
+    # THEN no applications should be returned
+    assert not filtered_applications
+
+
+def test_filter_get_applications_has_versions(
+    store_with_an_application_with_and_without_attributes: Store,
+):
+    """Tests that applications without versions are removed by filter_applications_has_versions."""
+    # GIVEN a store where one application has a version
+    applications: Query = filter_applications_is_not_external(
+        applications=store_with_an_application_with_and_without_attributes._get_query(
+            table=Application
+        )
+    )
+    for application in applications.all():
+        assert not application.versions
+    prices = {
+        PriorityEnum.standard.name: 2,
+        PriorityEnum.research.name: 3,
+        PriorityEnum.priority.name: 1,
+        PriorityEnum.priority.express: 0,
+    }
+    version = store_with_an_application_with_and_without_attributes.add_application_version(
+        application=applications.first(), prices=prices, valid_from=datetime.now(), version=1
+    )
+    store_with_an_application_with_and_without_attributes.session.add(version)
+    store_with_an_application_with_and_without_attributes.commit_to_store()
+
+    # WHEN fetching only applicatications with versions
+    filtered_applications: list[Application] = filter_applications_has_versions(
+        applications=applications
+    ).all()
+
+    # THEN only the application with the version should be returned
+    assert filtered_applications == [applications.first()]

--- a/tests/store/filters/test_status_application_filters.py
+++ b/tests/store/filters/test_status_application_filters.py
@@ -141,8 +141,6 @@ def test_filter_get_applications_has_versions(
             table=Application
         )
     )
-    for application in applications.all():
-        assert not application.versions
     prices = {
         PriorityEnum.standard.name: 2,
         PriorityEnum.research.name: 3,


### PR DESCRIPTION
## Description

In /options the applications returned all have versions. This PR adds such a filter to the new /applications/order_type. Closes https://github.com/Clinical-Genomics/add-new-tech/issues/123

### Added

-

### Changed

- /applications/order_type only returns applications which have versions

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
