### PR TITLE
Make type of ticket clear in store services

### DIFF
--- a/cg/services/orders/store_order_services/store_fastq_order_service.py
+++ b/cg/services/orders/store_order_services/store_fastq_order_service.py
@@ -65,9 +65,8 @@ class StoreFastqOrderService(StoreOrderService):
         case: Case = self.status_db.get_case_by_name_and_customer(
             customer=customer, case_name=str(ticket_id)
         )
-        status_db_order = Order(
+        status_db_order: Order = self.status_db.add_order(
             customer=customer,
-            order_date=datetime.now(),
             ticket_id=ticket_id,
         )
         with self.status_db.session.no_autoflush:

--- a/cg/services/orders/store_order_services/store_microbial_fastq_order_service.py
+++ b/cg/services/orders/store_order_services/store_microbial_fastq_order_service.py
@@ -24,7 +24,7 @@ class StoreMicrobialFastqOrderService(StoreOrderService):
         """Store the order in the statusDB and LIMS, return the database samples and LIMS info."""
         project_data, lims_map = self.lims.process_lims(
             samples=order.samples,
-            ticket=order.ticket_number,
+            ticket=order._generated_ticket_id,
             order_name=order.name,
             workflow=Workflow.RAW_DATA,
             customer=order.customer,
@@ -76,7 +76,7 @@ class StoreMicrobialFastqOrderService(StoreOrderService):
         return case
 
     def _create_db_order(self, order: MicrobialFastqOrder) -> Order:
-        ticket_id: str = order._generated_ticket_id
+        ticket_id: int = order._generated_ticket_id
         customer: Customer = self.status_db.get_customer_by_internal_id(
             customer_internal_id=order.customer
         )

--- a/cg/store/crud/create.py
+++ b/cg/store/crud/create.py
@@ -398,12 +398,12 @@ class CreateHandler(BaseHandler):
             **kwargs,
         )
 
-    def add_order(self, customer: Customer, ticket_id: str | int) -> Order:
+    def add_order(self, customer: Customer, ticket_id: int) -> Order:
         """Build a new Order record."""
         order = Order(
             customer=customer,
             order_date=datetime.now(),
-            ticket_id=int(ticket_id),
+            ticket_id=ticket_id,
         )
         return order
 


### PR DESCRIPTION
## Description
in #4032 Order ticket was made int. The store services were expecting a str. This PR changes those occurrences by casting the variable to a str

### Added

- Explicit str casting of ticket when necessary

### Changed

- Make use of the CRUD function `add_order` instead of calling the constructor

### Fixed

- Some calls to the old `ticket` attribute of the orders, changed to `_generated_tickket_id`


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
