### PR TITLE
Patch user rule

### DIFF
--- a/cg/services/orders/validation/rules/order/rules.py
+++ b/cg/services/orders/validation/rules/order/rules.py
@@ -4,6 +4,7 @@ from cg.services.orders.validation.errors.order_errors import (
     UserNotAssociatedWithCustomerError,
 )
 from cg.services.orders.validation.models.order import Order
+from cg.store.models import User
 from cg.store.store import Store
 
 
@@ -22,13 +23,13 @@ def validate_customer_exists(
 def validate_user_belongs_to_customer(
     order: Order, store: Store, **kwargs
 ) -> list[UserNotAssociatedWithCustomerError]:
+    user: User = store.get_user_by_entry_id(order._user_id)
     has_access: bool = store.is_user_associated_with_customer(
         user_id=order._user_id,
         customer_internal_id=order.customer,
     )
-
     errors: list[UserNotAssociatedWithCustomerError] = []
-    if not has_access:
+    if not user.is_admin or has_access:
         error = UserNotAssociatedWithCustomerError()
         errors.append(error)
     return errors

--- a/cg/services/orders/validation/rules/order/rules.py
+++ b/cg/services/orders/validation/rules/order/rules.py
@@ -29,7 +29,7 @@ def validate_user_belongs_to_customer(
         customer_internal_id=order.customer,
     )
     errors: list[UserNotAssociatedWithCustomerError] = []
-    if not user.is_admin or has_access:
+    if not (user.is_admin or has_access):
         error = UserNotAssociatedWithCustomerError()
         errors.append(error)
     return errors

--- a/cg/store/crud/read.py
+++ b/cg/store/crud/read.py
@@ -976,6 +976,14 @@ class ReadHandler(BaseHandler):
             filter_functions=[UserFilter.BY_EMAIL],
         ).first()
 
+    def get_user_by_entry_id(self, id: int) -> User | None:
+        """Return a user by its entry id."""
+        return apply_user_filter(
+            users=self._get_query(table=User),
+            user_id=id,
+            filter_functions=[UserFilter.BY_ID],
+        ).first()
+
     def is_user_associated_with_customer(self, user_id: int, customer_internal_id: str) -> bool:
         user: User | None = apply_user_filter(
             users=self._get_query(table=User),


### PR DESCRIPTION
## Description

Admins sometimes help customers place orders, but one of the new rules prevents this since the customer and user is not associated in StatusDB.

### Added

-

### Changed

-

### Fixed

- Admins are allowed to place orders for all customers


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
