### PR TITLE
Patch- pagination index starting from 1

### DIFF
--- a/cg/services/web_services/sample/service.py
+++ b/cg/services/web_services/sample/service.py
@@ -51,7 +51,7 @@ class SampleService:
             pattern=request.enquiry,
             customers=customers,
             limit=request.page_size,
-            offset=request.page,
+            offset=(request.page - 1) * request.page_size,
         )
         parsed_samples: list[dict] = [sample.to_dict() for sample in samples]
         return parsed_samples, total


### PR DESCRIPTION
## Description
Adds adjustment to the offset of the sample querying taking into account that the page number received starts from 1 (not from 0)

### Added

-

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
