### PR TITLE
Add rows for raredisease in order_type_application table

### DIFF
--- a/alembic/versions/2025_04_30_8e0b9e03054d_add_entries_for_raredisease_in_order_.py
+++ b/alembic/versions/2025_04_30_8e0b9e03054d_add_entries_for_raredisease_in_order_.py
@@ -1,0 +1,51 @@
+"""add entries for raredisease in order type application
+
+Revision ID: 8e0b9e03054d
+Revises: 039dbdf8af01
+Create Date: 2025-04-30 09:56:53.670128
+
+"""
+
+from typing import List
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Session, declarative_base
+
+from alembic import op
+
+Base = declarative_base()
+
+# revision identifiers, used by Alembic.
+revision = "8e0b9e03054d"
+down_revision = "039dbdf8af01"
+branch_labels = None
+depends_on = None
+
+bind: sa.Connection = op.get_bind()
+
+
+class OrderTypeApplication(Base):
+    __table__ = sa.Table("order_type_application", sa.MetaData(), autoload_with=bind)
+
+
+def upgrade():
+    session: Session = Session(bind=bind)
+    mip_dna_rows: List[OrderTypeApplication] = (
+        session.query(OrderTypeApplication).filter_by(order_type="MIP_DNA").all()
+    )
+
+    for row in mip_dna_rows:
+        rare_disease_row = OrderTypeApplication(
+            order_type="RAREDISEASE",  # type: ignore
+            application_id=row.application_id,  # type: ignore
+        )
+        session.add(rare_disease_row)
+
+    session.commit()
+
+
+def downgrade():
+    # removing all RAREDISEASE entries from the order_type_application table at a later date
+    # might have unintended consequences since they can be added in other ways than by this
+    # migration, so there is no downgrade
+    pass

--- a/cg/constants/sequencing.py
+++ b/cg/constants/sequencing.py
@@ -65,13 +65,13 @@ class SequencingPlatform(StrEnum):
 
 
 class SeqLibraryPrepCategory(StrEnum):
-    COVID: str = "cov"
-    MICROBIAL: str = "mic"
-    READY_MADE_LIBRARY: str = "rml"
-    TARGETED_GENOME_SEQUENCING: str = "tgs"
-    WHOLE_EXOME_SEQUENCING: str = "wes"
-    WHOLE_GENOME_SEQUENCING: str = "wgs"
-    WHOLE_TRANSCRIPTOME_SEQUENCING: str = "wts"
+    COVID = "cov"
+    MICROBIAL = "mic"
+    READY_MADE_LIBRARY = "rml"
+    TARGETED_GENOME_SEQUENCING = "tgs"
+    WHOLE_EXOME_SEQUENCING = "wes"
+    WHOLE_GENOME_SEQUENCING = "wgs"
+    WHOLE_TRANSCRIPTOME_SEQUENCING = "wts"
 
 
 DNA_PREP_CATEGORIES: list[SeqLibraryPrepCategory] = [


### PR DESCRIPTION
## Description
Closes #4367 

### Added

- Migration that duplicates all rows in the `order_type_application` table where the `order_type` is `MIP_DNA` but sets the `order_type` on the copied row to be `RAREDISEASE`

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Query the database to see that there are the same amount of rows for `RAREDISEASE` as `MIP_DNA` and with the same `application_id`

### Expected test outcome

- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
