### PR TITLE
Set metagenome lims ids

### DIFF
--- a/cg/services/orders/storing/implementations/metagenome_order_service.py
+++ b/cg/services/orders/storing/implementations/metagenome_order_service.py
@@ -93,6 +93,7 @@ class StoreMetagenomeOrderService(StoreOrderService):
             sex=Sex.UNKNOWN,
             comment=sample.comment,
             control=sample.control,
+            internal_id=sample._generated_lims_id,
             order=order.name,
             ordered=datetime.now(),
             original_ticket=order._generated_ticket_id,


### PR DESCRIPTION
## Description

I introduced a bug in #4048 wherein metagenome and taxprofiler orders do not get their samples' LIMS ids set in StatusDB. This PR addresses that

### Added

-

### Changed

-

### Fixed

- Set the LIMS internal id for metagenome orders


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
