### PR TITLE
chore: centralise app config

### DIFF
--- a/cg/apps/osticket.py
+++ b/cg/apps/osticket.py
@@ -13,6 +13,7 @@ from cg.io.controller import WriteFile, WriteStream
 LOG = logging.getLogger(__name__)
 TEXT_FILE_ATTACH_PARAMS = "data:text/plain;charset=utf-8,{content}"
 
+
 class OsTicket(object):
     """Interface to ticket system"""
 

--- a/cg/apps/osticket.py
+++ b/cg/apps/osticket.py
@@ -13,7 +13,6 @@ from cg.io.controller import WriteFile, WriteStream
 LOG = logging.getLogger(__name__)
 TEXT_FILE_ATTACH_PARAMS = "data:text/plain;charset=utf-8,{content}"
 
-
 class OsTicket(object):
     """Interface to ticket system"""
 

--- a/cg/server/app.py
+++ b/cg/server/app.py
@@ -60,7 +60,7 @@ def create_app():
 
 def _load_config(app: Flask):
     app.config.update(app_config.model_dump())
-
+    app.secret_key = app_config.secret_key
 
 def _configure_extensions(app: Flask):
     _initialize_logging(app)

--- a/cg/server/app.py
+++ b/cg/server/app.py
@@ -60,7 +60,7 @@ def create_app():
 
 def _load_config(app: Flask):
     app.config.update(app_config.model_dump())
-    
+
 
 def _configure_extensions(app: Flask):
     _initialize_logging(app)

--- a/cg/server/app.py
+++ b/cg/server/app.py
@@ -44,7 +44,7 @@ from cg.store.models import (
     Sample,
     User,
 )
-from app_config import app_config
+from cg.server.app_config import app_config
 
 
 def create_app():

--- a/cg/server/app.py
+++ b/cg/server/app.py
@@ -62,6 +62,7 @@ def _load_config(app: Flask):
     app.config.update(app_config.model_dump())
     app.secret_key = app_config.secret_key
 
+
 def _configure_extensions(app: Flask):
     _initialize_logging(app)
     certs_resp = requests.get("https://www.googleapis.com/oauth2/v1/certs")

--- a/cg/server/app.py
+++ b/cg/server/app.py
@@ -46,6 +46,7 @@ from cg.store.models import (
 )
 from app_config import app_config
 
+
 def create_app():
     """Generate a flask application."""
     app = Flask(__name__, template_folder="templates")

--- a/cg/server/app.py
+++ b/cg/server/app.py
@@ -44,7 +44,7 @@ from cg.store.models import (
     Sample,
     User,
 )
-
+from app_config import app_config
 
 def create_app():
     """Generate a flask application."""
@@ -58,8 +58,7 @@ def create_app():
 
 
 def _load_config(app: Flask):
-    app.config.update(app_config.dict())
-    app.secret_key = app.config["cg_secret_key"]
+    app.config.update(app_config.model_dump())
 
 
 def _configure_extensions(app: Flask):
@@ -82,8 +81,8 @@ def _initialize_logging(app):
 
 def _register_blueprints(app: Flask):
     oauth_bp = make_google_blueprint(
-        client_id=app.config["google_oauth_client_id"],
-        client_secret=app.config["google_oauth_client_secret"],
+        client_id=app_config.google_oauth_client_id,
+        client_secret=app_config.google_oauth_client_secret,
         scope=["openid", "https://www.googleapis.com/auth/userinfo.email"],
     )
 

--- a/cg/server/app.py
+++ b/cg/server/app.py
@@ -60,7 +60,7 @@ def create_app():
 
 def _load_config(app: Flask):
     app.config.update(app_config.model_dump())
-    app.secret_key = app_config.secret_key
+    app.secret_key = app_config.cg_secret_key
 
 
 def _configure_extensions(app: Flask):

--- a/cg/server/app.py
+++ b/cg/server/app.py
@@ -60,7 +60,7 @@ def create_app():
 
 def _load_config(app: Flask):
     app.config.update(app_config.model_dump())
-
+    
 
 def _configure_extensions(app: Flask):
     _initialize_logging(app)

--- a/cg/server/app_config.py
+++ b/cg/server/app_config.py
@@ -1,6 +1,7 @@
 from pydantic_settings import BaseSettings
 import os
 
+
 class AppConfig(BaseSettings):
     """Default values are overridden by environment variable at run-time."""
 
@@ -20,12 +21,13 @@ class AppConfig(BaseSettings):
     google_oauth_client_secret: str = os.getenv("GOOGLE_OAUTH_CLIENT_SECRET", "client_secret")
     trailblazer_host: str = os.getenv("TRAILBLAZER_HOST", "trailblazer_host")
     trailblazer_service_account: str = os.getenv("TRAILBLAZER_SERVICE_ACCOUNT", "service_account")
-    trailblazer_service_account_auth_file: str = os.getenv("TRAILBLAZER_SERVICE_ACCOUNT_AUTH_FILE", "auth_file.json")
+    trailblazer_service_account_auth_file: str = os.getenv(
+        "TRAILBLAZER_SERVICE_ACCOUNT_AUTH_FILE", "auth_file.json"
+    )
     freshdesk_url: str = os.getenv("FRESHDESK_URL", "https://company.freshdesk.com")
     freshdesk_api_key: str = os.getenv("FRESHDESK_API_KEY", "freshdesk_api_key")
     freshdesk_order_email_id: int = int(os.getenv("FRESHDESK_ORDER_EMAIL_ID", 10))
     freshdesk_environment: str = os.getenv("FRESHDESK_ENVIRONMENT", "Stage")
-
 
 
 app_config = AppConfig()

--- a/cg/server/app_config.py
+++ b/cg/server/app_config.py
@@ -1,30 +1,31 @@
 from pydantic_settings import BaseSettings
-
+import os
 
 class AppConfig(BaseSettings):
     """Default values are overridden by environment variable at run-time."""
 
-    gunicorn_workers: int = 4
-    gunicorn_threads: int = 4
-    gunicorn_bind: str = "0.0.0.0:8000"
-    gunicorn_timeout: int = 400
-    cg_sql_database_uri: str = "sqlite:///"
-    cg_secret_key: str = "thisIsNotASafeKey"
-    invoice_max_price: int = 750_000
-    lims_host: str = "lims_host"
-    lims_username: str = "username"
-    lims_password: str = "password"
-    support_system_email: str = "support@mail.com"
-    email_uri: str = "smtp://localhost"
-    google_oauth_client_id: str = "client_id"
-    google_oauth_client_secret: str = "client_secret"
-    trailblazer_host: str = "trailblazer_host"
-    trailblazer_service_account: str = "service_account"
-    trailblazer_service_account_auth_file: str = "auth_file.json"
-    freshdesk_url: str = "https://company.freshdesk.com"
-    freshdesk_api_key: str = "freshdesk_api_key"
-    freshdesk_order_email_id: int = 10
-    freshdesk_environment: str = "Stage"
+    gunicorn_workers: int = int(os.getenv("GUNICORN_WORKERS", 4))
+    gunicorn_threads: int = int(os.getenv("GUNICORN_THREADS", 4))
+    gunicorn_bind: str = os.getenv("GUNICORN_BIND", "0.0.0.0:8000")
+    gunicorn_timeout: int = int(os.getenv("GUNICORN_TIMEOUT", 400))
+    cg_sql_database_uri: str = os.getenv("CG_SQL_DATABASE_URI", "sqlite:///")
+    cg_secret_key: str = os.getenv("CG_SECRET_KEY", "thisIsNotASafeKey")
+    invoice_max_price: int = int(os.getenv("INVOICE_MAX_PRICE", 750_000))
+    lims_host: str = os.getenv("LIMS_HOST", "lims_host")
+    lims_username: str = os.getenv("LIMS_USERNAME", "username")
+    lims_password: str = os.getenv("LIMS_PASSWORD", "password")
+    support_system_email: str = os.getenv("SUPPORT_SYSTEM_EMAIL", "support@mail.com")
+    email_uri: str = os.getenv("EMAIL_URI", "smtp://localhost")
+    google_oauth_client_id: str = os.getenv("GOOGLE_OAUTH_CLIENT_ID", "client_id")
+    google_oauth_client_secret: str = os.getenv("GOOGLE_OAUTH_CLIENT_SECRET", "client_secret")
+    trailblazer_host: str = os.getenv("TRAILBLAZER_HOST", "trailblazer_host")
+    trailblazer_service_account: str = os.getenv("TRAILBLAZER_SERVICE_ACCOUNT", "service_account")
+    trailblazer_service_account_auth_file: str = os.getenv("TRAILBLAZER_SERVICE_ACCOUNT_AUTH_FILE", "auth_file.json")
+    freshdesk_url: str = os.getenv("FRESHDESK_URL", "https://company.freshdesk.com")
+    freshdesk_api_key: str = os.getenv("FRESHDESK_API_KEY", "freshdesk_api_key")
+    freshdesk_order_email_id: int = int(os.getenv("FRESHDESK_ORDER_EMAIL_ID", 10))
+    freshdesk_environment: str = os.getenv("FRESHDESK_ENVIRONMENT", "Stage")
+
 
 
 app_config = AppConfig()

--- a/cg/server/app_config.py
+++ b/cg/server/app_config.py
@@ -10,7 +10,7 @@ class AppConfig(BaseSettings):
     gunicorn_bind: str = os.getenv("GUNICORN_BIND", "0.0.0.0:8000")
     gunicorn_timeout: int = int(os.getenv("GUNICORN_TIMEOUT", 400))
     cg_sql_database_uri: str = os.getenv("CG_SQL_DATABASE_URI", "sqlite:///")
-    cg_secret_key: str = os.getenv("CG_SECRET_KEY", "thisIsNotASafeKey")
+    secret_key: str = os.getenv("CG_SECRET_KEY", "thisIsNotASafeKey")
     invoice_max_price: int = int(os.getenv("INVOICE_MAX_PRICE", 750_000))
     lims_host: str = os.getenv("LIMS_HOST", "lims_host")
     lims_username: str = os.getenv("LIMS_USERNAME", "username")

--- a/cg/server/app_config.py
+++ b/cg/server/app_config.py
@@ -2,43 +2,47 @@ from pydantic_settings import BaseSettings
 
 
 class AppConfig(BaseSettings):
-    """Default values are overridden by environment variable at run-time."""
+    """
+    Default values are overridden by environment variable at run-time.
+    The environment variables are defined in the servers repo config/CGVS/config/container-env/cg.env
+    """
 
-# Gunicorn settings
+    # Gunicorn settings
     gunicorn_workers: int = 4
     gunicorn_threads: int = 4
     gunicorn_bind: str = "0.0.0.0:8000"
     gunicorn_timeout: int = 400
-    
+
     # Database settings
     cg_sql_database_uri: str = "sqlite:///"
-    
+
     # Security settings
     cg_secret_key: str = "thisIsNotASafeKey"
     invoice_max_price: int = 750_000
-    
+
     # LIMS settings
     lims_host: str = "lims_host"
     lims_username: str = "username"
     lims_password: str = "password"
-    
+
     # Email settings
     support_system_email: str = "support@mail.com"
     email_uri: str = "smtp://localhost"
-    
+
     # Google OAuth settings
     google_oauth_client_id: str = "client_id"
     google_oauth_client_secret: str = "client_secret"
-    
+
     # Trailblazer settings
     trailblazer_host: str = "trailblazer_host"
     trailblazer_service_account: str = "service_account"
     trailblazer_service_account_auth_file: str = "auth_file.json"
-    
+
     # Freshdesk settings
     freshdesk_url: str = "https://company.freshdesk.com"
     freshdesk_api_key: str = "freshdesk_api_key"
     freshdesk_order_email_id: int = 10
     freshdesk_environment: str = "Stage"
+
 
 app_config = AppConfig()

--- a/cg/server/app_config.py
+++ b/cg/server/app_config.py
@@ -1,33 +1,44 @@
 from pydantic_settings import BaseSettings
-import os
 
 
 class AppConfig(BaseSettings):
     """Default values are overridden by environment variable at run-time."""
 
-    gunicorn_workers: int = int(os.getenv("GUNICORN_WORKERS", 4))
-    gunicorn_threads: int = int(os.getenv("GUNICORN_THREADS", 4))
-    gunicorn_bind: str = os.getenv("GUNICORN_BIND", "0.0.0.0:8000")
-    gunicorn_timeout: int = int(os.getenv("GUNICORN_TIMEOUT", 400))
-    cg_sql_database_uri: str = os.getenv("CG_SQL_DATABASE_URI", "sqlite:///")
-    secret_key: str = os.getenv("CG_SECRET_KEY", "thisIsNotASafeKey")
-    invoice_max_price: int = int(os.getenv("INVOICE_MAX_PRICE", 750_000))
-    lims_host: str = os.getenv("LIMS_HOST", "lims_host")
-    lims_username: str = os.getenv("LIMS_USERNAME", "username")
-    lims_password: str = os.getenv("LIMS_PASSWORD", "password")
-    support_system_email: str = os.getenv("SUPPORT_SYSTEM_EMAIL", "support@mail.com")
-    email_uri: str = os.getenv("EMAIL_URI", "smtp://localhost")
-    google_oauth_client_id: str = os.getenv("GOOGLE_OAUTH_CLIENT_ID", "client_id")
-    google_oauth_client_secret: str = os.getenv("GOOGLE_OAUTH_CLIENT_SECRET", "client_secret")
-    trailblazer_host: str = os.getenv("TRAILBLAZER_HOST", "trailblazer_host")
-    trailblazer_service_account: str = os.getenv("TRAILBLAZER_SERVICE_ACCOUNT", "service_account")
-    trailblazer_service_account_auth_file: str = os.getenv(
-        "TRAILBLAZER_SERVICE_ACCOUNT_AUTH_FILE", "auth_file.json"
-    )
-    freshdesk_url: str = os.getenv("FRESHDESK_URL", "https://company.freshdesk.com")
-    freshdesk_api_key: str = os.getenv("FRESHDESK_API_KEY", "freshdesk_api_key")
-    freshdesk_order_email_id: int = int(os.getenv("FRESHDESK_ORDER_EMAIL_ID", 10))
-    freshdesk_environment: str = os.getenv("FRESHDESK_ENVIRONMENT", "Stage")
-
+# Gunicorn settings
+    gunicorn_workers: int = 4
+    gunicorn_threads: int = 4
+    gunicorn_bind: str = "0.0.0.0:8000"
+    gunicorn_timeout: int = 400
+    
+    # Database settings
+    cg_sql_database_uri: str = "sqlite:///"
+    
+    # Security settings
+    cg_secret_key: str = "thisIsNotASafeKey"
+    invoice_max_price: int = 750_000
+    
+    # LIMS settings
+    lims_host: str = "lims_host"
+    lims_username: str = "username"
+    lims_password: str = "password"
+    
+    # Email settings
+    support_system_email: str = "support@mail.com"
+    email_uri: str = "smtp://localhost"
+    
+    # Google OAuth settings
+    google_oauth_client_id: str = "client_id"
+    google_oauth_client_secret: str = "client_secret"
+    
+    # Trailblazer settings
+    trailblazer_host: str = "trailblazer_host"
+    trailblazer_service_account: str = "service_account"
+    trailblazer_service_account_auth_file: str = "auth_file.json"
+    
+    # Freshdesk settings
+    freshdesk_url: str = "https://company.freshdesk.com"
+    freshdesk_api_key: str = "freshdesk_api_key"
+    freshdesk_order_email_id: int = 10
+    freshdesk_environment: str = "Stage"
 
 app_config = AppConfig()

--- a/cg/server/ext.py
+++ b/cg/server/ext.py
@@ -29,6 +29,7 @@ from cg.store.database import initialize_database
 from cg.store.store import Store
 from app_config import app_config
 
+
 class FlaskLims(LimsAPI):
     def __init__(self, app=None):
         if app:

--- a/cg/server/ext.py
+++ b/cg/server/ext.py
@@ -27,7 +27,7 @@ from cg.services.web_services.case.service import CaseWebService
 from cg.services.web_services.sample.service import SampleService
 from cg.store.database import initialize_database
 from cg.store.store import Store
-from app_config import app_config
+from cg.server.app_config import app_config
 
 
 class FlaskLims(LimsAPI):

--- a/cg/server/ext.py
+++ b/cg/server/ext.py
@@ -27,7 +27,7 @@ from cg.services.web_services.case.service import CaseWebService
 from cg.services.web_services.sample.service import SampleService
 from cg.store.database import initialize_database
 from cg.store.store import Store
-
+from app_config import app_config
 
 class FlaskLims(LimsAPI):
     def __init__(self, app=None):
@@ -37,9 +37,9 @@ class FlaskLims(LimsAPI):
     def init_app(self, app):
         config = {
             "lims": {
-                "host": app.config["lims_host"],
-                "username": app.config["lims_username"],
-                "password": app.config["lims_password"],
+                "host": app_config.lims_host,
+                "username": app_config.lims_username,
+                "password": app_config.lims_password,
             }
         }
         super(FlaskLims, self).__init__(config)
@@ -51,7 +51,7 @@ class FlaskStore(Store):
             self.init_app(app)
 
     def init_app(self, app):
-        uri = app.config["cg_sql_database_uri"]
+        uri = app_config.cg_sql_database_uri
         initialize_database(uri)
         super(FlaskStore, self).__init__()
 
@@ -69,14 +69,11 @@ class AnalysisClient(TrailblazerAPI):
             self.init_app(app)
 
     def init_app(self, app):
-        service_account: str = app.config["trailblazer_service_account"]
-        service_account_auth_file: str = app.config["trailblazer_service_account_auth_file"]
-        host: str = app.config["trailblazer_host"]
         config = {
             "trailblazer": {
-                "service_account": service_account,
-                "service_account_auth_file": service_account_auth_file,
-                "host": host,
+                "service_account": app_config.trailblazer_service_account,
+                "service_account_auth_file": app_config.trailblazer_service_account_auth_file,
+                "host": app_config.trailblazer_host,
             }
         }
         super(AnalysisClient, self).__init__(config)


### PR DESCRIPTION
## Description

Centralise the flask app config values.

### Added

-

### Changed

- Change the class app_config to read in ENV values or set a default if it is not present.

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
