### PR TITLE
(Improve order flow) Rework response mapping

### DIFF
--- a/cg/services/order_validation_service/models/case.py
+++ b/cg/services/order_validation_service/models/case.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Discriminator, Field, Tag, model_validator
+from pydantic import BaseModel, ConfigDict, Discriminator, Field, Tag, model_validator
 from typing_extensions import Annotated
 
 from cg.constants.priority import PriorityTerms
@@ -57,3 +57,5 @@ class Case(BaseModel):
                 if value == "":
                     data[key] = None
         return data
+
+    model_config = ConfigDict(extra="ignore")

--- a/cg/services/order_validation_service/models/order.py
+++ b/cg/services/order_validation_service/models/order.py
@@ -15,7 +15,7 @@ class Order(BaseModel):
     name: str = Field(min_length=1)
     skip_reception_control: bool = False
     ticket_number: str | None = Field(None, pattern=TICKET_PATTERN)
-    user_id: int
+    user_id: int = Field(None, exclude=True)
 
     @model_validator(mode="before")
     def convert_empty_strings_to_none(cls, data):

--- a/cg/services/order_validation_service/models/order.py
+++ b/cg/services/order_validation_service/models/order.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from cg.constants import DataDelivery
 from cg.models.orders.constants import OrderType
@@ -24,3 +24,5 @@ class Order(BaseModel):
                 if value == "":
                     data[key] = None
         return data
+
+    model_config = ConfigDict(extra="ignore")

--- a/cg/services/order_validation_service/models/order.py
+++ b/cg/services/order_validation_service/models/order.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, Field, model_validator
 
 from cg.constants import DataDelivery
 from cg.models.orders.constants import OrderType
@@ -24,5 +24,3 @@ class Order(BaseModel):
                 if value == "":
                     data[key] = None
         return data
-
-    model_config = ConfigDict(extra="ignore")

--- a/cg/services/order_validation_service/models/order.py
+++ b/cg/services/order_validation_service/models/order.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from cg.constants import DataDelivery
 from cg.models.orders.constants import OrderType
@@ -15,7 +15,7 @@ class Order(BaseModel):
     name: str = Field(min_length=1)
     skip_reception_control: bool = False
     ticket_number: str | None = Field(None, pattern=TICKET_PATTERN)
-    user_id: int = Field(None, exclude=True)
+    user_id: int
 
     @model_validator(mode="before")
     def convert_empty_strings_to_none(cls, data):
@@ -24,3 +24,5 @@ class Order(BaseModel):
                 if value == "":
                     data[key] = None
         return data
+
+    model_config = ConfigDict(extra="ignore")

--- a/cg/services/order_validation_service/models/sample.py
+++ b/cg/services/order_validation_service/models/sample.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from cg.models.orders.sample_base import NAME_PATTERN, ContainerEnum
 
@@ -28,3 +28,5 @@ class Sample(BaseModel):
                 if value == "":
                     data[key] = None
         return data
+
+    model_config = ConfigDict(extra="ignore")

--- a/cg/services/order_validation_service/response_mapper.py
+++ b/cg/services/order_validation_service/response_mapper.py
@@ -1,19 +1,19 @@
 from typing import Any
 
 from cg.services.order_validation_service.errors.case_errors import CaseError
-from cg.services.order_validation_service.errors.case_sample_errors import (
-    CaseSampleError,
-)
+from cg.services.order_validation_service.errors.case_sample_errors import CaseSampleError
 from cg.services.order_validation_service.errors.order_errors import OrderError
 from cg.services.order_validation_service.errors.sample_errors import SampleError
-from cg.services.order_validation_service.errors.validation_errors import (
-    ValidationErrors,
-)
+from cg.services.order_validation_service.errors.validation_errors import ValidationErrors
+from cg.services.order_validation_service.models.order import Order
 
 
-def create_order_validation_response(raw_order: dict, errors: ValidationErrors) -> dict:
+def create_order_validation_response(
+    raw_order: dict, errors: ValidationErrors, model: type[Order]
+) -> dict:
     """Ensures each field in the order looks like: {value: raw value, errors: [errors]}"""
-    wrap_fields(raw_order)
+    partially_validated_model: model = model.model_construct(**raw_order)
+    wrap_fields(partially_validated_model.model_dump())
     map_errors_to_order(order=raw_order, errors=errors)
     return raw_order
 

--- a/cg/services/order_validation_service/response_mapper.py
+++ b/cg/services/order_validation_service/response_mapper.py
@@ -13,9 +13,10 @@ def create_order_validation_response(
 ) -> dict:
     """Ensures each field in the order looks like: {value: raw value, errors: [errors]}"""
     partially_validated_model: model = model.model_construct(**raw_order)
-    wrap_fields(partially_validated_model.model_dump())
-    map_errors_to_order(order=raw_order, errors=errors)
-    return raw_order
+    response: dict = partially_validated_model.model_dump(by_alias=True)
+    wrap_fields(response)
+    map_errors_to_order(order=response, errors=errors)
+    return response
 
 
 def map_errors_to_order(order: dict, errors: ValidationErrors) -> None:

--- a/cg/services/order_validation_service/workflows/balsamic/validation_service.py
+++ b/cg/services/order_validation_service/workflows/balsamic/validation_service.py
@@ -1,35 +1,21 @@
 from cg.services.order_validation_service.errors.case_errors import CaseError
-from cg.services.order_validation_service.errors.case_sample_errors import (
-    CaseSampleError,
-)
+from cg.services.order_validation_service.errors.case_sample_errors import CaseSampleError
 from cg.services.order_validation_service.errors.order_errors import OrderError
-from cg.services.order_validation_service.errors.validation_errors import (
-    ValidationErrors,
-)
-from cg.services.order_validation_service.model_validator.model_validator import (
-    ModelValidator,
-)
-from cg.services.order_validation_service.order_validation_service import (
-    OrderValidationService,
-)
-from cg.services.order_validation_service.response_mapper import (
-    create_order_validation_response,
-)
+from cg.services.order_validation_service.errors.validation_errors import ValidationErrors
+from cg.services.order_validation_service.model_validator.model_validator import ModelValidator
+from cg.services.order_validation_service.order_validation_service import OrderValidationService
+from cg.services.order_validation_service.response_mapper import create_order_validation_response
 from cg.services.order_validation_service.utils import (
     apply_case_sample_validation,
     apply_case_validation,
     apply_order_validation,
 )
-from cg.services.order_validation_service.workflows.balsamic.models.order import (
-    BalsamicOrder,
-)
+from cg.services.order_validation_service.workflows.balsamic.models.order import BalsamicOrder
 from cg.services.order_validation_service.workflows.balsamic.validation_rules import (
     CASE_RULES,
     CASE_SAMPLE_RULES,
 )
-from cg.services.order_validation_service.workflows.order_validation_rules import (
-    ORDER_RULES,
-)
+from cg.services.order_validation_service.workflows.order_validation_rules import ORDER_RULES
 from cg.store.store import Store
 
 
@@ -40,7 +26,9 @@ class BalsamicValidationService(OrderValidationService):
 
     def validate(self, raw_order: dict) -> dict:
         errors: ValidationErrors = self._get_errors(raw_order)
-        return create_order_validation_response(raw_order=raw_order, errors=errors)
+        return create_order_validation_response(
+            raw_order=raw_order, errors=errors, model=BalsamicOrder
+        )
 
     def _get_errors(self, raw_order: dict) -> ValidationErrors:
         order, field_errors = ModelValidator.validate(order=raw_order, model=BalsamicOrder)

--- a/cg/services/order_validation_service/workflows/microbial_fastq/validation_service.py
+++ b/cg/services/order_validation_service/workflows/microbial_fastq/validation_service.py
@@ -25,7 +25,9 @@ class MicrobialFastqValidationService(OrderValidationService):
 
     def validate(self, raw_order: dict) -> dict:
         errors: ValidationErrors = self._get_errors(raw_order)
-        return create_order_validation_response(raw_order=raw_order, errors=errors)
+        return create_order_validation_response(
+            raw_order=raw_order, errors=errors, model=MicrobialFastqOrder
+        )
 
     def _get_errors(self, raw_order: dict) -> ValidationErrors:
         order, field_errors = ModelValidator.validate(order=raw_order, model=MicrobialFastqOrder)

--- a/cg/services/order_validation_service/workflows/microsalt/validation_service.py
+++ b/cg/services/order_validation_service/workflows/microsalt/validation_service.py
@@ -1,30 +1,16 @@
 from cg.services.order_validation_service.errors.order_errors import OrderError
 from cg.services.order_validation_service.errors.sample_errors import SampleError
-from cg.services.order_validation_service.errors.validation_errors import (
-    ValidationErrors,
-)
-from cg.services.order_validation_service.model_validator.model_validator import (
-    ModelValidator,
-)
-from cg.services.order_validation_service.order_validation_service import (
-    OrderValidationService,
-)
-from cg.services.order_validation_service.response_mapper import (
-    create_order_validation_response,
-)
+from cg.services.order_validation_service.errors.validation_errors import ValidationErrors
+from cg.services.order_validation_service.model_validator.model_validator import ModelValidator
+from cg.services.order_validation_service.order_validation_service import OrderValidationService
+from cg.services.order_validation_service.response_mapper import create_order_validation_response
 from cg.services.order_validation_service.utils import (
     apply_order_validation,
     apply_sample_validation,
 )
-from cg.services.order_validation_service.workflows.microsalt.models.order import (
-    MicrosaltOrder,
-)
-from cg.services.order_validation_service.workflows.microsalt.validation_rules import (
-    SAMPLE_RULES,
-)
-from cg.services.order_validation_service.workflows.order_validation_rules import (
-    ORDER_RULES,
-)
+from cg.services.order_validation_service.workflows.microsalt.models.order import MicrosaltOrder
+from cg.services.order_validation_service.workflows.microsalt.validation_rules import SAMPLE_RULES
+from cg.services.order_validation_service.workflows.order_validation_rules import ORDER_RULES
 from cg.store.store import Store
 
 
@@ -35,7 +21,9 @@ class MicroSaltValidationService(OrderValidationService):
 
     def validate(self, raw_order: dict) -> dict:
         errors: ValidationErrors = self._get_errors(raw_order)
-        return create_order_validation_response(raw_order=raw_order, errors=errors)
+        return create_order_validation_response(
+            raw_order=raw_order, errors=errors, model=MicrosaltOrder
+        )
 
     def _get_errors(self, raw_order: dict) -> ValidationErrors:
         order, field_errors = ModelValidator.validate(order=raw_order, model=MicrosaltOrder)

--- a/cg/services/order_validation_service/workflows/mip_dna/validation_service.py
+++ b/cg/services/order_validation_service/workflows/mip_dna/validation_service.py
@@ -4,6 +4,7 @@ from cg.services.order_validation_service.errors.order_errors import OrderError
 from cg.services.order_validation_service.errors.validation_errors import ValidationErrors
 from cg.services.order_validation_service.model_validator.model_validator import ModelValidator
 from cg.services.order_validation_service.order_validation_service import OrderValidationService
+from cg.services.order_validation_service.response_mapper import create_order_validation_response
 from cg.services.order_validation_service.utils import (
     apply_case_sample_validation,
     apply_case_validation,
@@ -14,7 +15,6 @@ from cg.services.order_validation_service.workflows.mip_dna.validation_rules imp
     CASE_RULES,
     CASE_SAMPLE_RULES,
 )
-from cg.services.order_validation_service.response_mapper import create_order_validation_response
 from cg.services.order_validation_service.workflows.order_validation_rules import ORDER_RULES
 from cg.store.store import Store
 
@@ -26,7 +26,9 @@ class MipDnaValidationService(OrderValidationService):
 
     def validate(self, raw_order: dict) -> dict:
         errors: ValidationErrors = self._get_errors(raw_order)
-        return create_order_validation_response(raw_order=raw_order, errors=errors)
+        return create_order_validation_response(
+            raw_order=raw_order, errors=errors, model=MipDnaOrder
+        )
 
     def _get_errors(self, raw_order: dict) -> ValidationErrors:
         order, field_errors = ModelValidator.validate(order=raw_order, model=MipDnaOrder)

--- a/cg/services/order_validation_service/workflows/mutant/validation_service.py
+++ b/cg/services/order_validation_service/workflows/mutant/validation_service.py
@@ -21,7 +21,9 @@ class MutantValidationService(OrderValidationService):
 
     def validate(self, raw_order: dict) -> dict:
         errors: ValidationErrors = self._get_errors(raw_order)
-        return create_order_validation_response(raw_order=raw_order, errors=errors)
+        return create_order_validation_response(
+            raw_order=raw_order, errors=errors, model=MutantOrder
+        )
 
     def _get_errors(self, raw_order: dict) -> ValidationErrors:
         order, field_errors = ModelValidator.validate(order=raw_order, model=MutantOrder)

--- a/cg/services/order_validation_service/workflows/rna_fusion/validation_service.py
+++ b/cg/services/order_validation_service/workflows/rna_fusion/validation_service.py
@@ -25,7 +25,9 @@ class RnaFusionValidationService(OrderValidationService):
 
     def validate(self, raw_order: dict) -> dict:
         errors: ValidationErrors = self._get_errors(raw_order)
-        return create_order_validation_response(raw_order=raw_order, errors=errors)
+        return create_order_validation_response(
+            raw_order=raw_order, errors=errors, model=RnaFusionOrder
+        )
 
     def _get_errors(self, raw_order: dict) -> ValidationErrors:
         order, field_errors = ModelValidator.validate(order=raw_order, model=RnaFusionOrder)

--- a/cg/services/order_validation_service/workflows/tomte/validation_service.py
+++ b/cg/services/order_validation_service/workflows/tomte/validation_service.py
@@ -26,7 +26,9 @@ class TomteValidationService(OrderValidationService):
 
     def validate(self, raw_order: dict) -> dict:
         errors: ValidationErrors = self._get_errors(raw_order)
-        return create_order_validation_response(raw_order=raw_order, errors=errors)
+        return create_order_validation_response(
+            raw_order=raw_order, errors=errors, model=TomteOrder
+        )
 
     def _get_errors(self, raw_order: dict) -> ValidationErrors:
         order, field_errors = ModelValidator.validate(order=raw_order, model=TomteOrder)

--- a/tests/services/order_validation_service/workflows/balsamic/test_validation_integration.py
+++ b/tests/services/order_validation_service/workflows/balsamic/test_validation_integration.py
@@ -1,6 +1,4 @@
-from cg.services.order_validation_service.workflows.balsamic.models.order import (
-    BalsamicOrder,
-)
+from cg.services.order_validation_service.workflows.balsamic.models.order import BalsamicOrder
 from cg.services.order_validation_service.workflows.balsamic.validation_service import (
     BalsamicValidationService,
 )
@@ -56,7 +54,7 @@ def test_case_error_conversion(
 
     # GIVEN an order with a faulty case priority
     valid_order.cases[0].priority = "Non-existent priority"
-    order = valid_order.model_dump()
+    order = valid_order.model_dump(by_alias=True)
 
     # WHEN validating the order
     response: dict = balsamic_validation_service.validate(order)

--- a/tests/services/order_validation_service/workflows/balsamic/test_validation_integration.py
+++ b/tests/services/order_validation_service/workflows/balsamic/test_validation_integration.py
@@ -54,7 +54,7 @@ def test_case_error_conversion(
 
     # GIVEN an order with a faulty case priority
     valid_order.cases[0].priority = "Non-existent priority"
-    order = valid_order.model_dump(by_alias=True)
+    order = valid_order.model_dump()
 
     # WHEN validating the order
     response: dict = balsamic_validation_service.validate(order)


### PR DESCRIPTION
## Description

Closes https://github.com/Clinical-Genomics/improve-order-flow/issues/105.

### Added

-

### Changed

-

### Fixed

- The response from validate_order is based on the _expected_ pydantic model rather than the request


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
