### PR TITLE
Remove BALSAMIC_QC order type option

### DIFF
--- a/alembic/versions/2025_02_11_0037f4bf9be3_remove_balsamic_qc_as_option.py
+++ b/alembic/versions/2025_02_11_0037f4bf9be3_remove_balsamic_qc_as_option.py
@@ -46,6 +46,7 @@ def upgrade():
         column_name="order_type",
         existing_type=sa.Enum(*old_order_types),
         type_=sa.Enum(*new_order_types),
+        nullable=False,
     )
 
 
@@ -55,4 +56,5 @@ def downgrade():
         column_name="order_type",
         existing_type=sa.Enum(*new_order_types),
         type_=sa.Enum(*old_order_types),
+        nullable=False,
     )

--- a/alembic/versions/2025_02_11_0037f4bf9be3_remove_balsamic_qc_as_option.py
+++ b/alembic/versions/2025_02_11_0037f4bf9be3_remove_balsamic_qc_as_option.py
@@ -1,0 +1,58 @@
+"""Remove Balsamic-QC as option
+
+Revision ID: 0037f4bf9be3
+Revises: a9568bb3a8b7
+Create Date: 2025-02-11 09:13:35.303826
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0037f4bf9be3"
+down_revision = "a9568bb3a8b7"
+branch_labels = None
+depends_on = None
+
+
+old_order_types = [
+    "BALSAMIC",
+    "BALSAMIC_QC",
+    "BALSAMIC_UMI",
+    "FASTQ",
+    "FLUFFY",
+    "METAGENOME",
+    "MICROBIAL_FASTQ",
+    "MICROSALT",
+    "MIP_DNA",
+    "MIP_RNA",
+    "PACBIO_LONG_READ",
+    "RML",
+    "RNAFUSION",
+    "SARS_COV_2",
+    "TAXPROFILER",
+    "TOMTE",
+]
+
+new_order_types = old_order_types.copy()
+new_order_types.remove("BALSAMIC_QC")
+
+
+def upgrade():
+    op.alter_column(
+        table_name="order_type_application",
+        column_name="order_type",
+        existing_type=sa.Enum(*old_order_types),
+        type_=sa.Enum(*new_order_types),
+    )
+
+
+def downgrade():
+    op.alter_column(
+        table_name="order_type_application",
+        column_name="order_type",
+        existing_type=sa.Enum(*new_order_types),
+        type_=sa.Enum(*old_order_types),
+    )


### PR DESCRIPTION
## Description

BALSAMIC_QC support has dropped but the enum in the actual db table order_type_application was missed. This PR remedies that.

### Added

-

### Changed

-

### Fixed

- The OrderTypeApplication table no longer references BALSAMIC_QC.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
