### PR TITLE
(Pipeline Integration) Merge PrepareFastqAPI into the FastqFetcher

### DIFF
--- a/cg/exc.py
+++ b/cg/exc.py
@@ -86,6 +86,10 @@ class DecompressionNeededError(CgError):
     """Raised when decompression still needed to start analysis."""
 
 
+class DecompressionCouldNotStartError(CgError):
+    """Raised when decompression could not be started."""
+
+
 class DeliveryReportError(CgError):
     """
     Exception related to delivery report creation.

--- a/cg/meta/compress/compress.py
+++ b/cg/meta/compress/compress.py
@@ -364,9 +364,8 @@ class CompressAPI:
         """Return an object containing compression data for a case."""
         sample_compressions: list[SampleCompressionData] = []
         for sample in case.samples:
-            sample_id: str = sample.internal_id
             sample_compression_data: SampleCompressionData = self.get_sample_compression_data(
-                sample_id
+                sample.internal_id
             )
             sample_compressions.append(sample_compression_data)
         return CaseCompressionData(

--- a/cg/models/compression_data.py
+++ b/cg/models/compression_data.py
@@ -268,3 +268,58 @@ class CompressionData:
 
     def __repr__(self):
         return f"CompressionData(stub:{self.stub})"
+
+
+class SampleCompressionData:
+    def __init__(self, sample_id: str, compression_objects: list[CompressionData]):
+        self.sample_id = sample_id
+        self.compression_objects = compression_objects
+
+    def is_decompression_needed(self) -> bool:
+        """Check if decompression is needed for the specified sample."""
+        LOG.debug(f"Checking if decompression is needed for {self.sample_id}.")
+        return any(
+            not compression_object.is_compression_pending and not compression_object.pair_exists()
+            for compression_object in self.compression_objects
+        )
+
+    def is_spring_decompression_running(self) -> bool:
+        """Check if sample is being decompressed"""
+        return any(
+            compression_object.is_compression_pending
+            for compression_object in self.compression_objects
+        )
+
+    def can_be_decompressed(self) -> bool:
+        """Returns True if at least one Spring file can be decompressed, otherwise False"""
+        return any(
+            compression_object.is_spring_decompression_possible
+            for compression_object in self.compression_objects
+        )
+
+
+class CaseCompressionData:
+    def __init__(self, case_id: str, sample_compression_data: list[SampleCompressionData]):
+        self.case_id = case_id
+        self.sample_compression_data = sample_compression_data
+
+    def is_spring_decompression_needed(self) -> bool:
+        """Check if spring decompression needs to be started"""
+        return any(
+            sample_compression.is_decompression_needed()
+            for sample_compression in self.sample_compression_data
+        )
+
+    def is_spring_decompression_running(self) -> bool:
+        """Check if case is being decompressed"""
+        return any(
+            sample_compression.is_spring_decompression_running()
+            for sample_compression in self.sample_compression_data
+        )
+
+    def can_at_least_one_sample_be_decompressed(self) -> bool:
+        """Returns True if at least one sample can be decompressed, otherwise False"""
+        return any(
+            sample_compression.can_be_decompressed()
+            for sample_compression in self.sample_compression_data
+        )

--- a/cg/models/compression_data.py
+++ b/cg/models/compression_data.py
@@ -271,6 +271,8 @@ class CompressionData:
 
 
 class SampleCompressionData:
+    """Object encapsulating a sample's compression status."""
+
     def __init__(self, sample_id: str, compression_objects: list[CompressionData]):
         self.sample_id = sample_id
         self.compression_objects = compression_objects
@@ -299,6 +301,8 @@ class SampleCompressionData:
 
 
 class CaseCompressionData:
+    """Object encapsulating a case's compression status."""
+
     def __init__(self, case_id: str, sample_compression_data: list[SampleCompressionData]):
         self.case_id = case_id
         self.sample_compression_data = sample_compression_data

--- a/cg/services/analysis_starter/input_fetcher/implementations/fastq_fetcher.py
+++ b/cg/services/analysis_starter/input_fetcher/implementations/fastq_fetcher.py
@@ -161,7 +161,7 @@ class FastqFetcher(InputFetcher):
         for sample in case.samples:
             if self._should_skip_sample(case=case, sample=sample):
                 LOG.warning(f"Skipping sample {sample.internal_id} - it has no reads.")
-                return
+                continue
             self._add_decompressed_sample(sample=sample)
 
     def _add_decompressed_sample(self, sample: Sample) -> None:

--- a/cg/services/analysis_starter/input_fetcher/implementations/fastq_fetcher.py
+++ b/cg/services/analysis_starter/input_fetcher/implementations/fastq_fetcher.py
@@ -1,13 +1,17 @@
 import logging
+from pathlib import Path
+
+from housekeeper.store.models import File, Version
 
 from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.constants import SequencingFileTag
-from cg.constants.constants import CaseActions
-from cg.exc import AnalysisNotReadyError
+from cg.constants.constants import PIPELINES_USING_PARTIAL_ANALYSES, CaseActions
+from cg.exc import AnalysisNotReadyError, DecompressionCouldNotStartError
 from cg.meta.archive.archive import SpringArchiveAPI
-from cg.meta.workflow.prepare_fastq import PrepareFastqAPI
+from cg.meta.compress import CompressAPI, files
+from cg.models.compression_data import CaseCompressionData, CompressionData, SampleCompressionData
 from cg.services.analysis_starter.input_fetcher.input_fetcher import InputFetcher
-from cg.store.models import Case
+from cg.store.models import Case, Sample
 from cg.store.store import Store
 
 LOG = logging.getLogger(__name__)
@@ -19,12 +23,12 @@ class FastqFetcher(InputFetcher):
         self,
         status_db: Store,
         housekeeper_api: HousekeeperAPI,
-        prepare_fastq_api: PrepareFastqAPI,
+        compress_api: CompressAPI,
         spring_archive_api: SpringArchiveAPI,
     ):
         self.status_db = status_db
         self.housekeeper_api = housekeeper_api
-        self.prepare_fastq_api = prepare_fastq_api
+        self.compress_api = compress_api
         self.spring_archive_api = spring_archive_api
 
     def ensure_files_are_ready(self, case_id: str) -> None:
@@ -33,7 +37,7 @@ class FastqFetcher(InputFetcher):
             AnalysisNotReadyError if the FASTQ files are not ready to be analysed."""
         self._ensure_files_are_present(case_id)
         self._resolve_decompression(case_id)
-        if not self._is_raw_data_ready_for_analysis(case_id):
+        if not self._are_fastq_files_ready_for_analysis(case_id):
             raise AnalysisNotReadyError("FASTQ files are not present for the analysis to start")
 
     def _ensure_files_are_present(self, case_id: str) -> None:
@@ -71,54 +75,41 @@ class FastqFetcher(InputFetcher):
         """
         Decompresses a case if needed and adds new fastq files to Housekeeper.
         """
-        if self.prepare_fastq_api.is_spring_decompression_needed(case_id):
-            self._decompress_case(case_id)
-            return
-
-        if self.prepare_fastq_api.is_spring_decompression_running(case_id):
+        case_compression_data: CaseCompressionData = self._get_case_compression_data(case_id)
+        if case_compression_data.is_spring_decompression_needed():
+            LOG.info(f"The analysis for {case_id} could not start, decompression is needed")
+            if not case_compression_data.can_at_least_one_sample_be_decompressed():
+                self._set_to_analyze_if_decompressing(case_compression_data)
+            else:
+                self._decompress_case(case_id)
+        elif case_compression_data.is_spring_decompression_running():
             self.status_db.set_case_action(case_internal_id=case_id, action=CaseActions.ANALYZE)
             return
 
-        self.prepare_fastq_api.add_decompressed_fastq_files_to_housekeeper(case_id)
+        self._add_decompressed_fastq_files_to_housekeeper(case_id)
 
     def _decompress_case(self, case_id: str) -> None:
         """Decompress all possible fastq files for all samples in a case"""
-
-        LOG.info(f"The analysis for {case_id} could not start, decompression is needed")
-        is_decompression_possible: bool = (
-            self.prepare_fastq_api.can_at_least_one_sample_be_decompressed(case_id)
-        )
-        if not is_decompression_possible:
-            # Raise error? This is messy
-            self._set_to_analyze_if_decompressing(case_id)
-            return
-        case: Case = self.status_db.get_case_by_internal_id(internal_id=case_id)
-        any_decompression_started = False
-        for sample in case.samples:
-            sample_id: str = sample.internal_id
-            is_decompression_started: bool = self.prepare_fastq_api.compress_api.decompress_spring(
-                sample_id
-            )
-            if is_decompression_started:
-                any_decompression_started = True
-
-        if not any_decompression_started:
-            # Raise error?
+        case: Case = self.status_db.get_case_by_internal_id(case_id)
+        try:
+            self.compress_api.decompress_case(case)
+        except DecompressionCouldNotStartError:
             LOG.warning(f"Decompression failed to start for {case_id}")
             return
         self.status_db.set_case_action(case_internal_id=case_id, action=CaseActions.ANALYZE)
         LOG.info(f"Decompression started for {case_id}")
 
-    def _is_raw_data_ready_for_analysis(self, case_id: str) -> bool:
+    def _are_fastq_files_ready_for_analysis(self, case_id: str) -> bool:
         """Returns True if no files need to be retrieved from an external location and if all Spring files are
         decompressed."""
 
-        # Should this reference spring files? No need to be vague in the fastq fetcher
+        case_compression_data: CaseCompressionData = self._get_case_compression_data(case_id)
         if self._does_any_file_need_to_be_retrieved(case_id):
             return False
-        if self.prepare_fastq_api.is_spring_decompression_needed(
-            case_id
-        ) or self.prepare_fastq_api.is_spring_decompression_running(case_id):
+        if (
+            case_compression_data.is_spring_decompression_needed()
+            or case_compression_data.is_spring_decompression_running()
+        ):
             LOG.warning(f"Case {case_id} is not ready - not all files are decompressed.")
             return False
         return True
@@ -142,16 +133,69 @@ class FastqFetcher(InputFetcher):
             self.status_db.is_case_down_sampled(case_id) or self.status_db.is_case_external(case_id)
         )
 
-    def _set_to_analyze_if_decompressing(self, case_id: str) -> None:
+    def _set_to_analyze_if_decompressing(self, case_compression_data: CaseCompressionData) -> None:
         """Sets a case's action to 'analyze' if it is currently being decompressed."""
-        is_decompression_running: bool = self.prepare_fastq_api.is_spring_decompression_running(
-            case_id
-        )
-        if not is_decompression_running:
-            # Raise error?
-            LOG.warning(f"Decompression can not be started for {case_id}")
+        case_id: str = case_compression_data.case_id
+        if case_compression_data.is_spring_decompression_running():
+            LOG.info(
+                f"Decompression is running for {case_id}, analysis will be started when decompression is done"
+            )
+            self.status_db.set_case_action(case_internal_id=case_id, action=CaseActions.ANALYZE)
+
+    def _get_case_compression_data(self, case_id: str) -> CaseCompressionData:
+        """Return an object containing compression data for a case."""
+        case: Case = self.status_db.get_case_by_internal_id(case_id)
+        sample_compressions: list[SampleCompressionData] = []
+        for sample in case.samples:
+            sample_id = sample.internal_id
+            sample_compression_data: SampleCompressionData = self._get_sample_compression_data(
+                sample_id
+            )
+            sample_compressions.append(sample_compression_data)
+        return CaseCompressionData(case_id=case_id, sample_compression_data=sample_compressions)
+
+    def _get_sample_compression_data(self, sample_id: str) -> SampleCompressionData:
+        compression_objects: list[CompressionData] = []
+        version_obj: Version = self.housekeeper_api.get_latest_bundle_version(sample_id)
+        compression_objects.extend(files.get_spring_paths(version_obj))
+        return SampleCompressionData(sample_id=sample_id, compression_objects=compression_objects)
+
+    @staticmethod
+    def _should_skip_sample(case: Case, sample: Sample):
+        """
+        For some workflows, we want to start a partial analysis disregarding the samples with no reads.
+        This method returns true if we should skip the sample.
+        """
+        return case.data_analysis in PIPELINES_USING_PARTIAL_ANALYSES and not sample.has_reads
+
+    def _add_decompressed_fastq_files_to_housekeeper(self, case_id: str) -> None:
+        """Adds decompressed FASTQ files to Housekeeper for a case, if there are any."""
+        case: Case = self.status_db.get_case_by_internal_id(internal_id=case_id)
+        for sample in case.samples:
+            self._add_decompressed_sample(sample=sample, case=case)
+
+    def _add_decompressed_sample(self, sample: Sample, case: Case) -> None:
+        """Adds decompressed FASTQ files to Housekeeper for a sample, if there are any."""
+        sample_id = sample.internal_id
+        if self._should_skip_sample(case=case, sample=sample):
+            LOG.warning(f"Skipping sample {sample_id} - it has no reads.")
             return
-        LOG.info(
-            f"Decompression is running for {case_id}, analysis will be started when decompression is done"
+        compression_data: SampleCompressionData = self._get_sample_compression_data(sample_id)
+        if not self._are_all_fastqs_in_housekeeper(compression_data):
+            self.compress_api.add_decompressed_fastq(sample)
+
+    def _are_all_fastqs_in_housekeeper(
+        self, sample_compression_data: SampleCompressionData
+    ) -> bool:
+        """Returns true if all Spring files are decompressed for the sample."""
+        sample_id: str = sample_compression_data.sample_id
+        version: Version = self.housekeeper_api.get_latest_bundle_version(sample_id)
+        fastq_files = files.get_hk_files_dict(tags=[SequencingFileTag.FASTQ], version_obj=version)
+        return all(
+            self._is_fastq_pair_in_housekeeper(compression=compression, fastq_files=fastq_files)
+            for compression in sample_compression_data.compression_objects
         )
-        self.status_db.set_case_action(case_internal_id=case_id, action=CaseActions.ANALYZE)
+
+    @staticmethod
+    def _is_fastq_pair_in_housekeeper(compression: CompressionData, fastq_files: dict[Path, File]):
+        return compression.fastq_first in fastq_files and compression.fastq_second in fastq_files


### PR DESCRIPTION
## Description

This PR introduces two new classes, `CaseCompressionData` and `SampleCompressionData` which encapsulate data on a case's/sample's compression status. It moves the functionality of the `PrepareFastqAPI` into the `FastqFetcher` since their purposes overlapped. 

Removing the PrepareFastqAPI completely is out of scope for this PR. It inherits from the MetaAPI and this coupling makes me consider it a separate task. The other parts of the code which use PrepareFastqAPI, such as the DownsamplingAPI should only need the CompressAPI after this PR though.

### Added

- CaseCompressionData
- SampleCompressionData

### Changed

- PrepareFastqAPI not needed in the FastqFetcher

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
