### PR TITLE
(Improve order flow) Set default index sequence

### DIFF
--- a/cg/services/orders/validation/workflows/fluffy/models/sample.py
+++ b/cg/services/orders/validation/workflows/fluffy/models/sample.py
@@ -1,10 +1,15 @@
-from pydantic import BeforeValidator, Field
+import logging
+
+from pydantic import BeforeValidator, Field, model_validator
 from typing_extensions import Annotated
 
 from cg.models.orders.sample_base import ContainerEnum, ControlEnum, PriorityEnum
 from cg.services.orders.validation.constants import IndexEnum
+from cg.services.orders.validation.index_sequences import INDEX_SEQUENCES
 from cg.services.orders.validation.models.sample import Sample
 from cg.services.orders.validation.utils import parse_control
+
+LOG = logging.getLogger(__name__)
 
 
 class FluffySample(Sample):
@@ -20,3 +25,16 @@ class FluffySample(Sample):
     rml_plate_name: str | None = None
     volume: int
     well_position_rml: str | None = None
+
+    @model_validator(mode="after")
+    def set_default_index_sequence(self):
+        """Set a default index_sequence from the index and index_number."""
+        if not self.index_sequence and (self.index and self.index_number):
+            try:
+                self.index_sequence = INDEX_SEQUENCES[self.index][self.index_number - 1]
+            except Exception:
+                # Could be that the index is not known or that the index number is out of range
+                LOG.warning(
+                    f"No index sequence set and no suitable sequence found for index {self.index}, number {self.index_number}"
+                )
+        return self

--- a/cg/services/orders/validation/workflows/fluffy/models/sample.py
+++ b/cg/services/orders/validation/workflows/fluffy/models/sample.py
@@ -33,7 +33,6 @@ class FluffySample(Sample):
             try:
                 self.index_sequence = INDEX_SEQUENCES[self.index][self.index_number - 1]
             except Exception:
-                # Could be that the index is not known or that the index number is out of range
                 LOG.warning(
                     f"No index sequence set and no suitable sequence found for index {self.index}, number {self.index_number}"
                 )

--- a/cg/services/orders/validation/workflows/rml/models/sample.py
+++ b/cg/services/orders/validation/workflows/rml/models/sample.py
@@ -33,7 +33,6 @@ class RmlSample(Sample):
             try:
                 self.index_sequence = INDEX_SEQUENCES[self.index][self.index_number - 1]
             except Exception:
-                # Could be that the index is not known or that the index number is out of range
                 LOG.warning(
                     f"No index sequence set and no suitable sequence found for index {self.index}, number {self.index_number}"
                 )

--- a/cg/services/orders/validation/workflows/rml/models/sample.py
+++ b/cg/services/orders/validation/workflows/rml/models/sample.py
@@ -1,10 +1,15 @@
-from pydantic import BeforeValidator, Field
+import logging
+
+from pydantic import BeforeValidator, Field, model_validator
 from typing_extensions import Annotated
 
 from cg.models.orders.sample_base import ContainerEnum, ControlEnum, PriorityEnum
 from cg.services.orders.validation.constants import IndexEnum
+from cg.services.orders.validation.index_sequences import INDEX_SEQUENCES
 from cg.services.orders.validation.models.sample import Sample
 from cg.services.orders.validation.utils import parse_control
+
+LOG = logging.getLogger(__name__)
 
 
 class RmlSample(Sample):
@@ -20,3 +25,16 @@ class RmlSample(Sample):
     rml_plate_name: str | None = None
     volume: int
     well_position_rml: str | None = None
+
+    @model_validator(mode="after")
+    def set_default_index_sequence(self):
+        """Set a default index_sequence from the index and index_number."""
+        if not self.index_sequence and (self.index and self.index_number):
+            try:
+                self.index_sequence = INDEX_SEQUENCES[self.index][self.index_number - 1]
+            except Exception:
+                # Could be that the index is not known or that the index number is out of range
+                LOG.warning(
+                    f"No index sequence set and no suitable sequence found for index {self.index}, number {self.index_number}"
+                )
+        return self


### PR DESCRIPTION
## Description

Closes https://github.com/Clinical-Genomics/improve-order-flow/issues/137 by setting a default index sequence under the conditions

- Index is set
- Index number is set
- Index sequence is not set

### Added

-

### Changed

-

### Fixed

- Default index sequence is set for RML and Fluffy orders


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
