### PR TITLE
(Pipeline implementation) Add Seqera config and method bodies

### DIFF
--- a/cg/models/cg_config.py
+++ b/cg/models/cg_config.py
@@ -22,6 +22,7 @@ from cg.apps.tb import TrailblazerAPI
 from cg.clients.arnold.api import ArnoldAPIClient
 from cg.clients.chanjo2.client import Chanjo2APIClient
 from cg.clients.janus.api import JanusAPIClient
+from cg.constants import Workflow
 from cg.constants.observations import LoqusdbInstance
 from cg.constants.priority import SlurmQos
 from cg.meta.delivery.delivery import DeliveryAPI
@@ -347,6 +348,14 @@ class ExternalConfig(BaseModel):
     caesar: str
 
 
+class SeqeraPlatformConfig(BaseModel):
+    base_url: str
+    bearer_token: str
+    compute_environments: dict[SlurmQos, str]
+    workflow_ids: dict[Workflow, int]
+    workspace_id: int
+
+
 class DataFlowConfig(BaseModel):
     database_name: str
     user: str
@@ -449,6 +458,7 @@ class CGConfig(BaseModel):
     pigz: CommonAppConfig | None = None
     run_names_services_: RunNamesServices | None = None
     sample_sheet_api_: IlluminaSampleSheetService | None = None
+    seqera_platform: SeqeraPlatformConfig | None = None
     scout: CommonAppConfig = None
     scout_api_: ScoutAPI = None
     tar: CommonAppConfig | None = None

--- a/cg/services/analysis_starter/submitters/seqera_platform/client.py
+++ b/cg/services/analysis_starter/submitters/seqera_platform/client.py
@@ -1,12 +1,36 @@
+import requests
+
 from cg.constants import Workflow
+from cg.constants.priority import SlurmQos
+from cg.models.cg_config import SeqeraPlatformConfig
 
 
 class SeqeraPlatformClient:
-    def get_workflow_config(self, workflow: Workflow):
-        pass
+    def __init__(self, config: SeqeraPlatformConfig):
+        self.base_url: str = config.base_url
+        self.bearer_token: str = config.bearer_token
+        self.compute_environment_ids: dict[SlurmQos, str] = config.compute_environments
+        self.workflow_ids: dict[Workflow, int] = config.workflow_ids
+        self.workspace_id: int = config.workspace_id
 
-    def run_case(self, request):
-        pass
+    def get_workflow_config(self, workflow: Workflow) -> dict:
+        workflow_id: int = self.workflow_ids.get(workflow)
+        url = f"{self.base_url}/pipelines/{workflow_id}/launch"
+        params: dict = {"workspaceId": self.workspace_id}
+        response: requests.Response = requests.get(
+            url=url, headers={"Authorization": f"Bearer {self.bearer_token}"}, params=params
+        )
+        response.raise_for_status()
+        return response.json()
 
-    def get_session_id(self, workflow_id: str):
-        pass
+    def run_case(self, request) -> dict:
+        url = f"{self.base_url}/workflow/launch"
+        params: dict = {"workspaceId": self.workspace_id}
+        response: requests.Response = requests.post(
+            url=url,
+            headers={"Authorization": f"Bearer {self.bearer_token}"},
+            params=params,
+            json=request,
+        )
+        response.raise_for_status()
+        return response.json()


### PR DESCRIPTION
## Description

This PR adds parsing of the SeqeraPlatformConfig and fleshes out the SeqeraPlatformClient. So far no DTOs have been added so the return types are dicts.

### Added

- SeqeraPlatformConfig
- Method bodies in the SeqeraPlatformClient

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
