### PR TITLE
Add option to use BWA-MEM in Fluffy analysis commands

### DIFF
--- a/cg/cli/workflow/fluffy/base.py
+++ b/cg/cli/workflow/fluffy/base.py
@@ -13,6 +13,7 @@ from cg.models.cg_config import CGConfig
 
 ARGUMENT_CASE_ID = click.argument("case_id", required=True)
 OPTION_EXTERNAL_REF = click.option("-e", "--external-ref", is_flag=True)
+OPTION_USE_BWA_MEM = click.option("-b", "--use-bwa-mem", is_flag=True)
 
 LOG = logging.getLogger(__name__)
 
@@ -51,15 +52,27 @@ def create_samplesheet(context: CGConfig, case_id: str, dry_run: bool):
 @DRY_RUN
 @click.option("-c", "--config", help="Path to fluffy config in .json format")
 @OPTION_EXTERNAL_REF
+@OPTION_USE_BWA_MEM
 @click.pass_obj
-def run(context: CGConfig, case_id: str, dry_run: bool, config: str, external_ref: bool = False):
+def run(
+    context: CGConfig,
+    case_id: str,
+    dry_run: bool,
+    config: str,
+    external_ref: bool,
+    use_bwa_mem: bool,
+):
     """
     Run Fluffy analysis
     """
     analysis_api: FluffyAnalysisAPI = context.meta_apis["analysis_api"]
     analysis_api.status_db.verify_case_exists(case_internal_id=case_id)
     analysis_api.run_fluffy(
-        case_id=case_id, workflow_config=config, dry_run=dry_run, external_ref=external_ref
+        case_id=case_id,
+        workflow_config=config,
+        dry_run=dry_run,
+        external_ref=external_ref,
+        use_bwa_mem=use_bwa_mem,
     )
     if dry_run:
         return
@@ -78,12 +91,14 @@ def run(context: CGConfig, case_id: str, dry_run: bool, config: str, external_re
 @DRY_RUN
 @click.option("-c", "--config", help="Path to fluffy config in .json format")
 @OPTION_EXTERNAL_REF
+@OPTION_USE_BWA_MEM
 @click.pass_context
 def start(
     context: click.Context,
     case_id: str,
     dry_run: bool,
-    external_ref: bool = False,
+    external_ref: bool,
+    use_bwa_mem: bool,
     config: str = None,
 ):
     """
@@ -96,7 +111,14 @@ def start(
     analysis_api.prepare_fastq_files(case_id=case_id, dry_run=dry_run)
     context.invoke(link, case_id=case_id, dry_run=dry_run)
     context.invoke(create_samplesheet, case_id=case_id, dry_run=dry_run)
-    context.invoke(run, case_id=case_id, config=config, dry_run=dry_run, external_ref=external_ref)
+    context.invoke(
+        run,
+        case_id=case_id,
+        config=config,
+        dry_run=dry_run,
+        external_ref=external_ref,
+        use_bwa_mem=use_bwa_mem,
+    )
 
 
 @fluffy.command("start-available")

--- a/cg/meta/workflow/fluffy.py
+++ b/cg/meta/workflow/fluffy.py
@@ -227,7 +227,7 @@ class FluffyAnalysisAPI(AnalysisAPI):
             fluffy_sample_sheet.write_sample_sheet(sample_sheet_out_path)
 
     def run_fluffy(
-        self, case_id: str, dry_run: bool, workflow_config: str, external_ref: bool = False
+        self, case_id: str, dry_run: bool, workflow_config: str, external_ref: bool, use_bwa_mem: bool
     ) -> None:
         """
         Call fluffy with the configured command-line arguments
@@ -239,10 +239,8 @@ class FluffyAnalysisAPI(AnalysisAPI):
                 shutil.rmtree(output_path, ignore_errors=True)
         if not workflow_config:
             workflow_config = self.fluffy_config.as_posix()
-        if not external_ref:
-            batch_ref_flag = "--batch-ref"
-        else:
-            batch_ref_flag = ""
+        batch_ref_flag = "" if external_ref else "--batch-ref"
+        use_bwa_mem_flag = "--use-bwa-mem" if use_bwa_mem else ""
         command_args = [
             "--config",
             workflow_config,
@@ -254,6 +252,7 @@ class FluffyAnalysisAPI(AnalysisAPI):
             self.get_output_path(case_id=case_id).as_posix(),
             "--analyse",
             batch_ref_flag,
+            use_bwa_mem_flag,
             "--slurm_params",
             self.get_slurm_param_qos(case_id=case_id),
         ]

--- a/cg/meta/workflow/fluffy.py
+++ b/cg/meta/workflow/fluffy.py
@@ -245,7 +245,7 @@ class FluffyAnalysisAPI(AnalysisAPI):
         if not workflow_config:
             workflow_config = self.fluffy_config.as_posix()
         batch_ref_flag = "" if external_ref else "--batch-ref"
-        use_bwa_mem_flag = "--use-bwa-mem" if use_bwa_mem else ""
+        use_bwa_mem_flag = "--bwa-mem" if use_bwa_mem else ""
         command_args = [
             "--config",
             workflow_config,

--- a/cg/meta/workflow/fluffy.py
+++ b/cg/meta/workflow/fluffy.py
@@ -227,7 +227,12 @@ class FluffyAnalysisAPI(AnalysisAPI):
             fluffy_sample_sheet.write_sample_sheet(sample_sheet_out_path)
 
     def run_fluffy(
-        self, case_id: str, dry_run: bool, workflow_config: str, external_ref: bool, use_bwa_mem: bool
+        self,
+        case_id: str,
+        dry_run: bool,
+        workflow_config: str,
+        external_ref: bool,
+        use_bwa_mem: bool,
     ) -> None:
         """
         Call fluffy with the configured command-line arguments


### PR DESCRIPTION
## Description

### Added

- Option to use BWA-MEM in fluffy analysis commands


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
