### PR TITLE
Fix(CI) Update version of bump2version version used

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -10,7 +10,7 @@ jobs:
     name: Bump version and push tags to master
     steps:
       - name: Bump version
-        uses: Clinical-Genomics/bump2version-ci@v3
+        uses: Clinical-Genomics/bump2version-ci@2.0.3
         env:
           BUMPVERSION_TOKEN: ${{ secrets.BUMPVERSION_TOKEN }}
           BUMPVERSION_AUTHOR: ${{ secrets.BUMPVERSION_AUTHOR }}


### PR DESCRIPTION
## Description
bump2version-ci cannot deal with double quotes "like these" in commit messages. This was patched in https://github.com/Clinical-Genomics/bump2version-ci/pull/12.

However we seem to still be using the old version in our github action

### Changed

- Now uses Clinical-Genomics/bump2version-ci@2.0.3 instead of Clinical-Genomics/bump2version-ci@v3
