### PR TITLE
(Improve order flow) Fix validate_sample_names_different_from_case_names

### DIFF
--- a/cg/services/orders/validation/rules/case_sample/utils.py
+++ b/cg/services/orders/validation/rules/case_sample/utils.py
@@ -37,9 +37,7 @@ from cg.services.orders.validation.rules.utils import (
 )
 from cg.services.orders.validation.workflows.balsamic.models.sample import BalsamicSample
 from cg.services.orders.validation.workflows.balsamic_umi.models.sample import BalsamicUmiSample
-from cg.store.models import Application
-from cg.store.models import Case as DbCase
-from cg.store.models import Customer
+from cg.store.models import Application, Customer
 from cg.store.models import Sample as DbSample
 from cg.store.store import Store
 
@@ -314,6 +312,6 @@ def is_sample_not_from_collaboration(
 def get_existing_case_names(order: OrderWithCases, status_db: Store) -> set[str]:
     existing_case_names: set[str] = set()
     for _, case in order.enumerated_existing_cases:
-        db_case: DbCase | None = status_db.get_case_by_internal_id(case.internal_id)
-        existing_case_names.add(db_case.name)
+        if db_case := status_db.get_case_by_internal_id(case.internal_id):
+            existing_case_names.add(db_case.name)
     return existing_case_names

--- a/cg/services/orders/validation/rules/case_sample/utils.py
+++ b/cg/services/orders/validation/rules/case_sample/utils.py
@@ -37,7 +37,9 @@ from cg.services.orders.validation.rules.utils import (
 )
 from cg.services.orders.validation.workflows.balsamic.models.sample import BalsamicSample
 from cg.services.orders.validation.workflows.balsamic_umi.models.sample import BalsamicUmiSample
-from cg.store.models import Application, Customer
+from cg.store.models import Application
+from cg.store.models import Case as DbCase
+from cg.store.models import Customer
 from cg.store.models import Sample as DbSample
 from cg.store.store import Store
 
@@ -307,3 +309,11 @@ def is_sample_not_from_collaboration(
     db_sample: DbSample | None = store.get_sample_by_internal_id(sample.internal_id)
     customer: Customer | None = store.get_customer_by_internal_id(customer_id)
     return db_sample and customer and db_sample.customer not in customer.collaborators
+
+
+def get_existing_case_names(order: OrderWithCases, status_db: Store) -> set[str]:
+    existing_case_names: set[str] = set()
+    for _, case in order.enumerated_existing_cases:
+        db_case: DbCase | None = status_db.get_case_by_internal_id(case.internal_id)
+        existing_case_names.add(db_case.name)
+    return existing_case_names

--- a/tests/services/orders/validation_service/test_case_sample_rules.py
+++ b/tests/services/orders/validation_service/test_case_sample_rules.py
@@ -479,13 +479,13 @@ def test_validate_sex_subject_id_new_sex_unknown(valid_order: OrderWithCases, sa
 
 
 def test_validate_sample_names_different_from_case_names(
-    order_with_samples_having_same_names_as_cases: OrderWithCases,
+    order_with_samples_having_same_names_as_cases: OrderWithCases, base_store: Store
 ):
     # GIVEN an order with a case holding samples with the same name as cases in the order
 
     # WHEN validating that the sample names are different from the case names
     errors: list[SampleNameSameAsCaseNameError] = validate_sample_names_different_from_case_names(
-        order_with_samples_having_same_names_as_cases
+        order=order_with_samples_having_same_names_as_cases, store=base_store
     )
 
     # THEN a list with two errors should be returned


### PR DESCRIPTION
## Description

Existing cases do not have a name attribute which we can easily access so we need to fetch them from the database

### Added

-

### Changed

-

### Fixed

- validate_sample_names_different_from_case_names work with existing cases


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
