### PR TITLE
Add status rules for MIP-DNA validation rules

### DIFF
--- a/cg/services/orders/validation/errors/case_errors.py
+++ b/cg/services/orders/validation/errors/case_errors.py
@@ -56,3 +56,15 @@ class DoubleNormalError(NumberOfNormalSamplesError):
 
 class DoubleTumourError(NumberOfNormalSamplesError):
     message: str = "Only one tumour sample is allowed per case"
+
+
+class NewCaseWithoutAffectedSampleError(CaseError):
+    field: str = "sample_errors"
+    message: str = "Each case needs at least one affected sample"
+
+
+class ExistingCaseWithoutAffectedSampleError(CaseError):
+    field: str = "sample_errors"
+    message: str = (
+        "This case contains no affected sample. Please create a new case with at least one affected sample."
+    )

--- a/cg/services/orders/validation/workflows/mip_dna/models/sample.py
+++ b/cg/services/orders/validation/workflows/mip_dna/models/sample.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from pydantic import BeforeValidator, Field
 from typing_extensions import Annotated
 
@@ -20,7 +22,7 @@ class MipDnaSample(Sample):
     require_qc_ok: bool = False
     sex: SexEnum
     source: str
-    status: StatusEnum
+    status: Literal[StatusEnum.affected.value, StatusEnum.unaffected.value]
     subject_id: str = Field(pattern=NAME_PATTERN, max_length=128)
     tissue_block_size: TissueBlockEnum | None = None
     concentration_ng_ul: float | None = None

--- a/cg/services/orders/validation/workflows/mip_dna/validation_rules.py
+++ b/cg/services/orders/validation/workflows/mip_dna/validation_rules.py
@@ -4,6 +4,7 @@ from cg.services.orders.validation.rules.case.rules import (
     validate_case_names_not_repeated,
     validate_each_new_case_has_an_affected_sample,
     validate_existing_cases_belong_to_collaboration,
+    validate_existing_cases_have_an_affected_sample,
     validate_gene_panels_unique,
 )
 from cg.services.orders.validation.rules.case_sample.rules import (
@@ -42,6 +43,7 @@ MIP_DNA_CASE_RULES: list[callable] = [
     validate_case_names_available,
     validate_case_names_not_repeated,
     validate_each_new_case_has_an_affected_sample,
+    validate_existing_cases_have_an_affected_sample,
     validate_existing_cases_belong_to_collaboration,
     validate_gene_panels_exist,
     validate_gene_panels_unique,

--- a/cg/services/orders/validation/workflows/mip_dna/validation_rules.py
+++ b/cg/services/orders/validation/workflows/mip_dna/validation_rules.py
@@ -2,6 +2,7 @@ from cg.services.orders.validation.rules.case.rules import (
     validate_case_internal_ids_exist,
     validate_case_names_available,
     validate_case_names_not_repeated,
+    validate_each_new_case_has_an_affected_sample,
     validate_existing_cases_belong_to_collaboration,
     validate_gene_panels_unique,
 )
@@ -40,6 +41,7 @@ MIP_DNA_CASE_RULES: list[callable] = [
     validate_case_internal_ids_exist,
     validate_case_names_available,
     validate_case_names_not_repeated,
+    validate_each_new_case_has_an_affected_sample,
     validate_existing_cases_belong_to_collaboration,
     validate_gene_panels_exist,
     validate_gene_panels_unique,

--- a/tests/services/orders/validation_service/test_case_rules.py
+++ b/tests/services/orders/validation_service/test_case_rules.py
@@ -1,10 +1,12 @@
 from cg.constants import GenePanelMasterList
-from cg.models.orders.sample_base import ContainerEnum, SexEnum
+from cg.models.orders.sample_base import ContainerEnum, SexEnum, StatusEnum
 from cg.services.orders.validation.errors.case_errors import (
     CaseDoesNotExistError,
     CaseNameNotAvailableError,
     CaseOutsideOfCollaborationError,
+    ExistingCaseWithoutAffectedSampleError,
     MultipleSamplesInCaseError,
+    NewCaseWithoutAffectedSampleError,
     RepeatedCaseNameError,
 )
 from cg.services.orders.validation.models.existing_case import ExistingCase
@@ -13,7 +15,9 @@ from cg.services.orders.validation.rules.case.rules import (
     validate_case_internal_ids_exist,
     validate_case_names_available,
     validate_case_names_not_repeated,
+    validate_each_new_case_has_an_affected_sample,
     validate_existing_cases_belong_to_collaboration,
+    validate_existing_cases_have_an_affected_sample,
     validate_one_sample_per_case,
 )
 from cg.services.orders.validation.workflows.mip_dna.models.order import MipDnaOrder
@@ -138,3 +142,51 @@ def test_case_outside_of_collaboration(
 
     # THEN the error should concern the added existing case
     assert isinstance(errors[0], CaseOutsideOfCollaborationError)
+
+
+def test_new_case_without_affected_samples(mip_dna_order: MipDnaOrder):
+    """Tests that an error is returned if a new case does not contain any affected samples."""
+
+    # GIVEN an order containing a case without any affected samples
+    for sample in mip_dna_order.cases[0].samples:
+        sample.status = StatusEnum.unaffected
+
+    # WHEN validating that each case contains at least one affected sample
+    errors: list[NewCaseWithoutAffectedSampleError] = validate_each_new_case_has_an_affected_sample(
+        mip_dna_order
+    )
+
+    # THEN an error should be returned
+    assert errors
+
+    # THEN the error should concern the first case
+    assert errors[0].case_index == 0
+
+
+def test_existing_case_without_affected_samples(
+    mip_dna_order: MipDnaOrder,
+    store_with_multiple_cases_and_samples: Store,
+    case_id_with_single_sample: str,
+):
+    """Tests that an error is returned if an existing case does not contain any affected samples."""
+
+    # GIVEN an order containing an existing case without any affected samples
+    db_case: Case = store_with_multiple_cases_and_samples.get_case_by_internal_id(
+        case_id_with_single_sample
+    )
+    assert all(link.status != StatusEnum.affected for link in db_case.links)
+    existing_case = ExistingCase(internal_id=db_case.internal_id, panels=db_case.panels)
+    mip_dna_order.cases.append(existing_case)
+
+    # WHEN validating that each case contains at least one affected sample
+    errors: list[ExistingCaseWithoutAffectedSampleError] = (
+        validate_existing_cases_have_an_affected_sample(
+            order=mip_dna_order, store=store_with_multiple_cases_and_samples
+        )
+    )
+
+    # THEN an error should be returned
+    assert errors
+
+    # THEN the error should concern the first case
+    assert errors[0].case_index == mip_dna_order.cases.index(existing_case)


### PR DESCRIPTION
## Description

Closes #4054. 

### Added

- Validation rule ensuring that each new case contains at least one affected sample in MIP-DNA
- Validation rule ensuring that existing cases without at least one affected sample is not allowed in MIP-DNA
- Type hint for statuses of new MIP-DNA samples only allows for affected or unaffected

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
