### PR TITLE
Fix check for existing data

### DIFF
--- a/cg/meta/orders/utils.py
+++ b/cg/meta/orders/utils.py
@@ -1,19 +1,15 @@
 from cg.clients.freshdesk.constants import Status
 from cg.models.orders.constants import OrderType
 from cg.services.orders.constants import ORDER_TYPE_WORKFLOW_MAP
-from cg.services.orders.validation.models.case import Case
 from cg.services.orders.validation.models.order import Order
 from cg.services.orders.validation.models.order_with_cases import OrderWithCases
 
 
 def contains_existing_data(order: OrderWithCases) -> bool:
     """Check if the order contains any existing data"""
-
-    for enumerated_case in order.enumerated_cases:
-        case: Case = enumerated_case[1]
-        if case.enumerated_existing_samples:
-            return True
-    return False
+    return any(
+        not case.is_new or case.enumerated_existing_samples for _, case in order.enumerated_cases
+    )
 
 
 def get_ticket_tags(order: Order, order_type: OrderType) -> list[str]:


### PR DESCRIPTION
## Description

We currently access a property called `enumerated_existing_samples` for all cases in an order. But the attribute is only present on new cases. So we get nullpointer exceptions for existing cases in the order.

### Added

-

### Changed

-

### Fixed

- Check if the case is old before checking if it contains existing samples


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
