### PR TITLE
Patch tube well position behaviour

### DIFF
--- a/cg/models/lims/sample.py
+++ b/cg/models/lims/sample.py
@@ -64,6 +64,10 @@ class LimsSample(BaseModel):
     index_sequence: str | None
     udfs: Udf | None
 
+    @validator("well_position", pre=False)
+    def reset_well_positions_for_tubes(cls, value: str, values: dict[str, str]):
+        return None if values["container"] == "Tube" else value
+
     @classmethod
     def parse_obj(cls, obj: dict):
         parsed_obj: LimsSample = super().parse_obj(obj)


### PR DESCRIPTION
## Description

For samples in tubes, it makes no sense to specify the well_position, since there is only a single position. Nevertheless, LIMS can not handle any well positions for samples in tubes since the formatting on the well position is still expected to follow certain rules if provided. This PR overrides any provided well_position with a None value if the sample is in a tube.

### Added

-

### Changed

-

### Fixed

- Samples in tubes get their well position set to None


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
