### PR TITLE
(Improve order flow) Override microbial dump

### DIFF
--- a/cg/services/orders/lims_service/service.py
+++ b/cg/services/orders/lims_service/service.py
@@ -4,8 +4,6 @@ from cg.apps.lims import LimsAPI
 from cg.constants import DataDelivery, Workflow
 from cg.models.lims.sample import LimsSample
 from cg.services.orders.validation.models.sample import Sample
-from cg.services.orders.validation.workflows.microsalt.models.sample import MicrosaltSample
-from cg.services.orders.validation.workflows.mutant.models.sample import MutantSample
 
 LOG = logging.getLogger(__name__)
 
@@ -28,8 +26,6 @@ class OrderLimsService:
             dict_sample["data_analysis"] = workflow
             dict_sample["data_delivery"] = delivery_type
             dict_sample["family_name"] = sample._case_name
-            if isinstance(sample, MutantSample | MicrosaltSample):
-                dict_sample["verified_organism"] = sample._verified_organism
             lims_sample: LimsSample = LimsSample.parse_obj(dict_sample)
             samples_lims.append(lims_sample)
         return samples_lims

--- a/cg/services/orders/storing/implementations/microbial_order_service.py
+++ b/cg/services/orders/storing/implementations/microbial_order_service.py
@@ -89,7 +89,7 @@ class StoreMicrobialOrderService(StoreOrderService):
             organism_id = sample.organism
             reference_genome = sample.reference_genome
             organism: Organism = self.status.get_organism_by_internal_id(internal_id=organism_id)
-            is_verified = (
+            is_verified: bool = (
                 organism and organism.reference_genome == reference_genome and organism.verified
             )
             sample._verified_organism = is_verified

--- a/cg/services/orders/validation/workflows/microsalt/models/sample.py
+++ b/cg/services/orders/validation/workflows/microsalt/models/sample.py
@@ -14,7 +14,7 @@ class MicrosaltSample(Sample):
     organism: str
     priority: PriorityEnum
     reference_genome: str = Field(max_length=255)
-    _verified_organism: str | None = PrivateAttr(default=None)
+    _verified_organism: bool | None = PrivateAttr(default=None)
 
     def model_dump(self, **kwargs) -> dict:
         data = super().model_dump(**kwargs)

--- a/cg/services/orders/validation/workflows/microsalt/models/sample.py
+++ b/cg/services/orders/validation/workflows/microsalt/models/sample.py
@@ -15,3 +15,8 @@ class MicrosaltSample(Sample):
     priority: PriorityEnum
     reference_genome: str = Field(max_length=255)
     _verified_organism: str | None = PrivateAttr(default=None)
+
+    def model_dump(self, **kwargs) -> dict:
+        data = super().model_dump(**kwargs)
+        data["verified_organism"] = self._verified_organism
+        return data

--- a/cg/services/orders/validation/workflows/mutant/models/sample.py
+++ b/cg/services/orders/validation/workflows/mutant/models/sample.py
@@ -35,7 +35,7 @@ class MutantSample(Sample):
     region: Region
     region_code: str
     selection_criteria: SelectionCriteria
-    _verified_organism: str | None = PrivateAttr(default=None)
+    _verified_organism: bool | None = PrivateAttr(default=None)
 
     @model_validator(mode="before")
     @classmethod
@@ -62,4 +62,5 @@ class MutantSample(Sample):
     def model_dump(self, **kwargs) -> dict:
         data = super().model_dump(**kwargs)
         data["lab_code"] = self._lab_code
+        data["verified_organism"] = self._verified_organism
         return data


### PR DESCRIPTION
## Description

Override the microbial sample's model_dump so that we do not need special handling in the LIMS storing.

### Added

-

### Changed

-

### Fixed

- MutantSample and MicrosaltSample dumps the verified_organism value


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
