### PR TITLE
Fix(microFASTQ) Set internal_id when ordering

### DIFF
--- a/cg/services/orders/store_order_services/store_microbial_fastq_order_service.py
+++ b/cg/services/orders/store_order_services/store_microbial_fastq_order_service.py
@@ -40,6 +40,7 @@ class StoreMicrobialFastqOrderService(StoreOrderService):
                 {
                     "application": sample.application,
                     "comment": sample.comment,
+                    "internal_id": sample.internal_id,
                     "data_analysis": sample.data_analysis,
                     "data_delivery": sample.data_delivery,
                     "name": sample.name,

--- a/cg/services/orders/store_order_services/store_microbial_fastq_order_service.py
+++ b/cg/services/orders/store_order_services/store_microbial_fastq_order_service.py
@@ -113,6 +113,7 @@ class StoreMicrobialFastqOrderService(StoreOrderService):
             customer=customer,
             sex=SexOptions.UNKNOWN,
             comment=sample_dict["comment"],
+            internal_id=sample_dict["internal_id"],
             order=order,
             ordered=ordered,
             original_ticket=ticket_id,


### PR DESCRIPTION
## Description
A bug described in https://github.com/Clinical-Genomics/bug-reports/issues/11 causes samples created from microbial-fastq orders to have incorrect internal_ids

### Fixed
- internal_id is now set to the LIMS-ID when submitting an order