### PR TITLE
(Improve order flow) Existing sample collaboration rule

### DIFF
--- a/cg/services/orders/validation/errors/case_sample_errors.py
+++ b/cg/services/orders/validation/errors/case_sample_errors.py
@@ -165,3 +165,8 @@ class StatusUnknownError(CaseSampleError):
 class BufferMissingError(CaseSampleError):
     field: str = "elution_buffer"
     message: str = "Buffer must be specified with this application"
+
+
+class SampleOutsideOfCollaborationError(CaseSampleError):
+    field: str = "internal_id"
+    message: str = "Sample cannot be outside of collaboration"

--- a/cg/services/orders/validation/rules/case_sample/utils.py
+++ b/cg/services/orders/validation/rules/case_sample/utils.py
@@ -20,6 +20,7 @@ from cg.services.orders.validation.models.case_aliases import (
     CaseContainingRelatives,
     CaseWithSkipRC,
 )
+from cg.services.orders.validation.models.existing_sample import ExistingSample
 from cg.services.orders.validation.models.order_with_cases import OrderWithCases
 from cg.services.orders.validation.models.sample import Sample
 from cg.services.orders.validation.models.sample_aliases import (
@@ -36,7 +37,8 @@ from cg.services.orders.validation.rules.utils import (
 )
 from cg.services.orders.validation.workflows.balsamic.models.sample import BalsamicSample
 from cg.services.orders.validation.workflows.balsamic_umi.models.sample import BalsamicUmiSample
-from cg.store.models import Application
+from cg.store.models import Application, Customer
+from cg.store.models import Sample as DbSample
 from cg.store.store import Store
 
 
@@ -297,3 +299,11 @@ def is_sample_missing_capture_kit(sample: BalsamicSample | BalsamicUmiSample, st
         and application.prep_category == SeqLibraryPrepCategory.TARGETED_GENOME_SEQUENCING
         and not sample.capture_kit
     )
+
+
+def is_sample_not_from_collaboration(
+    customer_id: str, sample: ExistingSample, store: Store
+) -> bool:
+    db_sample: DbSample | None = store.get_sample_by_internal_id(sample.internal_id)
+    customer: Customer | None = store.get_customer_by_internal_id(customer_id)
+    return db_sample and customer and db_sample.customer not in customer.collaborators

--- a/cg/services/orders/validation/workflows/balsamic/validation_rules.py
+++ b/cg/services/orders/validation/workflows/balsamic/validation_rules.py
@@ -3,6 +3,7 @@ from cg.services.orders.validation.rules.case.rules import (
     validate_case_internal_ids_exist,
     validate_case_names_available,
     validate_case_names_not_repeated,
+    validate_existing_cases_belong_to_collaboration,
     validate_number_of_normal_samples,
 )
 from cg.services.orders.validation.rules.case_sample.rules import (
@@ -15,6 +16,7 @@ from cg.services.orders.validation.rules.case_sample.rules import (
     validate_concentration_interval_if_skip_rc,
     validate_concentration_required_if_skip_rc,
     validate_container_name_required,
+    validate_existing_samples_belong_to_collaboration,
     validate_sample_names_different_from_case_names,
     validate_sample_names_not_repeated,
     validate_samples_exist,
@@ -34,6 +36,7 @@ BALSAMIC_CASE_RULES: list[callable] = [
     validate_case_internal_ids_exist,
     validate_case_names_available,
     validate_case_names_not_repeated,
+    validate_existing_cases_belong_to_collaboration,
     validate_number_of_normal_samples,
 ]
 
@@ -48,6 +51,7 @@ BALSAMIC_CASE_SAMPLE_RULES: list[callable] = [
     validate_concentration_interval_if_skip_rc,
     validate_concentration_required_if_skip_rc,
     validate_container_name_required,
+    validate_existing_samples_belong_to_collaboration,
     validate_samples_exist,
     validate_sample_names_different_from_case_names,
     validate_sample_names_not_repeated,

--- a/cg/services/orders/validation/workflows/mip_dna/validation_rules.py
+++ b/cg/services/orders/validation/workflows/mip_dna/validation_rules.py
@@ -2,6 +2,7 @@ from cg.services.orders.validation.rules.case.rules import (
     validate_case_internal_ids_exist,
     validate_case_names_available,
     validate_case_names_not_repeated,
+    validate_existing_cases_belong_to_collaboration,
     validate_gene_panels_unique,
 )
 from cg.services.orders.validation.rules.case_sample.rules import (
@@ -13,6 +14,7 @@ from cg.services.orders.validation.rules.case_sample.rules import (
     validate_concentration_interval_if_skip_rc,
     validate_concentration_required_if_skip_rc,
     validate_container_name_required,
+    validate_existing_samples_belong_to_collaboration,
     validate_fathers_are_male,
     validate_fathers_in_same_case_as_children,
     validate_gene_panels_exist,
@@ -38,6 +40,7 @@ MIP_DNA_CASE_RULES: list[callable] = [
     validate_case_internal_ids_exist,
     validate_case_names_available,
     validate_case_names_not_repeated,
+    validate_existing_cases_belong_to_collaboration,
     validate_gene_panels_exist,
     validate_gene_panels_unique,
 ]
@@ -51,6 +54,7 @@ MIP_DNA_CASE_SAMPLE_RULES: list[callable] = [
     validate_concentration_interval_if_skip_rc,
     validate_concentration_required_if_skip_rc,
     validate_container_name_required,
+    validate_existing_samples_belong_to_collaboration,
     validate_fathers_are_male,
     validate_fathers_in_same_case_as_children,
     validate_mothers_are_female,

--- a/cg/services/orders/validation/workflows/mip_rna/validation_rules.py
+++ b/cg/services/orders/validation/workflows/mip_rna/validation_rules.py
@@ -2,6 +2,7 @@ from cg.services.orders.validation.rules.case.rules import (
     validate_case_internal_ids_exist,
     validate_case_names_available,
     validate_case_names_not_repeated,
+    validate_existing_cases_belong_to_collaboration,
 )
 from cg.services.orders.validation.rules.case_sample.rules import (
     validate_application_compatibility,
@@ -12,6 +13,7 @@ from cg.services.orders.validation.rules.case_sample.rules import (
     validate_concentration_interval_if_skip_rc,
     validate_concentration_required_if_skip_rc,
     validate_container_name_required,
+    validate_existing_samples_belong_to_collaboration,
     validate_sample_names_different_from_case_names,
     validate_sample_names_not_repeated,
     validate_samples_exist,
@@ -29,6 +31,7 @@ MIP_RNA_CASE_RULES: list[callable] = [
     validate_case_internal_ids_exist,
     validate_case_names_available,
     validate_case_names_not_repeated,
+    validate_existing_cases_belong_to_collaboration,
 ]
 
 MIP_RNA_CASE_SAMPLE_RULES: list[callable] = [
@@ -40,6 +43,7 @@ MIP_RNA_CASE_SAMPLE_RULES: list[callable] = [
     validate_concentration_interval_if_skip_rc,
     validate_concentration_required_if_skip_rc,
     validate_container_name_required,
+    validate_existing_samples_belong_to_collaboration,
     validate_sample_names_different_from_case_names,
     validate_sample_names_not_repeated,
     validate_samples_exist,

--- a/cg/services/orders/validation/workflows/rna_fusion/validation_rules.py
+++ b/cg/services/orders/validation/workflows/rna_fusion/validation_rules.py
@@ -2,6 +2,7 @@ from cg.services.orders.validation.rules.case.rules import (
     validate_case_internal_ids_exist,
     validate_case_names_available,
     validate_case_names_not_repeated,
+    validate_existing_cases_belong_to_collaboration,
     validate_one_sample_per_case,
 )
 from cg.services.orders.validation.rules.case_sample.rules import (
@@ -13,6 +14,7 @@ from cg.services.orders.validation.rules.case_sample.rules import (
     validate_concentration_interval_if_skip_rc,
     validate_concentration_required_if_skip_rc,
     validate_container_name_required,
+    validate_existing_samples_belong_to_collaboration,
     validate_sample_names_different_from_case_names,
     validate_sample_names_not_repeated,
     validate_samples_exist,
@@ -31,6 +33,7 @@ RNAFUSION_CASE_RULES: list[callable] = [
     validate_case_internal_ids_exist,
     validate_case_names_available,
     validate_case_names_not_repeated,
+    validate_existing_cases_belong_to_collaboration,
     validate_one_sample_per_case,
 ]
 
@@ -43,6 +46,7 @@ RNAFUSION_CASE_SAMPLE_RULES: list[callable] = [
     validate_concentration_interval_if_skip_rc,
     validate_concentration_required_if_skip_rc,
     validate_container_name_required,
+    validate_existing_samples_belong_to_collaboration,
     validate_samples_exist,
     validate_sample_names_different_from_case_names,
     validate_sample_names_not_repeated,

--- a/cg/services/orders/validation/workflows/tomte/validation_rules.py
+++ b/cg/services/orders/validation/workflows/tomte/validation_rules.py
@@ -2,6 +2,7 @@ from cg.services.orders.validation.rules.case.rules import (
     validate_case_internal_ids_exist,
     validate_case_names_available,
     validate_case_names_not_repeated,
+    validate_existing_cases_belong_to_collaboration,
     validate_gene_panels_unique,
 )
 from cg.services.orders.validation.rules.case_sample.rules import (
@@ -13,6 +14,7 @@ from cg.services.orders.validation.rules.case_sample.rules import (
     validate_concentration_interval_if_skip_rc,
     validate_concentration_required_if_skip_rc,
     validate_container_name_required,
+    validate_existing_samples_belong_to_collaboration,
     validate_fathers_are_male,
     validate_fathers_in_same_case_as_children,
     validate_gene_panels_exist,
@@ -37,6 +39,7 @@ TOMTE_CASE_RULES: list[callable] = [
     validate_case_internal_ids_exist,
     validate_case_names_available,
     validate_case_names_not_repeated,
+    validate_existing_cases_belong_to_collaboration,
     validate_gene_panels_exist,
     validate_gene_panels_unique,
 ]
@@ -47,10 +50,10 @@ TOMTE_CASE_SAMPLE_RULES: list[callable] = [
     validate_application_not_archived,
     validate_buffer_required,
     validate_buffer_skip_rc_condition,
-    validate_volume_required,
     validate_concentration_interval_if_skip_rc,
     validate_concentration_required_if_skip_rc,
     validate_container_name_required,
+    validate_existing_samples_belong_to_collaboration,
     validate_fathers_are_male,
     validate_fathers_in_same_case_as_children,
     validate_mothers_are_female,
@@ -64,6 +67,7 @@ TOMTE_CASE_SAMPLE_RULES: list[callable] = [
     validate_subject_sex_consistency,
     validate_tube_container_name_unique,
     validate_volume_interval,
+    validate_volume_required,
     validate_well_position_format,
     validate_well_positions_required,
     validate_wells_contain_at_most_one_sample,


### PR DESCRIPTION
## Description

Adds a rule similar to #4123 but for samples

### Added

-

### Changed

-

### Fixed

- Existing samples are enforced to belong to the same collaboration as the customer placing the order.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
