### PR TITLE
Configure multiqc so that it can handle more than 500 rows

### DIFF
--- a/cg/constants/nf_analysis.py
+++ b/cg/constants/nf_analysis.py
@@ -51,7 +51,7 @@ MULTIQC_NEXFLOW_CONFIG = """process {
         memory = { 4.GB * task.attempt }
         time   = { 4.h  * task.attempt }
         cpus = 2
-        ext.args = ' --data-format json '
+        ext.args = ' --data-format json --cl-config "max_table_rows: 10000" '
     }
 }
 """


### PR DESCRIPTION
## Description

By default, MultiQC starts using violin plots when a table has 500 rows or more (https://docs.seqera.io/multiqc/getting_started/config)  and the file `multiqc_general_stats.txt` was not generated for `thoroughstingray` case in production causing an issue in storing the case. 

I am planning to move the configs of  taxprofiler to servers as the rest of nf-pipelines.

https://github.com/Clinical-Genomics/cg/pull/3853
https://github.com/Clinical-Genomics/servers/pull/1469

### Fixed

- Configure multiqc so that it does not start using violin plots when a certain amount of rows has been reached.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b multiqc_patch -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

Tested the case on stage with the new configs and the file was being generated.

<img width="589" alt="Screenshot 2025-01-08 at 09 42 57" src="https://github.com/user-attachments/assets/278b51da-3188-47e6-b6c8-63e552efa99c" />

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
