### PR TITLE
(Improve order flow) Fix delivery types

### DIFF
--- a/cg/services/orders/storing/implementations/fastq_order_service.py
+++ b/cg/services/orders/storing/implementations/fastq_order_service.py
@@ -105,7 +105,7 @@ class StoreFastqOrderService(StoreOrderService):
             comment=sample.comment,
             internal_id=sample._generated_lims_id,
             ordered=datetime.now(),
-            original_ticket=str(ticket_id),
+            original_ticket=ticket_id,
             priority=sample.priority,
             tumour=sample.tumour,
             capture_kit=sample.capture_kit,

--- a/cg/services/orders/storing/implementations/fastq_order_service.py
+++ b/cg/services/orders/storing/implementations/fastq_order_service.py
@@ -5,6 +5,7 @@ from cg.constants import DataDelivery, GenePanelMasterList, Priority, Workflow
 from cg.constants.constants import CustomerId
 from cg.constants.sequencing import SeqLibraryPrepCategory
 from cg.models.orders.sample_base import SexEnum, StatusEnum
+from cg.services.orders.constants import ORDER_TYPE_WORKFLOW_MAP
 from cg.services.orders.lims_service.service import OrderLimsService
 from cg.services.orders.storing.constants import MAF_ORDER_ID
 from cg.services.orders.storing.service import StoreOrderService
@@ -82,8 +83,8 @@ class StoreFastqOrderService(StoreOrderService):
         """Return a Case database object."""
         priority: str = order.samples[0].priority
         case: Case = self.status_db.add_case(
-            data_analysis=Workflow.RAW_DATA,
-            data_delivery=DataDelivery.FASTQ,
+            data_analysis=ORDER_TYPE_WORKFLOW_MAP[order.order_type],
+            data_delivery=DataDelivery(order.delivery_type),
             name=str(db_order.ticket_id),
             priority=priority,
             ticket=str(db_order.ticket_id),

--- a/cg/services/orders/storing/implementations/pacbio_order_service.py
+++ b/cg/services/orders/storing/implementations/pacbio_order_service.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 from cg.constants import DataDelivery, Workflow
 from cg.models.orders.sample_base import StatusEnum
+from cg.services.orders.constants import ORDER_TYPE_WORKFLOW_MAP
 from cg.services.orders.lims_service.service import OrderLimsService
 from cg.services.orders.storing.service import StoreOrderService
 from cg.services.orders.validation.workflows.pacbio_long_read.models.order import PacbioOrder
@@ -77,16 +78,16 @@ class StorePacBioOrderService(StoreOrderService):
         return self.status_db.add_order(customer=customer, ticket_id=ticket_id)
 
     def _create_db_case_for_sample(
-        self, sample: PacbioSample, customer: Customer, ticket_id: str
+        self, sample: PacbioSample, customer: Customer, order: PacbioOrder
     ) -> Case:
         """Return a Case database object for a PacbioSample."""
         case_name: str = f"{sample.name}-case"
         case: Case = self.status_db.add_case(
-            data_analysis=Workflow.RAW_DATA,
-            data_delivery=DataDelivery.BAM,
+            data_analysis=ORDER_TYPE_WORKFLOW_MAP[order.order_type],
+            data_delivery=DataDelivery(order.delivery_type),
             name=case_name,
             priority=sample.priority,
-            ticket=ticket_id,
+            ticket=str(order._generated_ticket_id),
         )
         case.customer = customer
         return case

--- a/cg/services/orders/storing/implementations/pacbio_order_service.py
+++ b/cg/services/orders/storing/implementations/pacbio_order_service.py
@@ -29,7 +29,7 @@ class StorePacBioOrderService(StoreOrderService):
             order_name=order.name,
             workflow=Workflow.RAW_DATA,
             customer=order.customer,
-            delivery_type=order.delivery_type,
+            delivery_type=DataDelivery(order.delivery_type),
         )
         self._fill_in_sample_ids(samples=order.samples, lims_map=lims_map)
         new_samples = self.store_order_data_in_status_db(order=order)
@@ -51,7 +51,7 @@ class StorePacBioOrderService(StoreOrderService):
                 case: Case = self._create_db_case_for_sample(
                     sample=sample,
                     customer=status_db_order.customer,
-                    ticket_id=str(status_db_order.ticket_id),
+                    order=order,
                 )
                 db_sample: Sample = self._create_db_sample(
                     sample=sample,

--- a/cg/services/orders/validation/workflows/pacbio_long_read/constants.py
+++ b/cg/services/orders/validation/workflows/pacbio_long_read/constants.py
@@ -1,8 +1,8 @@
-from enum import Enum
+from enum import StrEnum
 
 from cg.constants import DataDelivery
 
 
-class PacbioDeliveryType(Enum):
+class PacbioDeliveryType(StrEnum):
     BAM = DataDelivery.BAM
     NO_DELIVERY = DataDelivery.NO_DELIVERY


### PR DESCRIPTION
## Description

This PR ensures that we fetch workflow and delivery type from the incoming order, rather than hard coding it. It makes future changes easier and also ensures that we support "No delivery".

### Added

-

### Changed

-

### Fixed

- No hard coding of delivery type or workflow in the storing services


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
