### PR TITLE
(Improve order flow) Make ticket id a private attribute

### DIFF
--- a/cg/services/order_validation_service/errors/order_errors.py
+++ b/cg/services/order_validation_service/errors/order_errors.py
@@ -11,11 +11,6 @@ class UserNotAssociatedWithCustomerError(OrderError):
     message: str = "User does not belong to customer"
 
 
-class TicketNumberRequiredError(OrderError):
-    field: str = "ticket_number"
-    message: str = "Ticket number is required"
-
-
 class CustomerCannotSkipReceptionControlError(OrderError):
     field: str = "skip_reception_control"
     message: str = "Customer cannot skip reception control"

--- a/cg/services/order_validation_service/models/order.py
+++ b/cg/services/order_validation_service/models/order.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, PrivateAttr, model_validator
 
 from cg.constants import DataDelivery
 from cg.models.orders.constants import OrderType
@@ -14,7 +14,7 @@ class Order(BaseModel):
     order_type: OrderType = Field(alias="project_type")
     name: str = Field(min_length=1)
     skip_reception_control: bool = False
-    ticket_number: str | None = Field(None, pattern=TICKET_PATTERN)
+    _ticket_number: int | None = PrivateAttr(default=None)
     user_id: int
 
     @model_validator(mode="before")

--- a/cg/services/order_validation_service/models/order.py
+++ b/cg/services/order_validation_service/models/order.py
@@ -3,8 +3,6 @@ from pydantic import BaseModel, Field, PrivateAttr, model_validator
 from cg.constants import DataDelivery
 from cg.models.orders.constants import OrderType
 
-TICKET_PATTERN = r"^#\d{4,}"
-
 
 class Order(BaseModel):
     comment: str | None = None
@@ -14,7 +12,7 @@ class Order(BaseModel):
     order_type: OrderType = Field(alias="project_type")
     name: str = Field(min_length=1)
     skip_reception_control: bool = False
-    _ticket_number: int | None = PrivateAttr(default=None)
+    _generated_ticket_id: int | None = PrivateAttr(default=None)
     user_id: int
 
     @model_validator(mode="before")

--- a/cg/services/order_validation_service/rules/order/rules.py
+++ b/cg/services/order_validation_service/rules/order/rules.py
@@ -3,14 +3,10 @@ from cg.services.order_validation_service.errors.order_errors import (
     CustomerDoesNotExistError,
     OrderError,
     OrderNameRequiredError,
-    TicketNumberRequiredError,
     UserNotAssociatedWithCustomerError,
 )
 from cg.services.order_validation_service.models.order import Order
-from cg.services.order_validation_service.rules.order.utils import (
-    is_order_name_missing,
-    is_ticket_number_missing,
-)
+from cg.services.order_validation_service.rules.order.utils import is_order_name_missing
 from cg.store.store import Store
 
 
@@ -35,17 +31,6 @@ def validate_user_belongs_to_customer(order: Order, store: Store, **kwargs) -> l
     errors: list[OrderError] = []
     if not has_access:
         error = UserNotAssociatedWithCustomerError()
-        errors.append(error)
-    return errors
-
-
-def validate_ticket_number_required_if_connected(
-    order: Order,
-    **kwargs,
-) -> list[TicketNumberRequiredError]:
-    errors: list[TicketNumberRequiredError] = []
-    if is_ticket_number_missing(order):
-        error = TicketNumberRequiredError()
         errors.append(error)
     return errors
 

--- a/cg/services/order_validation_service/workflows/order_validation_rules.py
+++ b/cg/services/order_validation_service/workflows/order_validation_rules.py
@@ -1,14 +1,11 @@
 from cg.services.order_validation_service.rules.order.rules import (
     validate_customer_can_skip_reception_control,
     validate_customer_exists,
-    validate_ticket_number_required_if_connected,
     validate_user_belongs_to_customer,
 )
-
 
 ORDER_RULES: list[callable] = [
     validate_customer_can_skip_reception_control,
     validate_customer_exists,
-    validate_ticket_number_required_if_connected,
     validate_user_belongs_to_customer,
 ]

--- a/cg/services/orders/store_order_services/store_fastq_order_service.py
+++ b/cg/services/orders/store_order_services/store_fastq_order_service.py
@@ -57,7 +57,7 @@ class StoreFastqOrderService(StoreOrderService):
 
     def store_items_in_status(self, order: FastqOrder) -> list[Sample]:
         """Store fastq samples in the status database including family connection and delivery"""
-        ticket_id: str | None = order.ticket_number
+        ticket_id: str | None = order._ticket_number
         customer: Customer = self.status_db.get_customer_by_internal_id(
             customer_internal_id=order.customer
         )

--- a/cg/services/orders/store_order_services/store_fastq_order_service.py
+++ b/cg/services/orders/store_order_services/store_fastq_order_service.py
@@ -57,7 +57,7 @@ class StoreFastqOrderService(StoreOrderService):
 
     def store_items_in_status(self, order: FastqOrder) -> list[Sample]:
         """Store fastq samples in the status database including family connection and delivery"""
-        ticket_id: str | None = order._ticket_number
+        ticket_id: str | None = order._generated_ticket_id
         customer: Customer = self.status_db.get_customer_by_internal_id(
             customer_internal_id=order.customer
         )

--- a/cg/services/orders/store_order_services/store_microbial_fastq_order_service.py
+++ b/cg/services/orders/store_order_services/store_microbial_fastq_order_service.py
@@ -76,7 +76,7 @@ class StoreMicrobialFastqOrderService(StoreOrderService):
         return case
 
     def _create_db_order(self, order: MicrobialFastqOrder) -> Order:
-        ticket_id: str = order.ticket_number
+        ticket_id: str = order._generated_ticket_id
         customer: Customer = self.status_db.get_customer_by_internal_id(
             customer_internal_id=order.customer
         )

--- a/tests/fixture_plugins/orders_fixtures/status_data_fixtures.py
+++ b/tests/fixture_plugins/orders_fixtures/status_data_fixtures.py
@@ -94,7 +94,7 @@ def valid_microbial_fastq_order(ticket_id: str) -> MicrobialFastqOrder:
         samples=[sample_1, sample_2, sample_3],
         name="MicrobialFastqOrder",
     )
-    order.ticket_number = ticket_id
+    order._generated_ticket_id = ticket_id
     return order
 
 

--- a/tests/fixture_plugins/orders_fixtures/status_data_fixtures.py
+++ b/tests/fixture_plugins/orders_fixtures/status_data_fixtures.py
@@ -112,5 +112,5 @@ def tomte_status_data(
 @pytest.fixture
 def fastq_order(fastq_order_to_submit: dict) -> FastqOrder:
     fastq_order = FastqOrder.model_validate(fastq_order_to_submit)
-    fastq_order.ticket_number = 123456
+    fastq_order._ticket_number = 123456
     return fastq_order

--- a/tests/fixture_plugins/orders_fixtures/status_data_fixtures.py
+++ b/tests/fixture_plugins/orders_fixtures/status_data_fixtures.py
@@ -112,5 +112,5 @@ def tomte_status_data(
 @pytest.fixture
 def fastq_order(fastq_order_to_submit: dict) -> FastqOrder:
     fastq_order = FastqOrder.model_validate(fastq_order_to_submit)
-    fastq_order._ticket_number = 123456
+    fastq_order._generated_ticket_id = 123456
     return fastq_order

--- a/tests/services/order_validation_service/conftest.py
+++ b/tests/services/order_validation_service/conftest.py
@@ -42,16 +42,17 @@ def create_case(samples: list[TomteSample]) -> TomteCase:
 
 
 def create_tomte_order(cases: list[TomteCase]) -> TomteOrder:
-    return TomteOrder(
+    order = TomteOrder(
         connect_to_ticket=True,
         delivery_type=TomteDeliveryType.FASTQ,
         name="order_name",
-        ticket_number="#12345",
         project_type=OrderType.TOMTE,
         user_id=1,
         customer="cust000",
         cases=cases,
     )
+    order._ticket_number = 123456
+    return order
 
 
 @pytest.fixture

--- a/tests/services/order_validation_service/conftest.py
+++ b/tests/services/order_validation_service/conftest.py
@@ -51,7 +51,7 @@ def create_tomte_order(cases: list[TomteCase]) -> TomteOrder:
         customer="cust000",
         cases=cases,
     )
-    order._ticket_number = 123456
+    order._generated_ticket_id = 123456
     return order
 
 

--- a/tests/services/order_validation_service/test_order_rules.py
+++ b/tests/services/order_validation_service/test_order_rules.py
@@ -1,29 +1,8 @@
-from cg.services.order_validation_service.errors.order_errors import (
-    OrderNameRequiredError,
-    TicketNumberRequiredError,
-)
+from cg.services.order_validation_service.errors.order_errors import OrderNameRequiredError
 from cg.services.order_validation_service.models.order import Order
 from cg.services.order_validation_service.rules.order.rules import (
     validate_name_required_for_new_order,
-    validate_ticket_number_required_if_connected,
 )
-
-
-def test_ticket_is_required(valid_order: Order):
-    # GIVEN an order that should be connected to a ticket but is missing a ticket number
-    valid_order.connect_to_ticket = True
-    valid_order.ticket_number = None
-
-    # WHEN validating the order
-    errors: list[TicketNumberRequiredError] = validate_ticket_number_required_if_connected(
-        valid_order
-    )
-
-    # THEN an error should be returned
-    assert errors
-
-    # THEN the error should be about the ticket number
-    assert isinstance(errors[0], TicketNumberRequiredError)
 
 
 def test_order_name_is_required(valid_order: Order):


### PR DESCRIPTION
## Description

Ticket id is not something that customers provide, so it should be a private attribute

### Added

-

### Changed

-

### Fixed

- ticket_id is a private attribute on the Order model


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
