### PR TITLE
(Improve order flow) Patch repeated case sample name rule

### DIFF
--- a/cg/services/order_validation_service/models/case.py
+++ b/cg/services/order_validation_service/models/case.py
@@ -38,8 +38,8 @@ class Case(BaseModel):
         return samples
 
     @property
-    def enumerated_existing_samples(self) -> list[tuple[int, Sample]]:
-        samples: list[tuple[int, Sample]] = []
+    def enumerated_existing_samples(self) -> list[tuple[int, ExistingSample]]:
+        samples: list[tuple[int, ExistingSample]] = []
         for sample_index, sample in self.enumerated_samples:
             if not sample.is_new:
                 samples.append((sample_index, sample))

--- a/cg/services/order_validation_service/models/order_with_cases.py
+++ b/cg/services/order_validation_service/models/order_with_cases.py
@@ -5,6 +5,7 @@ from cg.services.order_validation_service.models.case import Case
 from cg.services.order_validation_service.models.discriminators import has_internal_id
 from cg.services.order_validation_service.models.existing_case import ExistingCase
 from cg.services.order_validation_service.models.order import Order
+from cg.store.models import Sample
 
 NewCaseType = Annotated[Case, Tag("new")]
 ExistingCaseType = Annotated[ExistingCase, Tag("existing")]
@@ -14,7 +15,7 @@ class OrderWithCases(Order):
     cases: list[Annotated[NewCaseType | ExistingCaseType, Discriminator(has_internal_id)]]
 
     @property
-    def enumerated_cases(self) -> enumerate[Case]:
+    def enumerated_cases(self) -> enumerate[Case | ExistingCase]:
         return enumerate(self.cases)
 
     @property
@@ -32,3 +33,11 @@ class OrderWithCases(Order):
             if not case.is_new:
                 cases.append((case_index, case))
         return cases
+
+    @property
+    def enumerated_new_samples(self) -> list[tuple[int, int, Sample]]:
+        return [
+            (case_index, sample_index, sample)
+            for case_index, case in self.enumerated_new_cases
+            for sample_index, sample in case.enumerated_new_samples
+        ]

--- a/cg/services/order_validation_service/rules/case_sample/rules.py
+++ b/cg/services/order_validation_service/rules/case_sample/rules.py
@@ -35,13 +35,13 @@ from cg.services.order_validation_service.rules.case_sample.pedigree.validate_pe
 )
 from cg.services.order_validation_service.rules.case_sample.utils import (
     get_counter_container_names,
+    get_existing_sample_names,
     get_father_case_errors,
     get_father_sex_errors,
     get_invalid_panels,
     get_mother_case_errors,
     get_mother_sex_errors,
     get_occupied_well_errors,
-    get_old_sample_names,
     get_well_sample_map,
     is_concentration_missing,
     is_container_name_missing,
@@ -251,7 +251,7 @@ def validate_wells_contain_at_most_one_sample(
 def validate_sample_names_not_repeated(
     order: OrderWithCases, store: Store, **kwargs
 ) -> list[SampleNameRepeatedError]:
-    old_sample_names: set[str] = get_old_sample_names(order=order, status_db=store)
+    old_sample_names: set[str] = get_existing_sample_names(order=order, status_db=store)
     new_samples: list[tuple[int, int, Sample]] = order.enumerated_new_samples
     sample_name_counter = Counter([sample.name for _, _, sample in new_samples])
     return [

--- a/cg/services/order_validation_service/rules/case_sample/rules.py
+++ b/cg/services/order_validation_service/rules/case_sample/rules.py
@@ -41,6 +41,7 @@ from cg.services.order_validation_service.rules.case_sample.utils import (
     get_mother_case_errors,
     get_mother_sex_errors,
     get_occupied_well_errors,
+    get_old_sample_names,
     get_well_sample_map,
     is_concentration_missing,
     is_container_name_missing,
@@ -250,7 +251,7 @@ def validate_wells_contain_at_most_one_sample(
 def validate_sample_names_not_repeated(
     order: OrderWithCases, store: Store, **kwargs
 ) -> list[SampleNameRepeatedError]:
-    old_sample_names: set[str] = _get_old_sample_names(order=order, status_db=store)
+    old_sample_names: set[str] = get_old_sample_names(order=order, status_db=store)
     new_samples: list[tuple[int, int, Sample]] = order.enumerated_new_samples
     sample_name_counter = Counter([sample.name for _, _, sample in new_samples])
     return [
@@ -258,20 +259,6 @@ def validate_sample_names_not_repeated(
         for case_index, sample_index, sample in new_samples
         if sample_name_counter.get(sample.name) > 1 or sample.name in old_sample_names
     ]
-
-
-def _get_old_sample_names(order: OrderWithCases, status_db: Store) -> set[str]:
-    existing_sample_names: set[str] = set()
-    for case_index, case in order.enumerated_cases:
-        if case.is_new:
-            for sample_index, sample in case.enumerated_existing_samples:
-                db_sample = status_db.get_sample_by_internal_id(sample.internal_id)
-                existing_sample_names.add(db_sample.name)
-        else:
-            db_case = status_db.get_case_by_internal_id(case.internal_id)
-            for sample in db_case.samples:
-                existing_sample_names.add(sample.name)
-    return existing_sample_names
 
 
 def validate_fathers_are_male(order: OrderWithCases, **kwargs) -> list[InvalidFatherSexError]:

--- a/cg/services/order_validation_service/rules/case_sample/utils.py
+++ b/cg/services/order_validation_service/rules/case_sample/utils.py
@@ -290,7 +290,7 @@ def get_counter_container_names(order: OrderWithCases) -> Counter:
 
 def get_existing_sample_names(order: OrderWithCases, status_db: Store) -> set[str]:
     existing_sample_names: set[str] = set()
-    for case_index, case in order.enumerated_cases:
+    for case in order.cases:
         if case.is_new:
             for sample_index, sample in case.enumerated_existing_samples:
                 db_sample = status_db.get_sample_by_internal_id(sample.internal_id)

--- a/cg/services/order_validation_service/rules/case_sample/utils.py
+++ b/cg/services/order_validation_service/rules/case_sample/utils.py
@@ -288,7 +288,7 @@ def get_counter_container_names(order: OrderWithCases) -> Counter:
     return counter
 
 
-def get_old_sample_names(order: OrderWithCases, status_db: Store) -> set[str]:
+def get_existing_sample_names(order: OrderWithCases, status_db: Store) -> set[str]:
     existing_sample_names: set[str] = set()
     for case_index, case in order.enumerated_cases:
         if case.is_new:

--- a/tests/services/order_validation_service/test_case_sample_rules.py
+++ b/tests/services/order_validation_service/test_case_sample_rules.py
@@ -269,12 +269,14 @@ def test_multiple_samples_in_well_not_allowed(order_with_samples_in_same_well: O
     assert isinstance(errors[0], OccupiedWellError)
 
 
-def test_repeated_sample_names_not_allowed(order_with_repeated_sample_names: OrderWithCases):
+def test_repeated_sample_names_not_allowed(
+    order_with_repeated_sample_names: OrderWithCases, base_store: Store
+):
     # GIVEN an order with samples in a case with the same name
 
     # WHEN validating the order
     errors: list[SampleNameRepeatedError] = validate_sample_names_not_repeated(
-        order_with_repeated_sample_names
+        order=order_with_repeated_sample_names, store=base_store
     )
 
     # THEN errors are returned


### PR DESCRIPTION
## Description

The rule for sample name repetition for OrderWithCases is quite complex and the current implementation had some issues, mostly with regards to existing cases and samples. The changes in this PR intends to

1. Always allow repeated sample names for existing samples.
2. Not allow for repeated sample names within the new samples _across the whole order_.

### Added

-

### Changed

-

### Fixed

- Always allow repeated sample names for existing samples.
- Not allow for repeated sample names within the new samples _across the whole order_.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
