### PR TITLE
Fix broken Mutant validation

### DIFF
--- a/cg/services/orders/validation/workflows/mutant/models/sample.py
+++ b/cg/services/orders/validation/workflows/mutant/models/sample.py
@@ -43,7 +43,7 @@ class MutantSample(Sample):
     def set_original_lab_address(cls, data: any) -> any:
         if isinstance(data, dict):
             is_set = bool(data.get("original_lab_address"))
-            if not is_set:
+            if not is_set and data.get("original_lab"):
                 data["original_lab_address"] = ORIGINAL_LAB_ADDRESSES[data["original_lab"]]
         return data
 
@@ -52,7 +52,7 @@ class MutantSample(Sample):
     def set_region_code(cls, data: any) -> any:
         if isinstance(data, dict):
             is_set = bool(data.get("region_code"))
-            if not is_set:
+            if not is_set and data.get("region"):
                 data["region_code"] = REGION_CODES[data["region"]]
         return data
 


### PR DESCRIPTION
## Description

If one tries to save a mutant sample without region and original lab set, the backend gives an internal server error. This PR fixes that

### Added

-

### Changed

-

### Fixed

- Region code only set by validator if region is set
- Original lab address only set by validator if original lab is set.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
