### PR TITLE
Set before mode on Balsamic validators

### DIFF
--- a/cg/models/balsamic/config.py
+++ b/cg/models/balsamic/config.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from pathlib import Path
 
-from pydantic import BaseModel, field_validator, ValidationInfo
+from pydantic import BaseModel, ValidationInfo, field_validator
 
 from cg.constants.constants import SampleType
 
@@ -49,7 +49,7 @@ class BalsamicConfigReference(BaseModel):
     reference_genome: Path
     reference_genome_version: str | None = None
 
-    @field_validator("reference_genome_version")
+    @field_validator("reference_genome_version", mode="before")
     @classmethod
     def extract_genome_version_from_path(cls, _, info: ValidationInfo) -> str:
         """
@@ -81,7 +81,7 @@ class BalsamicConfigPanel(BaseModel):
         """Return the base name of the provided file path."""
         return Path(path).name
 
-    @field_validator("capture_kit_version")
+    @field_validator("capture_kit_version", mode="before")
     @classmethod
     def get_panel_version_from_filename(cls, _, info: ValidationInfo) -> str:
         """Return the panel bed version from its filename (e.g. gicfdna_3.1_hg19_design.bed)."""


### PR DESCRIPTION
## Description

Seems as if the "always=True" in Pydantic v1 needs to be converted to mode Before in some instances in Pydantic v2

### Added

-

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
