### PR TITLE
fix types for delivery report for Nallo

### DIFF
--- a/cg/constants/report.py
+++ b/cg/constants/report.py
@@ -37,11 +37,6 @@ REPORT_SUPPORTED_DATA_DELIVERY: tuple[DataDelivery, ...] = (
     DataDelivery.FASTQ_ANALYSIS_SCOUT,
     DataDelivery.FASTQ_QC_ANALYSIS,
     DataDelivery.FASTQ_SCOUT,
-    DataDelivery.SCOUT,
-)
-NALLO_REPORT_SUPPORTED_DATA_DELIVERY: tuple[DataDelivery, ...] = (
-    DataDelivery.ANALYSIS_FILES,
-    DataDelivery.ANALYSIS_SCOUT,
     DataDelivery.RAW_DATA_ANALYSIS,
     DataDelivery.RAW_DATA_ANALYSIS_SCOUT,
     DataDelivery.RAW_DATA_SCOUT,

--- a/cg/constants/report.py
+++ b/cg/constants/report.py
@@ -39,6 +39,14 @@ REPORT_SUPPORTED_DATA_DELIVERY: tuple[DataDelivery, ...] = (
     DataDelivery.FASTQ_SCOUT,
     DataDelivery.SCOUT,
 )
+NALLO_REPORT_SUPPORTED_DATA_DELIVERY: tuple[DataDelivery, ...] = (
+    DataDelivery.ANALYSIS_FILES,
+    DataDelivery.ANALYSIS_SCOUT,
+    DataDelivery.RAW_DATA_ANALYSIS,
+    DataDelivery.RAW_DATA_ANALYSIS_SCOUT,
+    DataDelivery.RAW_DATA_SCOUT,
+    DataDelivery.SCOUT,
+)
 
 NA_FIELD: str = "N/A"
 YES_FIELD: str = "Ja"

--- a/cg/meta/upload/nallo/nallo.py
+++ b/cg/meta/upload/nallo/nallo.py
@@ -7,7 +7,7 @@ import rich_click as click
 
 from cg.cli.generate.delivery_report.base import generate_delivery_report
 from cg.cli.upload.scout import upload_to_scout
-from cg.constants import REPORT_SUPPORTED_DATA_DELIVERY, DataDelivery
+from cg.constants import NALLO_REPORT_SUPPORTED_DATA_DELIVERY, DataDelivery
 from cg.meta.upload.upload_api import UploadAPI
 from cg.meta.workflow.nallo import NalloAnalysisAPI
 from cg.models.cg_config import CGConfig
@@ -28,12 +28,11 @@ class NalloUploadAPI(UploadAPI):
         analysis: Analysis = case.analyses[0]
         self.update_upload_started_at(analysis=analysis)
         # Delivery report generation
-        if case.data_delivery in REPORT_SUPPORTED_DATA_DELIVERY:
+        if case.data_delivery in NALLO_REPORT_SUPPORTED_DATA_DELIVERY:
             ctx.invoke(generate_delivery_report, case_id=case.internal_id)
-
-        # Scout specific upload
-        if DataDelivery.SCOUT in case.data_delivery:
-            ctx.invoke(upload_to_scout, case_id=case.internal_id, re_upload=restart)
+            # Scout specific upload
+            if DataDelivery.SCOUT in case.data_delivery:
+                ctx.invoke(upload_to_scout, case_id=case.internal_id, re_upload=restart)
         LOG.info(
             f"Upload of case {case.internal_id} was successful. Uploaded at {dt.datetime.now()} in StatusDB"
         )

--- a/cg/meta/upload/nallo/nallo.py
+++ b/cg/meta/upload/nallo/nallo.py
@@ -7,7 +7,7 @@ import rich_click as click
 
 from cg.cli.generate.delivery_report.base import generate_delivery_report
 from cg.cli.upload.scout import upload_to_scout
-from cg.constants import NALLO_REPORT_SUPPORTED_DATA_DELIVERY, DataDelivery
+from cg.constants import REPORT_SUPPORTED_DATA_DELIVERY, DataDelivery
 from cg.meta.upload.upload_api import UploadAPI
 from cg.meta.workflow.nallo import NalloAnalysisAPI
 from cg.models.cg_config import CGConfig
@@ -28,11 +28,11 @@ class NalloUploadAPI(UploadAPI):
         analysis: Analysis = case.analyses[0]
         self.update_upload_started_at(analysis=analysis)
         # Delivery report generation
-        if case.data_delivery in NALLO_REPORT_SUPPORTED_DATA_DELIVERY:
+        if case.data_delivery in REPORT_SUPPORTED_DATA_DELIVERY:
             ctx.invoke(generate_delivery_report, case_id=case.internal_id)
             # Scout specific upload
-            if DataDelivery.SCOUT in case.data_delivery:
-                ctx.invoke(upload_to_scout, case_id=case.internal_id, re_upload=restart)
+        if DataDelivery.SCOUT in case.data_delivery:
+            ctx.invoke(upload_to_scout, case_id=case.internal_id, re_upload=restart)
         LOG.info(
             f"Upload of case {case.internal_id} was successful. Uploaded at {dt.datetime.now()} in StatusDB"
         )

--- a/cg/meta/upload/nallo/nallo.py
+++ b/cg/meta/upload/nallo/nallo.py
@@ -30,7 +30,8 @@ class NalloUploadAPI(UploadAPI):
         # Delivery report generation
         if case.data_delivery in REPORT_SUPPORTED_DATA_DELIVERY:
             ctx.invoke(generate_delivery_report, case_id=case.internal_id)
-            # Scout specific upload
+
+        # Scout specific upload
         if DataDelivery.SCOUT in case.data_delivery:
             ctx.invoke(upload_to_scout, case_id=case.internal_id, re_upload=restart)
         LOG.info(


### PR DESCRIPTION
## Description

Fix the NalloUploadAPI with the correct data types for creating the delivery report and upload to scout

### Added

- Data delivery types containing `raw-data` to the allowed types for delivery report creation

### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b nallo-delivery-types-report -a
    ```

### How to test

- [x] Change the data delivery type of `maximumbluejay` to a correct type (`raw_data-analysis`)
- [x] run `cg upload -c maximumbluejay` and stop the execution when the delivery report has been uploaded to HK

### Expected test outcome

- [x] Check that the delivery report is created 

## Review

- [x] Tests executed by SD
- [x] "Merge and deploy" approved by IO
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Deployed to stage:
```shell

```
- [ ] Deployed to production:
```shell

```
