### PR TITLE
add analysis as parameter for method include_pedigree_picture

### DIFF
--- a/cg/meta/upload/scout/mip_config_builder.py
+++ b/cg/meta/upload/scout/mip_config_builder.py
@@ -81,7 +81,7 @@ class MipConfigBuilder(ScoutConfigBuilder):
             load_config.samples.append(
                 self.build_config_sample(case_sample=db_sample, hk_version=hk_version)
             )
-        self.include_pedigree_picture(load_config)
+        self.include_pedigree_picture(load_config=load_config, analysis=analysis)
         return load_config
 
     def include_case_files(self, load_config: MipLoadConfig, hk_version: Version) -> None:

--- a/cg/meta/upload/scout/nallo_config_builder.py
+++ b/cg/meta/upload/scout/nallo_config_builder.py
@@ -58,7 +58,7 @@ class NalloConfigBuilder(ScoutConfigBuilder):
         self.get_sample_information(
             load_config=load_config, analysis=analysis, hk_version=hk_version
         )
-        self.include_pedigree_picture(load_config)
+        self.include_pedigree_picture(load_config=load_config, analysis=analysis)
         load_config.human_genome_build = GenomeBuild.hg38
         load_config.rank_score_threshold = NALLO_RANK_MODEL_THRESHOLD
         load_config.rank_model_version = NALLO_RANK_MODEL_VERSION_SNV

--- a/cg/meta/upload/scout/raredisease_config_builder.py
+++ b/cg/meta/upload/scout/raredisease_config_builder.py
@@ -65,7 +65,7 @@ class RarediseaseConfigBuilder(ScoutConfigBuilder):
         self.get_sample_information(
             load_config=load_config, analysis=analysis, hk_version=hk_version
         )
-        self.include_pedigree_picture(load_config)
+        self.include_pedigree_picture(load_config=load_config, analysis=analysis)
         self.load_custom_image_sample(
             load_config=load_config, analysis=analysis, hk_version=hk_version
         )

--- a/cg/meta/upload/scout/scout_config_builder.py
+++ b/cg/meta/upload/scout/scout_config_builder.py
@@ -76,10 +76,11 @@ class ScoutConfigBuilder:
                 return True
         return False
 
-    def include_pedigree_picture(self, load_config: ScoutLoadConfig) -> None:
+    def include_pedigree_picture(self, load_config: ScoutLoadConfig, analysis: Analysis) -> None:
+        """Run Madeline only for cases with multiple related samples."""
         if self.is_multi_sample_case(load_config=load_config):
             if self.is_family_case(load_config=load_config):
-                svg_path: Path = self.run_madeline(self.analysis.case)
+                svg_path: Path = self.run_madeline(analysis.case)
                 load_config.madeline = str(svg_path)
             else:
                 LOG.info("family of unconnected samples - skip pedigree graph")


### PR DESCRIPTION
## Description
MIP cases with related samples have problems uploading to scout:
```
...
File "/home/proj/production/bin/miniconda3/envs/P_cg/lib/python3.11/site-packages/cg/meta/upload/scout/scout_config_builder.py", line 82, in include_pedigree_picture
   svg_path: Path = self.run_madeline(self.analysis.case)
                                      ^^^^^^^^^^^^^
AttributeError: 'MipConfigBuilder' object has no attribute 'analysis'
```
This PR adds an Analysis object as parameter to the `include_pedigree_picture` method of the `ScoutConfigBuilder` class.

### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
