### PR TITLE
fix(NFAnalysis) Prevent variable being overriden

### DIFF
--- a/cg/meta/workflow/nf_analysis.py
+++ b/cg/meta/workflow/nf_analysis.py
@@ -63,7 +63,7 @@ class NfAnalysisAPI(AnalysisAPI):
         self.conda_binary: str | None = None
         self.platform: str | None = None
         self.params: str | None = None
-        self.config: str | None = None
+        self.workflow_config_path: str | None = None
         self.resources: str | None = None
         self.tower_binary_path: str | None = None
         self.tower_workflow: str | None = None
@@ -136,7 +136,7 @@ class NfAnalysisAPI(AnalysisAPI):
         """Return nextflow config content."""
         config_files_list: list[str] = [
             self.platform,
-            self.config,
+            self.workflow_config_path,
             self.resources,
         ]
         extra_parameters_str: list[str] = [

--- a/cg/meta/workflow/raredisease.py
+++ b/cg/meta/workflow/raredisease.py
@@ -56,7 +56,7 @@ class RarediseaseAnalysisAPI(NfAnalysisAPI):
         self.conda_binary: str = config.raredisease.conda_binary
         self.platform: str = config.raredisease.platform
         self.params: str = config.raredisease.params
-        self.config: str = config.raredisease.config
+        self.workflow_config_path: str = config.raredisease.config
         self.resources: str = config.raredisease.resources
         self.tower_binary_path: str = config.tower_binary_path
         self.tower_workflow: str = config.raredisease.tower_workflow

--- a/cg/meta/workflow/rnafusion.py
+++ b/cg/meta/workflow/rnafusion.py
@@ -35,7 +35,7 @@ class RnafusionAnalysisAPI(NfAnalysisAPI):
         self.conda_binary: str = config.rnafusion.conda_binary
         self.platform: str = config.rnafusion.platform
         self.params: str = config.rnafusion.params
-        self.config: str = config.rnafusion.config
+        self.workflow_config_path: str = config.rnafusion.config
         self.resources: str = config.rnafusion.resources
         self.tower_binary_path: str = config.tower_binary_path
         self.tower_workflow: str = config.rnafusion.tower_workflow

--- a/cg/meta/workflow/tomte.py
+++ b/cg/meta/workflow/tomte.py
@@ -31,7 +31,7 @@ class TomteAnalysisAPI(NfAnalysisAPI):
         self.conda_binary: str = config.tomte.conda_binary
         self.platform: str = config.tomte.platform
         self.params: str = config.tomte.params
-        self.config: str = config.tomte.config
+        self.workflow_config_path: str = config.tomte.config
         self.resources: str = config.tomte.resources
         self.tower_binary_path: str = config.tower_binary_path
         self.tower_workflow: str = config.tomte.tower_workflow


### PR DESCRIPTION
## Description
See issue and bug report for full description. This PR renames the attribute self.config on NFAnalysisAPIs to avoid overriding the one set on the parent class.

### Fixed

- renamed NFAnalysisAPI.config to NFAnalysisAPI.workflow_config_path
