### PR TITLE
move annotated repeats from sample to case, bugfix

### DIFF
--- a/cg/resources/nallo_bundle_filenames.yaml
+++ b/cg/resources/nallo_bundle_filenames.yaml
@@ -134,12 +134,12 @@
   step: spanning_repeats
   tag: bam_index
 - format: vcf
-  id: SAMPLEID
+  id: CASEID
   path: PATHTOCASE/repeats/family/CASEID/CASEID_repeats_annotated.vcf.gz
   step: repeats_annotated
   tag: vcf_str
 - format: vcf
-  id: SAMPLEID
+  id: CASEID
   path: PATHTOCASE/repeats/family/CASEID/CASEID_repeats_annotated.vcf.gz.tbi
   step: repeats_annotated
   tag: vcf_str_index


### PR DESCRIPTION
## Description

### Added

-

### Changed

- move annotated repeats from sample to case

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do `cg workflow nallo report-deliver assuringredbird`
- [ ] Do `cg workflow nallo store-housekeeper assuringredbird`

### Expected test outcome

- [ ] Check that repeats_annotated files are shown under the case level
- [ ] Check that case successfully stores

<img width="1331" alt="image" src="https://github.com/user-attachments/assets/8b2da13f-010d-4d0d-8014-98f39732b2ad" />

<img width="688" alt="image" src="https://github.com/user-attachments/assets/6d4178ae-1a01-4166-ab9e-c6ead9132e84" />


## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
