### PR TITLE
Nallo Scout upload remove assembly

### DIFF
--- a/cg/meta/upload/scout/nallo_config_builder.py
+++ b/cg/meta/upload/scout/nallo_config_builder.py
@@ -107,11 +107,6 @@ class NalloConfigBuilder(ScoutConfigBuilder):
             sample_id=sample_id,
             hk_version=hk_version,
         )
-        config_sample.assembly_alignment_path = self.get_sample_file(
-            hk_tags=self.sample_tags.assembly_alignment_path,
-            sample_id=sample_id,
-            hk_version=hk_version,
-        )
         config_sample.alignment_path = self.get_sample_file(
             hk_tags=self.sample_tags.alignment_path,
             sample_id=sample_id,


### PR DESCRIPTION
## Description

Nallo: the assembly files are too big to view in the Scout browser, and should no longer be uploaded, until we find a solution.

### Added

-

### Changed

- Nallo Scout do not upload assembly file

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b nallo-remove-assembly-scout-upload
    ```

### How to test

- [x] Do `cg upload maximumbluejay`

### Expected test outcome

- [x] Check that the scout_load.yaml is generated successfully, and upload succeeds.
- [x] Check that the assembly path is not included in the sample files.
![image](https://github.com/user-attachments/assets/52ed23c5-0bac-4f81-8188-ee87e5dd083a)
![image](https://github.com/user-attachments/assets/ac8d069e-0fee-4cab-b2e9-b5849829e943)


- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
