### PR TITLE
Add nallo workflow run

### DIFF
--- a/cg/cli/workflow/nallo/base.py
+++ b/cg/cli/workflow/nallo/base.py
@@ -6,7 +6,7 @@ import rich_click as click
 
 from cg.cli.utils import CLICK_CONTEXT_SETTINGS
 
-from cg.cli.workflow.nf_analysis import config_case
+from cg.cli.workflow.nf_analysis import config_case, run
 
 from cg.constants.constants import MetaApis
 from cg.meta.workflow.analysis import AnalysisAPI
@@ -24,3 +24,4 @@ def nallo(context: click.Context) -> None:
 
 
 nallo.add_command(config_case)
+nallo.add_command(run)

--- a/tests/cli/workflow/nf_analysis/test_cli_run.py
+++ b/tests/cli/workflow/nf_analysis/test_cli_run.py
@@ -15,7 +15,7 @@ from cg.models.cg_config import CGConfig
 
 @pytest.mark.parametrize(
     "workflow",
-    NEXTFLOW_WORKFLOWS,
+    NEXTFLOW_WORKFLOWS + [Workflow.NALLO],
 )
 def test_run_without_options(cli_runner: CliRunner, workflow: Workflow, request: FixtureRequest):
     """Test run command for workflow without options."""
@@ -35,7 +35,7 @@ def test_run_without_options(cli_runner: CliRunner, workflow: Workflow, request:
 
 @pytest.mark.parametrize(
     "workflow",
-    NEXTFLOW_WORKFLOWS,
+    NEXTFLOW_WORKFLOWS + [Workflow.NALLO],
 )
 def test_run_with_missing_case(
     cli_runner: CliRunner,
@@ -64,7 +64,7 @@ def test_run_with_missing_case(
 
 @pytest.mark.parametrize(
     "workflow",
-    NEXTFLOW_WORKFLOWS,
+    NEXTFLOW_WORKFLOWS + [Workflow.NALLO],
 )
 def test_run_case_without_samples(
     cli_runner: CliRunner,
@@ -94,7 +94,7 @@ def test_run_case_without_samples(
 
 @pytest.mark.parametrize(
     "workflow",
-    NEXTFLOW_WORKFLOWS,
+    NEXTFLOW_WORKFLOWS + [Workflow.NALLO],
 )
 def test_run_case_without_config_files(
     cli_runner: CliRunner,
@@ -121,7 +121,7 @@ def test_run_case_without_config_files(
 
 @pytest.mark.parametrize(
     "workflow",
-    NEXTFLOW_WORKFLOWS,
+    NEXTFLOW_WORKFLOWS + [Workflow.NALLO],
 )
 def test_run_case_from_start_dry_run(
     cli_runner: CliRunner,
@@ -155,7 +155,7 @@ def test_run_case_from_start_dry_run(
 
 @pytest.mark.parametrize(
     "workflow",
-    NEXTFLOW_WORKFLOWS,
+    NEXTFLOW_WORKFLOWS + [Workflow.NALLO],
 )
 def test_run_case_with_revision_dry_run(
     cli_runner: CliRunner,
@@ -189,7 +189,7 @@ def test_run_case_with_revision_dry_run(
 
 @pytest.mark.parametrize(
     "workflow",
-    NEXTFLOW_WORKFLOWS,
+    NEXTFLOW_WORKFLOWS + [Workflow.NALLO],
 )
 def test_resume_case_dry_run(
     cli_runner: CliRunner,
@@ -225,7 +225,7 @@ def test_resume_case_dry_run(
 
 @pytest.mark.parametrize(
     "workflow",
-    NEXTFLOW_WORKFLOWS,
+    NEXTFLOW_WORKFLOWS + [Workflow.NALLO],
 )
 def test_resume_case_with_missing_tower_id(
     cli_runner: CliRunner,
@@ -253,7 +253,7 @@ def test_resume_case_with_missing_tower_id(
 
 @pytest.mark.parametrize(
     "workflow",
-    NEXTFLOW_WORKFLOWS,
+    NEXTFLOW_WORKFLOWS + [Workflow.NALLO],
 )
 def test_resume_using_nextflow_dry_run(
     cli_runner: CliRunner,

--- a/tests/cli/workflow/nf_analysis/test_cli_run.py
+++ b/tests/cli/workflow/nf_analysis/test_cli_run.py
@@ -206,7 +206,7 @@ def test_resume_case_dry_run(
     case_id: str = request.getfixturevalue(f"{workflow}_case_id")
 
     # GIVEN a mocked config
-    # request.getfixturevalue(f"{workflow}_mock_config")
+    # request.getfixturevalue(f"{workflow}_config")
 
     # WHEN invoking a command with dry-run and nf-tower-id specified
     result = cli_runner.invoke(
@@ -231,7 +231,7 @@ def test_resume_case_with_missing_tower_id(
     cli_runner: CliRunner,
     workflow: Workflow,
     caplog: LogCaptureFixture,
-    raredisease_mock_config,
+    raredisease_config,
     request: FixtureRequest,
 ):
     """Test resume command without providing NF-Tower ID and without existing Trailblazer config file."""
@@ -259,7 +259,7 @@ def test_resume_using_nextflow_dry_run(
     cli_runner: CliRunner,
     workflow: Workflow,
     caplog: LogCaptureFixture,
-    raredisease_mock_config,
+    raredisease_config,
     request: FixtureRequest,
 ):
     """Test command with case_id and config file using nextflow."""

--- a/tests/cli/workflow/nf_analysis/test_cli_run.py
+++ b/tests/cli/workflow/nf_analysis/test_cli_run.py
@@ -137,7 +137,7 @@ def test_run_case_from_start_dry_run(
     case_id: str = request.getfixturevalue(f"{workflow}_case_id")
 
     # GIVEN mocked config files
-    request.getfixturevalue(f"{workflow}_mock_config")
+    request.getfixturevalue(f"{workflow}_config")
 
     # WHEN invoking a command with dry-run specified
     result = cli_runner.invoke(
@@ -171,7 +171,7 @@ def test_run_case_with_revision_dry_run(
     case_id: str = request.getfixturevalue(f"{workflow}_case_id")
 
     # GIVEN a mocked config
-    request.getfixturevalue(f"{workflow}_mock_config")
+    request.getfixturevalue(f"{workflow}_config")
 
     # WHEN invoking a command with dry-run and revision specified
     result = cli_runner.invoke(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4102,7 +4102,7 @@ def taxprofiler_mock_analysis_finish(
 
 
 @pytest.fixture(scope="function")
-def taxprofiler_mock_config(taxprofiler_dir: Path, taxprofiler_case_id: str) -> None:
+def taxprofiler_config(taxprofiler_dir: Path, taxprofiler_case_id: str) -> None:
     """Create CSV sample sheet file for testing."""
     Path.mkdir(Path(taxprofiler_dir, taxprofiler_case_id), parents=True, exist_ok=True)
     Path(taxprofiler_dir, taxprofiler_case_id, f"{taxprofiler_case_id}_samplesheet").with_suffix(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2604,8 +2604,8 @@ def nallo_dir(tmpdir_factory, apps_dir: Path) -> str:
 
 
 @pytest.fixture(scope="function")
-def nallo_mock_config(nallo_dir: Path, nallo_case_id: str) -> None:
-    """Create nallo samplesheet.csv file for testing"""
+def nallo_config(nallo_dir: Path, nallo_case_id: str) -> None:
+    """Create Nallo samplesheet.csv file for testing"""
     Path.mkdir(Path(nallo_dir, nallo_case_id), parents=True, exist_ok=True)
     Path(nallo_dir, nallo_case_id, f"{nallo_case_id}_samplesheet").with_suffix(
         FileExtensions.CSV
@@ -2921,7 +2921,7 @@ def mock_deliverable(
 
 
 @pytest.fixture(scope="function")
-def raredisease_mock_config(raredisease_dir: Path, raredisease_case_id: str) -> None:
+def raredisease_config(raredisease_dir: Path, raredisease_case_id: str) -> None:
     """Create samplesheet.csv file for testing"""
     Path.mkdir(Path(raredisease_dir, raredisease_case_id), parents=True, exist_ok=True)
     Path(raredisease_dir, raredisease_case_id, f"{raredisease_case_id}_samplesheet").with_suffix(
@@ -3443,7 +3443,7 @@ def rnafusion_mock_analysis_finish(
 
 
 @pytest.fixture(scope="function")
-def rnafusion_mock_config(rnafusion_dir: Path, rnafusion_case_id: str) -> None:
+def rnafusion_config(rnafusion_dir: Path, rnafusion_case_id: str) -> None:
     """Create samplesheet.csv file for testing"""
     Path.mkdir(Path(rnafusion_dir, rnafusion_case_id), parents=True, exist_ok=True)
     Path(rnafusion_dir, rnafusion_case_id, f"{rnafusion_case_id}_samplesheet.csv").with_suffix(
@@ -3496,7 +3496,7 @@ def tomte_gene_panel_path(tomte_dir, tomte_case_id) -> Path:
 
 
 @pytest.fixture(scope="function")
-def tomte_mock_config(tomte_dir: Path, tomte_case_id: str) -> None:
+def tomte_config(tomte_dir: Path, tomte_case_id: str) -> None:
     """Create Tomte samplesheet.csv file for testing."""
     Path.mkdir(Path(tomte_dir, tomte_case_id), parents=True, exist_ok=True)
     Path(tomte_dir, tomte_case_id, f"{tomte_case_id}_samplesheet").with_suffix(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2604,6 +2604,15 @@ def nallo_dir(tmpdir_factory, apps_dir: Path) -> str:
 
 
 @pytest.fixture(scope="function")
+def nallo_mock_config(nallo_dir: Path, nallo_case_id: str) -> None:
+    """Create nallo samplesheet.csv file for testing"""
+    Path.mkdir(Path(nallo_dir, nallo_case_id), parents=True, exist_ok=True)
+    Path(nallo_dir, nallo_case_id, f"{nallo_case_id}_samplesheet").with_suffix(
+        FileExtensions.CSV
+    ).touch(exist_ok=True)
+
+
+@pytest.fixture(scope="function")
 def nallo_nexflow_config_file_path(nallo_dir, nallo_case_id) -> Path:
     """Path to config file."""
     return Path(nallo_dir, nallo_case_id, f"{nallo_case_id}_nextflow_config").with_suffix(


### PR DESCRIPTION
## Description
This PR aims to add the cg workflow run function for Nallo.

### Added

- cg workflow run nallo

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b add-nallo-run
    ```

### How to test

- [x] Do cg workflow nallo run rightalpaca
- [x] cg workflow nallo run --from-start rightalpaca --revision dev

### Expected test outcome

- [x] Check that command fails as there is no active tower id for this analysis.
<img width="514" alt="image" src="https://github.com/user-attachments/assets/8f3fb2e0-d1ce-4778-9cc0-c68ac33684e9" />

- [x] Command should succeed with --from-start flag:
<img width="1371" alt="image" src="https://github.com/user-attachments/assets/bfbc2d03-eb3e-4809-afea-11161ef80e1a" />

- [x] Analysis successfully submitted to tower stage:
<img width="1154" alt="image" src="https://github.com/user-attachments/assets/64eebdcb-1132-4947-a4e9-9484aad299e6" />


## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
