### PR TITLE
Patch skip rc

### DIFF
--- a/cg/services/orders/validation/models/order.py
+++ b/cg/services/orders/validation/models/order.py
@@ -1,7 +1,9 @@
-from pydantic import BaseModel, Field, PrivateAttr, model_validator
+from pydantic import BaseModel, BeforeValidator, Field, PrivateAttr, model_validator
+from typing_extensions import Annotated
 
 from cg.constants import DataDelivery
 from cg.models.orders.constants import OrderType
+from cg.services.orders.validation.models.utils import set_null_to_false
 
 
 class Order(BaseModel):
@@ -10,7 +12,7 @@ class Order(BaseModel):
     delivery_type: DataDelivery
     order_type: OrderType = Field(alias="project_type")
     name: str = Field(min_length=1)
-    skip_reception_control: bool = False
+    skip_reception_control: Annotated[bool, BeforeValidator(set_null_to_false)] = False
     _generated_ticket_id: int | None = PrivateAttr(default=None)
     _user_id: int = PrivateAttr(default=None)
 

--- a/cg/services/orders/validation/models/utils.py
+++ b/cg/services/orders/validation/models/utils.py
@@ -1,0 +1,2 @@
+def set_null_to_false(value: bool | None) -> bool:
+    return value if value else False

--- a/tests/services/orders/validation_service/test_model_validator.py
+++ b/tests/services/orders/validation_service/test_model_validator.py
@@ -133,12 +133,12 @@ def test_null_conversion(valid_order: TomteOrder, model_validator: ModelValidato
 
 
 def test_skip_rc_default_conversion(valid_order: TomteOrder, model_validator: ModelValidator):
-    # GIVEN a Tomte order with a sample with empty concentration
+    # GIVEN a Tomte order with skip_reception_control set to None
     valid_order.skip_reception_control = None
     raw_order: dict = valid_order.model_dump(by_alias=True)
 
     # WHEN validating the order
     order, _ = model_validator.validate(order=raw_order, model=TomteOrder)
 
-    # THEN the empty concentration should be converted to None
+    # THEN the skip_reception_control value should be converted to None
     assert order.skip_reception_control is False

--- a/tests/services/orders/validation_service/test_model_validator.py
+++ b/tests/services/orders/validation_service/test_model_validator.py
@@ -130,3 +130,15 @@ def test_null_conversion(valid_order: TomteOrder, model_validator: ModelValidato
 
     # THEN the empty concentration should be converted to None
     assert order.cases[0].samples[0].concentration_ng_ul is None
+
+
+def test_skip_rc_default_conversion(valid_order: TomteOrder, model_validator: ModelValidator):
+    # GIVEN a Tomte order with a sample with empty concentration
+    valid_order.skip_reception_control = None
+    raw_order: dict = valid_order.model_dump(by_alias=True)
+
+    # WHEN validating the order
+    order, _ = model_validator.validate(order=raw_order, model=TomteOrder)
+
+    # THEN the empty concentration should be converted to None
+    assert order.skip_reception_control is False


### PR DESCRIPTION
## Description

Sometimes skip reception control gets sent as None. This gets converted to False now.

### Fixed

- skip_reception_control gets converted to False if null


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
