### PR TITLE
Create one case per sample in fastq orders

### DIFF
--- a/cg/services/orders/storing/implementations/fastq_order_service.py
+++ b/cg/services/orders/storing/implementations/fastq_order_service.py
@@ -45,16 +45,18 @@ class StoreFastqOrderService(StoreOrderService):
         The stored data objects are:
         - Order
         - Samples
-        - One Case containing all samples
-        - For each Sample, a relationship between the sample and the Case
+        - One Case per sample
+        - For each Sample, a relationship between the sample and its Case
         - For each non-tumour WGS Sample, a MAF Case and a relationship between the Sample and the
         MAF Case
         """
         db_order: Order = self._create_db_order(order=order)
-        db_case: Case = self._create_db_case(order=order, db_order=db_order)
         new_samples = []
         with self.status_db.session.no_autoflush:
             for sample in order.samples:
+                db_case: Case = self._create_db_case_for_sample(
+                    sample=sample, order=order, customer=db_order.customer
+                )
                 db_sample: Sample = self._create_db_sample(
                     sample=sample,
                     order_name=order.name,
@@ -65,10 +67,10 @@ class StoreFastqOrderService(StoreOrderService):
                 case_sample: CaseSample = self.status_db.relate_sample(
                     case=db_case, sample=db_sample, status=StatusEnum.unknown
                 )
-                self.status_db.add_multiple_items_to_store([db_sample, case_sample])
+                self.status_db.add_multiple_items_to_store([db_sample, case_sample, db_case])
                 new_samples.append(db_sample)
-        db_order.cases.append(db_case)
-        self.status_db.add_multiple_items_to_store([db_order, db_case])
+                db_order.cases.append(db_case)
+        self.status_db.add_item_to_store(db_order)
         self.status_db.commit_to_store()
         return new_samples
 
@@ -80,17 +82,20 @@ class StoreFastqOrderService(StoreOrderService):
         )
         return self.status_db.add_order(customer=customer, ticket_id=ticket_id)
 
-    def _create_db_case(self, order: FastqOrder, db_order: Order) -> Case:
+    def _create_db_case_for_sample(
+        self, sample: FastqSample, order: FastqOrder, customer: Customer
+    ) -> Case:
         """Return a Case database object."""
-        priority: str = order.samples[0].priority
+        case_name: str = f"{sample.name}-case"
+        priority: str = sample.priority
         case: Case = self.status_db.add_case(
             data_analysis=ORDER_TYPE_WORKFLOW_MAP[order.order_type],
             data_delivery=DataDelivery(order.delivery_type),
-            name=str(db_order.ticket_id),
+            name=case_name,
             priority=priority,
-            ticket=str(db_order.ticket_id),
+            ticket=str(order._generated_ticket_id),
         )
-        case.customer = db_order.customer
+        case.customer = customer
         return case
 
     def _create_db_sample(

--- a/cg/services/orders/storing/implementations/fastq_order_service.py
+++ b/cg/services/orders/storing/implementations/fastq_order_service.py
@@ -55,7 +55,7 @@ class StoreFastqOrderService(StoreOrderService):
         with self.status_db.session.no_autoflush:
             for sample in order.samples:
                 db_case: Case = self._create_db_case_for_sample(
-                    sample=sample, order=order, customer=db_order.customer
+                    sample=sample, customer=db_order.customer, order=order
                 )
                 db_sample: Sample = self._create_db_sample(
                     sample=sample,
@@ -83,10 +83,13 @@ class StoreFastqOrderService(StoreOrderService):
         return self.status_db.add_order(customer=customer, ticket_id=ticket_id)
 
     def _create_db_case_for_sample(
-        self, sample: FastqSample, order: FastqOrder, customer: Customer
+        self,
+        sample: FastqSample,
+        customer: Customer,
+        order: FastqOrder,
     ) -> Case:
         """Return a Case database object."""
-        ticket_id: str = str(order._generated_ticket_id)
+        ticket_id = str(order._generated_ticket_id)
         case_name: str = f"{sample.name}-{ticket_id}"
         priority: str = sample.priority
         case: Case = self.status_db.add_case(

--- a/cg/services/orders/storing/implementations/fastq_order_service.py
+++ b/cg/services/orders/storing/implementations/fastq_order_service.py
@@ -86,14 +86,15 @@ class StoreFastqOrderService(StoreOrderService):
         self, sample: FastqSample, order: FastqOrder, customer: Customer
     ) -> Case:
         """Return a Case database object."""
-        case_name: str = f"{sample.name}-case"
+        ticket_id: str = str(order._generated_ticket_id)
+        case_name: str = f"{sample.name}-{ticket_id}"
         priority: str = sample.priority
         case: Case = self.status_db.add_case(
             data_analysis=ORDER_TYPE_WORKFLOW_MAP[order.order_type],
             data_delivery=DataDelivery(order.delivery_type),
             name=case_name,
             priority=priority,
-            ticket=str(order._generated_ticket_id),
+            ticket=ticket_id,
         )
         case.customer = customer
         return case

--- a/cg/services/orders/storing/implementations/microbial_fastq_order_service.py
+++ b/cg/services/orders/storing/implementations/microbial_fastq_order_service.py
@@ -78,13 +78,14 @@ class StoreMicrobialFastqOrderService(StoreOrderService):
         self, sample: MicrobialFastqSample, customer: Customer, order: MicrobialFastqOrder
     ) -> Case:
         """Return a Case database object for a MicrobialFastqSample."""
-        case_name: str = f"{sample.name}-case"
+        ticket_id = str(order._generated_ticket_id)
+        case_name: str = f"{sample.name}-{ticket_id}"
         case: Case = self.status_db.add_case(
             data_analysis=ORDER_TYPE_WORKFLOW_MAP[order.order_type],
             data_delivery=DataDelivery(order.delivery_type),
             name=case_name,
             priority=sample.priority,
-            ticket=str(order._generated_ticket_id),
+            ticket=ticket_id,
         )
         case.customer = customer
         return case

--- a/tests/services/orders/store_service/test_fastq_order_service.py
+++ b/tests/services/orders/store_service/test_fastq_order_service.py
@@ -9,7 +9,7 @@ from cg.constants.sequencing import SeqLibraryPrepCategory
 from cg.services.orders.storing.constants import MAF_ORDER_ID
 from cg.services.orders.storing.implementations.fastq_order_service import StoreFastqOrderService
 from cg.services.orders.validation.workflows.fastq.models.order import FastqOrder
-from cg.store.models import Application, Case, Order, Sample
+from cg.store.models import Application, Case, CaseSample, Order, Sample
 from cg.store.store import Store
 from tests.store_helpers import StoreHelpers
 
@@ -38,12 +38,14 @@ def test_store_order_data_in_status_db(
     db_samples: list[Sample] = store_to_submit_and_validate_orders._get_query(table=Sample).all()
     assert set(new_samples) == set(db_samples)
 
-    # THEN it should create one case for the analysis and one MAF case
+    # THEN it should create one case per sample and one MAF case
     cases: list[Case] = store_to_submit_and_validate_orders._get_query(table=Case).all()
-    assert len(cases) == 2
-    assert len(db_samples[0].links) == 2
+    assert len(cases) == 3
+    links: list[CaseSample] = store_to_submit_and_validate_orders._get_query(table=CaseSample).all()
+    assert len(links) == 3
     assert cases[0].data_analysis == Workflow.MIP_DNA
     assert cases[1].data_analysis == Workflow.RAW_DATA
+    assert cases[2].data_analysis == Workflow.RAW_DATA
 
     # THEN the analysis case has allowed data deliveries
     assert cases[1].data_delivery in [DataDelivery.FASTQ, DataDelivery.NO_DELIVERY]


### PR DESCRIPTION
## Description
Closes #4181 
Modify the Fastq storing service to create one case per sample in the cg database, instead of one case containing all samples.

### Changed

- Method `store_order_data_in_status_db` from `StoreFastqOrderService`
- The unit test of the method above

### How to test

- [x] Submit a Fastq order in stage

### Expected test outcome

- [x] Check that one case per sample is created with the correct name

## Review

- [x] Tests executed by SD
- [x] "Merge and deploy" approved by CO
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Deployed to stage:
```shell

```
- [ ] Deployed to production:
```shell

```
