### PR TITLE
fixed scout url for nallo

### DIFF
--- a/cg/services/delivery_message/messages/raw_data_analysis_scout_message.py
+++ b/cg/services/delivery_message/messages/raw_data_analysis_scout_message.py
@@ -1,10 +1,10 @@
 from cg.services.delivery_message.messages.delivery_message import DeliveryMessage
-from cg.services.delivery_message.messages.utils import get_caesar_delivery_path, get_scout38_link
+from cg.services.delivery_message.messages.utils import get_caesar_delivery_path, get_scout_link
 from cg.store.models import Case
 
 
 def get_case_message(case: Case) -> str:
-    scout_link: str = get_scout38_link(case)
+    scout_link: str = get_scout_link(case)
     delivery_path: str = get_caesar_delivery_path(case)
     return (
         "Hello,\n\n"
@@ -16,7 +16,7 @@ def get_case_message(case: Case) -> str:
 
 
 def get_cases_message(cases: list[Case]) -> str:
-    scout_links: list[str] = [get_scout38_link(case) for case in cases]
+    scout_links: list[str] = [get_scout_link(case) for case in cases]
     scout_links_row_separated: str = "\n".join(scout_links)
     delivery_path: str = get_caesar_delivery_path(cases[0])
     return (

--- a/cg/services/delivery_message/messages/raw_data_scout_message.py
+++ b/cg/services/delivery_message/messages/raw_data_scout_message.py
@@ -1,14 +1,13 @@
 from cg.services.delivery_message.messages.delivery_message import DeliveryMessage
 from cg.services.delivery_message.messages.utils import (
     get_caesar_delivery_path,
-    get_scout38_link,
     get_scout_link,
 )
 from cg.store.models import Case
 
 
 def get_case_message(case: Case) -> str:
-    scout_link: str = get_scout38_link(case)
+    scout_link: str = get_scout_link(case)
     delivery_path: str = get_caesar_delivery_path(case)
     return (
         "Hello,\n\n"
@@ -20,7 +19,7 @@ def get_case_message(case: Case) -> str:
 
 
 def get_cases_message(cases: list[Case]) -> str:
-    scout_links: list[str] = [get_scout38_link(case) for case in cases]
+    scout_links: list[str] = [get_scout_link(case) for case in cases]
     scout_links_row_separated: str = "\n".join(scout_links)
     delivery_path: str = get_caesar_delivery_path(cases[0])
     return (

--- a/cg/services/delivery_message/messages/raw_data_scout_message.py
+++ b/cg/services/delivery_message/messages/raw_data_scout_message.py
@@ -1,8 +1,5 @@
 from cg.services.delivery_message.messages.delivery_message import DeliveryMessage
-from cg.services.delivery_message.messages.utils import (
-    get_caesar_delivery_path,
-    get_scout_link,
-)
+from cg.services.delivery_message.messages.utils import get_caesar_delivery_path, get_scout_link
 from cg.store.models import Case
 
 

--- a/cg/services/delivery_message/messages/utils.py
+++ b/cg/services/delivery_message/messages/utils.py
@@ -1,3 +1,4 @@
+from cg.constants import Workflow
 from cg.store.models import Case
 
 
@@ -10,13 +11,12 @@ def get_caesar_delivery_path(case: Case) -> str:
 def get_scout_link(case: Case) -> str:
     customer_id: str = case.customer.internal_id
     case_name: str = case.name
-    return f"https://scout.scilifelab.se/{customer_id}/{case_name}"
-
-
-def get_scout38_link(case: Case) -> str:
-    customer_id: str = case.customer.internal_id
-    case_name: str = case.name
-    return f"https://scout38.scilifelab.se/{customer_id}/{case_name}"
+    url: str = (
+        "https://scout38.sys.scilifelab.se/"
+        if case.data_analysis == Workflow.NALLO
+        else "https://scout.scilifelab.se/"
+    )
+    return f"{url}{customer_id}/{case_name}"
 
 
 def get_scout_links_row_separated(cases: list[Case]) -> str:

--- a/tests/fixture_plugins/delivery_message_fixtures/message_fixtures.py
+++ b/tests/fixture_plugins/delivery_message_fixtures/message_fixtures.py
@@ -56,7 +56,7 @@ def nallo_raw_data_analysis_scout_message(
     return (
         "Hello,\n\n"
         "The analysis has been uploaded to Scout for the following case:\n\n"
-        f"https://scout38.scilifelab.se/{customer_id}/{nallo_case_id}\n\n"
+        f"https://scout38.sys.scilifelab.se/{customer_id}/{nallo_case_id}\n\n"
         "The raw data and analysis files are currently being uploaded to your inbox on Caesar:\n\n"
         f"/home/{customer_id}/inbox/{ticket_id}"
     )
@@ -68,7 +68,7 @@ def nallo_raw_data_scout_message(customer_id: str, nallo_case_id: str, ticket_id
     return (
         "Hello,\n\n"
         "The analysis has been uploaded to Scout for the following case:\n\n"
-        f"https://scout38.scilifelab.se/{customer_id}/{nallo_case_id}\n\n"
+        f"https://scout38.sys.scilifelab.se/{customer_id}/{nallo_case_id}\n\n"
         "The raw data files are currently being uploaded to your inbox on Caesar:\n\n"
         f"/home/{customer_id}/inbox/{ticket_id}"
     )


### PR DESCRIPTION
## Description

### Fixed

- The url of Scout38 was missing the `.sys.`
- For Nallo cases with delivery type `scout` the old Scout url would have been shown. Now it always checks for the workflow to choose the url.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
