### PR TITLE
removed deprecated fields in microsalt sample

### DIFF
--- a/cg/services/order_validation_service/workflows/microsalt/models/sample.py
+++ b/cg/services/order_validation_service/workflows/microsalt/models/sample.py
@@ -11,6 +11,4 @@ class MicrosaltSample(Sample):
     extraction_method: ExtractionMethod
     organism: str
     priority: PriorityEnum
-    quantity: int | None = None
     reference_genome: str = Field(max_length=255)
-    sample_concentration: float | None = None


### PR DESCRIPTION
## Description
Fields quantity and concentration were removed form the microsalt order in https://github.com/Clinical-Genomics/clinical-genomics-ui/issues/545. This PR updates the validation for this order removing those fields

### Added

-

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
