### PR TITLE
Patch well position format rule

### DIFF
--- a/cg/services/orders/validation/rules/case_sample/utils.py
+++ b/cg/services/orders/validation/rules/case_sample/utils.py
@@ -254,8 +254,8 @@ def create_invalid_concentration_error(
 
 def is_invalid_plate_well_format(sample: Sample) -> bool:
     """Check if a sample has an invalid well format."""
-    correct_well_position_pattern: str = r"^[A-H]:([1-9]|1[0-2])$"
-    if sample.is_on_plate:
+    if sample.is_on_plate and sample.well_position:
+        correct_well_position_pattern: str = r"^[A-H]:([1-9]|1[0-2])$"
         return not bool(re.match(correct_well_position_pattern, sample.well_position))
     return False
 

--- a/tests/services/orders/validation_service/test_case_sample_rules.py
+++ b/tests/services/orders/validation_service/test_case_sample_rules.py
@@ -75,6 +75,18 @@ def test_validate_well_position_format(valid_order: OrderWithCases):
     assert errors[0].sample_index == 0 and errors[0].case_index == 0
 
 
+def test_validate_well_position_format_is_none(valid_order: OrderWithCases):
+
+    # GIVEN an order with a missing well position
+    valid_order.cases[0].samples[0].well_position = None
+
+    # WHEN validating the well position format
+    errors: list[WellFormatError] = validate_well_position_format(order=valid_order)
+
+    # THEN no error should be returned
+    assert not errors
+
+
 def test_validate_tube_container_name_unique(valid_order: OrderWithCases):
 
     # GIVEN an order with two samples with the same tube container name


### PR DESCRIPTION
## Description

One of our validation rules gives null pointer exceptions when a well position is missing. The missing well position is also caught by another rule, so this PR makes the well position format rule only trigger when the well position is provided.

### Added

-

### Changed

-

### Fixed

- Well position format is only validated if the well position is provided.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
