### PR TITLE
add pacbio service

### DIFF
--- a/cg/server/endpoints/orders.py
+++ b/cg/server/endpoints/orders.py
@@ -44,6 +44,7 @@ from cg.server.ext import (
     mutant_validation_service,
     order_service,
     order_submitter_registry,
+    pacbio_long_read_validation_service,
     rna_fusion_validation_service,
     ticket_handler,
     tomte_validation_service,
@@ -274,16 +275,18 @@ def validate_order(order_type: OrderType):
     response = {}
     if order_type == OrderType.BALSAMIC:
         response = balsamic_validation_service.validate(raw_order)
-    if order_type == OrderType.MICROBIAL_FASTQ:
+    elif order_type == OrderType.MICROBIAL_FASTQ:
         response = microbial_fastq_validation_service.validate(raw_order)
-    if order_type == OrderType.MICROSALT:
+    elif order_type == OrderType.MICROSALT:
         response = microsalt_validation_service.validate(raw_order)
-    if order_type == OrderType.MIP_DNA:
+    elif order_type == OrderType.MIP_DNA:
         response = mip_dna_validation_service.validate(raw_order)
-    if order_type == OrderType.SARS_COV_2:
+    elif order_type == OrderType.PACBIO_LONG_READ:
+        response = pacbio_long_read_validation_service.validate(raw_order)
+    elif order_type == OrderType.SARS_COV_2:
         response = mutant_validation_service.validate(raw_order)
-    if order_type == OrderType.RNAFUSION:
+    elif order_type == OrderType.RNAFUSION:
         response = rna_fusion_validation_service.validate(raw_order)
-    if order_type == OrderType.TOMTE:
+    elif order_type == OrderType.TOMTE:
         response = tomte_validation_service.validate(raw_order)
     return jsonify(response), HTTPStatus.OK

--- a/cg/server/ext.py
+++ b/cg/server/ext.py
@@ -27,6 +27,9 @@ from cg.services.order_validation_service.workflows.mip_dna.validation_service i
 from cg.services.order_validation_service.workflows.mutant.validation_service import (
     MutantValidationService,
 )
+from cg.services.order_validation_service.workflows.pacbio_long_read.validation_service import (
+    PacbioLongReadValidationService,
+)
 from cg.services.order_validation_service.workflows.rna_fusion.validation_service import (
     RnaFusionValidationService,
 )
@@ -123,6 +126,7 @@ microbial_fastq_validation_service = MicrobialFastqValidationService(store=db)
 microsalt_validation_service = MicroSaltValidationService(store=db)
 mip_dna_validation_service = MipDnaValidationService(store=db)
 mutant_validation_service = MutantValidationService(store=db)
+pacbio_long_read_validation_service = PacbioLongReadValidationService(store=db)
 rna_fusion_validation_service = RnaFusionValidationService(store=db)
 tomte_validation_service = TomteValidationService(store=db)
 

--- a/cg/services/order_validation_service/rules/sample/rules.py
+++ b/cg/services/order_validation_service/rules/sample/rules.py
@@ -34,6 +34,9 @@ def validate_application_compatibility(
     store: Store,
     **kwargs,
 ) -> list[ApplicationNotCompatibleError]:
+    """
+    Validate that the applications of all samples in the order are compatible with the order type.
+    """
     errors: list[ApplicationNotCompatibleError] = []
     order_type: OrderType = order.order_type
     for sample_index, sample in order.enumerated_samples:
@@ -51,6 +54,7 @@ def validate_application_compatibility(
 def validate_application_exists(
     order: OrderWithSamples, store: Store, **kwargs
 ) -> list[ApplicationNotValidError]:
+    """Validate that the applications of all samples in the order exist in the database."""
     errors: list[ApplicationNotValidError] = []
     for sample_index, sample in order.enumerated_samples:
         if not store.get_application_by_tag(sample.application):
@@ -95,6 +99,7 @@ def validate_organism_exists(
 def validate_sample_names_available(
     order: OrderWithSamples, store: Store, **kwargs
 ) -> list[SampleNameNotAvailableError]:
+    """Validate that the sample names do not exists in the database under the same customer."""
     errors: list[SampleNameNotAvailableError] = []
     customer = store.get_customer_by_internal_id(order.customer)
     for sample_index, sample in order.enumerated_samples:
@@ -117,6 +122,7 @@ def validate_tube_container_name_unique(
     order: OrderWithSamples,
     **kwargs,
 ) -> list[ContainerNameRepeatedError]:
+    """Validate that the container names are unique for tube samples."""
     errors: list[ContainerNameRepeatedError] = []
     repeated_container_name_indices: list = get_indices_for_tube_repeated_container_name(order)
     for sample_index in repeated_container_name_indices:

--- a/cg/services/order_validation_service/workflows/pacbio_long_read/validation_rules.py
+++ b/cg/services/order_validation_service/workflows/pacbio_long_read/validation_rules.py
@@ -1,0 +1,29 @@
+from cg.services.order_validation_service.rules.sample.rules import (
+    validate_application_compatibility,
+    validate_application_exists,
+    validate_applications_not_archived,
+    validate_container_name_required,
+    validate_sample_names_available,
+    validate_sample_names_unique,
+    validate_tube_container_name_unique,
+    validate_volume_interval,
+    validate_volume_required,
+    validate_well_position_format,
+    validate_well_positions_required,
+    validate_wells_contain_at_most_one_sample,
+)
+
+SAMPLE_RULES: list[callable] = [
+    validate_application_compatibility,
+    validate_application_exists,
+    validate_applications_not_archived,
+    validate_container_name_required,
+    validate_sample_names_available,
+    validate_sample_names_unique,
+    validate_tube_container_name_unique,
+    validate_volume_interval,
+    validate_volume_required,
+    validate_wells_contain_at_most_one_sample,
+    validate_well_position_format,
+    validate_well_positions_required,
+]

--- a/cg/services/order_validation_service/workflows/pacbio_long_read/validation_service.py
+++ b/cg/services/order_validation_service/workflows/pacbio_long_read/validation_service.py
@@ -8,13 +8,15 @@ from cg.services.order_validation_service.utils import (
     apply_order_validation,
     apply_sample_validation,
 )
-from cg.services.order_validation_service.workflows.microsalt.models.order import MicrosaltOrder
-from cg.services.order_validation_service.workflows.microsalt.validation_rules import SAMPLE_RULES
 from cg.services.order_validation_service.workflows.order_validation_rules import ORDER_RULES
+from cg.services.order_validation_service.workflows.pacbio_long_read.models.order import PacbioOrder
+from cg.services.order_validation_service.workflows.pacbio_long_read.validation_rules import (
+    SAMPLE_RULES,
+)
 from cg.store.store import Store
 
 
-class MicroSaltValidationService(OrderValidationService):
+class PacbioLongReadValidationService(OrderValidationService):
 
     def __init__(self, store: Store):
         self.store = store
@@ -24,7 +26,7 @@ class MicroSaltValidationService(OrderValidationService):
         return create_order_validation_response(raw_order=raw_order, errors=errors)
 
     def _get_errors(self, raw_order: dict) -> ValidationErrors:
-        order, field_errors = ModelValidator.validate(order=raw_order, model=MicrosaltOrder)
+        order, field_errors = ModelValidator.validate(order=raw_order, model=PacbioOrder)
 
         if not order:
             return field_errors


### PR DESCRIPTION
## Description
Closes https://github.com/Clinical-Genomics/improve-order-flow/issues/85

### Added

- Pacbio validation service
- Sample rules for pacbio
- instantiation of the service in `ext.py`.
- Include service in endpoint

### Changed

- docstrings of some functions
- Turned if statements into elifs

### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
