### PR TITLE
technical debt( rework order.workflow column)

### DIFF
--- a/alembic/versions/2024_11_11_05ffb5e13d7b_remove_order_workflow.py
+++ b/alembic/versions/2024_11_11_05ffb5e13d7b_remove_order_workflow.py
@@ -1,0 +1,51 @@
+"""remove_order_workflow
+
+Revision ID: 05ffb5e13d7b
+Revises: 3503b53a9bc3
+Create Date: 2024-11-11 09:35:33.020098
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "05ffb5e13d7b"
+down_revision = "3503b53a9bc3"
+branch_labels = None
+depends_on = None
+workflows = [
+    "balsamic",
+    "balsamic-pon",
+    "balsamic-qc",
+    "balsamic-umi",
+    "demultiplex",
+    "raw-data",
+    "fluffy",
+    "microsalt",
+    "mip-dna",
+    "mip-rna",
+    "mutant",
+    "raredisease",
+    "rnafusion",
+    "rsync",
+    "spring",
+    "taxprofiler",
+    "sars-cov-2",
+    "tomte",
+]
+
+
+def upgrade():
+    op.drop_column(table_name="order", column_name="workflow")
+
+
+def downgrade():
+    op.add_column(
+        "order",
+        sa.Column(
+            "workflow",
+            type_=sa.Enum(*workflows),
+        ),
+    )

--- a/cg/cli/add.py
+++ b/cg/cli/add.py
@@ -292,7 +292,6 @@ def add_case(
         order = Order(
             customer_id=customer.id,
             ticket_id=int(ticket),
-            workflow=data_analysis,
         )
     new_case.orders.append(order)
 

--- a/cg/services/orders/store_order_services/store_case_order.py
+++ b/cg/services/orders/store_order_services/store_case_order.py
@@ -164,7 +164,6 @@ class StoreCaseOrderService(StoreOrderService):
             customer=customer,
             order_date=datetime.now(),
             ticket_id=int(ticket_id),
-            workflow=Workflow(items[0]["data_analysis"]),
         )
         for case in items:
             status_db_case: Case = self.status_db.get_case_by_internal_id(

--- a/cg/services/orders/store_order_services/store_fastq_order_service.py
+++ b/cg/services/orders/store_order_services/store_fastq_order_service.py
@@ -105,7 +105,6 @@ class StoreFastqOrderService(StoreOrderService):
             customer=customer,
             order_date=datetime.now(),
             ticket_id=int(ticket_id),
-            workflow=Workflow(submitted_case["data_analysis"]),
         )
         with self.status_db.session.no_autoflush:
             for sample in items:

--- a/cg/services/orders/store_order_services/store_metagenome_order.py
+++ b/cg/services/orders/store_order_services/store_metagenome_order.py
@@ -90,7 +90,6 @@ class StoreMetagenomeOrderService(StoreOrderService):
             customer=customer,
             order_date=datetime.now(),
             ticket_id=int(ticket_id),
-            workflow=Workflow(case_dict["data_analysis"]),
         )
         with self.status_db.session.no_autoflush:
             for sample in case_dict["samples"]:

--- a/cg/services/orders/store_order_services/store_microbial_fastq_order_service.py
+++ b/cg/services/orders/store_order_services/store_microbial_fastq_order_service.py
@@ -66,7 +66,6 @@ class StoreMicrobialFastqOrderService(StoreOrderService):
             customer=customer,
             order_date=datetime.now(),
             ticket_id=int(ticket_id),
-            workflow=Workflow.RAW_DATA,
         )
         for sample in items:
             case_name: str = f'{sample["name"]}-case'

--- a/cg/services/orders/store_order_services/store_microbial_order.py
+++ b/cg/services/orders/store_order_services/store_microbial_order.py
@@ -105,7 +105,6 @@ class StoreMicrobialOrderService(StoreOrderService):
             customer=customer,
             order_date=datetime.now(),
             ticket_id=int(ticket_id),
-            workflow=data_analysis,
         )
 
         with self.status.session.no_autoflush:

--- a/cg/services/orders/store_order_services/store_pacbio_order_service.py
+++ b/cg/services/orders/store_order_services/store_pacbio_order_service.py
@@ -69,7 +69,6 @@ class StorePacBioOrderService(StoreOrderService):
             customer=customer,
             order_date=datetime.now(),
             ticket_id=int(ticket_id),
-            workflow=Workflow.RAW_DATA,
         )
         new_samples = []
         with self.status_db.session.no_autoflush:

--- a/cg/services/orders/store_order_services/store_pool_order.py
+++ b/cg/services/orders/store_order_services/store_pool_order.py
@@ -128,7 +128,6 @@ class StorePoolOrderService(StoreOrderService):
             customer=customer,
             order_date=datetime.now(),
             ticket_id=int(ticket_id),
-            workflow=Workflow(items[0]["data_analysis"]),
         )
         new_pools: list[Pool] = []
         new_samples: list[Sample] = []

--- a/cg/store/base.py
+++ b/cg/store/base.py
@@ -11,6 +11,7 @@ from cg.store.models import (
     Application,
     ApplicationLimitations,
     ApplicationVersion,
+    Order,
 )
 from cg.store.models import Base as ModelBase
 from cg.store.models import (
@@ -84,6 +85,10 @@ class BaseHandler:
         return (
             self._get_query(table=Sample).join(Case.links).join(CaseSample.sample).join(Case.orders)
         )
+
+    def _get_join_order_case_query(self) -> Query:
+        """Return a query joining sample, cases_sample, case and order. Selects from sample."""
+        return self._get_query(table=Order).join(Order.cases)
 
     def _get_join_application_ordertype_query(self) -> Query:
         """Return join application to order type query."""

--- a/cg/store/crud/read.py
+++ b/cg/store/crud/read.py
@@ -1391,10 +1391,15 @@ class ReadHandler(BaseHandler):
 
     def get_orders(self, orders_request: OrdersRequest) -> tuple[list[Order], int]:
         """Filter, sort and paginate orders based on the provided request."""
-        orders: Query = apply_order_filters(
-            orders=self._get_query(Order),
-            filters=[OrderFilter.BY_WORKFLOW, OrderFilter.BY_SEARCH, OrderFilter.BY_OPEN],
+        order_case: Query = self._get_join_order_case_query()
+        order_for_workflow: Query = apply_case_filter(
+            cases=order_case,
+            filter_functions=[CaseFilter.WITH_WORKFLOW],
             workflow=orders_request.workflow,
+        )
+        orders: Query = apply_order_filters(
+            orders=order_for_workflow,
+            filters=[OrderFilter.BY_SEARCH, OrderFilter.BY_OPEN],
             search=orders_request.search,
             is_open=orders_request.is_open,
         )

--- a/cg/store/filters/status_order_filters.py
+++ b/cg/store/filters/status_order_filters.py
@@ -9,12 +9,6 @@ from cg.server.dto.orders.orders_request import OrderSortField, SortOrder
 from cg.store.models import Customer, Order
 
 
-def filter_orders_by_workflow(orders: Query, workflow: str | None, **kwargs) -> Query:
-    if workflow == Workflow.BALSAMIC:
-        return orders.filter(Order.workflow.startswith(workflow))
-    return orders.filter(Order.workflow == workflow) if workflow else orders
-
-
 def filter_orders_by_id(orders: Query, id: int | None, **kwargs) -> Query:
     return orders.filter(Order.id == id) if id else orders
 
@@ -65,7 +59,6 @@ class OrderFilter(Enum):
     BY_IDS: Callable = filter_orders_by_ids
     BY_SEARCH: Callable = filter_orders_by_search
     BY_TICKET_ID: Callable = filter_orders_by_ticket_id
-    BY_WORKFLOW: Callable = filter_orders_by_workflow
     BY_OPEN: Callable = filter_orders_by_is_open
     PAGINATE: Callable = apply_pagination
     SORT: Callable = apply_sorting
@@ -77,7 +70,6 @@ def apply_order_filters(
     id: int = None,
     ids: list[int] = None,
     ticket_id: int = None,
-    workflow: SortOrder = None,
     page: int = None,
     page_size: int = None,
     sort_field: OrderSortField = None,
@@ -90,7 +82,6 @@ def apply_order_filters(
             orders=orders,
             id=id,
             ids=ids,
-            workflow=workflow,
             page=page,
             page_size=page_size,
             ticket_id=ticket_id,

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -991,8 +991,11 @@ class Order(Base):
     customer: Mapped[Customer] = orm.relationship(foreign_keys=[customer_id])
     order_date: Mapped[datetime] = mapped_column(default=datetime.now)
     ticket_id: Mapped[int] = mapped_column(unique=True, index=True)
-    workflow: Mapped[str] = mapped_column(types.Enum(*(workflow.value for workflow in Workflow)))
     is_open: Mapped[bool] = mapped_column(default=True)
+
+    @property
+    def workflow(self) -> Workflow:
+        return self.cases[0].data_analysis
 
     def to_dict(self):
         return to_dict(model_instance=self)

--- a/tests/meta/archive/conftest.py
+++ b/tests/meta/archive/conftest.py
@@ -286,7 +286,6 @@ def archive_store(
     order = Order(
         customer_id=customer_ddn.id,
         ticket_id=new_samples[0].original_ticket,
-        workflow=case.data_analysis,
     )
     base_store.session.add(order)
     base_store.session.add(case)

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -51,7 +51,6 @@ def order(
         customer_id=customer.id,
         ticket_id=1,
         order_date=datetime.now(),
-        workflow=Workflow.MIP_DNA,
     )
     order.cases.append(server_case)
     order.cases.append(server_case_in_same_order)
@@ -60,21 +59,26 @@ def order(
 
 @pytest.fixture
 def order_another(helpers: StoreHelpers, customer_another: Customer) -> Order:
+    case: Case = helpers.add_case(name="another_case", store=store, data_analysis=Workflow.MIP_DNA)
     order: Order = helpers.add_order(
         store=store, customer_id=customer_another.id, ticket_id=2, order_date=datetime.now()
     )
+    order.cases.append(case)
     return order
 
 
 @pytest.fixture
 def order_balsamic(helpers: StoreHelpers, customer_another: Customer) -> Order:
+    case: Case = helpers.add_case(
+        name="balsamic_case", store=store, data_analysis=Workflow.BALSAMIC
+    )
     order: Order = helpers.add_order(
         store=store,
         customer_id=customer_another.id,
         ticket_id=3,
         order_date=datetime.now(),
-        workflow=Workflow.BALSAMIC,
     )
+    order.cases.append(case)
     return order
 
 

--- a/tests/store/crud/conftest.py
+++ b/tests/store/crud/conftest.py
@@ -456,22 +456,31 @@ def three_pool_names() -> list[str]:
 
 @pytest.fixture
 def order(helpers: StoreHelpers, store: Store) -> Order:
+    case: Case = helpers.add_case(data_analysis=Workflow.MIP_DNA, store=store, name="order_case")
     order: Order = helpers.add_order(
         store=store, customer_id=1, ticket_id=1, order_date=datetime.now()
     )
+    order.cases.append(case)
     return order
 
 
 @pytest.fixture
 def order_another(helpers: StoreHelpers, store: Store) -> Order:
+    case: Case = helpers.add_case(
+        data_analysis=Workflow.MIP_DNA, store=store, name="order_another_case"
+    )
     order: Order = helpers.add_order(
         store=store, customer_id=2, ticket_id=2, order_date=datetime.now()
     )
+    order.cases.append(case)
     return order
 
 
 @pytest.fixture
 def order_balsamic(helpers: StoreHelpers, store: Store) -> Order:
+    case: Case = helpers.add_case(
+        data_analysis=Workflow.BALSAMIC, store=store, name="order_balsamic_case"
+    )
     order: Order = helpers.add_order(
         store=store,
         customer_id=2,
@@ -479,4 +488,5 @@ def order_balsamic(helpers: StoreHelpers, store: Store) -> Order:
         order_date=datetime.now(),
         workflow=Workflow.BALSAMIC,
     )
+    order.cases.append(case)
     return order

--- a/tests/store/filters/test_status_order_filters.py
+++ b/tests/store/filters/test_status_order_filters.py
@@ -13,7 +13,6 @@ def test_filter_orders_by_ticket_no_matching_ticket(base_store: Store, non_exist
         id=1,
         customer_id=1,
         ticket_id=1,
-        workflow=Workflow.MIP_DNA,
     )
     base_store.session.add(order)
     base_store.session.commit()
@@ -33,7 +32,6 @@ def test_filter_orders_by_ticket_id_matching_ticket(base_store: Store, ticket_id
         id=1,
         customer_id=1,
         ticket_id=int(ticket_id),
-        workflow=Workflow.MIP_DNA,
     )
     base_store.session.add(order)
     base_store.session.commit()

--- a/tests/store_helpers.py
+++ b/tests/store_helpers.py
@@ -516,7 +516,9 @@ class StoreHelpers:
         workflow: Workflow = Workflow.MIP_DNA,
     ) -> Order:
         order = Order(
-            customer_id=customer_id, ticket_id=ticket_id, order_date=order_date, workflow=workflow
+            customer_id=customer_id,
+            ticket_id=ticket_id,
+            order_date=order_date,
         )
         store.session.add(order)
         store.session.commit()
@@ -568,7 +570,6 @@ class StoreHelpers:
         order = store.get_order_by_ticket_id(ticket_id=int(case_info["tickets"])) or Order(
             ticket_id=int(case_info["tickets"]),
             customer_id=customer_obj.id,
-            workflow=case_info.get("data_analysis", Workflow.MIP_DNA),
         )
         case = Case(
             name=case_info["name"],


### PR DESCRIPTION
## Description

Removes the order.workflow column in the database.

Reason: 
While the worfklow column on the order table is an accurate representation of how orders are placed currently it is not optimal for the following reasons.

1. Introduces data redudancy
2. Limits flexibility between orders and cases if requirements change

### Changed

- Removed workflow column from order table
- Changed get_orders() crud function to perform a case join and filter on the workflow there instead
-  Added property workflow to orders model, which gets the workflow of the first case associated with it. NOTE: if requirements change where we have multiple different workflows per order this will require attention

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
