### PR TITLE
add(FOHM upload tags fetcher)

### DIFF
--- a/cg/meta/upload/fohm/fohm.py
+++ b/cg/meta/upload/fohm/fohm.py
@@ -205,7 +205,7 @@ class FOHMUploadAPI:
             case: Case = sample.links[0].case
             delivery_service = self._delivery_factory.build_delivery_service(
                 case=case,
-                delivery_type=DataDelivery.FASTQ,
+                delivery_type=DataDelivery.FASTQ_ANALYSIS,
                 delivery_destination=DeliveryDestination.FOHM,
                 delivery_structure=DeliveryStructure.FLAT,
             )

--- a/cg/meta/upload/fohm/fohm.py
+++ b/cg/meta/upload/fohm/fohm.py
@@ -15,7 +15,7 @@ from cg.io.csv import read_csv, write_csv_from_dict
 from cg.models.cg_config import CGConfig
 from cg.models.email import EmailInfo
 from cg.models.fohm.reports import FohmComplementaryReport, FohmPangolinReport
-from cg.services.deliver_files.constants import DeliveryDestination
+from cg.services.deliver_files.constants import DeliveryDestination, DeliveryStructure
 from cg.services.deliver_files.factory import (
     DeliveryServiceFactory,
 )
@@ -206,7 +206,8 @@ class FOHMUploadAPI:
             delivery_service = self._delivery_factory.build_delivery_service(
                 case=case,
                 delivery_type=DataDelivery.FASTQ,
-                delivery_destination=DeliveryDestination.BASE,
+                delivery_destination=DeliveryDestination.FOHM,
+                delivery_structure=DeliveryStructure.FLAT,
             )
             delivery_service.deliver_files_for_fohm_upload(
                 case=case, sample_id=sample.internal_id, delivery_base_path=self.daily_rawdata_path

--- a/cg/services/deliver_files/constants.py
+++ b/cg/services/deliver_files/constants.py
@@ -5,7 +5,19 @@ class DeliveryDestination(Enum):
     """Enum for the DeliveryDestination
     BASE: Deliver to the base folder provided in the call
     CUSTOMER: Deliver to the customer folder on hasta
+    FOHM: Deliver to the FOHM folder on hasta
     """
 
     BASE = "base"
     CUSTOMER = "customer"
+    FOHM = "fohm"
+
+
+class DeliveryStructure(Enum):
+    """Enum for the DeliveryStructure
+    FLAT: Deliver the files in a flat structure, i.e. all files in the same folder
+    NESTED: Deliver the files in a nested structure, i.e. files in folders for each sample/case
+    """
+
+    FLAT: str = "flat"
+    NESTED: str = "nested"

--- a/cg/services/deliver_files/file_fetcher/analysis_service.py
+++ b/cg/services/deliver_files/file_fetcher/analysis_service.py
@@ -42,7 +42,10 @@ class AnalysisDeliveryFileFetcher(FetchDeliveryFilesService):
         """Return a list of analysis files to be delivered for a case."""
         LOG.debug(f"[FETCH SERVICE] Fetching analysis files for case: {case_id}")
         case: Case = self.status_db.get_case_by_internal_id(internal_id=case_id)
-        analysis_case_files: list[CaseFile] = self._get_analysis_case_delivery_files(case)
+        analysis_case_files: list[CaseFile] = self._get_analysis_case_delivery_files(
+            case=case, sample_id=sample_id
+        )
+
         analysis_sample_files: list[SampleFile] = self._get_analysis_sample_delivery_files(
             case=case, sample_id=sample_id
         )
@@ -73,9 +76,11 @@ class AnalysisDeliveryFileFetcher(FetchDeliveryFilesService):
     @handle_missing_bundle_errors
     def _get_sample_files_from_case_bundle(
         self, workflow: Workflow, sample_id: str, case_id: str
-    ) -> list[SampleFile]:
+    ) -> list[SampleFile] | None:
         """Return a list of files from a case bundle with a sample id as tag."""
         sample_tags: list[set[str]] = self.tags_fetcher.fetch_tags(workflow).sample_tags
+        if not sample_tags:
+            return []
         sample_tags_with_sample_id: list[set[str]] = [tag | {sample_id} for tag in sample_tags]
         sample_files: list[File] = self.hk_api.get_files_from_latest_version_containing_tags(
             bundle_name=case_id, tags=sample_tags_with_sample_id
@@ -105,13 +110,17 @@ class AnalysisDeliveryFileFetcher(FetchDeliveryFilesService):
         return delivery_files
 
     @handle_missing_bundle_errors
-    def _get_analysis_case_delivery_files(self, case: Case) -> list[CaseFile]:
+    def _get_analysis_case_delivery_files(
+        self, case: Case, sample_id: str | None
+    ) -> list[CaseFile] | None:
         """
         Return a complete list of analysis case files to be delivered and ignore analysis sample
         files.
         """
         case_tags: list[set[str]] = self.tags_fetcher.fetch_tags(case.data_analysis).case_tags
-        sample_id_tags: list[str] = case.sample_ids
+        if not case_tags:
+            return []
+        sample_id_tags: list[str] = [sample_id] if sample_id else case.sample_ids
         case_files: list[File] = self.hk_api.get_files_from_latest_version_containing_tags(
             bundle_name=case.internal_id, tags=case_tags, excluded_tags=sample_id_tags
         )

--- a/cg/services/deliver_files/file_formatter/component_files/concatenation_service.py
+++ b/cg/services/deliver_files/file_formatter/component_files/concatenation_service.py
@@ -182,7 +182,7 @@ class SampleFileConcatenationFormatter(ComponentFormatter):
         list_of_files: list[Path] = get_all_files_in_directory_tree(delivery_path)
         for sample_name in sample_names:
             for file in list_of_files:
-                if sample_name in file.as_posix() and self._is_fastq_file(file):
+                if sample_name in file.as_posix() and self._is_lane_fastq_file(file):
                     LOG.debug(
                         f"[CONCATENATION SERVICE] Found fastq file: {file} for sample: {sample_name}"
                     )
@@ -256,7 +256,7 @@ class SampleFileConcatenationFormatter(ComponentFormatter):
             formatted_files: list[FormattedFile]: List of formatted files.
         """
         for formatted_file in formatted_files:
-            if self._is_fastq_file(formatted_file.formatted_path):
+            if self._is_lane_fastq_file(formatted_file.formatted_path):
                 formatted_file.formatted_path = concatenation_maps[formatted_file.formatted_path]
 
     @staticmethod
@@ -280,5 +280,8 @@ class SampleFileConcatenationFormatter(ComponentFormatter):
                     )
 
     @staticmethod
-    def _is_fastq_file(file_path: Path) -> bool:
-        return f"{FileFormat.FASTQ}{FileExtensions.GZIP}" in file_path.as_posix()
+    def _is_lane_fastq_file(file_path: Path) -> bool:
+        return (
+            f".*_L[0-9]{3}_R[1-2]_[0-9]+{FileExtensions.FASTQ}{FileExtensions.GZIP}"
+            in file_path.as_posix()
+        )

--- a/cg/services/deliver_files/file_formatter/component_files/concatenation_service.py
+++ b/cg/services/deliver_files/file_formatter/component_files/concatenation_service.py
@@ -1,5 +1,7 @@
 import logging
 from pathlib import Path
+import re
+
 from cg.constants.constants import ReadDirection, FileFormat, FileExtensions
 from cg.services.deliver_files.file_formatter.component_files.abstract import ComponentFormatter
 from cg.services.deliver_files.file_formatter.component_files.models import FastqFile
@@ -193,6 +195,10 @@ class SampleFileConcatenationFormatter(ComponentFormatter):
                             read_direction=self._determine_read_direction(file),
                         )
                     )
+        if not sample_paths:
+            raise FileNotFoundError(
+                f"Could not find any fastq files to concatenate in {delivery_path}."
+            )
         return sample_paths
 
     @staticmethod
@@ -281,7 +287,21 @@ class SampleFileConcatenationFormatter(ComponentFormatter):
 
     @staticmethod
     def _is_lane_fastq_file(file_path: Path) -> bool:
+        """Check if a fastq file is a from a lane and read direction.
+        Note pattern: *_L[0-9]{3}_R[1-2]_[0-9]{3}.fastq.gz
+        *_ is a wildcard for the flow cell id followed by sample name.
+        L[0-9]{3} is the lane number, i.e. L001, L002 etc.
+        R[1-2] is the read direction, i.e. R1 or R2.
+        [0-9]{3} is the trailing three digits after read direction.
+        args:
+            file_path: Path: Path to the fastq file.
+        """
+
+        pattern = f".*_L[0-9]{{3}}_R[1-2]_[0-9]{{3}}{FileExtensions.FASTQ}{FileExtensions.GZIP}"
         return (
-            f".*_L[0-9]{3}_R[1-2]_[0-9]+{FileExtensions.FASTQ}{FileExtensions.GZIP}"
-            in file_path.as_posix()
+            re.fullmatch(
+                pattern=pattern,
+                string=file_path.name,
+            )
+            is not None
         )

--- a/cg/services/deliver_files/file_formatter/component_files/mutant_service.py
+++ b/cg/services/deliver_files/file_formatter/component_files/mutant_service.py
@@ -65,6 +65,7 @@ class MutantFileFormatter(ComponentFormatter):
         """
         This functions adds the region and lab code to the file name of the formatted files.
         Note: The region and lab code is fetched from LIMS using the sample id. It is required for delivery of the files.
+        This should only be done for concatenated fastq files.
 
         args:
             formatted_files: The formatted files to add the metadata to
@@ -72,19 +73,24 @@ class MutantFileFormatter(ComponentFormatter):
         """
         appended_formatted_files: list[FormattedFile] = []
         for formatted_file in formatted_files:
-            sample_id: str = self._get_sample_id_by_original_path(
-                original_path=formatted_file.original_path, sample_files=sample_files
-            )
-            lims_meta_data = self.lims_api.get_sample_region_and_lab_code(sample_id)
+            if self.file_formatter._is_fastq_file(formatted_file.formatted_path):
+                sample_id: str = self._get_sample_id_by_original_path(
+                    original_path=formatted_file.original_path, sample_files=sample_files
+                )
+                lims_meta_data = self.lims_api.get_sample_region_and_lab_code(sample_id)
 
-            new_original_path: Path = formatted_file.formatted_path
-            new_formatted_path = Path(
-                formatted_file.formatted_path.parent,
-                f"{lims_meta_data}{formatted_file.formatted_path.name}",
-            )
-            appended_formatted_files.append(
-                FormattedFile(original_path=new_original_path, formatted_path=new_formatted_path)
-            )
+                new_original_path: Path = formatted_file.formatted_path
+                new_formatted_path = Path(
+                    formatted_file.formatted_path.parent,
+                    f"{lims_meta_data}{formatted_file.formatted_path.name}",
+                )
+                appended_formatted_files.append(
+                    FormattedFile(
+                        original_path=new_original_path, formatted_path=new_formatted_path
+                    )
+                )
+            else:
+                appended_formatted_files.append(formatted_file)
         return appended_formatted_files
 
     @staticmethod

--- a/cg/services/deliver_files/file_formatter/component_files/mutant_service.py
+++ b/cg/services/deliver_files/file_formatter/component_files/mutant_service.py
@@ -63,9 +63,9 @@ class MutantFileFormatter(ComponentFormatter):
     def _is_concatenated_file(file_path: Path) -> bool:
         """Check if the file is a concatenated file.
         Returns True if the file is a concatenated file, otherwise False.
-        regex pattern: *._R[1,2]_[0-9]+.fastq.gz
+        regex pattern: *._[1,2].fastq.gz
         *. is the sample id
-        _R[1,2] is the read direction
+        _[1,2] is the read direction
         .fastq.gz is the file extension
         args:
             file_path: The file path to check

--- a/cg/services/deliver_files/file_formatter/component_files/mutant_service.py
+++ b/cg/services/deliver_files/file_formatter/component_files/mutant_service.py
@@ -73,7 +73,7 @@ class MutantFileFormatter(ComponentFormatter):
         """
         appended_formatted_files: list[FormattedFile] = []
         for formatted_file in formatted_files:
-            if self.file_formatter._is_fastq_file(formatted_file.formatted_path):
+            if self.file_formatter._is_lane_fastq_file(formatted_file.formatted_path):
                 sample_id: str = self._get_sample_id_by_original_path(
                     original_path=formatted_file.original_path, sample_files=sample_files
                 )

--- a/cg/services/deliver_files/tag_fetcher/fohm_upload_service.py
+++ b/cg/services/deliver_files/tag_fetcher/fohm_upload_service.py
@@ -1,5 +1,4 @@
-from cg.constants import Workflow
-from cg.constants.housekeeper_tags import SequencingFileTag
+from cg.constants import Workflow, SequencingFileTag
 from cg.services.deliver_files.tag_fetcher.abstract import FetchDeliveryFileTagsService
 from cg.services.deliver_files.tag_fetcher.error_handling import handle_tag_errors
 from cg.services.deliver_files.tag_fetcher.models import DeliveryFileTags
@@ -10,11 +9,25 @@ class FOHMUploadTagsFetcher(FetchDeliveryFileTagsService):
 
     @handle_tag_errors
     def fetch_tags(self, workflow: Workflow) -> DeliveryFileTags:
-        """Fetch the tags for the bam files to deliver."""
+        """
+        Fetch the tags for the bam files to deliver.
+        NOTE: workflow raw data here is required to fit the implementation of the raw data delivery file fetcher.
+        if workflow is MUTANT, return tags for consensus-sample and vcf-report to fetch sample files from the case bundle.
+        if workflow is RAW_DATA, return tags for fastq to fetch fastq files from the sample bundle.
+        Required since some of the sample specific files are stored on the case bundle, but also fastq files.
+        Not separating these would cause fetching of case bundle fastq files if present.
+        """
         self._validate_workflow(workflow=workflow)
-        return DeliveryFileTags(
-            case_tags=None,
-            sample_tags=[{SequencingFileTag.FASTQ, "consensus-sample", "vcf-report"}],
+        return (
+            DeliveryFileTags(
+                case_tags=None,
+                sample_tags=[{"consensus-sample", "vcf-report"}],
+            )
+            if workflow == Workflow.MUTANT
+            else DeliveryFileTags(
+                case_tags=None,
+                sample_tags=[{SequencingFileTag.FASTQ}],
+            )
         )
 
     @staticmethod

--- a/cg/services/deliver_files/tag_fetcher/fohm_upload_service.py
+++ b/cg/services/deliver_files/tag_fetcher/fohm_upload_service.py
@@ -1,0 +1,25 @@
+from cg.constants import Workflow
+from cg.constants.housekeeper_tags import SequencingFileTag
+from cg.services.deliver_files.tag_fetcher.abstract import FetchDeliveryFileTagsService
+from cg.services.deliver_files.tag_fetcher.error_handling import handle_tag_errors
+from cg.services.deliver_files.tag_fetcher.models import DeliveryFileTags
+
+
+class FOHMUploadTagsFetcher(FetchDeliveryFileTagsService):
+    """Class to fetch tags for FOHM upload files."""
+
+    @handle_tag_errors
+    def fetch_tags(self, workflow: Workflow) -> DeliveryFileTags:
+        """Fetch the tags for the bam files to deliver."""
+        self._validate_workflow(workflow=workflow)
+        return DeliveryFileTags(
+            case_tags=[{"fohm-delivery"}],
+            sample_tags=[{SequencingFileTag.FASTQ}],
+        )
+
+    @staticmethod
+    def _validate_workflow(workflow: Workflow):
+        """Validate the workflow."""
+        if workflow != Workflow.MUTANT:
+            raise ValueError(f"Workflow {workflow} is not supported for FOHM upload file delivery.")
+        return workflow

--- a/cg/services/deliver_files/tag_fetcher/fohm_upload_service.py
+++ b/cg/services/deliver_files/tag_fetcher/fohm_upload_service.py
@@ -13,8 +13,8 @@ class FOHMUploadTagsFetcher(FetchDeliveryFileTagsService):
         """Fetch the tags for the bam files to deliver."""
         self._validate_workflow(workflow=workflow)
         return DeliveryFileTags(
-            case_tags=[{"fohm-delivery"}],
-            sample_tags=[{SequencingFileTag.FASTQ}],
+            case_tags=None,
+            sample_tags=[{SequencingFileTag.FASTQ, "consensus-sample", "vcf-report"}],
         )
 
     @staticmethod

--- a/cg/services/deliver_files/tag_fetcher/fohm_upload_service.py
+++ b/cg/services/deliver_files/tag_fetcher/fohm_upload_service.py
@@ -23,6 +23,6 @@ class FOHMUploadTagsFetcher(FetchDeliveryFileTagsService):
         Validate the workflow.
         NOTE: workflow raw data here is required to fit the implementation of the raw data delivery file fetcher.
         """
-        if workflow != Workflow.MUTANT or workflow != Workflow.RAW_DATA:
+        if workflow not in [Workflow.MUTANT, Workflow.RAW_DATA]:
             raise ValueError(f"Workflow {workflow} is not supported for FOHM upload file delivery.")
         return workflow

--- a/cg/services/deliver_files/tag_fetcher/fohm_upload_service.py
+++ b/cg/services/deliver_files/tag_fetcher/fohm_upload_service.py
@@ -19,7 +19,10 @@ class FOHMUploadTagsFetcher(FetchDeliveryFileTagsService):
 
     @staticmethod
     def _validate_workflow(workflow: Workflow):
-        """Validate the workflow."""
-        if workflow != Workflow.MUTANT:
+        """
+        Validate the workflow.
+        NOTE: workflow raw data here is required to fit the implementation of the raw data delivery file fetcher.
+        """
+        if workflow != Workflow.MUTANT or workflow != Workflow.RAW_DATA:
             raise ValueError(f"Workflow {workflow} is not supported for FOHM upload file delivery.")
         return workflow

--- a/cg/services/deliver_files/tag_fetcher/fohm_upload_service.py
+++ b/cg/services/deliver_files/tag_fetcher/fohm_upload_service.py
@@ -16,12 +16,15 @@ class FOHMUploadTagsFetcher(FetchDeliveryFileTagsService):
         if workflow is RAW_DATA, return tags for fastq to fetch fastq files from the sample bundle.
         Required since some of the sample specific files are stored on the case bundle, but also fastq files.
         Not separating these would cause fetching of case bundle fastq files if present.
+
+        args:
+            workflow: Workflow: The workflow to fetch tags
         """
         self._validate_workflow(workflow=workflow)
         return (
             DeliveryFileTags(
                 case_tags=None,
-                sample_tags=[{"consensus-sample", "vcf-report"}],
+                sample_tags=[{"consensus-sample"}, {"vcf-report"}],
             )
             if workflow == Workflow.MUTANT
             else DeliveryFileTags(
@@ -35,6 +38,8 @@ class FOHMUploadTagsFetcher(FetchDeliveryFileTagsService):
         """
         Validate the workflow.
         NOTE: workflow raw data here is required to fit the implementation of the raw data delivery file fetcher.
+        args:
+            workflow: Workflow: The workflow to validate.
         """
         if workflow not in [Workflow.MUTANT, Workflow.RAW_DATA]:
             raise ValueError(f"Workflow {workflow} is not supported for FOHM upload file delivery.")

--- a/cg/services/fastq_concatenation_service/fastq_concatenation_service.py
+++ b/cg/services/fastq_concatenation_service/fastq_concatenation_service.py
@@ -13,8 +13,8 @@ LOG = logging.getLogger(__name__)
 class FastqConcatenationService:
     """Fastq file concatenation service."""
 
-    @staticmethod
     def concatenate(
+        self,
         sample_id: str,
         fastq_directory: Path,
         forward_output_path: Path,
@@ -32,6 +32,9 @@ class FastqConcatenationService:
         """
         LOG.debug(
             f"[Concatenation Service] Concatenating fastq files for {sample_id} in {fastq_directory}"
+        )
+        self._concatenation_paths_exist(
+            forward_output_path=forward_output_path, reverse_output_path=reverse_output_path
         )
         temp_forward: Path | None = concatenate_fastq_reads_for_direction(
             directory=fastq_directory, sample_id=sample_id, direction=ReadDirection.FORWARD
@@ -55,3 +58,11 @@ class FastqConcatenationService:
         if temp_reverse:
             LOG.info(f"Concatenated reverse reads to {reverse_output_path}")
             temp_reverse.rename(reverse_output_path)
+
+    @staticmethod
+    def _concatenation_paths_exist(forward_output_path: Path, reverse_output_path: Path) -> bool:
+        """Check if the concatenation paths exist."""
+        if forward_output_path.exists() or reverse_output_path.exists():
+            raise FileExistsError(
+                "The concatenation paths already exist in the directory. This could cause data loss or duplication issues. Please remove the existing files before concatenating."
+            )

--- a/cg/services/fastq_concatenation_service/fastq_concatenation_service.py
+++ b/cg/services/fastq_concatenation_service/fastq_concatenation_service.py
@@ -13,8 +13,8 @@ LOG = logging.getLogger(__name__)
 class FastqConcatenationService:
     """Fastq file concatenation service."""
 
+    @staticmethod
     def concatenate(
-        self,
         sample_id: str,
         fastq_directory: Path,
         forward_output_path: Path,
@@ -32,9 +32,6 @@ class FastqConcatenationService:
         """
         LOG.debug(
             f"[Concatenation Service] Concatenating fastq files for {sample_id} in {fastq_directory}"
-        )
-        self._concatenation_paths_exist(
-            forward_output_path=forward_output_path, reverse_output_path=reverse_output_path
         )
         temp_forward: Path | None = concatenate_fastq_reads_for_direction(
             directory=fastq_directory, sample_id=sample_id, direction=ReadDirection.FORWARD
@@ -58,11 +55,3 @@ class FastqConcatenationService:
         if temp_reverse:
             LOG.info(f"Concatenated reverse reads to {reverse_output_path}")
             temp_reverse.rename(reverse_output_path)
-
-    @staticmethod
-    def _concatenation_paths_exist(forward_output_path: Path, reverse_output_path: Path) -> bool:
-        """Check if the concatenation paths exist."""
-        if forward_output_path.exists() or reverse_output_path.exists():
-            raise FileExistsError(
-                "The concatenation paths already exist in the directory. This could cause data loss or duplication issues. Please remove the existing files before concatenating."
-            )

--- a/tests/fixture_plugins/delivery_fixtures/bundle_fixtures.py
+++ b/tests/fixture_plugins/delivery_fixtures/bundle_fixtures.py
@@ -109,8 +109,12 @@ def hk_delivery_case_bundle_fohm_upload(
     sample_id: str,
     another_sample_id: str,
     delivery_report_file: Path,
-    delivery_cram_file: Path,
-    delivery_another_cram_file: Path,
+    delivery_case_fastq_file: Path,
+    delivery_another_case_fastq_file: Path,
+    delivery_consensus_sample_file: Path,
+    delivery_another_consensus_sample_file: Path,
+    delivery_vcf_report_file: Path,
+    delivery_another_vcf_report_file: Path,
 ) -> dict:
     case_hk_bundle: dict[str, Any] = deepcopy(case_hk_bundle_no_files)
     case_hk_bundle["name"] = case_id
@@ -122,12 +126,32 @@ def hk_delivery_case_bundle_fohm_upload(
         },
         {
             "archive": False,
-            "path": delivery_cram_file.as_posix(),
+            "path": delivery_case_fastq_file.as_posix(),
+            "tags": ["fastq", sample_id],
+        },
+        {
+            "archive": False,
+            "path": delivery_another_case_fastq_file.as_posix(),
+            "tags": ["fastq", another_sample_id],
+        },
+        {
+            "archive": False,
+            "path": delivery_consensus_sample_file.as_posix(),
             "tags": ["consensus-sample", sample_id],
         },
         {
             "archive": False,
-            "path": delivery_another_cram_file.as_posix(),
+            "path": delivery_another_consensus_sample_file.as_posix(),
+            "tags": ["consensus-sample", another_sample_id],
+        },
+        {
+            "archive": False,
+            "path": delivery_vcf_report_file.as_posix(),
+            "tags": ["vcf-report", sample_id],
+        },
+        {
+            "archive": False,
+            "path": delivery_another_vcf_report_file.as_posix(),
             "tags": ["vcf-report", another_sample_id],
         },
     ]

--- a/tests/fixture_plugins/delivery_fixtures/bundle_fixtures.py
+++ b/tests/fixture_plugins/delivery_fixtures/bundle_fixtures.py
@@ -100,3 +100,35 @@ def hk_delivery_case_bundle(
         },
     ]
     return case_hk_bundle
+
+
+@pytest.fixture
+def hk_delivery_case_bundle_fohm_upload(
+    case_hk_bundle_no_files: dict[str, Any],
+    case_id: str,
+    sample_id: str,
+    another_sample_id: str,
+    delivery_report_file: Path,
+    delivery_cram_file: Path,
+    delivery_another_cram_file: Path,
+) -> dict:
+    case_hk_bundle: dict[str, Any] = deepcopy(case_hk_bundle_no_files)
+    case_hk_bundle["name"] = case_id
+    case_hk_bundle["files"] = [
+        {
+            "archive": False,
+            "path": delivery_report_file.as_posix(),
+            "tags": [HK_DELIVERY_REPORT_TAG, case_id],
+        },
+        {
+            "archive": False,
+            "path": delivery_cram_file.as_posix(),
+            "tags": ["consensus-sample", sample_id],
+        },
+        {
+            "archive": False,
+            "path": delivery_another_cram_file.as_posix(),
+            "tags": ["vcf-report", another_sample_id],
+        },
+    ]
+    return case_hk_bundle

--- a/tests/fixture_plugins/delivery_fixtures/context_fixtures.py
+++ b/tests/fixture_plugins/delivery_fixtures/context_fixtures.py
@@ -21,16 +21,33 @@ def delivery_housekeeper_api(
     hk_delivery_case_bundle: dict[str, Any],
 ) -> HousekeeperAPI:
     """Delivery API Housekeeper context."""
+    hk_api: HousekeeperAPI = real_housekeeper_api
+    helpers.ensure_hk_bundle(store=hk_api, bundle_data=hk_delivery_sample_bundle, include=True)
     helpers.ensure_hk_bundle(
-        store=real_housekeeper_api, bundle_data=hk_delivery_sample_bundle, include=True
+        store=hk_api, bundle_data=hk_delivery_another_sample_bundle, include=True
+    )
+    helpers.ensure_hk_bundle(store=hk_api, bundle_data=hk_delivery_case_bundle, include=True)
+    return hk_api
+
+
+@pytest.fixture
+def delivery_fohm_upload_housekeeper_api(
+    real_housekeeper_api: HousekeeperAPI,
+    helpers: StoreHelpers,
+    hk_delivery_case_bundle_fohm_upload: dict[str, Any],
+    hk_delivery_sample_bundle: dict[str, Any],
+    hk_delivery_another_sample_bundle: dict[str, Any],
+) -> HousekeeperAPI:
+    """Delivery API Housekeeper context."""
+    hk_api: HousekeeperAPI = real_housekeeper_api
+    helpers.ensure_hk_bundle(store=hk_api, bundle_data=hk_delivery_sample_bundle, include=True)
+    helpers.ensure_hk_bundle(
+        store=hk_api, bundle_data=hk_delivery_another_sample_bundle, include=True
     )
     helpers.ensure_hk_bundle(
-        store=real_housekeeper_api, bundle_data=hk_delivery_another_sample_bundle, include=True
+        store=hk_api, bundle_data=hk_delivery_case_bundle_fohm_upload, include=True
     )
-    helpers.ensure_hk_bundle(
-        store=real_housekeeper_api, bundle_data=hk_delivery_case_bundle, include=True
-    )
-    return real_housekeeper_api
+    return hk_api
 
 
 @pytest.fixture
@@ -140,6 +157,68 @@ def delivery_store_microsalt(
 
     for sample_microsalt in [sample, another_sample, sample_not_enough_reads]:
         helpers.add_relationship(store=status_db, case=case, sample=sample_microsalt)
+
+    return status_db
+
+
+@pytest.fixture
+def delivery_store_mutant(
+    cg_context: CGConfig,
+    helpers: StoreHelpers,
+    case_id: str,
+    no_sample_case_id: str,
+    case_name: str,
+    sample_id: str,
+    another_sample_id: str,
+    sample_id_not_enough_reads: str,
+    total_sequenced_reads_pass: int,
+    total_sequenced_reads_not_pass: int,
+    sample_name: str,
+    another_sample_name: str,
+    microbial_application_tag: str,
+) -> Store:
+    """Delivery API StatusDB context for Mutant."""
+    status_db: Store = cg_context.status_db
+
+    # Error case without samples
+    helpers.add_case(store=status_db, internal_id=no_sample_case_id, name=no_sample_case_id)
+
+    # Mutant case with fastq-analysis as data delivery
+    case: Case = helpers.add_case(
+        store=status_db,
+        internal_id=case_id,
+        name=case_name,
+        data_analysis=Workflow.MUTANT,
+        data_delivery=DataDelivery.FASTQ_ANALYSIS,
+    )
+    order: Order = helpers.add_order(store=status_db, customer_id=case.customer.id, ticket_id=1)
+    case.orders.append(order)
+    # Mutant samples
+    sample: Sample = helpers.add_sample(
+        store=status_db,
+        application_tag=microbial_application_tag,
+        internal_id=sample_id,
+        name=sample_name,
+        reads=total_sequenced_reads_pass,
+    )
+
+    another_sample: Sample = helpers.add_sample(
+        store=status_db,
+        application_tag=microbial_application_tag,
+        internal_id=another_sample_id,
+        name=another_sample_name,
+        reads=total_sequenced_reads_pass,
+    )
+
+    sample_not_enough_reads: Sample = helpers.add_sample(
+        store=status_db,
+        application_tag=microbial_application_tag,
+        internal_id=sample_id_not_enough_reads,
+        reads=total_sequenced_reads_not_pass,
+    )
+
+    for sample_mutant in [sample, another_sample, sample_not_enough_reads]:
+        helpers.add_relationship(store=status_db, case=case, sample=sample_mutant)
 
     return status_db
 

--- a/tests/fixture_plugins/delivery_fixtures/delivery_files_models_fixtures.py
+++ b/tests/fixture_plugins/delivery_fixtures/delivery_files_models_fixtures.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 import pytest
@@ -361,20 +362,20 @@ def swap_file_paths_with_inbox_paths(
 
 
 @pytest.fixture
-def lims_naming_matadata() -> str:
+def lims_naming_metadata() -> str:
     return "01_SE100_"
 
 
 @pytest.fixture
 def expected_mutant_formatted_files(
-    expected_concatenated_fastq_formatted_files, lims_naming_matadata
+    expected_concatenated_fastq_formatted_files, lims_naming_metadata
 ) -> list[FormattedFile]:
     unique_combinations = []
     for formatted_file in expected_concatenated_fastq_formatted_files:
         formatted_file.original_path = formatted_file.formatted_path
         formatted_file.formatted_path = Path(
             formatted_file.formatted_path.parent,
-            f"{lims_naming_matadata}{formatted_file.formatted_path.name}",
+            f"{lims_naming_metadata}{formatted_file.formatted_path.name}",
         )
         if formatted_file not in unique_combinations:
             unique_combinations.append(formatted_file)

--- a/tests/fixture_plugins/delivery_fixtures/delivery_files_models_fixtures.py
+++ b/tests/fixture_plugins/delivery_fixtures/delivery_files_models_fixtures.py
@@ -302,10 +302,10 @@ def fastq_concatenation_sample_files(
     sample_files = []
     for sample_id, sample_name in sample_data:
         fastq_paths: list[Path] = [
-            Path(tmp_path, inbox, f"{sample_id}_1_R1_1.fastq.gz"),
-            Path(tmp_path, inbox, f"{sample_id}_2_R1_1.fastq.gz"),
-            Path(tmp_path, inbox, f"{sample_id}_1_R2_1.fastq.gz"),
-            Path(tmp_path, inbox, f"{sample_id}_2_R2_1.fastq.gz"),
+            Path(tmp_path, inbox, f"{sample_id}_L001_R1_001.fastq.gz"),
+            Path(tmp_path, inbox, f"{sample_id}_L002_R1_001.fastq.gz"),
+            Path(tmp_path, inbox, f"{sample_id}_L001_R2_001.fastq.gz"),
+            Path(tmp_path, inbox, f"{sample_id}_L002_R2_001.fastq.gz"),
         ]
 
         sample_files.extend(
@@ -328,10 +328,10 @@ def fastq_concatenation_sample_files_flat(tmp_path: Path) -> list[SampleFile]:
     sample_files = []
     for sample_id, sample_name in sample_data:
         fastq_paths: list[Path] = [
-            Path(tmp_path, f"{sample_id}_1_R1_1.fastq.gz"),
-            Path(tmp_path, f"{sample_id}_2_R1_1.fastq.gz"),
-            Path(tmp_path, f"{sample_id}_1_R2_1.fastq.gz"),
-            Path(tmp_path, f"{sample_id}_2_R2_1.fastq.gz"),
+            Path(tmp_path, f"{sample_id}_L001_R1_001.fastq.gz"),
+            Path(tmp_path, f"{sample_id}_L002_R1_001.fastq.gz"),
+            Path(tmp_path, f"{sample_id}_L001_R2_001.fastq.gz"),
+            Path(tmp_path, f"{sample_id}_L002_R2_001.fastq.gz"),
         ]
 
         sample_files.extend(

--- a/tests/fixture_plugins/delivery_fixtures/delivery_formatted_files_fixtures.py
+++ b/tests/fixture_plugins/delivery_fixtures/delivery_formatted_files_fixtures.py
@@ -85,10 +85,10 @@ def expected_concatenated_fastq_formatted_files(
         replaced_sample_file_name: str = sample_file.file_path.name.replace(
             sample_file.sample_id, sample_file.sample_name
         )
-        replaced_sample_file_name = replaced_sample_file_name.replace("1_R1_1", "1")
-        replaced_sample_file_name = replaced_sample_file_name.replace("2_R1_1", "1")
-        replaced_sample_file_name = replaced_sample_file_name.replace("1_R2_1", "2")
-        replaced_sample_file_name = replaced_sample_file_name.replace("2_R2_1", "2")
+        replaced_sample_file_name = replaced_sample_file_name.replace("L001_R1_001", "1")
+        replaced_sample_file_name = replaced_sample_file_name.replace("L002_R1_001", "1")
+        replaced_sample_file_name = replaced_sample_file_name.replace("L001_R2_001", "2")
+        replaced_sample_file_name = replaced_sample_file_name.replace("L002_R2_001", "2")
         formatted_file_path = Path(
             sample_file.file_path.parent, sample_file.sample_name, replaced_sample_file_name
         )
@@ -107,10 +107,10 @@ def expected_concatenated_fastq_flat_formatted_files(
         replaced_sample_file_name: str = sample_file.file_path.name.replace(
             sample_file.sample_id, sample_file.sample_name
         )
-        replaced_sample_file_name = replaced_sample_file_name.replace("1_R1_1", "1")
-        replaced_sample_file_name = replaced_sample_file_name.replace("2_R1_1", "1")
-        replaced_sample_file_name = replaced_sample_file_name.replace("1_R2_1", "2")
-        replaced_sample_file_name = replaced_sample_file_name.replace("2_R2_1", "2")
+        replaced_sample_file_name = replaced_sample_file_name.replace("L001_R1_001", "1")
+        replaced_sample_file_name = replaced_sample_file_name.replace("L002_R1_001", "1")
+        replaced_sample_file_name = replaced_sample_file_name.replace("L001_R2_001", "2")
+        replaced_sample_file_name = replaced_sample_file_name.replace("L002_R2_001", "2")
         formatted_file_path = Path(sample_file.file_path.parent, replaced_sample_file_name)
         formatted_files.append(
             FormattedFile(original_path=sample_file.file_path, formatted_path=formatted_file_path)

--- a/tests/fixture_plugins/delivery_fixtures/delivery_services_fixtures.py
+++ b/tests/fixture_plugins/delivery_fixtures/delivery_services_fixtures.py
@@ -74,20 +74,6 @@ def bam_data_delivery_service(
 
 
 @pytest.fixture
-def fohm_data_delivery_service(
-    delivery_housekeeper_api: HousekeeperAPI,
-    delivery_store_microsalt: Store,
-) -> RawDataAndAnalysisDeliveryFileFetcher:
-    """Fixture to get an instance of FetchFastqDeliveryFilesService."""
-    tag_service = FOHMUploadTagsFetcher()
-    return RawDataAndAnalysisDeliveryFileFetcher(
-        hk_api=delivery_housekeeper_api,
-        status_db=delivery_store_microsalt,
-        tags_fetcher=tag_service,
-    )
-
-
-@pytest.fixture
 def bam_data_delivery_service_no_housekeeper_bundle(
     real_housekeeper_api: HousekeeperAPI,
     delivery_store_microsalt: Store,
@@ -97,6 +83,20 @@ def bam_data_delivery_service_no_housekeeper_bundle(
     return RawDataDeliveryFileFetcher(
         hk_api=real_housekeeper_api,
         status_db=delivery_store_microsalt,
+        tags_fetcher=tag_service,
+    )
+
+
+@pytest.fixture
+def fohm_data_delivery_service(
+    delivery_fohm_upload_housekeeper_api: HousekeeperAPI,
+    delivery_store_mutant: Store,
+) -> RawDataAndAnalysisDeliveryFileFetcher:
+    """Fixture to get an instance of FetchFastqDeliveryFilesService."""
+    tag_service = FOHMUploadTagsFetcher()
+    return RawDataAndAnalysisDeliveryFileFetcher(
+        hk_api=delivery_fohm_upload_housekeeper_api,
+        status_db=delivery_store_mutant,
         tags_fetcher=tag_service,
     )
 

--- a/tests/fixture_plugins/delivery_fixtures/delivery_services_fixtures.py
+++ b/tests/fixture_plugins/delivery_fixtures/delivery_services_fixtures.py
@@ -1,10 +1,14 @@
 import pytest
 
 from cg.apps.housekeeper.hk import HousekeeperAPI
+from cg.services.deliver_files.file_fetcher.analysis_raw_data_service import (
+    RawDataAndAnalysisDeliveryFileFetcher,
+)
 from cg.services.deliver_files.file_formatter.destination.base_service import BaseDeliveryFormatter
 from cg.services.deliver_files.tag_fetcher.bam_service import (
     BamDeliveryTagsFetcher,
 )
+from cg.services.deliver_files.tag_fetcher.fohm_upload_service import FOHMUploadTagsFetcher
 from cg.services.deliver_files.tag_fetcher.sample_and_case_service import (
     SampleAndCaseDeliveryTagsFetcher,
 )
@@ -63,6 +67,20 @@ def bam_data_delivery_service(
     """Fixture to get an instance of FetchFastqDeliveryFilesService."""
     tag_service = BamDeliveryTagsFetcher()
     return RawDataDeliveryFileFetcher(
+        hk_api=delivery_housekeeper_api,
+        status_db=delivery_store_microsalt,
+        tags_fetcher=tag_service,
+    )
+
+
+@pytest.fixture
+def fohm_data_delivery_service(
+    delivery_housekeeper_api: HousekeeperAPI,
+    delivery_store_microsalt: Store,
+) -> RawDataAndAnalysisDeliveryFileFetcher:
+    """Fixture to get an instance of FetchFastqDeliveryFilesService."""
+    tag_service = FOHMUploadTagsFetcher()
+    return RawDataAndAnalysisDeliveryFileFetcher(
         hk_api=delivery_housekeeper_api,
         status_db=delivery_store_microsalt,
         tags_fetcher=tag_service,

--- a/tests/fixture_plugins/delivery_fixtures/path_fixtures.py
+++ b/tests/fixture_plugins/delivery_fixtures/path_fixtures.py
@@ -9,7 +9,7 @@ from cg.constants import FileExtensions
 
 @pytest.fixture
 def delivery_fastq_file(tmp_path: Path, sample_id: str) -> Path:
-    file = Path(tmp_path, f"{sample_id}_R1_001{FileExtensions.FASTQ_GZ}")
+    file = Path(tmp_path, f"{sample_id}_L001_R1_001{FileExtensions.FASTQ_GZ}")
     file.touch()
     return file
 
@@ -34,7 +34,7 @@ def delivery_bam_file(tmp_path: Path, sample_id: str) -> Path:
 
 @pytest.fixture
 def delivery_another_fastq_file(tmp_path: Path, another_sample_id: str) -> Path:
-    file = Path(tmp_path, f"{another_sample_id}_R1_001{FileExtensions.FASTQ_GZ}")
+    file = Path(tmp_path, f"{another_sample_id}L001_R1_001{FileExtensions.FASTQ_GZ}")
     file.touch()
     return file
 

--- a/tests/fixture_plugins/delivery_fixtures/path_fixtures.py
+++ b/tests/fixture_plugins/delivery_fixtures/path_fixtures.py
@@ -15,6 +15,17 @@ def delivery_fastq_file(tmp_path: Path, sample_id: str) -> Path:
 
 
 @pytest.fixture
+def delivery_case_fastq_file(tmp_path: Path, sample_id: str) -> Path:
+    """
+    This represents a fastq file stored on a case bundle. Mutant stored file like this in the past.
+    This fixture servers the purpose to make sure these files are not fetched during delivery.
+    """
+    file = Path(tmp_path, f"{sample_id}_concat_{FileExtensions.FASTQ_GZ}")
+    file.touch()
+    return file
+
+
+@pytest.fixture
 def delivery_bam_file(tmp_path: Path, sample_id: str) -> Path:
     file = Path(tmp_path, f"{sample_id}_R1_001{FileExtensions.BAM}")
     file.touch()
@@ -24,6 +35,17 @@ def delivery_bam_file(tmp_path: Path, sample_id: str) -> Path:
 @pytest.fixture
 def delivery_another_fastq_file(tmp_path: Path, another_sample_id: str) -> Path:
     file = Path(tmp_path, f"{another_sample_id}_R1_001{FileExtensions.FASTQ_GZ}")
+    file.touch()
+    return file
+
+
+@pytest.fixture
+def delivery_another_case_fastq_file(tmp_path: Path, another_sample_id: str) -> Path:
+    """
+    This represents a fastq file stored on a case bundle. Mutant stored file like this in the past.
+    This fixture servers the purpose to make sure these files are not fetched during delivery.
+    """
+    file = Path(tmp_path, f"{another_sample_id}_concat_{FileExtensions.FASTQ_GZ}")
     file.touch()
     return file
 
@@ -73,3 +95,31 @@ def delivery_another_cram_file(tmp_path: Path, another_sample_id: str) -> Path:
 @pytest.fixture
 def delivery_ticket_dir_path(tmp_path: Path, ticket_id: str) -> Path:
     return Path(tmp_path, ticket_id)
+
+
+@pytest.fixture
+def delivery_consensus_sample_file(tmp_path: Path, sample_id: str) -> Path:
+    file = Path(tmp_path, f"{sample_id}_consensus_sample{FileExtensions.VCF}")
+    file.touch()
+    return file
+
+
+@pytest.fixture
+def delivery_another_consensus_sample_file(tmp_path: Path, another_sample_id: str) -> Path:
+    file = Path(tmp_path, f"{another_sample_id}_consensus_sample{FileExtensions.VCF}")
+    file.touch()
+    return file
+
+
+@pytest.fixture
+def delivery_vcf_report_file(tmp_path: Path, sample_id: str) -> Path:
+    file = Path(tmp_path, f"{sample_id}_vcf_report{FileExtensions.VCF}")
+    file.touch()
+    return file
+
+
+@pytest.fixture
+def delivery_another_vcf_report_file(tmp_path: Path, another_sample_id: str) -> Path:
+    file = Path(tmp_path, f"{another_sample_id}_vcf_report{FileExtensions.VCF}")
+    file.touch()
+    return file

--- a/tests/services/fastq_file_service/conftest.py
+++ b/tests/services/fastq_file_service/conftest.py
@@ -39,6 +39,19 @@ def fastqs_dir(tmp_path: Path, sample_id: str) -> Path:
 
 
 @pytest.fixture
+def fastq_dir_existing_concatenated_files(tmp_path: Path, sample_id: str) -> Path:
+    fastq_dir: Path = create_fastqs_directory(tmp_path=tmp_path)
+    create_fastq_files(
+        fastq_dir=fastq_dir, number_forward_reads=3, number_reverse_reads=3, sample_id=sample_id
+    )
+    forward_output_path = Path(fastq_dir, "forward.fastq.gz")
+    reverse_output_path = Path(fastq_dir, "reverse.fastq.gz")
+    forward_output_path.write_text("Existing concatenated forward reads")
+    reverse_output_path.write_text("Existing concatenated reverse reads")
+    return fastq_dir
+
+
+@pytest.fixture
 def fastqs_forward(tmp_path: Path, sample_id: str) -> Path:
     """Return a directory with only forward reads."""
     fastq_dir: Path = create_fastqs_directory(tmp_path=tmp_path)

--- a/tests/services/fastq_file_service/test_fastq_file_service.py
+++ b/tests/services/fastq_file_service/test_fastq_file_service.py
@@ -63,20 +63,24 @@ def test_concatenate(
 
 
 def test_concatenate_when_output_exists(
-    fastq_file_service: FastqConcatenationService, fastqs_dir: Path, sample_id: str
+    fastq_file_service: FastqConcatenationService,
+    fastq_dir_existing_concatenated_files: Path,
+    sample_id: str,
 ):
     # GIVEN a directory with forward and reverse reads
-    existing_fastq_files = list(fastqs_dir.iterdir())
-    existing_forward: Path = existing_fastq_files[0]
+    forward_output_path = Path(fastq_dir_existing_concatenated_files, "forward.fastq.gz")
+    reverse_output_path = Path(fastq_dir_existing_concatenated_files, "reverse.fastq.gz")
 
     # GIVEN that the forward output file already exists
-    forward_output_path = existing_forward
-    reverse_output_path = Path(fastqs_dir, "reverse.fastq.gz")
+    assert forward_output_path.exists()
+    assert reverse_output_path.exists()
+    assert "Existing" in forward_output_path.read_text()
+    assert "Existing" in reverse_output_path.read_text()
 
     # WHEN concatenating the reads
     fastq_file_service.concatenate(
         sample_id=sample_id,
-        fastq_directory=fastqs_dir,
+        fastq_directory=fastq_dir_existing_concatenated_files,
         forward_output_path=forward_output_path,
         reverse_output_path=reverse_output_path,
         remove_raw=True,
@@ -89,10 +93,12 @@ def test_concatenate_when_output_exists(
     # THEN the concatenated forward reads only contain forward reads
     assert "forward" in forward_output_path.read_text()
     assert "reverse" not in forward_output_path.read_text()
+    assert "Existing" not in forward_output_path.read_text()
 
     # THEN the concatenated reverse reads only contain reverse reads
     assert "reverse" in reverse_output_path.read_text()
     assert "forward" not in reverse_output_path.read_text()
+    assert "Existing" not in reverse_output_path.read_text()
 
 
 def test_concatenate_missing_reverse(

--- a/tests/services/fastq_file_service/test_fastq_file_service.py
+++ b/tests/services/fastq_file_service/test_fastq_file_service.py
@@ -67,6 +67,7 @@ def test_concatenate_when_output_exists(
     fastq_dir_existing_concatenated_files: Path,
     sample_id: str,
 ):
+    """Test that existing concatenated files are overwritten when already existing."""
     # GIVEN a directory with forward and reverse reads
     forward_output_path = Path(fastq_dir_existing_concatenated_files, "forward.fastq.gz")
     reverse_output_path = Path(fastq_dir_existing_concatenated_files, "reverse.fastq.gz")

--- a/tests/services/file_delivery/delivery_file_service/test_service_builder.py
+++ b/tests/services/file_delivery/delivery_file_service/test_service_builder.py
@@ -5,6 +5,7 @@ from _pytest.fixtures import FixtureRequest
 from pydantic import BaseModel
 
 from cg.constants import DataDelivery, Workflow
+from cg.services.deliver_files.constants import DeliveryDestination, DeliveryStructure
 from cg.services.deliver_files.deliver_files_service.deliver_files_service import (
     DeliverFilesService,
 )
@@ -26,10 +27,20 @@ from cg.services.deliver_files.file_formatter.component_files.concatenation_serv
 from cg.services.deliver_files.file_formatter.component_files.sample_service import (
     SampleFileFormatter,
 )
+from cg.services.deliver_files.file_formatter.path_name.abstract import PathNameFormatter
+from cg.services.deliver_files.file_formatter.path_name.flat_structure import (
+    FlatStructurePathFormatter,
+)
+from cg.services.deliver_files.file_formatter.path_name.nested_structure import (
+    NestedStructurePathFormatter,
+)
+from cg.services.deliver_files.file_mover.abstract import DestinationFilesMover
+from cg.services.deliver_files.file_mover.base_service import BaseDestinationFilesMover
 from cg.services.deliver_files.file_mover.customer_inbox_service import (
     CustomerInboxDestinationFilesMover,
 )
 from cg.services.deliver_files.tag_fetcher.abstract import FetchDeliveryFileTagsService
+from cg.services.deliver_files.tag_fetcher.fohm_upload_service import FOHMUploadTagsFetcher
 from cg.services.deliver_files.tag_fetcher.sample_and_case_service import (
     SampleAndCaseDeliveryTagsFetcher,
 )
@@ -43,11 +54,14 @@ class DeliveryServiceScenario(BaseModel):
     delivery_type: DataDelivery
     expected_tag_fetcher: type[FetchDeliveryFileTagsService]
     expected_file_fetcher: type[FetchDeliveryFilesService]
-    expected_file_mover: type[CustomerInboxDestinationFilesMover]
+    expected_file_mover: type[DestinationFilesMover]
     expected_sample_file_formatter: type[
         SampleFileFormatter | SampleFileConcatenationFormatter | MutantFileFormatter
     ]
+    expected_path_name_formatter: type[PathNameFormatter]
     store_name: str
+    delivery_destination: DeliveryDestination
+    delivery_structure: DeliveryStructure
 
 
 @pytest.mark.parametrize(
@@ -61,7 +75,10 @@ class DeliveryServiceScenario(BaseModel):
             expected_file_fetcher=RawDataDeliveryFileFetcher,
             expected_file_mover=CustomerInboxDestinationFilesMover,
             expected_sample_file_formatter=SampleFileConcatenationFormatter,
+            expected_path_name_formatter=NestedStructurePathFormatter,
             store_name="microbial_store",
+            delivery_destination=DeliveryDestination.CUSTOMER,
+            delivery_structure=DeliveryStructure.NESTED,
         ),
         DeliveryServiceScenario(
             app_tag="VWGDPTR001",
@@ -71,7 +88,10 @@ class DeliveryServiceScenario(BaseModel):
             expected_file_fetcher=AnalysisDeliveryFileFetcher,
             expected_file_mover=CustomerInboxDestinationFilesMover,
             expected_sample_file_formatter=MutantFileFormatter,
+            expected_path_name_formatter=NestedStructurePathFormatter,
             store_name="mutant_store",
+            delivery_destination=DeliveryDestination.CUSTOMER,
+            delivery_structure=DeliveryStructure.NESTED,
         ),
         DeliveryServiceScenario(
             app_tag="PANKTTR020",
@@ -81,10 +101,39 @@ class DeliveryServiceScenario(BaseModel):
             expected_file_fetcher=RawDataAndAnalysisDeliveryFileFetcher,
             expected_file_mover=CustomerInboxDestinationFilesMover,
             expected_sample_file_formatter=SampleFileFormatter,
+            expected_path_name_formatter=NestedStructurePathFormatter,
             store_name="applications_store",
+            delivery_destination=DeliveryDestination.CUSTOMER,
+            delivery_structure=DeliveryStructure.NESTED,
+        ),
+        DeliveryServiceScenario(
+            app_tag="VWGDPTR001",
+            data_analysis=Workflow.MUTANT,
+            delivery_type=DataDelivery.ANALYSIS_FILES,
+            expected_tag_fetcher=FOHMUploadTagsFetcher,
+            expected_file_fetcher=AnalysisDeliveryFileFetcher,
+            expected_file_mover=BaseDestinationFilesMover,
+            expected_sample_file_formatter=MutantFileFormatter,
+            expected_path_name_formatter=FlatStructurePathFormatter,
+            store_name="mutant_store",
+            delivery_destination=DeliveryDestination.FOHM,
+            delivery_structure=DeliveryStructure.FLAT,
+        ),
+        DeliveryServiceScenario(
+            app_tag="VWGDPTR001",
+            data_analysis=Workflow.MUTANT,
+            delivery_type=DataDelivery.ANALYSIS_FILES,
+            expected_tag_fetcher=SampleAndCaseDeliveryTagsFetcher,
+            expected_file_fetcher=AnalysisDeliveryFileFetcher,
+            expected_file_mover=BaseDestinationFilesMover,
+            expected_sample_file_formatter=MutantFileFormatter,
+            expected_path_name_formatter=FlatStructurePathFormatter,
+            store_name="mutant_store",
+            delivery_destination=DeliveryDestination.BASE,
+            delivery_structure=DeliveryStructure.FLAT,
         ),
     ],
-    ids=["microbial-fastq", "SARS-COV2", "Targeted"],
+    ids=["microbial-fastq", "SARS-COV2", "Targeted", "FOHM Upload", "base"],
 )
 def test_build_delivery_service(scenario: DeliveryServiceScenario, request: FixtureRequest):
     # GIVEN a delivery service builder with mocked store and hk_api
@@ -106,7 +155,11 @@ def test_build_delivery_service(scenario: DeliveryServiceScenario, request: Fixt
     ]
 
     # WHEN building a delivery service
-    delivery_service: DeliverFilesService = builder.build_delivery_service(case=case_mock)
+    delivery_service: DeliverFilesService = builder.build_delivery_service(
+        case=case_mock,
+        delivery_destination=scenario.delivery_destination,
+        delivery_structure=scenario.delivery_structure,
+    )
 
     # THEN the correct file formatter and file fetcher services are used
     assert isinstance(delivery_service.file_manager.tags_fetcher, scenario.expected_tag_fetcher)
@@ -116,3 +169,12 @@ def test_build_delivery_service(scenario: DeliveryServiceScenario, request: Fixt
         delivery_service.file_formatter.sample_file_formatter,
         scenario.expected_sample_file_formatter,
     )
+    if not isinstance(delivery_service.file_formatter.sample_file_formatter, MutantFileFormatter):
+        assert isinstance(
+            delivery_service.file_formatter.sample_file_formatter.path_name_formatter,
+            scenario.expected_path_name_formatter,
+        )
+        assert isinstance(
+            delivery_service.file_formatter.case_file_formatter.path_name_formatter,
+            scenario.expected_path_name_formatter,
+        )

--- a/tests/services/file_delivery/file_fetcher/test_file_fetching_service.py
+++ b/tests/services/file_delivery/file_fetcher/test_file_fetching_service.py
@@ -8,8 +8,9 @@ from cg.services.deliver_files.file_fetcher.models import DeliveryFiles
 
 
 @pytest.mark.parametrize(
-    "expected_delivery_files,delivery_file_service,sample_id",
+    "expected_delivery_files,delivery_file_service,sample_id_to_fetch",
     [
+        ("expected_fohm_delivery_files", "fohm_data_delivery_service", "empty_sample"),
         ("expected_fastq_delivery_files", "raw_data_delivery_service", "empty_sample"),
         ("expected_analysis_delivery_files", "analysis_delivery_service", "empty_sample"),
         ("expected_bam_delivery_files", "bam_data_delivery_service", "empty_sample"),
@@ -19,7 +20,7 @@ from cg.services.deliver_files.file_fetcher.models import DeliveryFiles
 def test_get_files_to_deliver(
     expected_delivery_files: DeliveryFiles,
     delivery_file_service: FetchDeliveryFilesService,
-    sample_id: str | None,
+    sample_id_to_fetch: str | None,
     case_id: str,
     request,
 ):
@@ -27,7 +28,7 @@ def test_get_files_to_deliver(
     # GIVEN a case id, samples that are present in Housekeeper and a delivery service
     delivery_file_service = request.getfixturevalue(delivery_file_service)
     expected_delivery_files = request.getfixturevalue(expected_delivery_files)
-    sample_id = request.getfixturevalue(sample_id)
+    sample_id: str | None = request.getfixturevalue(sample_id_to_fetch)
 
     # WHEN getting the files to deliver
     delivery_files: DeliveryFiles = delivery_file_service.get_files_to_deliver(

--- a/tests/services/file_delivery/file_formatter/component_files/test_formatter_utils.py
+++ b/tests/services/file_delivery/file_formatter/component_files/test_formatter_utils.py
@@ -104,7 +104,7 @@ def test_component_formatters(
 def test_mutant_file_formatter(
     mutant_moved_files: list[SampleFile],
     expected_mutant_formatted_files: list[FormattedFile],
-    lims_naming_matadata: str,
+    lims_naming_metadata: str,
 ):
     # GIVEN existing ticket directory path and a customer inbox
     ticket_dir_path: Path = mutant_moved_files[0].file_path.parent
@@ -115,7 +115,7 @@ def test_mutant_file_formatter(
         moved_file.file_path.touch()
 
     lims_mock = Mock()
-    lims_mock.get_sample_region_and_lab_code.return_value = lims_naming_matadata
+    lims_mock.get_sample_region_and_lab_code.return_value = lims_naming_metadata
     file_formatter = MutantFileFormatter(
         file_manager=FileManager(),
         file_formatter=SampleFileConcatenationFormatter(

--- a/tests/services/file_delivery/tag_fetcher/test_tag_service.py
+++ b/tests/services/file_delivery/tag_fetcher/test_tag_service.py
@@ -10,6 +10,7 @@ from cg.services.deliver_files.tag_fetcher.bam_service import (
 from cg.services.deliver_files.tag_fetcher.exc import (
     FetchDeliveryFileTagsError,
 )
+from cg.services.deliver_files.tag_fetcher.fohm_upload_service import FOHMUploadTagsFetcher
 from cg.services.deliver_files.tag_fetcher.models import DeliveryFileTags
 from cg.services.deliver_files.tag_fetcher.sample_and_case_service import (
     SampleAndCaseDeliveryTagsFetcher,
@@ -64,3 +65,15 @@ def test_bam_delivery_tags_fetcher():
     # THEN assert that the tags are fetched
     assert tags.case_tags is None
     assert tags.sample_tags == [{"bam"}]
+
+
+def test_fohm_upload_tags_fetcher():
+    # GIVEN a tag fetcher
+    test_fetcher = FOHMUploadTagsFetcher()
+
+    # WHEN fetching the tags for the files to deliver
+    tags: DeliveryFileTags = test_fetcher.fetch_tags(Workflow.MUTANT)
+
+    # THEN assert that the tags are fetched
+    assert tags.case_tags is None
+    assert tags.sample_tags == [{"consensus-sample", "vcf-report"}]

--- a/tests/services/file_delivery/tag_fetcher/test_tag_service.py
+++ b/tests/services/file_delivery/tag_fetcher/test_tag_service.py
@@ -76,4 +76,4 @@ def test_fohm_upload_tags_fetcher():
 
     # THEN assert that the tags are fetched
     assert tags.case_tags is None
-    assert tags.sample_tags == [{"consensus-sample", "vcf-report"}]
+    assert tags.sample_tags == [{"consensus-sample"}, {"vcf-report"}]


### PR DESCRIPTION
## Description

The FOHM upload requires different files from the housekeeper bundle than an ordinary mutant file delivery.

This PR addresses the need for a different file tag fetcher

### Added

- FOHMUploadFileTagFetcher
- DestinationStructure enum
- Expanded tests for delivery service factory
- Documentation


### Changed

- Changes the way the pathnameformatters are retrieved from a destination base to a structure based approach. This was needed as the destination and structure were becoming intertwined but would need to serve different purposes.

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b fohm-upload-file-fetcher -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
