### PR TITLE
add nallo to limitations table

### DIFF
--- a/alembic/versions/2025_03_06_3a0250e5526d_add_nallo_to_limitations_table.py
+++ b/alembic/versions/2025_03_06_3a0250e5526d_add_nallo_to_limitations_table.py
@@ -28,6 +28,7 @@ old_options = (
     "demultiplex",
     "fastq",
     "fluffy",
+    "jasen",
     "microsalt",
     "mip-dna",
     "mip-rna",

--- a/alembic/versions/2025_03_06_3a0250e5526d_add_nallo_to_limitations_table.py
+++ b/alembic/versions/2025_03_06_3a0250e5526d_add_nallo_to_limitations_table.py
@@ -6,8 +6,9 @@ Create Date: 2025-03-06 11:07:29.158959
 
 """
 
+from sqlalchemy.dialects import mysql
+
 from alembic import op
-import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.

--- a/alembic/versions/2025_03_06_3a0250e5526d_add_nallo_to_limitations_table.py
+++ b/alembic/versions/2025_03_06_3a0250e5526d_add_nallo_to_limitations_table.py
@@ -1,0 +1,52 @@
+"""add-nallo-to-limitations-table
+
+Revision ID: 3a0250e5526d
+Revises: 6f368f57df4a
+Create Date: 2025-03-06 11:07:29.158959
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '3a0250e5526d'
+down_revision = '6f368f57df4a'
+branch_labels = None
+depends_on = None
+
+
+new_workflow = "nallo"
+
+old_options = (
+    "balsamic",
+    "balsamic-pon",
+    "balsamic-qc",
+    "balsamic-umi",
+    "demultiplex",
+    "fastq",
+    "fluffy",
+    "microsalt",
+    "mip-dna",
+    "mip-rna",
+    "mutant",
+    "raredisease",
+    "rnafusion",
+    "rsync",
+    "spring",
+    "taxprofiler",
+    "tomte",
+)
+
+new_options = sorted(old_options + (new_workflow,))
+
+old_analysis_enum = mysql.ENUM(*old_options)
+new_analysis_enum = mysql.ENUM(*new_options)
+
+
+def upgrade():
+    op.alter_column("application_limitations", "workflow", type_=new_analysis_enum)
+
+
+def downgrade():
+    op.alter_column("application_limitations", "workflow", type_=old_analysis_enum)

--- a/alembic/versions/2025_03_06_3a0250e5526d_add_nallo_to_limitations_table.py
+++ b/alembic/versions/2025_03_06_3a0250e5526d_add_nallo_to_limitations_table.py
@@ -5,13 +5,14 @@ Revises: 6f368f57df4a
 Create Date: 2025-03-06 11:07:29.158959
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision = '3a0250e5526d'
-down_revision = '6f368f57df4a'
+revision = "3a0250e5526d"
+down_revision = "6f368f57df4a"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Description

This PR aims to add Nallo to the limitations table. Copied the tomte implementation for this: https://github.com/Clinical-Genomics/cg/pull/3043

### Added

- Nallo to statusDB limitations table

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
