### PR TITLE
(Bug) Set correct priority on case orders

### DIFF
--- a/cg/services/orders/lims_service/service.py
+++ b/cg/services/orders/lims_service/service.py
@@ -30,6 +30,8 @@ class OrderLimsService:
             dict_sample["data_analysis"] = workflow
             dict_sample["data_delivery"] = delivery_type
             dict_sample["family_name"] = sample._case_name
+            if not dict_sample.get("priority"):
+                dict_sample["priority"] = sample._case_priority
             if skip_reception_control:
                 dict_sample["skip_reception_control"] = True
             lims_sample: LimsSample = LimsSample.parse_obj(dict_sample)

--- a/cg/services/orders/validation/models/case.py
+++ b/cg/services/orders/validation/models/case.py
@@ -72,3 +72,10 @@ class Case(BaseModel):
         for _, sample in self.enumerated_new_samples:
             sample._case_name = self.name
         return self
+
+    @model_validator(mode="after")
+    def set_case_priority_on_new_samples(self):
+        """Sets the priority on new samples, so it can be easily fetched when stored in LIMS."""
+        for _, sample in self.enumerated_new_samples:
+            sample._case_priority = self.priority
+        return self

--- a/cg/services/orders/validation/models/sample.py
+++ b/cg/services/orders/validation/models/sample.py
@@ -1,11 +1,12 @@
 from pydantic import BaseModel, Field, PrivateAttr, model_validator
 
-from cg.models.orders.sample_base import NAME_PATTERN, ContainerEnum
+from cg.models.orders.sample_base import NAME_PATTERN, ContainerEnum, PriorityEnum
 
 
 class Sample(BaseModel):
     application: str = Field(min_length=1)
     _case_name: str = PrivateAttr(default="")
+    _case_priority: PriorityEnum | None = PrivateAttr(default=None)
     comment: str | None = None
     container: ContainerEnum
     container_name: str | None = None

--- a/tests/fixtures/cgweb_orders/mip.json
+++ b/tests/fixtures/cgweb_orders/mip.json
@@ -6,7 +6,7 @@
 			"panels": [
 				"AID"
 			],
-			"priority": "standard",
+			"priority": "priority",
 			"samples": [
 				{
 					"age_at_sampling": null,

--- a/tests/services/orders/lims_service/test_order_lims_service.py
+++ b/tests/services/orders/lims_service/test_order_lims_service.py
@@ -36,7 +36,7 @@ def test_to_lims_mip(mip_dna_order: MipDnaOrder):
     # THEN it should pick out relevant UDFs
     first_sample: LimsSample = samples[0]
     assert first_sample.well_position == "A:1"
-    assert first_sample.udfs.priority == "standard"
+    assert first_sample.udfs.priority == "priority"
     assert first_sample.udfs.application == "WGSPCFC030"
     assert first_sample.udfs.source == "blood"
     assert first_sample.udfs.customer == "cust003"


### PR DESCRIPTION
## Description

Ever since #3815, all case orders, i.e. MIP-DNA, MIP-RNA, Balsamic, Balsamic-UMI, RNAFusion, and Tomte, have only gotten priority = standard set in LIMS. This PR remedies that miss and I will open a deviation for affected orders. 

### Added

-

### Changed

-

### Fixed

- Case priority is set on samples for case orders


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
