### PR TITLE
(Improve order flow) Patch control parsing

### DIFF
--- a/cg/services/order_validation_service/utils.py
+++ b/cg/services/order_validation_service/utils.py
@@ -1,5 +1,6 @@
 from typing import Callable
 
+from cg.models.orders.sample_base import ControlEnum
 from cg.services.order_validation_service.constants import ElutionBuffer
 from cg.services.order_validation_service.errors.case_errors import CaseError
 from cg.services.order_validation_service.errors.case_sample_errors import CaseSampleError
@@ -45,3 +46,7 @@ def apply_sample_validation(rules: list[Callable], order: Order, store: Store) -
 
 def parse_buffer(buffer: str | None) -> ElutionBuffer | None:
     return ElutionBuffer.OTHER if buffer and buffer.startswith("Other") else buffer
+
+
+def parse_control(control: ControlEnum | None) -> ControlEnum:
+    return control or ControlEnum.not_control

--- a/cg/services/order_validation_service/utils.py
+++ b/cg/services/order_validation_service/utils.py
@@ -49,4 +49,5 @@ def parse_buffer(buffer: str | None) -> ElutionBuffer | None:
 
 
 def parse_control(control: ControlEnum | None) -> ControlEnum:
+    """Convert the control value into one of the Enum values if it's None."""
     return control or ControlEnum.not_control

--- a/cg/services/order_validation_service/workflows/balsamic/models/sample.py
+++ b/cg/services/order_validation_service/workflows/balsamic/models/sample.py
@@ -4,7 +4,7 @@ from typing_extensions import Annotated
 from cg.models.orders.sample_base import NAME_PATTERN, ControlEnum, SexEnum, StatusEnum
 from cg.services.order_validation_service.constants import ElutionBuffer, TissueBlockEnum
 from cg.services.order_validation_service.models.sample import Sample
-from cg.services.order_validation_service.utils import parse_buffer
+from cg.services.order_validation_service.utils import parse_buffer, parse_control
 
 
 class BalsamicSample(Sample):
@@ -12,7 +12,7 @@ class BalsamicSample(Sample):
     capture_kit: str | None = None
     comment: str | None = None
     concentration_ng_ul: float | None = None
-    control: ControlEnum | None = None
+    control: Annotated[ControlEnum, BeforeValidator(parse_control)] = ControlEnum.not_control
     elution_buffer: Annotated[ElutionBuffer | None, BeforeValidator(parse_buffer)] = None
     formalin_fixation_time: int | None = None
     phenotype_groups: list[str] | None = None

--- a/cg/services/order_validation_service/workflows/fluffy/models/sample.py
+++ b/cg/services/order_validation_service/workflows/fluffy/models/sample.py
@@ -1,11 +1,15 @@
+from pydantic import BeforeValidator
+from typing_extensions import Annotated
+
 from cg.models.orders.sample_base import ControlEnum, PriorityEnum
 from cg.services.order_validation_service.constants import IndexEnum
 from cg.services.order_validation_service.models.sample import Sample
+from cg.services.order_validation_service.utils import parse_control
 
 
 class FluffySample(Sample):
     concentration_sample: float | None = None
-    control: ControlEnum | None = None
+    control: Annotated[ControlEnum, BeforeValidator(parse_control)] = ControlEnum.not_control
     priority: PriorityEnum
     index: IndexEnum
     index_number: str | None

--- a/cg/services/order_validation_service/workflows/metagenome/models/sample.py
+++ b/cg/services/order_validation_service/workflows/metagenome/models/sample.py
@@ -4,12 +4,12 @@ from typing_extensions import Annotated
 from cg.models.orders.sample_base import ControlEnum, PriorityEnum
 from cg.services.order_validation_service.constants import ElutionBuffer
 from cg.services.order_validation_service.models.sample import Sample
-from cg.services.order_validation_service.utils import parse_buffer
+from cg.services.order_validation_service.utils import parse_buffer, parse_control
 
 
 class MetagenomeSample(Sample):
     concentration_ng_ul: float | None = None
-    control: ControlEnum | None = None
+    control: Annotated[ControlEnum, BeforeValidator(parse_control)] = ControlEnum.not_control
     elution_buffer: Annotated[ElutionBuffer, BeforeValidator(parse_buffer)]
     organism: str
     priority: PriorityEnum

--- a/cg/services/order_validation_service/workflows/microbial_fastq/models/sample.py
+++ b/cg/services/order_validation_service/workflows/microbial_fastq/models/sample.py
@@ -4,11 +4,11 @@ from typing_extensions import Annotated
 from cg.models.orders.sample_base import ControlEnum, PriorityEnum
 from cg.services.order_validation_service.constants import ElutionBuffer
 from cg.services.order_validation_service.models.sample import Sample
-from cg.services.order_validation_service.utils import parse_buffer
+from cg.services.order_validation_service.utils import parse_buffer, parse_control
 
 
 class MicrobialFastqSample(Sample):
-    control: ControlEnum | None = None
+    control: Annotated[ControlEnum, BeforeValidator(parse_control)] = ControlEnum.not_control
     elution_buffer: Annotated[ElutionBuffer, BeforeValidator(parse_buffer)]
     priority: PriorityEnum
     quantity: int | None = None

--- a/cg/services/order_validation_service/workflows/microsalt/models/sample.py
+++ b/cg/services/order_validation_service/workflows/microsalt/models/sample.py
@@ -4,11 +4,11 @@ from typing_extensions import Annotated
 from cg.models.orders.sample_base import ControlEnum, PriorityEnum
 from cg.services.order_validation_service.constants import ElutionBuffer, ExtractionMethod
 from cg.services.order_validation_service.models.sample import Sample
-from cg.services.order_validation_service.utils import parse_buffer
+from cg.services.order_validation_service.utils import parse_buffer, parse_control
 
 
 class MicrosaltSample(Sample):
-    control: ControlEnum | None = None
+    control: Annotated[ControlEnum, BeforeValidator(parse_control)] = ControlEnum.not_control
     elution_buffer: Annotated[ElutionBuffer, BeforeValidator(parse_buffer)]
     extraction_method: ExtractionMethod
     organism: str

--- a/cg/services/order_validation_service/workflows/mip_dna/models/sample.py
+++ b/cg/services/order_validation_service/workflows/mip_dna/models/sample.py
@@ -4,12 +4,12 @@ from typing_extensions import Annotated
 from cg.models.orders.sample_base import NAME_PATTERN, ControlEnum, SexEnum, StatusEnum
 from cg.services.order_validation_service.constants import ElutionBuffer, TissueBlockEnum
 from cg.services.order_validation_service.models.sample import Sample
-from cg.services.order_validation_service.utils import parse_buffer
+from cg.services.order_validation_service.utils import parse_buffer, parse_control
 
 
 class MipDnaSample(Sample):
     age_at_sampling: float | None = None
-    control: ControlEnum | None = None
+    control: Annotated[ControlEnum, BeforeValidator(parse_control)] = ControlEnum.not_control
     elution_buffer: Annotated[ElutionBuffer | None, BeforeValidator(parse_buffer)] = None
     father: str | None = Field(None, pattern=NAME_PATTERN)
     formalin_fixation_time: int | None = None

--- a/cg/services/order_validation_service/workflows/mip_rna/models/sample.py
+++ b/cg/services/order_validation_service/workflows/mip_rna/models/sample.py
@@ -4,13 +4,13 @@ from typing_extensions import Annotated
 from cg.models.orders.sample_base import NAME_PATTERN, ControlEnum, SexEnum
 from cg.services.order_validation_service.constants import ElutionBuffer, TissueBlockEnum
 from cg.services.order_validation_service.models.sample import Sample
-from cg.services.order_validation_service.utils import parse_buffer
+from cg.services.order_validation_service.utils import parse_buffer, parse_control
 
 
 class MipRnaSample(Sample):
     age_at_sampling: float | None = None
     concentration_ng_ul: float | None = None
-    control: ControlEnum
+    control: Annotated[ControlEnum, BeforeValidator(parse_control)] = ControlEnum.not_control
     elution_buffer: Annotated[ElutionBuffer | None, BeforeValidator(parse_buffer)] = None
     formalin_fixation_time: int | None = None
     phenotype_groups: list[str] | None = None

--- a/cg/services/order_validation_service/workflows/mutant/models/sample.py
+++ b/cg/services/order_validation_service/workflows/mutant/models/sample.py
@@ -6,7 +6,7 @@ from typing_extensions import Annotated
 from cg.models.orders.sample_base import ControlEnum, PriorityEnum
 from cg.services.order_validation_service.constants import ElutionBuffer, ExtractionMethod
 from cg.services.order_validation_service.models.sample import Sample
-from cg.services.order_validation_service.utils import parse_buffer
+from cg.services.order_validation_service.utils import parse_buffer, parse_control
 from cg.services.order_validation_service.workflows.mutant.constants import (
     OriginalLab,
     PreProcessingMethod,
@@ -19,7 +19,7 @@ from cg.services.order_validation_service.workflows.mutant.constants import (
 class MutantSample(Sample):
     collection_date: date
     concentration_sample: float | None = None
-    control: ControlEnum
+    control: Annotated[ControlEnum, BeforeValidator(parse_control)] = ControlEnum.not_control
     elution_buffer: Annotated[ElutionBuffer, BeforeValidator(parse_buffer)]
     extraction_method: ExtractionMethod
     organism: str

--- a/cg/services/order_validation_service/workflows/rml/models/sample.py
+++ b/cg/services/order_validation_service/workflows/rml/models/sample.py
@@ -1,9 +1,13 @@
+from pydantic import BeforeValidator
+from typing_extensions import Annotated
+
 from cg.models.orders.sample_base import ControlEnum, PriorityEnum
 from cg.services.order_validation_service.models.sample import Sample
+from cg.services.order_validation_service.utils import parse_control
 
 
 class RmlSample(Sample):
-    control: ControlEnum | None = None
+    control: Annotated[ControlEnum, BeforeValidator(parse_control)] = ControlEnum.not_control
     index: str
     index_number: int
     pool: str

--- a/cg/services/order_validation_service/workflows/rna_fusion/models/sample.py
+++ b/cg/services/order_validation_service/workflows/rna_fusion/models/sample.py
@@ -4,13 +4,13 @@ from typing_extensions import Annotated
 from cg.models.orders.sample_base import NAME_PATTERN, ControlEnum, SexEnum
 from cg.services.order_validation_service.constants import ElutionBuffer, TissueBlockEnum
 from cg.services.order_validation_service.models.sample import Sample
-from cg.services.order_validation_service.utils import parse_buffer
+from cg.services.order_validation_service.utils import parse_buffer, parse_control
 
 
 class RnaFusionSample(Sample):
     age_at_sampling: float | None = None
     concentration_ng_ul: float | None = None
-    control: ControlEnum | None = None
+    control: Annotated[ControlEnum, BeforeValidator(parse_control)] = ControlEnum.not_control
     elution_buffer: Annotated[ElutionBuffer | None, BeforeValidator(parse_buffer)] = None
     formalin_fixation_time: int | None = None
     phenotype_groups: list[str] | None = None

--- a/cg/services/order_validation_service/workflows/taxprofiler/models/sample.py
+++ b/cg/services/order_validation_service/workflows/taxprofiler/models/sample.py
@@ -4,12 +4,12 @@ from typing_extensions import Annotated
 from cg.models.orders.sample_base import ControlEnum, PriorityEnum
 from cg.services.order_validation_service.constants import ElutionBuffer
 from cg.services.order_validation_service.models.sample import Sample
-from cg.services.order_validation_service.utils import parse_buffer
+from cg.services.order_validation_service.utils import parse_buffer, parse_control
 
 
 class TaxprofilerSample(Sample):
     concentration_ng_ul: float | None = None
-    control: ControlEnum | None = None
+    control: Annotated[ControlEnum, BeforeValidator(parse_control)] = ControlEnum.not_control
     elution_buffer: Annotated[ElutionBuffer, BeforeValidator(parse_buffer)]
     organism: str
     priority: PriorityEnum

--- a/cg/services/order_validation_service/workflows/tomte/models/sample.py
+++ b/cg/services/order_validation_service/workflows/tomte/models/sample.py
@@ -5,12 +5,12 @@ from cg.constants.constants import GenomeVersion
 from cg.models.orders.sample_base import NAME_PATTERN, ControlEnum, SexEnum, StatusEnum
 from cg.services.order_validation_service.constants import ElutionBuffer, TissueBlockEnum
 from cg.services.order_validation_service.models.sample import Sample
-from cg.services.order_validation_service.utils import parse_buffer
+from cg.services.order_validation_service.utils import parse_buffer, parse_control
 
 
 class TomteSample(Sample):
     age_at_sampling: float | None = None
-    control: ControlEnum | None
+    control: Annotated[ControlEnum, BeforeValidator(parse_control)] = ControlEnum.not_control
     elution_buffer: Annotated[ElutionBuffer | None, BeforeValidator(parse_buffer)] = None
     father: str | None = Field(None, pattern=NAME_PATTERN)
     formalin_fixation_time: int | None = None


### PR DESCRIPTION
## Description

We have some discrepancies between order types in whether the control is required or not. This PR solves it by adding a blank string as default.

### Added

-

### Changed

-

### Fixed

- Parsing of control options standardised.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
