### PR TITLE
Patch(cleaning) Delete correct sequencing directories

### DIFF
--- a/cg/services/illumina/cleaning/clean_runs_service.py
+++ b/cg/services/illumina/cleaning/clean_runs_service.py
@@ -62,14 +62,12 @@ class IlluminaCleanRunsService:
             self.set_sample_sheet_path_from_housekeeper()
             if self.can_run_directory_be_deleted():
                 if self.dry_run:
-                    LOG.debug(
-                        f"Dry run: Would have removed: {self.sequencing_run_dir_data.get_sequencing_runs_dir()}"
-                    )
+                    LOG.debug(f"Dry run: Would have removed: {self.sequencing_run_dir_data.path}")
                     return
                 remove_directory_and_contents(self.sequencing_run_dir_data.path)
         except Exception as error:
             raise IlluminaCleanRunError(
-                f"Sequencing run with path {self.sequencing_run_dir_data.get_sequencing_runs_dir()} not removed: {repr(error)}"
+                f"Sequencing run with path {self.sequencing_run_dir_data.path} not removed: {repr(error)}"
             )
 
     def set_sample_sheet_path_from_housekeeper(self):

--- a/cg/services/illumina/cleaning/clean_runs_service.py
+++ b/cg/services/illumina/cleaning/clean_runs_service.py
@@ -9,15 +9,12 @@ from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.constants import SequencingFileTag
 from cg.constants.time import TWENTY_ONE_DAYS
 from cg.exc import (
-    IlluminaCleanRunError,
     HousekeeperBundleVersionMissingError,
     HousekeeperFileMissingError,
+    IlluminaCleanRunError,
 )
 from cg.models.run_devices.illumina_run_directory_data import IlluminaRunDirectoryData
-from cg.store.models import (
-    IlluminaSequencingRun,
-    IlluminaSampleSequencingMetrics,
-)
+from cg.store.models import IlluminaSampleSequencingMetrics, IlluminaSequencingRun
 from cg.store.store import Store
 from cg.utils.files import remove_directory_and_contents
 from cg.utils.time import is_directory_older_than_days_old
@@ -69,9 +66,7 @@ class IlluminaCleanRunsService:
                         f"Dry run: Would have removed: {self.sequencing_run_dir_data.get_sequencing_runs_dir()}"
                     )
                     return
-                remove_directory_and_contents(
-                    self.sequencing_run_dir_data.get_sequencing_runs_dir()
-                )
+                remove_directory_and_contents(self.sequencing_run_dir_data.path)
         except Exception as error:
             raise IlluminaCleanRunError(
                 f"Sequencing run with path {self.sequencing_run_dir_data.get_sequencing_runs_dir()} not removed: {repr(error)}"


### PR DESCRIPTION
## Description
See issue #4307

This PR changes the logic back to what it was before. See this comment: https://github.com/Clinical-Genomics/cg/pull/3349/files#r2011987641

### Fixed

- The deletion now occurs on the actual directory provided



### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
