### PR TITLE
(Improve order flow) Patch pedigree validation

### DIFF
--- a/cg/services/order_validation_service/models/case.py
+++ b/cg/services/order_validation_service/models/case.py
@@ -26,7 +26,7 @@ class Case(BaseModel):
         return True
 
     @property
-    def enumerated_samples(self):
+    def enumerated_samples(self) -> enumerate[NewSample | ExistingSampleType]:
         return enumerate(self.samples)
 
     @property

--- a/cg/services/order_validation_service/models/case.py
+++ b/cg/services/order_validation_service/models/case.py
@@ -46,7 +46,7 @@ class Case(BaseModel):
         return samples
 
     def get_sample(self, sample_name: str) -> Sample | None:
-        for sample in self.samples:
+        for _, sample in self.enumerated_new_samples:
             if sample.name == sample_name:
                 return sample
 

--- a/cg/services/order_validation_service/rules/case_sample/pedigree/models.py
+++ b/cg/services/order_validation_service/rules/case_sample/pedigree/models.py
@@ -1,8 +1,6 @@
 from cg.services.order_validation_service.models.aliases import CaseContainingRelatives
 from cg.services.order_validation_service.models.existing_sample import ExistingSample
-from cg.services.order_validation_service.workflows.mip_dna.models.case import MipDnaCase
 from cg.services.order_validation_service.workflows.mip_dna.models.sample import MipDnaSample
-from cg.services.order_validation_service.workflows.tomte.models.case import TomteCase
 from cg.services.order_validation_service.workflows.tomte.models.sample import TomteSample
 from cg.store.store import Store
 
@@ -45,7 +43,7 @@ class FamilyTree:
 
     def __init__(self, case: CaseContainingRelatives, case_index: int, store: Store):
         self.graph: dict[str, Node] = {}
-        self.case: TomteCase | MipDnaCase = case
+        self.case: CaseContainingRelatives = case
         self.case_index: int = case_index
         self.store = store
         self._add_nodes()

--- a/cg/services/order_validation_service/rules/case_sample/pedigree/models.py
+++ b/cg/services/order_validation_service/rules/case_sample/pedigree/models.py
@@ -1,9 +1,12 @@
+from cg.services.order_validation_service.models.aliases import CaseContainingRelatives
 from cg.services.order_validation_service.models.existing_sample import ExistingSample
 from cg.services.order_validation_service.workflows.mip_dna.models.case import MipDnaCase
 from cg.services.order_validation_service.workflows.mip_dna.models.sample import MipDnaSample
 from cg.services.order_validation_service.workflows.tomte.models.case import TomteCase
 from cg.services.order_validation_service.workflows.tomte.models.sample import TomteSample
 from cg.store.store import Store
+
+SampleWithParents = TomteSample | MipDnaSample | ExistingSample
 
 
 class Node:
@@ -17,12 +20,12 @@ class Node:
 
     def __init__(
         self,
-        sample: TomteSample | MipDnaSample | ExistingSample,
+        sample: SampleWithParents,
         case_index: int,
         sample_index: int,
         sample_name: str,
     ):
-        self.sample: TomteSample | MipDnaSample | ExistingSample = sample
+        self.sample: SampleWithParents = sample
         self.sample_name: str = sample_name
         self.sample_index: int = sample_index
         self.case_index: int = case_index
@@ -40,7 +43,7 @@ class FamilyTree:
     graph's edges.
     """
 
-    def __init__(self, case: TomteCase | MipDnaCase, case_index: int, store: Store):
+    def __init__(self, case: CaseContainingRelatives, case_index: int, store: Store):
         self.graph: dict[str, Node] = {}
         self.case: TomteCase | MipDnaCase = case
         self.case_index: int = case_index

--- a/cg/services/order_validation_service/rules/case_sample/pedigree/models.py
+++ b/cg/services/order_validation_service/rules/case_sample/pedigree/models.py
@@ -68,7 +68,7 @@ class FamilyTree:
     def _add_edges(self) -> None:
         """Add edges to the graph by populating each node's 'mother' and 'father' property."""
         for node in self.graph.values():
-            sample: TomteSample = node.sample
+            sample: SampleWithParents = node.sample
             if sample.mother:
                 node.mother = self.graph.get(sample.mother)
             if sample.father:

--- a/cg/services/order_validation_service/rules/case_sample/pedigree/models.py
+++ b/cg/services/order_validation_service/rules/case_sample/pedigree/models.py
@@ -11,7 +11,7 @@ class Node:
     """
     This class is used to represent the samples in the family tree graph. The variables 'mother' and
     'father' refer to other nodes in the family tree, and can be thought of as an edge in the graph.
-    Because the 'mother' and 'father' is tracked using the sample's _name_ in the order, and
+    Because the 'mother' and 'father' are tracked using the sample's _name_ in the order, and
     because said name is not set in the ExistingSample model, we require the sample name as a
     separate input.
     """

--- a/cg/services/order_validation_service/rules/case_sample/pedigree/models.py
+++ b/cg/services/order_validation_service/rules/case_sample/pedigree/models.py
@@ -7,6 +7,14 @@ from cg.store.store import Store
 
 
 class Node:
+    """
+    This class is used to represent the samples in the family tree graph. The variables 'mother' and
+    'father' refer to other nodes in the family tree, and can be thought of as an edge in the graph.
+    Because the 'mother' and 'father' is tracked using the sample's _name_ in the order, and
+    because said name is not set in the ExistingSample model, we require the sample name as a
+    separate input.
+    """
+
     def __init__(
         self,
         sample: TomteSample | MipDnaSample | ExistingSample,
@@ -25,15 +33,24 @@ class Node:
 
 
 class FamilyTree:
+    """
+    This class is a directed graph representing a family tree from a submitted order with specified
+    mothers and fathers. Each node represents a sample, and each node has a property 'mother' and
+    a property 'father' referring to other nodes in the graph. These may be thought of as the
+    graph's edges.
+    """
+
     def __init__(self, case: TomteCase | MipDnaCase, case_index: int, store: Store):
         self.graph: dict[str, Node] = {}
-        self.case: TomteCase = case
+        self.case: TomteCase | MipDnaCase = case
         self.case_index: int = case_index
         self.store = store
         self._add_nodes()
         self._add_edges()
 
     def _add_nodes(self) -> None:
+        """Add a node to the graph for each sample in the graph. For existing samples, the name
+        is fetched from StatusDB."""
         for sample_index, sample in self.case.enumerated_samples:
             if sample.is_new:
                 sample_name = sample.name
@@ -48,6 +65,7 @@ class FamilyTree:
             self.graph[sample_name] = node
 
     def _add_edges(self) -> None:
+        """Add edges to the graph by populating each node's 'mother' and 'father' property."""
         for node in self.graph.values():
             sample: TomteSample = node.sample
             if sample.mother:

--- a/cg/services/order_validation_service/rules/case_sample/pedigree/models.py
+++ b/cg/services/order_validation_service/rules/case_sample/pedigree/models.py
@@ -1,12 +1,21 @@
+from cg.services.order_validation_service.models.existing_sample import ExistingSample
+from cg.services.order_validation_service.workflows.mip_dna.models.case import MipDnaCase
+from cg.services.order_validation_service.workflows.mip_dna.models.sample import MipDnaSample
 from cg.services.order_validation_service.workflows.tomte.models.case import TomteCase
-from cg.services.order_validation_service.workflows.tomte.models.sample import (
-    TomteSample,
-)
+from cg.services.order_validation_service.workflows.tomte.models.sample import TomteSample
+from cg.store.store import Store
 
 
 class Node:
-    def __init__(self, sample: TomteSample, case_index: int, sample_index: int):
-        self.sample: TomteSample = sample
+    def __init__(
+        self,
+        sample: TomteSample | MipDnaSample | ExistingSample,
+        case_index: int,
+        sample_index: int,
+        sample_name: str,
+    ):
+        self.sample: TomteSample | MipDnaSample | ExistingSample = sample
+        self.sample_name: str = sample_name
         self.sample_index: int = sample_index
         self.case_index: int = case_index
         self.father: Node | None = None
@@ -16,17 +25,27 @@ class Node:
 
 
 class FamilyTree:
-    def __init__(self, case: TomteCase, case_index: int):
+    def __init__(self, case: TomteCase | MipDnaCase, case_index: int, store: Store):
         self.graph: dict[str, Node] = {}
         self.case: TomteCase = case
         self.case_index: int = case_index
+        self.store = store
         self._add_nodes()
         self._add_edges()
 
     def _add_nodes(self) -> None:
         for sample_index, sample in self.case.enumerated_samples:
-            node = Node(sample=sample, sample_index=sample_index, case_index=self.case_index)
-            self.graph[sample.name] = node
+            if sample.is_new:
+                sample_name = sample.name
+            else:
+                sample_name = self.store.get_sample_by_internal_id(sample.internal_id).name
+            node = Node(
+                sample=sample,
+                sample_index=sample_index,
+                case_index=self.case_index,
+                sample_name=sample_name,
+            )
+            self.graph[sample_name] = node
 
     def _add_edges(self) -> None:
         for node in self.graph.values():

--- a/cg/services/order_validation_service/rules/case_sample/pedigree/utils.py
+++ b/cg/services/order_validation_service/rules/case_sample/pedigree/utils.py
@@ -6,13 +6,10 @@ from cg.services.order_validation_service.errors.case_sample_errors import (
     SampleIsOwnFatherError,
     SampleIsOwnMotherError,
 )
-from cg.services.order_validation_service.workflows.tomte.models.sample import (
-    TomteSample,
-)
-from cg.services.order_validation_service.rules.case_sample.pedigree.models import (
-    FamilyTree,
-    Node,
-)
+from cg.services.order_validation_service.models.existing_sample import ExistingSample
+from cg.services.order_validation_service.rules.case_sample.pedigree.models import FamilyTree, Node
+from cg.services.order_validation_service.workflows.mip_dna.models.sample import MipDnaSample
+from cg.services.order_validation_service.workflows.tomte.models.sample import TomteSample
 
 
 def validate_tree(pedigree: FamilyTree) -> list[PedigreeError]:
@@ -47,14 +44,14 @@ def get_error(node: Node, parent_type: str) -> PedigreeError:
 
 
 def get_mother_error(node: Node) -> PedigreeError:
-    sample: TomteSample = node.sample
-    if sample.name == sample.mother:
+    sample: TomteSample | MipDnaSample | ExistingSample = node.sample
+    if node.sample_name == sample.mother:
         return SampleIsOwnMotherError(sample_index=node.sample_index, case_index=node.case_index)
     return DescendantAsMotherError(sample_index=node.sample_index, case_index=node.case_index)
 
 
 def get_father_error(node: Node) -> PedigreeError:
     sample: TomteSample = node.sample
-    if sample.name == sample.father:
+    if node.sample_name == sample.father:
         return SampleIsOwnFatherError(sample_index=node.sample_index, case_index=node.case_index)
     return DescendantAsFatherError(sample_index=node.sample_index, case_index=node.case_index)

--- a/cg/services/order_validation_service/rules/case_sample/pedigree/utils.py
+++ b/cg/services/order_validation_service/rules/case_sample/pedigree/utils.py
@@ -57,7 +57,7 @@ def get_mother_error(node: Node) -> PedigreeError:
 
 def get_father_error(node: Node) -> PedigreeError:
     """Called when the node's 'father' creates a cycle in the family tree. For clearer feedback
-    we distinguish between the sample being its own mother, and other more complex situations."""
+    we distinguish between the sample being its own father, and other more complex situations."""
     sample: TomteSample = node.sample
     if node.sample_name == sample.father:
         return SampleIsOwnFatherError(sample_index=node.sample_index, case_index=node.case_index)

--- a/cg/services/order_validation_service/rules/case_sample/pedigree/utils.py
+++ b/cg/services/order_validation_service/rules/case_sample/pedigree/utils.py
@@ -13,6 +13,8 @@ from cg.services.order_validation_service.workflows.tomte.models.sample import T
 
 
 def validate_tree(pedigree: FamilyTree) -> list[PedigreeError]:
+    """This performs a DFS algorithm on the family tree to find any cycles, which indicates an
+    order error."""
     errors: list[PedigreeError] = []
     for node in pedigree.nodes:
         if not node.visited:
@@ -21,7 +23,8 @@ def validate_tree(pedigree: FamilyTree) -> list[PedigreeError]:
 
 
 def detect_cycles(node: Node, errors: list[PedigreeError]) -> None:
-    """Detect cycles in the pedigree graph using depth-first search"""
+    """Detect cycles in the pedigree graph using depth-first search. If a cycle is detected,
+    this is considered an error."""
     node.visited = True
     node.in_current_path = True
 
@@ -44,6 +47,8 @@ def get_error(node: Node, parent_type: str) -> PedigreeError:
 
 
 def get_mother_error(node: Node) -> PedigreeError:
+    """Called when the node's 'mother' creates a cycle in the family tree. For clearer feedback
+    we distinguish between the sample being its own mother, and other more complex situations."""
     sample: TomteSample | MipDnaSample | ExistingSample = node.sample
     if node.sample_name == sample.mother:
         return SampleIsOwnMotherError(sample_index=node.sample_index, case_index=node.case_index)
@@ -51,6 +56,8 @@ def get_mother_error(node: Node) -> PedigreeError:
 
 
 def get_father_error(node: Node) -> PedigreeError:
+    """Called when the node's 'father' creates a cycle in the family tree. For clearer feedback
+    we distinguish between the sample being its own mother, and other more complex situations."""
     sample: TomteSample = node.sample
     if node.sample_name == sample.father:
         return SampleIsOwnFatherError(sample_index=node.sample_index, case_index=node.case_index)

--- a/cg/services/order_validation_service/rules/case_sample/pedigree/validate_pedigree.py
+++ b/cg/services/order_validation_service/rules/case_sample/pedigree/validate_pedigree.py
@@ -1,9 +1,10 @@
 from cg.services.order_validation_service.errors.case_sample_errors import PedigreeError
-from cg.services.order_validation_service.workflows.tomte.models.case import TomteCase
 from cg.services.order_validation_service.rules.case_sample.pedigree.models import FamilyTree
 from cg.services.order_validation_service.rules.case_sample.pedigree.utils import validate_tree
+from cg.services.order_validation_service.workflows.tomte.models.case import TomteCase
+from cg.store.store import Store
 
 
-def get_pedigree_errors(case: TomteCase, case_index: int) -> list[PedigreeError]:
-    pedigree = FamilyTree(case=case, case_index=case_index)
+def get_pedigree_errors(case: TomteCase, case_index: int, store: Store) -> list[PedigreeError]:
+    pedigree = FamilyTree(case=case, case_index=case_index, store=store)
     return validate_tree(pedigree)

--- a/cg/services/order_validation_service/rules/case_sample/pedigree/validate_pedigree.py
+++ b/cg/services/order_validation_service/rules/case_sample/pedigree/validate_pedigree.py
@@ -9,7 +9,6 @@ from cg.store.store import Store
 def get_pedigree_errors(
     case: TomteCase | MipDnaCase, case_index: int, store: Store
 ) -> list[PedigreeError]:
-    """This method finds errors within the order's family tree. These are errors of the kind
-    where a sample is marked as its own ancestor."""
+    """Return a list of errors if any sample is labelled as its own ancestor in the family tree."""
     pedigree = FamilyTree(case=case, case_index=case_index, store=store)
     return validate_tree(pedigree)

--- a/cg/services/order_validation_service/rules/case_sample/pedigree/validate_pedigree.py
+++ b/cg/services/order_validation_service/rules/case_sample/pedigree/validate_pedigree.py
@@ -1,10 +1,15 @@
 from cg.services.order_validation_service.errors.case_sample_errors import PedigreeError
 from cg.services.order_validation_service.rules.case_sample.pedigree.models import FamilyTree
 from cg.services.order_validation_service.rules.case_sample.pedigree.utils import validate_tree
+from cg.services.order_validation_service.workflows.mip_dna.models.case import MipDnaCase
 from cg.services.order_validation_service.workflows.tomte.models.case import TomteCase
 from cg.store.store import Store
 
 
-def get_pedigree_errors(case: TomteCase, case_index: int, store: Store) -> list[PedigreeError]:
+def get_pedigree_errors(
+    case: TomteCase | MipDnaCase, case_index: int, store: Store
+) -> list[PedigreeError]:
+    """This method finds errors within the order's family tree. These are errors of the kind
+    where a sample is marked as its own ancestor."""
     pedigree = FamilyTree(case=case, case_index=case_index, store=store)
     return validate_tree(pedigree)

--- a/cg/services/order_validation_service/rules/case_sample/rules.py
+++ b/cg/services/order_validation_service/rules/case_sample/rules.py
@@ -327,10 +327,12 @@ def validate_mothers_in_same_case_as_children(
     return errors
 
 
-def validate_pedigree(order: OrderWithCases, **kwargs) -> list[PedigreeError]:
+def validate_pedigree(order: OrderWithCases, store: Store, **kwargs) -> list[PedigreeError]:
     errors: list[PedigreeError] = []
     for case_index, case in order.enumerated_cases:
-        case_errors: list[PedigreeError] = get_pedigree_errors(case=case, case_index=case_index)
+        case_errors: list[PedigreeError] = get_pedigree_errors(
+            case=case, case_index=case_index, store=store
+        )
         errors.extend(case_errors)
     return errors
 

--- a/tests/services/order_validation_service/conftest.py
+++ b/tests/services/order_validation_service/conftest.py
@@ -5,6 +5,7 @@ from cg.constants.sequencing import SeqLibraryPrepCategory
 from cg.models.orders.constants import OrderType
 from cg.models.orders.sample_base import ContainerEnum, ControlEnum, SexEnum, StatusEnum
 from cg.services.order_validation_service.constants import MINIMUM_VOLUME
+from cg.services.order_validation_service.models.existing_sample import ExistingSample
 from cg.services.order_validation_service.order_type_maps import ORDER_TYPE_RULE_SET_MAP, RuleSet
 from cg.services.order_validation_service.order_validation_service import OrderValidationService
 from cg.services.order_validation_service.workflows.tomte.constants import TomteDeliveryType
@@ -152,6 +153,24 @@ def order_with_sample_cycle():
 
     child.mother = mother.name
     child.father = father.name
+
+    father.mother = grandmother.name
+    father.father = child.name  # Cycle introduced here
+
+    case = create_case([child, father, mother, grandfather, grandmother])
+    return create_tomte_order([case])
+
+
+@pytest.fixture
+def order_with_existing_sample_cycle():
+    child: TomteSample = create_tomte_sample(1)
+    father = ExistingSample(internal_id="ExistingSampleInternalId", status=StatusEnum.unaffected)
+    mother: TomteSample = create_tomte_sample(3)
+    grandfather: TomteSample = create_tomte_sample(4)
+    grandmother: TomteSample = create_tomte_sample(5)
+
+    child.mother = mother.name
+    child.father = "ExistingSampleName"
 
     father.mother = grandmother.name
     father.father = child.name  # Cycle introduced here

--- a/tests/services/order_validation_service/workflows/tomte/test_case_sample_rules.py
+++ b/tests/services/order_validation_service/workflows/tomte/test_case_sample_rules.py
@@ -142,12 +142,13 @@ def test_existing_samples_in_tree(
 def test_existing_sample_cycle_not_allowed(
     order_with_existing_sample_cycle: TomteOrder, base_store: Store, helpers: StoreHelpers
 ):
-    # GIVEN an order containing an existing sample
-    for sample in order_with_existing_sample_cycle.cases[0].samples:
-        if not sample.is_new:
-            helpers.add_sample(
-                store=base_store, name="ExistingSampleName", internal_id=sample.internal_id
-            )
+
+    # GIVEN an order containing an existing sample and a cycle
+    existing_sample = order_with_existing_sample_cycle.cases[0].samples[1]
+    assert not existing_sample.is_new
+    helpers.add_sample(
+        store=base_store, name="ExistingSampleName", internal_id=existing_sample.internal_id
+    )
 
     # WHEN validating the order
     errors: list[PedigreeError] = validate_pedigree(


### PR DESCRIPTION
## Description

The pedigree validation breaks down when new samples are in the mix since we have internal ids instead of sample names. This PR addresses this issue

### Added

-

### Changed

-

### Fixed

- Read existing samples' names from the database and store in the graph nodes


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
