### PR TITLE
Rework order storing

### DIFF
--- a/cg/server/endpoints/orders.py
+++ b/cg/server/endpoints/orders.py
@@ -180,7 +180,6 @@ def submit_order(order_type):
             user_name=g.current_user.name,
             user_mail=g.current_user.email,
         )
-        order_service.create_order(order_in)
 
     except (  # user misbehaviour
         OrderError,

--- a/cg/services/orders/order_service/order_service.py
+++ b/cg/services/orders/order_service/order_service.py
@@ -1,4 +1,3 @@
-from cg.models.orders.order import OrderIn
 from cg.server.dto.orders.orders_request import OrdersRequest
 from cg.server.dto.orders.orders_response import Order as OrderResponse
 from cg.server.dto.orders.orders_response import OrdersResponse
@@ -11,7 +10,7 @@ from cg.services.orders.order_summary_service.dto.order_summary import OrderSumm
 from cg.services.orders.order_summary_service.order_summary_service import (
     OrderSummaryService,
 )
-from cg.store.models import Case, Order
+from cg.store.models import Order
 from cg.store.store import Store
 
 
@@ -32,14 +31,6 @@ class OrderService:
             return OrdersResponse(orders=[], total_count=0)
         summaries: list[OrderSummary] = self.summary_service.get_summaries(order_ids)
         return create_orders_response(orders=orders, summaries=summaries, total=total_count)
-
-    def create_order(self, order_data: OrderIn) -> OrderResponse:
-        """Creates an order and links it to the given cases."""
-        order: Order = self.store.add_order(order_data)
-        cases: list[Case] = self.store.get_cases_by_ticket_id(order_data.ticket)
-        for case in cases:
-            self.store.link_case_to_order(order_id=order.id, case_id=case.id)
-        return create_order_response(order)
 
     def set_open(self, order_id: int, open: bool) -> OrderResponse:
         order: Order = self.store.update_order_status(order_id=order_id, open=open)

--- a/cg/services/orders/store_order_services/store_fastq_order_service.py
+++ b/cg/services/orders/store_order_services/store_fastq_order_service.py
@@ -1,14 +1,21 @@
 import logging
 from datetime import datetime
 
-from cg.constants import Workflow, DataDelivery, GenePanelMasterList, Priority
+from cg.constants import DataDelivery, GenePanelMasterList, Priority, Workflow
 from cg.constants.constants import CustomerId, PrepCategory
 from cg.exc import OrderError
 from cg.models.orders.order import OrderIn
 from cg.models.orders.sample_base import StatusEnum
 from cg.services.orders.order_lims_service.order_lims_service import OrderLimsService
 from cg.services.orders.submitters.order_submitter import StoreOrderService
-from cg.store.models import Case, CaseSample, Sample, Customer, ApplicationVersion
+from cg.store.models import (
+    ApplicationVersion,
+    Case,
+    CaseSample,
+    Customer,
+    Order,
+    Sample,
+)
 from cg.store.store import Store
 
 LOG = logging.getLogger(__name__)
@@ -61,7 +68,7 @@ class StoreFastqOrderService(StoreOrderService):
         }
         return status_data
 
-    def create_maf_case(self, sample_obj: Sample) -> None:
+    def create_maf_case(self, sample_obj: Sample, order: Order) -> None:
         """Add a MAF case to the Status database."""
         case: Case = self.status_db.add_case(
             data_analysis=Workflow(Workflow.MIP_DNA),
@@ -77,6 +84,7 @@ class StoreFastqOrderService(StoreOrderService):
         relationship: CaseSample = self.status_db.relate_sample(
             case=case, sample=sample_obj, status=StatusEnum.unknown
         )
+        order.cases.append(case)
         self.status_db.session.add_all([case, relationship])
 
     def store_items_in_status(
@@ -93,6 +101,12 @@ class StoreFastqOrderService(StoreOrderService):
             customer=customer, case_name=ticket_id
         )
         submitted_case: dict = items[0]
+        status_db_order = Order(
+            customer=customer,
+            order_date=datetime.now(),
+            ticket_id=int(ticket_id),
+            workflow=Workflow(submitted_case["data_analysis"]),
+        )
         with self.status_db.session.no_autoflush:
             for sample in items:
                 new_sample = self.status_db.add_sample(
@@ -130,13 +144,14 @@ class StoreFastqOrderService(StoreOrderService):
                     not new_sample.is_tumour
                     and new_sample.prep_category == PrepCategory.WHOLE_GENOME_SEQUENCING
                 ):
-                    self.create_maf_case(sample_obj=new_sample)
+                    self.create_maf_case(sample_obj=new_sample, order=status_db_order)
                 case.customer = customer
                 new_relationship = self.status_db.relate_sample(
                     case=case, sample=new_sample, status=StatusEnum.unknown
                 )
                 self.status_db.session.add_all([case, new_relationship])
-
+        status_db_order.cases.append(case)
+        self.status_db.session.add(status_db_order)
         self.status_db.session.add_all(new_samples)
         self.status_db.session.commit()
         return new_samples

--- a/cg/services/orders/store_order_services/store_microbial_fastq_order_service.py
+++ b/cg/services/orders/store_order_services/store_microbial_fastq_order_service.py
@@ -6,7 +6,7 @@ from cg.models.orders.sample_base import StatusEnum
 from cg.services.orders.order_lims_service.order_lims_service import OrderLimsService
 from cg.services.orders.submitters.order_submitter import StoreOrderService
 from cg.store.exc import EntryNotFoundError
-from cg.store.models import Case, CaseSample, Customer, Sample
+from cg.store.models import Case, CaseSample, Customer, Order, Sample
 from cg.store.store import Store
 
 
@@ -61,6 +61,12 @@ class StoreMicrobialFastqOrderService(StoreOrderService):
     ) -> list[Sample]:
         customer: Customer = self._get_customer(customer_id)
         new_samples: list[Sample] = []
+        status_db_order = Order(
+            customer=customer,
+            order_date=datetime.now(),
+            ticket_id=int(ticket_id),
+            workflow=Workflow.RAW_DATA,
+        )
         for sample in items:
             case_name: str = f'{sample["name"]}-case'
             case: Case = self._create_case_for_sample(
@@ -79,8 +85,10 @@ class StoreMicrobialFastqOrderService(StoreOrderService):
             case_sample: CaseSample = self.status_db.relate_sample(
                 case=case, sample=db_sample, status=StatusEnum.unknown
             )
+            status_db_order.cases.append(case)
             self.status_db.add_multiple_items_to_store([case, db_sample, case_sample])
             new_samples.append(db_sample)
+        self.status_db.session.add(status_db_order)
         self.status_db.commit_to_store()
         return new_samples
 

--- a/cg/services/orders/store_order_services/store_microbial_order.py
+++ b/cg/services/orders/store_order_services/store_microbial_order.py
@@ -1,12 +1,20 @@
 import logging
 from datetime import datetime
 
-from cg.constants import Workflow, DataDelivery, Sex
+from cg.constants import DataDelivery, Sex, Workflow
 from cg.models.orders.order import OrderIn
 from cg.models.orders.samples import MicrobialSample
 from cg.services.orders.order_lims_service.order_lims_service import OrderLimsService
 from cg.services.orders.submitters.order_submitter import StoreOrderService
-from cg.store.models import Sample, Customer, Case, ApplicationVersion, Organism, CaseSample
+from cg.store.models import (
+    ApplicationVersion,
+    Case,
+    CaseSample,
+    Customer,
+    Order,
+    Organism,
+    Sample,
+)
 from cg.store.store import Store
 
 LOG = logging.getLogger(__name__)
@@ -39,7 +47,7 @@ class StoreMicrobialOrderService(StoreOrderService):
         samples = self.store_items_in_status(
             customer_id=status_data["customer"],
             order=status_data["order"],
-            ordered=project_data["date"] if project_data else dt.datetime.now(),
+            ordered=project_data["date"] if project_data else datetime.now(),
             ticket_id=order.ticket,
             items=status_data["samples"],
             comment=status_data["comment"],
@@ -93,6 +101,12 @@ class StoreMicrobialOrderService(StoreOrderService):
             customer_internal_id=customer_id
         )
         new_samples = []
+        status_db_order = Order(
+            customer=customer,
+            order_date=datetime.now(),
+            ticket_id=int(ticket_id),
+            workflow=data_analysis,
+        )
 
         with self.status.session.no_autoflush:
             for sample_data in items:
@@ -157,6 +171,8 @@ class StoreMicrobialOrderService(StoreOrderService):
                 new_samples.append(new_sample)
 
             case.priority = priority
+            status_db_order.cases.append(case)
+            self.status.session.add(status_db_order)
             self.status.session.add_all(new_samples)
             self.status.session.commit()
         return sample_objs

--- a/cg/services/orders/store_order_services/store_pacbio_order_service.py
+++ b/cg/services/orders/store_order_services/store_pacbio_order_service.py
@@ -69,7 +69,7 @@ class StorePacBioOrderService(StoreOrderService):
             customer=customer,
             order_date=datetime.now(),
             ticket_id=int(ticket_id),
-            workflow=Workflow(samples[0]["data_analysis"]),
+            workflow=Workflow.RAW_DATA,
         )
         new_samples = []
         with self.status_db.session.no_autoflush:

--- a/cg/services/orders/store_order_services/store_pool_order.py
+++ b/cg/services/orders/store_order_services/store_pool_order.py
@@ -1,14 +1,22 @@
 import logging
 from datetime import datetime
 
-from cg.constants import Workflow, DataDelivery
+from cg.constants import DataDelivery, Workflow
 from cg.exc import OrderError
 from cg.models.orders.order import OrderIn
 from cg.models.orders.sample_base import SexEnum
 from cg.models.orders.samples import RmlSample
 from cg.services.orders.order_lims_service.order_lims_service import OrderLimsService
 from cg.services.orders.submitters.order_submitter import StoreOrderService
-from cg.store.models import ApplicationVersion, Customer, Pool, Sample, CaseSample, Case
+from cg.store.models import (
+    ApplicationVersion,
+    Case,
+    CaseSample,
+    Customer,
+    Order,
+    Pool,
+    Sample,
+)
 from cg.store.store import Store
 
 LOG = logging.getLogger(__name__)
@@ -116,6 +124,12 @@ class StorePoolOrderService(StoreOrderService):
         customer: Customer = self.status_db.get_customer_by_internal_id(
             customer_internal_id=customer_id
         )
+        status_db_order = Order(
+            customer=customer,
+            order_date=datetime.now(),
+            ticket_id=int(ticket_id),
+            workflow=Workflow(items[0]["data_analysis"]),
+        )
         new_pools: list[Pool] = []
         new_samples: list[Sample] = []
         for pool in items:
@@ -171,7 +185,9 @@ class StorePoolOrderService(StoreOrderService):
                     case=case, sample=new_sample, status="unknown"
                 )
                 self.status_db.session.add(link)
+            status_db_order.cases.append(case)
             new_pools.append(new_pool)
+        self.status_db.session.add(status_db_order)
         self.status_db.session.add_all(new_pools)
         self.status_db.session.commit()
         return new_pools


### PR DESCRIPTION
## Description

When I reworked the filter cases on ticket id in #3833, we started being unable to connect an order to its cases. This PR ensures that the order storing is not dependent on the ticket being in the case table

### Added

-

### Changed

-

### Fixed

- Orders are connected to their cases


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
