### PR TITLE
Allow all order types in JSON orders

### DIFF
--- a/cg/apps/orderform/json_orderform_parser.py
+++ b/cg/apps/orderform/json_orderform_parser.py
@@ -1,5 +1,5 @@
 from cg.apps.orderform.orderform_parser import OrderformParser
-from cg.constants import DataDelivery, Workflow
+from cg.constants import DataDelivery
 from cg.exc import OrderFormError
 from cg.models.orders.constants import OrderType
 from cg.models.orders.json_sample import JsonSample
@@ -18,7 +18,7 @@ class JsonOrderformParser(OrderformParser):
             raise OrderFormError(f"mixed 'Data Analysis' types: {', '.join(data_analyses)}")
 
         data_analysis: str = data_analyses.pop()
-        if data_analysis in Workflow.__members__.values():
+        if data_analysis in OrderType.__members__.values():
             return data_analysis
 
         raise OrderFormError(f"Unsupported data_analysis: {data_analyses} for json data")

--- a/cg/models/orders/json_sample.py
+++ b/cg/models/orders/json_sample.py
@@ -2,6 +2,7 @@ from pydantic import BeforeValidator, constr
 from typing_extensions import Annotated
 
 from cg.constants import DataDelivery, Workflow
+from cg.models.orders.constants import OrderType
 from cg.models.orders.sample_base import OrderSample
 from cg.models.orders.validators.json_sample_validators import convert_well, join_list
 
@@ -12,7 +13,7 @@ class JsonSample(OrderSample):
     concentration_ng_ul: str | None = None
     concentration_sample: str | None = None
     control: str | None = None
-    data_analysis: Workflow = Workflow.MIP_DNA
+    data_analysis: OrderType = Workflow.MIP_DNA
     data_delivery: DataDelivery = DataDelivery.SCOUT
     index: str | None = None
     panels: list[str] | None = None


### PR DESCRIPTION
## Description

We currently only allow for workflows in the JsonOrderformParser. The Raw data workflows such as fastq, metagenome, rml and microbial_fastq suffer as a consequence. Given that some customers want to place JSON orders for some of them, see #4272, we need to support it.

### Added

-

### Changed

-

### Fixed

- JSONOrderformParser supports all order types instead of workflows.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
