### PR TITLE
rework pacbio store service

### DIFF
--- a/cg/services/orders/store_order_services/store_pacbio_order_service.py
+++ b/cg/services/orders/store_order_services/store_pacbio_order_service.py
@@ -46,7 +46,6 @@ class StorePacBioOrderService(StoreOrderService):
         - For each Sample, a Case
         - For each Sample, a relationship between the Sample and its Case
         """
-        # Add order
         status_db_order: Order = self._create_db_order(order=order)
         new_samples = []
         with self.status_db.session.no_autoflush:

--- a/cg/services/orders/store_order_services/store_pacbio_order_service.py
+++ b/cg/services/orders/store_order_services/store_pacbio_order_service.py
@@ -48,7 +48,7 @@ class StorePacBioOrderService(StoreOrderService):
         """
         status_db_order: Order = self._create_db_order(order=order)
         new_samples = []
-        with self.status_db.session.no_autoflush:
+        with self.status_db.no_autoflush_context():
             for sample in order.samples:
                 case: Case = self._create_db_case_for_sample(
                     sample=sample,

--- a/cg/services/orders/store_order_services/store_pacbio_order_service.py
+++ b/cg/services/orders/store_order_services/store_pacbio_order_service.py
@@ -34,10 +34,10 @@ class StorePacBioOrderService(StoreOrderService):
             delivery_type=DataDelivery(order.delivery_type),
         )
         self._fill_in_sample_ids(samples=order.samples, lims_map=lims_map)
-        new_samples = self._store_samples_in_statusdb(order=order)
+        new_samples = self.store_order_data_in_status_db(order=order)
         return {"project": project_data, "records": new_samples}
 
-    def _store_samples_in_statusdb(self, order: PacbioOrder) -> list[Sample]:
+    def store_order_data_in_status_db(self, order: PacbioOrder) -> list[Sample]:
         """
         Store all order data in the Status database for a Pacbio order. Return the samples.
         The stored data objects are:

--- a/cg/services/orders/store_order_services/store_pacbio_order_service.py
+++ b/cg/services/orders/store_order_services/store_pacbio_order_service.py
@@ -37,30 +37,6 @@ class StorePacBioOrderService(StoreOrderService):
         new_samples = self._store_samples_in_statusdb(order=order)
         return {"project": project_data, "records": new_samples}
 
-    @staticmethod
-    def order_to_status(order: OrderIn) -> dict:
-        """Convert order input to status for PacBio-only orders."""
-        status_data = {
-            "customer": order.customer,
-            "order": order.name,
-            "samples": [
-                {
-                    "application": sample.application,
-                    "comment": sample.comment,
-                    "data_analysis": sample.data_analysis,
-                    "data_delivery": sample.data_delivery,
-                    "name": sample.name,
-                    "priority": sample.priority,
-                    "sex": sample.sex,
-                    "tumour": sample.tumour,
-                    "volume": sample.volume,
-                    "subject_id": sample.subject_id,
-                }
-                for sample in order.samples
-            ],
-        }
-        return status_data
-
     def _store_samples_in_statusdb(self, order: PacbioOrder) -> list[Sample]:
         """
         Store all order data in the Status database for a Pacbio order. Return the samples.

--- a/cg/services/orders/submitters/pacbio_order_submitter.py
+++ b/cg/services/orders/submitters/pacbio_order_submitter.py
@@ -1,4 +1,4 @@
-from cg.models.orders.order import OrderIn
+from cg.services.order_validation_service.workflows.pacbio_long_read.models.order import PacbioOrder
 from cg.services.orders.store_order_services.store_pacbio_order_service import (
     StorePacBioOrderService,
 )
@@ -19,8 +19,7 @@ class PacbioOrderSubmitter(OrderSubmitter):
         self.order_validation_service = order_validation_service
         self.order_store_service = order_store_service
 
-    def submit_order(self, order_in: OrderIn) -> dict:
+    def submit_order(self, order: PacbioOrder) -> dict:
         """Submit a fastq order."""
-        self.order_validation_service.validate_order(order_in)
-        result: dict = self.order_store_service.store_order(order_in)
+        result: dict = self.order_store_service.store_order(order=order)
         return result

--- a/cg/store/store.py
+++ b/cg/store/store.py
@@ -36,6 +36,10 @@ class Store(
         """Add multiple items to the store."""
         self.session.add_all(items)
 
+    def no_autoflush_context(self):
+        """Return a context manager that disables autoflush for the session."""
+        return self.session.no_autoflush
+
     def rollback(self):
         """Rollback any pending change to the store."""
         self.session.rollback()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,6 +120,7 @@ pytest_plugins = [
     "tests.fixture_plugins.orders_fixtures.order_form_fixtures",
     "tests.fixture_plugins.orders_fixtures.order_store_service_fixtures",
     "tests.fixture_plugins.orders_fixtures.order_to_submit_fixtures",
+    "tests.fixture_plugins.orders_fixtures.orders_fixtures",
     "tests.fixture_plugins.orders_fixtures.status_data_fixtures",
     "tests.fixture_plugins.pacbio_fixtures.context_fixtures",
     "tests.fixture_plugins.pacbio_fixtures.dto_fixtures",

--- a/tests/fixture_plugins/orders_fixtures/orders_fixtures.py
+++ b/tests/fixture_plugins/orders_fixtures/orders_fixtures.py
@@ -1,0 +1,99 @@
+import pytest
+
+from cg.models.orders.constants import OrderType
+from cg.models.orders.sample_base import ContainerEnum, PriorityEnum, SexEnum
+from cg.services.order_validation_service.constants import ElutionBuffer
+from cg.services.order_validation_service.workflows.fastq.models.order import FastqOrder
+from cg.services.order_validation_service.workflows.microbial_fastq.constants import (
+    MicrobialFastqDeliveryType,
+)
+from cg.services.order_validation_service.workflows.microbial_fastq.models.order import (
+    MicrobialFastqOrder,
+)
+from cg.services.order_validation_service.workflows.microbial_fastq.models.sample import (
+    MicrobialFastqSample,
+)
+from cg.services.order_validation_service.workflows.pacbio_long_read.constants import (
+    PacbioDeliveryType,
+)
+from cg.services.order_validation_service.workflows.pacbio_long_read.models.order import PacbioOrder
+from cg.services.order_validation_service.workflows.pacbio_long_read.models.sample import (
+    PacbioSample,
+)
+
+
+def create_pacbio_sample(id: int) -> PacbioSample:
+    return PacbioSample(
+        application="LWPBELB070",
+        comment="",
+        container=ContainerEnum.plate,
+        container_name="Pacbio plate",
+        name=f"fastq-sample-{id}",
+        volume=54,
+        concentration_ng_ul=30,
+        priority=PriorityEnum.priority,
+        quantity=54,
+        require_qc_ok=True,
+        sex=SexEnum.male,
+        source="blood",
+        subject_id=f"pacbio-subject-{id}",
+        well_position=f"A:{id}",
+        tumour=False,
+    )
+
+
+@pytest.fixture
+def valid_pacbio_order(ticket_id: str) -> PacbioOrder:
+    sample_1: PacbioSample = create_pacbio_sample(1)
+    sample_2: PacbioSample = create_pacbio_sample(2)
+    sample_3: PacbioSample = create_pacbio_sample(3)
+    samples = [sample_1, sample_2, sample_3]
+    order = PacbioOrder(
+        customer="cust000",
+        project_type=OrderType.PACBIO_LONG_READ,
+        user_id=0,
+        delivery_type=PacbioDeliveryType.BAM,
+        samples=samples,
+        name="PacbioOrder",
+    )
+    order._generated_ticket_id = int(ticket_id)
+    return order
+
+
+@pytest.fixture
+def fastq_order(fastq_order_to_submit: dict) -> FastqOrder:
+    fastq_order = FastqOrder.model_validate(fastq_order_to_submit)
+    fastq_order._generated_ticket_id = 123456
+    return fastq_order
+
+
+def create_microbial_fastq_sample(id: int) -> MicrobialFastqSample:
+    return MicrobialFastqSample(
+        application="MWRNXTR003",
+        comment="",
+        container=ContainerEnum.tube,
+        container_name="Fastq tube",
+        name=f"microfastq-sample-{id}",
+        volume=54,
+        elution_buffer=ElutionBuffer.WATER,
+        priority=PriorityEnum.priority,
+        quantity=54,
+        require_qc_ok=True,
+    )
+
+
+@pytest.fixture
+def valid_microbial_fastq_order(ticket_id: str) -> MicrobialFastqOrder:
+    sample_1: MicrobialFastqSample = create_microbial_fastq_sample(1)
+    sample_2: MicrobialFastqSample = create_microbial_fastq_sample(2)
+    sample_3: MicrobialFastqSample = create_microbial_fastq_sample(3)
+    order = MicrobialFastqOrder(
+        customer="cust000",
+        project_type=OrderType.MICROBIAL_FASTQ,
+        user_id=0,
+        delivery_type=MicrobialFastqDeliveryType.FASTQ,
+        samples=[sample_1, sample_2, sample_3],
+        name="MicrobialFastqOrder",
+    )
+    order._generated_ticket_id = ticket_id
+    return order

--- a/tests/fixture_plugins/orders_fixtures/status_data_fixtures.py
+++ b/tests/fixture_plugins/orders_fixtures/status_data_fixtures.py
@@ -2,26 +2,11 @@ import pytest
 
 from cg.models.orders.constants import OrderType
 from cg.models.orders.order import OrderIn
-from cg.models.orders.sample_base import ContainerEnum, PriorityEnum
-from cg.services.order_validation_service.constants import ElutionBuffer
-from cg.services.order_validation_service.workflows.fastq.models.order import FastqOrder
-from cg.services.order_validation_service.workflows.microbial_fastq.constants import (
-    MicrobialFastqDeliveryType,
-)
-from cg.services.order_validation_service.workflows.microbial_fastq.models.order import (
-    MicrobialFastqOrder,
-)
-from cg.services.order_validation_service.workflows.microbial_fastq.models.sample import (
-    MicrobialFastqSample,
-)
 from cg.services.orders.store_order_services.store_case_order import StoreCaseOrderService
 from cg.services.orders.store_order_services.store_metagenome_order import (
     StoreMetagenomeOrderService,
 )
 from cg.services.orders.store_order_services.store_microbial_order import StoreMicrobialOrderService
-from cg.services.orders.store_order_services.store_pacbio_order_service import (
-    StorePacBioOrderService,
-)
 from cg.services.orders.store_order_services.store_pool_order import StorePoolOrderService
 
 
@@ -33,16 +18,6 @@ def balsamic_status_data(
     project: OrderType = OrderType.BALSAMIC
     order: OrderIn = OrderIn.parse_obj(obj=balsamic_order_to_submit, project=project)
     return store_generic_order_service.order_to_status(order=order)
-
-
-@pytest.fixture
-def pacbio_status_data(
-    pacbio_order_to_submit: dict, store_pacbio_order_service: StorePacBioOrderService
-) -> dict:
-    """Parse pacbio order example."""
-    project: OrderType = OrderType.PACBIO_LONG_READ
-    order: OrderIn = OrderIn.parse_obj(obj=pacbio_order_to_submit, project=project)
-    return store_pacbio_order_service.order_to_status(order=order)
 
 
 @pytest.fixture
@@ -64,38 +39,6 @@ def microbial_status_data(
     project: OrderType = OrderType.MICROSALT
     order: OrderIn = OrderIn.parse_obj(obj=microbial_order_to_submit, project=project)
     return store_microbial_order_service.order_to_status(order=order)
-
-
-def create_microbial_fastq_sample(id: int) -> MicrobialFastqSample:
-    return MicrobialFastqSample(
-        application="MWRNXTR003",
-        comment="",
-        container=ContainerEnum.tube,
-        container_name="Fastq tube",
-        name=f"microfastq-sample-{id}",
-        volume=54,
-        elution_buffer=ElutionBuffer.WATER,
-        priority=PriorityEnum.priority,
-        quantity=54,
-        require_qc_ok=True,
-    )
-
-
-@pytest.fixture
-def valid_microbial_fastq_order(ticket_id: str) -> MicrobialFastqOrder:
-    sample_1: MicrobialFastqSample = create_microbial_fastq_sample(1)
-    sample_2: MicrobialFastqSample = create_microbial_fastq_sample(2)
-    sample_3: MicrobialFastqSample = create_microbial_fastq_sample(3)
-    order = MicrobialFastqOrder(
-        customer="cust000",
-        project_type=OrderType.MICROBIAL_FASTQ,
-        user_id=0,
-        delivery_type=MicrobialFastqDeliveryType.FASTQ,
-        samples=[sample_1, sample_2, sample_3],
-        name="MicrobialFastqOrder",
-    )
-    order._generated_ticket_id = ticket_id
-    return order
 
 
 @pytest.fixture
@@ -126,20 +69,3 @@ def rml_status_data(
     project: OrderType = OrderType.RML
     order: OrderIn = OrderIn.parse_obj(obj=rml_order_to_submit, project=project)
     return store_pool_order_service.order_to_status(order=order)
-
-
-@pytest.fixture
-def tomte_status_data(
-    tomte_order_to_submit: dict, store_generic_order_service: StoreCaseOrderService
-) -> dict:
-    """Parse TOMTE order example."""
-    project: OrderType = OrderType.TOMTE
-    order: OrderIn = OrderIn.parse_obj(obj=tomte_order_to_submit, project=project)
-    return store_generic_order_service.order_to_status(order=order)
-
-
-@pytest.fixture
-def fastq_order(fastq_order_to_submit: dict) -> FastqOrder:
-    fastq_order = FastqOrder.model_validate(fastq_order_to_submit)
-    fastq_order._generated_ticket_id = 123456
-    return fastq_order

--- a/tests/services/orders/order_store_service/test_pacbio_order_service.py
+++ b/tests/services/orders/order_store_service/test_pacbio_order_service.py
@@ -1,63 +1,42 @@
-from datetime import datetime
-
 from cg.constants import DataDelivery, Workflow
-from cg.models.orders.constants import OrderType
-from cg.models.orders.order import OrderIn
+from cg.constants.sequencing import SeqLibraryPrepCategory
 from cg.models.orders.sample_base import SexEnum
+from cg.services.order_validation_service.workflows.pacbio_long_read.models.order import PacbioOrder
 from cg.services.orders.store_order_services.store_pacbio_order_service import (
     StorePacBioOrderService,
 )
 from cg.store.models import Case, Sample
 from cg.store.store import Store
-
-
-def test_order_to_status(
-    pacbio_order_to_submit: dict, store_pacbio_order_service: StorePacBioOrderService
-):
-    """Test that a PacBio order is parsed correctly."""
-    # GIVEN a PacBio order with two samples
-    order = OrderIn.parse_obj(pacbio_order_to_submit, OrderType.PACBIO_LONG_READ)
-
-    # WHEN parsing for status
-    data = store_pacbio_order_service.order_to_status(order=order)
-
-    # THEN it should pick out samples and relevant information
-    assert len(data["samples"]) == 2
-    first_sample = data["samples"][0]
-    assert first_sample["name"] == "prov1"
-    assert first_sample["application"] == "WGSPCFC060"
-    assert first_sample["priority"] == "priority"
-    assert first_sample["tumour"] is False
-    assert first_sample["volume"] == "25"
-
-    # THEN the other sample is a tumour
-    assert data["samples"][1]["tumour"] is True
+from tests.store_helpers import StoreHelpers
 
 
 def test_store_order(
     base_store: Store,
-    pacbio_status_data: dict,
-    ticket_id: str,
+    valid_pacbio_order: PacbioOrder,
     store_pacbio_order_service: StorePacBioOrderService,
+    helpers: StoreHelpers,
 ):
     """Test that a PacBio order is stored in the database."""
     # GIVEN a basic store with no samples and a PacBio order
     assert not base_store._get_query(table=Sample).first()
     assert base_store._get_query(table=Case).count() == 0
 
+    # GIVEN that a Pacbio application exists in the store
+    helpers.ensure_application_version(
+        store=base_store,
+        application_tag="LWPBELB070",
+        prep_category=SeqLibraryPrepCategory.WHOLE_EXOME_SEQUENCING,
+    )
+
     # WHEN storing the order
     new_samples: list[Sample] = store_pacbio_order_service._store_samples_in_statusdb(
-        customer_id=pacbio_status_data["customer"],
-        order=pacbio_status_data["order"],
-        ordered=datetime.now(),
-        ticket_id=ticket_id,
-        samples=pacbio_status_data["samples"],
+        order=valid_pacbio_order
     )
 
     # THEN it should store the samples and create a case for each sample
-    assert len(new_samples) == 2
-    assert len(base_store._get_query(table=Sample).all()) == 2
-    assert base_store._get_query(table=Case).count() == 2
+    assert len(new_samples) == 3
+    assert len(base_store._get_query(table=Sample).all()) == 3
+    assert base_store._get_query(table=Case).count() == 3
     for new_sample in new_samples:
         assert len(new_sample.links) == 1
         case_link = new_sample.links[0]
@@ -66,7 +45,7 @@ def test_store_order(
         assert case_link.case.data_delivery in [DataDelivery.BAM, DataDelivery.NO_DELIVERY]
 
     # THEN the sample sex should be stored
-    assert new_samples[0].sex == SexEnum.female
+    assert new_samples[0].sex == SexEnum.male
 
     # THEN the analysis for the case should be RAW_DATA
     assert new_samples[0].links[0].case.data_analysis == Workflow.RAW_DATA

--- a/tests/services/orders/order_store_service/test_pacbio_order_service.py
+++ b/tests/services/orders/order_store_service/test_pacbio_order_service.py
@@ -5,27 +5,30 @@ from cg.services.order_validation_service.workflows.pacbio_long_read.models.orde
 from cg.services.orders.store_order_services.store_pacbio_order_service import (
     StorePacBioOrderService,
 )
-from cg.store.models import Case, Sample
+from cg.store.models import Case, Order, Sample
 from cg.store.store import Store
 from tests.store_helpers import StoreHelpers
 
 
-def test_store_order(
+def test_store_order_data_in_status_db(
     base_store: Store,
     valid_pacbio_order: PacbioOrder,
     store_pacbio_order_service: StorePacBioOrderService,
     helpers: StoreHelpers,
 ):
     """Test that a PacBio order is stored in the database."""
-    # GIVEN a basic store with no samples and a PacBio order
+    # GIVEN a valid Pacbio order and a Pacbio store service
+
+    # GIVEN a basic store with no samples, cases nor orders
     assert not base_store._get_query(table=Sample).first()
     assert base_store._get_query(table=Case).count() == 0
+    assert base_store._get_query(table=Order).count() == 0
 
     # GIVEN that a Pacbio application exists in the store
     helpers.ensure_application_version(
         store=base_store,
         application_tag="LWPBELB070",
-        prep_category=SeqLibraryPrepCategory.WHOLE_EXOME_SEQUENCING,
+        prep_category=SeqLibraryPrepCategory.WHOLE_GENOME_SEQUENCING,
     )
 
     # WHEN storing the order
@@ -33,19 +36,21 @@ def test_store_order(
         order=valid_pacbio_order
     )
 
+    # THEN it should store the order
+    assert base_store._get_query(table=Order).count() == 1
+
     # THEN it should store the samples and create a case for each sample
     assert len(new_samples) == 3
     assert len(base_store._get_query(table=Sample).all()) == 3
     assert base_store._get_query(table=Case).count() == 3
     for new_sample in new_samples:
+        # THEN the sample sex should be stored
+        assert new_sample.sex == SexEnum.male
+        # THEN the sample should have a relationship with a case
         assert len(new_sample.links) == 1
         case_link = new_sample.links[0]
         assert case_link.case in base_store.get_cases()
-        assert case_link.case.data_analysis
+        # THEN the analysis for the case should be RAW_DATA
+        assert case_link.case.data_analysis == Workflow.RAW_DATA
+        # THEN the delivery type for the case should be BAM or NO_DELIVERY
         assert case_link.case.data_delivery in [DataDelivery.BAM, DataDelivery.NO_DELIVERY]
-
-    # THEN the sample sex should be stored
-    assert new_samples[0].sex == SexEnum.male
-
-    # THEN the analysis for the case should be RAW_DATA
-    assert new_samples[0].links[0].case.data_analysis == Workflow.RAW_DATA

--- a/tests/services/orders/order_store_service/test_pacbio_order_service.py
+++ b/tests/services/orders/order_store_service/test_pacbio_order_service.py
@@ -29,7 +29,7 @@ def test_store_order(
     )
 
     # WHEN storing the order
-    new_samples: list[Sample] = store_pacbio_order_service._store_samples_in_statusdb(
+    new_samples: list[Sample] = store_pacbio_order_service.store_order_data_in_status_db(
         order=valid_pacbio_order
     )
 


### PR DESCRIPTION
## Description
Closes https://github.com/Clinical-Genomics/improve-order-flow/issues/113
Rework the Pacbio store service so that it receives a PacbioOrder instead of an OrderIn

### Added

- Fixture for Pacbio order

### Changed

- Pacbio store service in the ordering
- Pacbio submitter

### Fixed

- Tests


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
