### PR TITLE
(Improve order flow) Fix ExistingSample

### DIFF
--- a/cg/services/order_validation_service/models/existing_sample.py
+++ b/cg/services/order_validation_service/models/existing_sample.py
@@ -7,7 +7,7 @@ class ExistingSample(BaseModel):
     father: str | None = Field(None, pattern=NAME_PATTERN)
     internal_id: str
     mother: str | None = Field(None, pattern=NAME_PATTERN)
-    status: StatusEnum
+    status: StatusEnum | None = None
 
     @property
     def is_new(self) -> bool:


### PR DESCRIPTION
## Description

Existing sample has Status as a mandatory field, even though some order types supporting reruns can't provide it. This PR makes it optional.

### Added

-

### Changed

-

### Fixed

- Status is an optional field for existing samples


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
