### PR TITLE
(Improve order flow) Fix other alias

### DIFF
--- a/cg/services/order_validation_service/constants.py
+++ b/cg/services/order_validation_service/constants.py
@@ -8,10 +8,9 @@ class TissueBlockEnum(StrEnum):
 
 
 class ElutionBuffer(StrEnum):
-    """The choices of buffers. The way to specify 'other buffer' is not consistent in the forms."""
+    """The choices of buffers."""
 
-    OTHER_1 = "Other (add to comment)"
-    OTHER_2 = 'Other (specify in "Comments")'
+    OTHER = 'Other (specify in "Comments")'
     TRIS_HCL = "Tris-HCl"
     WATER = "Nuclease-free water"
 

--- a/cg/services/order_validation_service/constants.py
+++ b/cg/services/order_validation_service/constants.py
@@ -8,7 +8,8 @@ class TissueBlockEnum(StrEnum):
 
 
 class ElutionBuffer(StrEnum):
-    OTHER = "Other (add to comment)"
+    OTHER_1 = "Other (add to comment)"
+    OTHER_2 = 'Other (specify in "Comments")'
     TRIS_HCL = "Tris-HCl"
     WATER = "Nuclease-free water"
 

--- a/cg/services/order_validation_service/constants.py
+++ b/cg/services/order_validation_service/constants.py
@@ -10,7 +10,7 @@ class TissueBlockEnum(StrEnum):
 class ElutionBuffer(StrEnum):
     """The choices of buffers."""
 
-    OTHER = 'Other (specify in "Comments")'
+    OTHER = "Other"
     TRIS_HCL = "Tris-HCl"
     WATER = "Nuclease-free water"
 

--- a/cg/services/order_validation_service/constants.py
+++ b/cg/services/order_validation_service/constants.py
@@ -8,6 +8,8 @@ class TissueBlockEnum(StrEnum):
 
 
 class ElutionBuffer(StrEnum):
+    """The choices of buffers. The way to specify 'other buffer' is not consistent in the forms."""
+
     OTHER_1 = "Other (add to comment)"
     OTHER_2 = 'Other (specify in "Comments")'
     TRIS_HCL = "Tris-HCl"

--- a/cg/services/order_validation_service/utils.py
+++ b/cg/services/order_validation_service/utils.py
@@ -1,6 +1,6 @@
 from typing import Callable
 
-
+from cg.services.order_validation_service.constants import ElutionBuffer
 from cg.services.order_validation_service.errors.case_errors import CaseError
 from cg.services.order_validation_service.errors.case_sample_errors import CaseSampleError
 from cg.services.order_validation_service.errors.order_errors import OrderError
@@ -41,3 +41,7 @@ def apply_sample_validation(rules: list[Callable], order: Order, store: Store) -
         rule_errors: list[SampleError] = rule(order=order, store=store)
         errors.extend(rule_errors)
     return errors
+
+
+def parse_buffer(buffer: str | None) -> ElutionBuffer | None:
+    return ElutionBuffer.OTHER if buffer and buffer.startswith("Other") else buffer

--- a/cg/services/order_validation_service/workflows/balsamic/models/sample.py
+++ b/cg/services/order_validation_service/workflows/balsamic/models/sample.py
@@ -1,12 +1,11 @@
-from pydantic import Field
+from pydantic import BeforeValidator, Field
+from typing_extensions import Annotated
 
 from cg.constants.constants import GenomeVersion
 from cg.models.orders.sample_base import NAME_PATTERN, ControlEnum, SexEnum, StatusEnum
-from cg.services.order_validation_service.constants import (
-    ElutionBuffer,
-    TissueBlockEnum,
-)
+from cg.services.order_validation_service.constants import ElutionBuffer, TissueBlockEnum
 from cg.services.order_validation_service.models.sample import Sample
+from cg.services.order_validation_service.utils import parse_buffer
 
 
 class BalsamicSample(Sample):
@@ -15,7 +14,7 @@ class BalsamicSample(Sample):
     comment: str | None = None
     concentration_ng_ul: float | None = None
     control: ControlEnum | None = None
-    elution_buffer: ElutionBuffer | None = None
+    elution_buffer: Annotated[ElutionBuffer | None, BeforeValidator(parse_buffer)] = None
     formalin_fixation_time: int | None = None
     is_tumour: bool
     phenotype_groups: list[str] | None = None

--- a/cg/services/order_validation_service/workflows/fastq/models/sample.py
+++ b/cg/services/order_validation_service/workflows/fastq/models/sample.py
@@ -1,13 +1,15 @@
-from pydantic import Field
+from pydantic import BeforeValidator, Field
+from typing_extensions import Annotated
 
 from cg.models.orders.sample_base import NAME_PATTERN, PriorityEnum, SexEnum
 from cg.services.order_validation_service.constants import ElutionBuffer
 from cg.services.order_validation_service.models.sample import Sample
+from cg.services.order_validation_service.utils import parse_buffer
 
 
 class FastqSample(Sample):
     concentration_ng_ul: float | None = None
-    elution_buffer: ElutionBuffer
+    elution_buffer: Annotated[ElutionBuffer, BeforeValidator(parse_buffer)]
     priority: PriorityEnum
     quantity: int | None = None
     require_qc_ok: bool

--- a/cg/services/order_validation_service/workflows/metagenome/models/sample.py
+++ b/cg/services/order_validation_service/workflows/metagenome/models/sample.py
@@ -1,12 +1,16 @@
+from pydantic import BeforeValidator
+from typing_extensions import Annotated
+
 from cg.models.orders.sample_base import ControlEnum, PriorityEnum
 from cg.services.order_validation_service.constants import ElutionBuffer
 from cg.services.order_validation_service.models.sample import Sample
+from cg.services.order_validation_service.utils import parse_buffer
 
 
 class MetagenomeSample(Sample):
     concentration_ng_ul: float | None = None
     control: ControlEnum | None = None
-    elution_buffer: ElutionBuffer
+    elution_buffer: Annotated[ElutionBuffer, BeforeValidator(parse_buffer)]
     organism: str
     priority: PriorityEnum
     quantity: int | None = None

--- a/cg/services/order_validation_service/workflows/microbial_fastq/models/sample.py
+++ b/cg/services/order_validation_service/workflows/microbial_fastq/models/sample.py
@@ -1,11 +1,15 @@
+from pydantic import BeforeValidator
+from typing_extensions import Annotated
+
 from cg.models.orders.sample_base import ControlEnum, PriorityEnum
 from cg.services.order_validation_service.constants import ElutionBuffer
 from cg.services.order_validation_service.models.sample import Sample
+from cg.services.order_validation_service.utils import parse_buffer
 
 
 class MicrobialFastqSample(Sample):
     control: ControlEnum | None = None
-    elution_buffer: ElutionBuffer
+    elution_buffer: Annotated[ElutionBuffer, BeforeValidator(parse_buffer)]
     priority: PriorityEnum
     quantity: int | None = None
     require_qc_ok: bool

--- a/cg/services/order_validation_service/workflows/microsalt/models/sample.py
+++ b/cg/services/order_validation_service/workflows/microsalt/models/sample.py
@@ -1,13 +1,15 @@
-from pydantic import Field
+from pydantic import BeforeValidator, Field
+from typing_extensions import Annotated
 
 from cg.models.orders.sample_base import ControlEnum, PriorityEnum
-from cg.services.order_validation_service.constants import ExtractionMethod
+from cg.services.order_validation_service.constants import ElutionBuffer, ExtractionMethod
 from cg.services.order_validation_service.models.sample import Sample
+from cg.services.order_validation_service.utils import parse_buffer
 
 
 class MicrosaltSample(Sample):
     control: ControlEnum | None = None
-    elution_buffer: str
+    elution_buffer: Annotated[ElutionBuffer, BeforeValidator(parse_buffer)]
     extraction_method: ExtractionMethod
     organism: str
     priority: PriorityEnum

--- a/cg/services/order_validation_service/workflows/mip_dna/models/sample.py
+++ b/cg/services/order_validation_service/workflows/mip_dna/models/sample.py
@@ -1,14 +1,16 @@
-from pydantic import Field
+from pydantic import BeforeValidator, Field
+from typing_extensions import Annotated
 
 from cg.models.orders.sample_base import NAME_PATTERN, ControlEnum, SexEnum, StatusEnum
-from cg.services.order_validation_service.constants import TissueBlockEnum
+from cg.services.order_validation_service.constants import ElutionBuffer, TissueBlockEnum
 from cg.services.order_validation_service.models.sample import Sample
+from cg.services.order_validation_service.utils import parse_buffer
 
 
 class MipDnaSample(Sample):
     age_at_sampling: float | None = None
     control: ControlEnum | None = None
-    elution_buffer: str | None = None
+    elution_buffer: Annotated[ElutionBuffer | None, BeforeValidator(parse_buffer)] = None
     father: str | None = Field(None, pattern=NAME_PATTERN)
     formalin_fixation_time: int | None = None
     mother: str | None = Field(None, pattern=NAME_PATTERN)

--- a/cg/services/order_validation_service/workflows/mutant/models/sample.py
+++ b/cg/services/order_validation_service/workflows/mutant/models/sample.py
@@ -1,11 +1,12 @@
 from datetime import date
 
+from pydantic import BeforeValidator
+from typing_extensions import Annotated
+
 from cg.models.orders.sample_base import ControlEnum, PriorityEnum
-from cg.services.order_validation_service.constants import (
-    ElutionBuffer,
-    ExtractionMethod,
-)
+from cg.services.order_validation_service.constants import ElutionBuffer, ExtractionMethod
 from cg.services.order_validation_service.models.sample import Sample
+from cg.services.order_validation_service.utils import parse_buffer
 from cg.services.order_validation_service.workflows.mutant.constants import (
     OriginalLab,
     PreProcessingMethod,
@@ -19,7 +20,7 @@ class MutantSample(Sample):
     collection_date: date
     concentration_sample: float | None = None
     control: ControlEnum
-    elution_buffer: ElutionBuffer
+    elution_buffer: Annotated[ElutionBuffer, BeforeValidator(parse_buffer)]
     extraction_method: ExtractionMethod
     organism: str
     original_lab: OriginalLab

--- a/cg/services/order_validation_service/workflows/rna_fusion/models/sample.py
+++ b/cg/services/order_validation_service/workflows/rna_fusion/models/sample.py
@@ -1,18 +1,17 @@
-from pydantic import Field
+from pydantic import BeforeValidator, Field
+from typing_extensions import Annotated
 
 from cg.models.orders.sample_base import NAME_PATTERN, ControlEnum, SexEnum
-from cg.services.order_validation_service.constants import (
-    ElutionBuffer,
-    TissueBlockEnum,
-)
+from cg.services.order_validation_service.constants import ElutionBuffer, TissueBlockEnum
 from cg.services.order_validation_service.models.sample import Sample
+from cg.services.order_validation_service.utils import parse_buffer
 
 
 class RnaFusionSample(Sample):
     age_at_sampling: float | None = None
     concentration_ng_ul: float | None = None
     control: ControlEnum | None = None
-    elution_buffer: ElutionBuffer | None = None
+    elution_buffer: Annotated[ElutionBuffer | None, BeforeValidator(parse_buffer)] = None
     formalin_fixation_time: int | None = None
     phenotype_groups: list[str] | None = None
     phenotype_terms: list[str] | None = None

--- a/cg/services/order_validation_service/workflows/tomte/models/sample.py
+++ b/cg/services/order_validation_service/workflows/tomte/models/sample.py
@@ -1,15 +1,17 @@
-from pydantic import Field
+from pydantic import BeforeValidator, Field
+from typing_extensions import Annotated
 
 from cg.constants.constants import GenomeVersion
 from cg.models.orders.sample_base import NAME_PATTERN, ControlEnum, SexEnum, StatusEnum
-from cg.services.order_validation_service.constants import TissueBlockEnum
+from cg.services.order_validation_service.constants import ElutionBuffer, TissueBlockEnum
 from cg.services.order_validation_service.models.sample import Sample
+from cg.services.order_validation_service.utils import parse_buffer
 
 
 class TomteSample(Sample):
     age_at_sampling: float | None = None
     control: ControlEnum | None
-    elution_buffer: str | None = None
+    elution_buffer: Annotated[ElutionBuffer | None, BeforeValidator(parse_buffer)] = None
     father: str | None = Field(None, pattern=NAME_PATTERN)
     formalin_fixation_time: int | None = None
     mother: str | None = Field(None, pattern=NAME_PATTERN)


### PR DESCRIPTION
## Description

We run into issues due to the order forms not formatted the "other" buffer option in a homogeneous way:

![image](https://github.com/user-attachments/assets/7d32d18d-b823-4c64-acdc-450faa50e52b)

On top of this, the order form owners will aim to remove the "Specify in comments"/"add to comment" addition, and just exchange the buffer for anything but Nuclease-free water or Tris-HCl either way. This PR changes the enum to only have the option stating "Other" and adds a before validator to the pydantic models for parsing any buffer beginning with "Other" to this option.

### Added

-

### Changed

-

### Fixed

- Other is the only allowed formatting of the other buffer option. 
- Validator for parsing the elution buffer


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
