### PR TITLE
Make alembic revision 8e0b9e03054d idempotent

### DIFF
--- a/alembic/versions/2025_04_30_8e0b9e03054d_add_entries_for_raredisease_in_order_.py
+++ b/alembic/versions/2025_04_30_8e0b9e03054d_add_entries_for_raredisease_in_order_.py
@@ -33,11 +33,18 @@ def upgrade():
     )
 
     for row in mip_dna_rows:
-        rare_disease_row = OrderTypeApplication(
-            order_type="RAREDISEASE",  # type: ignore
-            application_id=row.application_id,  # type: ignore
+        exists: OrderTypeApplication | None = (
+            session.query(OrderTypeApplication)
+            .filter_by(order_type="RAREDISEASE", application_id=row.application_id)
+            .first()
         )
-        session.add(rare_disease_row)
+
+        if not exists:
+            rare_disease_row = OrderTypeApplication(
+                order_type="RAREDISEASE",  # type: ignore
+                application_id=row.application_id,  # type: ignore
+            )
+            session.add(rare_disease_row)
 
     session.commit()
 


### PR DESCRIPTION
## Description

### Fixed

- The alembic migration for revision 8e0b9e03054d would fail if downgraded and then upgraded again. This change removes that issue. 

### How to test

- [x] Given a database previously migrated to 8e0b9e03054d
- [x] Run `alembic downgrade 039dbdf8af01` and then `alembic upgrade 8e0b9e03054d`

### Expected test outcome

- [x] No errors are expected
- [x] copy/paste the output.

```
$ alembic downgrade 039dbdf8af01
INFO  [alembic.runtime.migration] Context impl MySQLImpl.
INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
INFO  [alembic.runtime.migration] Running downgrade 8e0b9e03054d -> 039dbdf8af01, add entries for raredisease in order type application

$ alembic upgrade 8e0b9e03054d
INFO  [alembic.runtime.migration] Context impl MySQLImpl.
INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 039dbdf8af01 -> 8e0b9e03054d, add entries for raredisease in order type application
```
## Review

- [x] Tests executed by LL
- [x] "Merge and deploy" approved by IO
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [x] Does not need an individual deploy
