### PR TITLE
Add order name max length restriction

### DIFF
--- a/cg/services/orders/validation/models/order.py
+++ b/cg/services/orders/validation/models/order.py
@@ -11,7 +11,7 @@ class Order(BaseModel):
     customer: str = Field(min_length=1)
     delivery_type: DataDelivery
     order_type: OrderType = Field(alias="project_type")
-    name: str = Field(min_length=1)
+    name: str = Field(min_length=1, max_length=64)
     skip_reception_control: Annotated[bool, BeforeValidator(set_null_to_false)] = False
     _generated_ticket_id: int | None = PrivateAttr(default=None)
     _user_id: int = PrivateAttr(default=None)


### PR DESCRIPTION
## Description

Our sample.order column only allows for 64 characters. This is where the order name goes, so we should validate that the name is short enough to be persisted.

### Added

-

### Changed

-

### Fixed

- Max restriction of 64 characters on the order name


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
