### PR TITLE
fix(dragen) Prevent double booking dragen nodes during demux

### DIFF
--- a/cg/models/slurm/sbatch.py
+++ b/cg/models/slurm/sbatch.py
@@ -23,4 +23,4 @@ class Sbatch(BaseModel):
 class SbatchDragen(Sbatch):
     partition: str = HastaSlurmPartitions.DRAGEN
     nodes: int = 1
-    cpus_per_task: int = 24
+    cpus_per_task: int = 48


### PR DESCRIPTION
## Description
During the autumn the SLURM configuration for cg-dragen was updated from stating it has 24 cores to the correct 48 cores. However since we still tell send the SLURM jobs out in cg, requesting 24 cores, SLURM can now allocate two such jobs to the same node.

In theory this means that the second one will just wait until the first one has completed, since they both need access to the "special dragen" board on the machine.

### Changed

- Demultiplexing job now requests 48 cores
