### PR TITLE
Allow for multiple smrt cell IDs in Pacbio sample metrics

### DIFF
--- a/cg/server/endpoints/sequencing_metrics/dtos.py
+++ b/cg/server/endpoints/sequencing_metrics/dtos.py
@@ -5,7 +5,7 @@ from cg.services.sample_run_metrics_service.dtos import PacbioSequencingMetricsD
 
 class PacbioSequencingMetricsRequest(BaseModel):
     sample_id: str | None = None
-    smrt_cell_id: str | None = None
+    smrt_cell_ids: list[str] | None = None
 
 
 class PacbioSequencingMetricsResponse(BaseModel):

--- a/cg/server/endpoints/sequencing_metrics/pacbio_sequencing_metrics.py
+++ b/cg/server/endpoints/sequencing_metrics/pacbio_sequencing_metrics.py
@@ -18,8 +18,8 @@ PACBIO_SAMPLE_SEQUENCING_METRICS_BLUEPRINT.before_request(before_request)
 @PACBIO_SAMPLE_SEQUENCING_METRICS_BLUEPRINT.route("/pacbio_sample_sequencing_metrics")
 @handle_endpoint_errors
 def get_sequencing_metrics():
-    sequencing_metrics_request = PacbioSequencingMetricsRequest.model_validate(
-        request.args.to_dict()
+    sequencing_metrics_request = PacbioSequencingMetricsRequest(
+        sample_id=request.args.get("sample_id"), smrt_cell_ids=request.args.getlist("smrt_cell_ids")
     )
     metrics: list[PacbioSequencingMetricsDTO] = sample_run_metrics_service.get_pacbio_metrics(
         sequencing_metrics_request

--- a/cg/services/sample_run_metrics_service/sample_run_metrics_service.py
+++ b/cg/services/sample_run_metrics_service/sample_run_metrics_service.py
@@ -24,7 +24,7 @@ class SampleRunMetricsService:
         response: list[PacbioSequencingMetricsDTO] = []
         sequencing_metrics: list[PacbioSampleSequencingMetrics] = (
             self.store.get_pacbio_sample_sequencing_metrics(
-                sample_id=metrics_request.sample_id, smrt_cell_id=metrics_request.smrt_cell_id
+                sample_id=metrics_request.sample_id, smrt_cell_ids=metrics_request.smrt_cell_ids
             )
         )
         for db_metrics in sequencing_metrics:

--- a/cg/store/crud/read.py
+++ b/cg/store/crud/read.py
@@ -1800,7 +1800,7 @@ class ReadHandler(BaseHandler):
         return rna_dna_collections
 
     def get_pacbio_sample_sequencing_metrics(
-        self, sample_id: str | None, smrt_cell_id: str | None
+        self, sample_id: str | None, smrt_cell_ids: list[str] | None
     ) -> list[PacbioSampleSequencingMetrics]:
         """
         Fetches data from PacbioSampleSequencingMetrics filtered on sample_internal_id and/or smrt_cell_id.
@@ -1813,8 +1813,8 @@ class ReadHandler(BaseHandler):
         )
         if sample_id:
             sequencing_metrics = sequencing_metrics.filter(Sample.internal_id == sample_id)
-        if smrt_cell_id:
-            sequencing_metrics = sequencing_metrics.filter(RunDevice.internal_id == smrt_cell_id)
+        if smrt_cell_ids:
+            sequencing_metrics = sequencing_metrics.filter(RunDevice.internal_id.in_(smrt_cell_ids))
         return sequencing_metrics.all()
 
     def get_pacbio_sequencing_runs_by_run_name(self, run_name: str) -> list[PacbioSequencingRun]:

--- a/tests/services/sample_run_metrics_service/test_sample_metrics_service.py
+++ b/tests/services/sample_run_metrics_service/test_sample_metrics_service.py
@@ -73,7 +73,7 @@ def test_get_pacbio_metrics_by_smrt_cell_id(
     # GIVEN a SampleRunMetricsService and a database containing Pacbio data
 
     # WHEN fetching a specific PacbioSampleSequencingMetrics
-    metrics_request = PacbioSequencingMetricsRequest(smrt_cell_id="internal_id")
+    metrics_request = PacbioSequencingMetricsRequest(smrt_cell_ids=["internal_id"])
     sequencing_metrics: list[PacbioSequencingMetricsDTO] = (
         sample_run_metrics_service.get_pacbio_metrics(metrics_request)
     )
@@ -88,7 +88,7 @@ def test_get_pacbio_metrics_by_non_existent_smrt_cell_id(
     # GIVEN a SampleRunMetricsService and a database containing Pacbio data
 
     # WHEN fetching a specific PacbioSampleSequencingMetrics
-    metrics_request = PacbioSequencingMetricsRequest(smrt_cell_id="I do not exist")
+    metrics_request = PacbioSequencingMetricsRequest(smrt_cell_ids=["I do not exist"])
     metrics: list[PacbioSequencingMetricsDTO] = sample_run_metrics_service.get_pacbio_metrics(
         metrics_request
     )


### PR DESCRIPTION
## Description

Closes #4261.

### Added

-

### Changed

- smrt_cell_ids parsed as a list in the pacbio sample sequencing metrics endpoint

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
