### PR TITLE
Fix(Dockerfile) Make compatible with new poetry version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ENV TRAILBLAZER_SERVICE_ACCOUNT_AUTH_FILE="auth_file"
 
 
 WORKDIR /home/src/app
-COPY pyproject.toml poetry.lock gunicorn.conf.py README.md ./
+COPY pyproject.toml poetry.lock gunicorn.conf.py ./
 
 RUN pip install --no-cache-dir poetry \
     && poetry config virtualenvs.create false \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,11 @@ COPY pyproject.toml poetry.lock gunicorn.conf.py README.md ./
 
 RUN pip install --no-cache-dir poetry \
     && poetry config virtualenvs.create false \
-    && poetry install --no-interaction --no-ansi
+    && poetry install --no-interaction --no-ansi --no-root
 
 COPY cg ./cg
+
+RUN poetry install --no-interaction --no-ansi
 
 CMD gunicorn \
     --config gunicorn.conf.py \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ENV TRAILBLAZER_SERVICE_ACCOUNT_AUTH_FILE="auth_file"
 
 
 WORKDIR /home/src/app
-COPY pyproject.toml poetry.lock gunicorn.conf.py ./
+COPY pyproject.toml poetry.lock gunicorn.conf.py README.md ./
 
 RUN pip install --no-cache-dir poetry \
     && poetry config virtualenvs.create false \


### PR DESCRIPTION
## Description
Poetry version 2.0.0 was released recently, converting some previous warnings to errors. This causes our dockerfile to fail when installing the dependencies using poetry.

### Fixed
- Copies README file into container
- Split install of requirements our of install of actual cg-repo