### PR TITLE
(Improve order flow) Add existing case collaboration rule

### DIFF
--- a/cg/services/orders/validation/errors/case_errors.py
+++ b/cg/services/orders/validation/errors/case_errors.py
@@ -31,6 +31,11 @@ class CaseDoesNotExistError(CaseError):
     message: str = "The case does not exist"
 
 
+class CaseOutsideOfCollaborationError(CaseError):
+    field: str = "internal_id"
+    message: str = "Case does not belong to collaboration"
+
+
 class MultipleSamplesInCaseError(CaseError):
     field: str = "sample_errors"
     message: str = "Multiple samples in the same case not allowed"

--- a/cg/services/orders/validation/models/order_with_cases.py
+++ b/cg/services/orders/validation/models/order_with_cases.py
@@ -27,8 +27,8 @@ class OrderWithCases(Order):
         return cases
 
     @property
-    def enumerated_existing_cases(self) -> list[tuple[int, Case]]:
-        cases: list[tuple[int, Case]] = []
+    def enumerated_existing_cases(self) -> list[tuple[int, ExistingCase]]:
+        cases: list[tuple[int, ExistingCase]] = []
         for case_index, case in self.enumerated_cases:
             if not case.is_new:
                 cases.append((case_index, case))

--- a/cg/services/orders/validation/rules/case/utils.py
+++ b/cg/services/orders/validation/rules/case/utils.py
@@ -1,6 +1,8 @@
+from cg.services.orders.validation.models.existing_case import ExistingCase
 from cg.services.orders.validation.workflows.balsamic.models.case import BalsamicCase
 from cg.services.orders.validation.workflows.balsamic_umi.models.case import BalsamicUmiCase
-from cg.store.models import Sample
+from cg.store.models import Case as DbCase
+from cg.store.models import Customer, Sample
 from cg.store.store import Store
 
 
@@ -26,3 +28,9 @@ def get_number_of_tumours(case: BalsamicCase | BalsamicUmiCase, store: Store) ->
             if db_sample.is_tumour:
                 number_of_tumours += 1
     return number_of_tumours
+
+
+def is_case_not_from_collaboration(case: ExistingCase, customer_id: str, store: Store) -> bool:
+    db_case: DbCase | None = store.get_case_by_internal_id(case.internal_id)
+    customer: Customer | None = store.get_customer_by_internal_id(customer_id)
+    return db_case and customer and db_case.customer not in customer.collaborators


### PR DESCRIPTION
## Description

This PR adds a rule ensuring that any existing case belongs to the customer placing the order's collaboration.

### Added

-

### Changed

-

### Fixed

- Existing cases are forced to be part of the customer's collaboration


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
