### PR TITLE
Fix-dragen-cpu-and-exclusiveness

### DIFF
--- a/cg/apps/slurm/sbatch.py
+++ b/cg/apps/slurm/sbatch.py
@@ -25,7 +25,8 @@ DRAGEN_SBATCH_HEADER_TEMPLATE = """#! /bin/bash
 #SBATCH --job-name={job_name}
 #SBATCH --partition=dragen
 #SBATCH --account={account}
-#SBATCH --cpus-per-task=24
+#SBATCH --cpus-per-task=48
+#SBATCH --exclusive
 #SBATCH --nodes=1
 #SBATCH --error={log_dir}/{job_name}.stderr
 #SBATCH --output={log_dir}/{job_name}.stdout

--- a/cg/apps/slurm/sbatch.py
+++ b/cg/apps/slurm/sbatch.py
@@ -23,11 +23,10 @@ log "Running on: $(hostname)"
 
 DRAGEN_SBATCH_HEADER_TEMPLATE = """#! /bin/bash
 #SBATCH --job-name={job_name}
-#SBATCH --partition=dragen
+#SBATCH --partition={partition}
 #SBATCH --account={account}
-#SBATCH --cpus-per-task=48
 #SBATCH --exclusive
-#SBATCH --nodes=1
+#SBATCH --mem=0 # Allocates all memory on the node
 #SBATCH --error={log_dir}/{job_name}.stderr
 #SBATCH --output={log_dir}/{job_name}.stdout
 #SBATCH --mail-type=FAIL

--- a/cg/apps/slurm/slurm_api.py
+++ b/cg/apps/slurm/slurm_api.py
@@ -9,7 +9,7 @@ from cg.apps.slurm.sbatch import (
     SBATCH_HEADER_TEMPLATE,
 )
 from cg.constants.slurm import Slurm
-from cg.models.slurm.sbatch import Sbatch
+from cg.models.slurm.sbatch import Sbatch, SbatchDragen
 from cg.utils import Process
 
 LOG = logging.getLogger(__name__)
@@ -31,7 +31,7 @@ class SlurmAPI:
     @staticmethod
     def generate_sbatch_content(sbatch_parameters: Sbatch) -> str:
         """Take a parameters object and generate a string with sbatch information."""
-        if hasattr(sbatch_parameters, Slurm.PARTITION):
+        if isinstance(sbatch_parameters, SbatchDragen):
             sbatch_header: str = SlurmAPI.generate_dragen_sbatch_header(
                 sbatch_parameters=sbatch_parameters
             )

--- a/cg/models/slurm/sbatch.py
+++ b/cg/models/slurm/sbatch.py
@@ -22,5 +22,3 @@ class Sbatch(BaseModel):
 
 class SbatchDragen(Sbatch):
     partition: str = HastaSlurmPartitions.DRAGEN
-    nodes: int = 1
-    cpus_per_task: int = 48


### PR DESCRIPTION
## Description

Improvements to sbatch header template:

* [`cg/apps/slurm/sbatch.py`](diffhunk://#diff-be86a26009742479cb7b8ac08a1fd412c1db832a8914211ba81aec5ea14d4ed8L26-R29): Modified the `DRAGEN_SBATCH_HEADER_TEMPLATE` to allow dynamic partition allocation and exclusive memory and node allocation.

Enhancements to Slurm API:

* [`cg/apps/slurm/slurm_api.py`](diffhunk://#diff-031d68f0609426c4b6929c361354511b05e369babb69d3d68b7b7f2a9a721cf9L34-R34): Refined the `generate_sbatch_content` method to check for `SbatchDragen` instances instead of the `Slurm.PARTITION` attribute.

Updates to sbatch model:

* [`cg/models/slurm/sbatch.py`](diffhunk://#diff-93618eb94ec7d1ba5633e0317c5d859738205545a3fa3153082a2ff56f27d85dL25-L26): Removed the `nodes` and `cpus_per_task` attributes from the `SbatchDragen` model to align with the new sbatch header template.

### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
