### PR TITLE
Feat(Hermes) Allow container path to be configured

### DIFF
--- a/cg/apps/hermes/hermes_api.py
+++ b/cg/apps/hermes/hermes_api.py
@@ -18,6 +18,7 @@ class HermesApi:
         self.process = Process(
             binary=config["hermes"]["binary_path"],
         )
+        self.container_path: str = config["hermes"]["container_path"]
         self.container_mount_volume = config["hermes"]["container_mount_volume"]
 
     def convert_deliverables(
@@ -33,7 +34,7 @@ class HermesApi:
             "run",
             "--bind",
             self.container_mount_volume,
-            "/home/proj/stage/singularity_containers/hermes_latest.sif",
+            self.container_path,
             "convert",
             "deliverables",
             "--workflow",

--- a/cg/models/cg_config.py
+++ b/cg/models/cg_config.py
@@ -27,9 +27,7 @@ from cg.constants.priority import SlurmQos
 from cg.meta.delivery.delivery import DeliveryAPI
 from cg.services.analysis_service.analysis_service import AnalysisService
 from cg.services.decompression_service.decompressor import Decompressor
-from cg.services.deliver_files.factory import (
-    DeliveryServiceFactory,
-)
+from cg.services.deliver_files.factory import DeliveryServiceFactory
 from cg.services.deliver_files.rsync.models import RsyncDeliveryConfig
 from cg.services.deliver_files.rsync.service import DeliveryRsyncService
 from cg.services.fastq_concatenation_service.fastq_concatenation_service import (
@@ -145,6 +143,10 @@ class CommonAppConfig(BaseModel):
     binary_path: str | None = None
     config_path: str | None = None
     container_mount_volume: str | None = None
+
+
+class HermesConfig(CommonAppConfig):
+    container_path: str
 
 
 class FluffyUploadConfig(BaseModel):
@@ -425,7 +427,7 @@ class CGConfig(BaseModel):
     genotype_api_: GenotypeAPI = None
     gens: CommonAppConfig = None
     gens_api_: GensAPI = None
-    hermes: CommonAppConfig = None
+    hermes: HermesConfig = None
     hermes_api_: HermesApi = None
     janus: ClientConfig | None = None
     janus_api_: JanusAPIClient | None = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1227,6 +1227,7 @@ def hermes_api(hermes_process: ProcessMock) -> HermesApi:
         "hermes": {
             "binary_path": "/bin/true",
             "container_mount_volume": "a_str",
+            "container_path": "/singularity_cache",
         }
     }
     hermes_api = HermesApi(config=hermes_config)
@@ -2051,7 +2052,7 @@ def context_config(
             "upload_password": "pass",
             "submitter": "s.submitter",
         },
-        "hermes": {"binary_path": "hermes"},
+        "hermes": {"binary_path": "hermes", "container_path": "/singularity_cache"},
         "housekeeper": {"database": hk_uri, "root": str(housekeeper_dir)},
         "lims": {
             "host": "https://lims.scilifelab.se",


### PR DESCRIPTION
## Description
The path of the Hermes container is hard-coded into the HermesAPI. This prevents any testing of changes in hermes without actually changing this string in a separate cg PR.

This PR allows it to be set in the config instead.

### Changed

- Allows the container path to be configured in the config of the CLI