### PR TITLE
(Pipeline integration) Add subprocess submitter

### DIFF
--- a/cg/models/cg_config.py
+++ b/cg/models/cg_config.py
@@ -306,7 +306,7 @@ class TaxprofilerConfig(CommonAppConfig):
 
 class MicrosaltConfig(BaseModel):
     binary_path: str
-    conda_binary: str | None = None
+    conda_binary: str
     conda_env: str
     queries_path: str
     root: str

--- a/cg/services/analysis_starter/configurator/implementations/microsalt.py
+++ b/cg/services/analysis_starter/configurator/implementations/microsalt.py
@@ -2,9 +2,9 @@ import logging
 from pathlib import Path
 
 from cg.apps.lims import LimsAPI
-from cg.constants.constants import Workflow
 from cg.exc import CaseNotConfiguredError
 from cg.meta.workflow.fastq import MicrosaltFastqHandler
+from cg.models.cg_config import MicrosaltConfig
 from cg.services.analysis_starter.configurator.configurator import Configurator
 from cg.services.analysis_starter.configurator.file_creators.microsalt_config import (
     MicrosaltConfigFileCreator,
@@ -21,11 +21,13 @@ class MicrosaltConfigurator(Configurator):
         config_file_creator: MicrosaltConfigFileCreator,
         fastq_handler: MicrosaltFastqHandler,
         lims_api: LimsAPI,
+        microsalt_config: MicrosaltConfig,
         store: Store,
     ):
         self.config_file_creator = config_file_creator
         self.fastq_handler = fastq_handler
         self.lims_api = lims_api
+        self.config = microsalt_config
         self.store = store
 
     def configure(self, case_id: str) -> MicrosaltCaseConfig:
@@ -39,6 +41,12 @@ class MicrosaltConfigurator(Configurator):
             raise CaseNotConfiguredError(
                 f"Please ensure that the config file {config_file_path.as_posix} exists."
             )
+        fastq_directory: Path = self.fastq_handler.get_case_fastq_path(case_id)
         return MicrosaltCaseConfig(
-            case_id=case_id, config_file_path=config_file_path, workflow=Workflow.MICROSALT
+            binary=self.config.binary_path,
+            case_id=case_id,
+            conda_binary=self.config.conda_binary,
+            config_file=config_file_path.as_posix(),
+            environment=self.config.conda_env,
+            fastq_directory=fastq_directory.as_posix(),
         )

--- a/cg/services/analysis_starter/configurator/models/microsalt.py
+++ b/cg/services/analysis_starter/configurator/models/microsalt.py
@@ -1,7 +1,6 @@
-from pathlib import Path
-
 from pydantic import BaseModel
 
+from cg.constants import Workflow
 from cg.services.analysis_starter.configurator.abstract_model import CaseConfig
 
 
@@ -24,4 +23,9 @@ class MicrosaltConfigContent(BaseModel):
 
 
 class MicrosaltCaseConfig(CaseConfig):
-    config_file_path: Path
+    binary: str
+    conda_binary: str
+    config_file: str
+    environment: str
+    fastq_directory: str
+    workflow: Workflow = Workflow.MICROSALT

--- a/cg/services/analysis_starter/submitters/subprocess/commands.py
+++ b/cg/services/analysis_starter/submitters/subprocess/commands.py
@@ -1,0 +1,6 @@
+from cg.constants import Workflow
+
+WORKFLOW_COMMAND_MAP: dict[Workflow, str] = {
+    Workflow.MICROSALT: "{conda_binary} run --name {environment} "
+    "{binary} analyse {config_file} --input {fastq_directory}"
+}

--- a/cg/services/analysis_starter/submitters/subprocess/submitter.py
+++ b/cg/services/analysis_starter/submitters/subprocess/submitter.py
@@ -1,0 +1,22 @@
+import subprocess
+
+from cg.services.analysis_starter.configurator.abstract_model import CaseConfig
+from cg.services.analysis_starter.submitters.submitter import Submitter
+from cg.services.analysis_starter.submitters.subprocess.commands import WORKFLOW_COMMAND_MAP
+
+
+class SubprocessSubmitter(Submitter):
+    def submit(self, case_config: CaseConfig):
+        command: str = self._get_command(case_config)
+        subprocess.run(
+            args=command,
+            shell=True,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+    @staticmethod
+    def _get_command(case_config: CaseConfig) -> str:
+        command: str = WORKFLOW_COMMAND_MAP[case_config.workflow]
+        return command.format(**case_config.model_dump())

--- a/tests/fixture_plugins/analysis_starter/configurator_fixtures.py
+++ b/tests/fixture_plugins/analysis_starter/configurator_fixtures.py
@@ -26,6 +26,7 @@ from cg.store.store import Store
 @pytest.fixture
 def microsalt_configurator(
     microsalt_config_file_creator: MicrosaltConfigFileCreator,
+    cg_context: CGConfig,
     microsalt_fastq_handler: MicrosaltFastqHandler,
     lims_api: LimsAPI,
     microsalt_store: Store,
@@ -34,6 +35,7 @@ def microsalt_configurator(
         config_file_creator=microsalt_config_file_creator,
         fastq_handler=microsalt_fastq_handler,
         lims_api=lims_api,
+        microsalt_config=cg_context.microsalt,
         store=microsalt_store,
     )
 

--- a/tests/services/analysis_starter/test_microsalt_configurator.py
+++ b/tests/services/analysis_starter/test_microsalt_configurator.py
@@ -3,16 +3,15 @@ from unittest import mock
 
 import pytest
 
-from cg.constants import DataDelivery, FileExtensions, Priority, Workflow
+from cg.constants import FileExtensions, Workflow
 from cg.exc import CaseNotConfiguredError, CgDataError
 from cg.io.controller import WriteFile
 from cg.meta.workflow.fastq import FastqHandler
-from cg.models.orders.sample_base import SexEnum, StatusEnum
 from cg.services.analysis_starter.configurator.implementations.microsalt import (
     MicrosaltConfigurator,
 )
 from cg.services.analysis_starter.configurator.models.microsalt import MicrosaltCaseConfig
-from cg.store.models import Application, Case, Customer, Organism, Sample
+from cg.store.models import Case, Organism, Sample
 
 
 @pytest.fixture(autouse=True)
@@ -74,9 +73,12 @@ def test_get_config_path_success(
         # THEN the returned configuration should be correct
         assert config.case_id == microsalt_case.internal_id
         assert config.workflow == Workflow.MICROSALT
-        assert config.config_file_path == Path(
-            microsalt_configurator.config_file_creator.queries_path,
-            microsalt_case.internal_id + FileExtensions.JSON,
+        assert (
+            config.config_file
+            == Path(
+                microsalt_configurator.config_file_creator.queries_path,
+                microsalt_case.internal_id + FileExtensions.JSON,
+            ).as_posix()
         )
 
 

--- a/tests/services/analysis_starter/test_subprocess_submitter.py
+++ b/tests/services/analysis_starter/test_subprocess_submitter.py
@@ -1,0 +1,36 @@
+import subprocess
+from unittest import mock
+
+from cg.services.analysis_starter.configurator.models.microsalt import MicrosaltCaseConfig
+from cg.services.analysis_starter.submitters.subprocess.submitter import SubprocessSubmitter
+
+
+def test_subprocess_submitter():
+    # GIVEN a SubProcessSubmitter
+    subprocess_submitter = SubprocessSubmitter()
+
+    # WHEN submitting a case using a valid case config
+    microsalt_case_config = MicrosaltCaseConfig(
+        binary="/path/to/microsalt/binary",
+        case_id="microsalt_case",
+        conda_binary="/path/to/conda/binary",
+        config_file="/path/to/microsalt_case/config.json",
+        environment="S_microsalt",
+        fastq_directory="/path/to/microsalt_case/fastq",
+    )
+    with mock.patch.object(subprocess, "run") as mock_run:
+        subprocess_submitter.submit(microsalt_case_config)
+
+        # THEN the analysis should have been started
+        expected_args = (
+            "/path/to/conda/binary run --name S_microsalt "
+            "/path/to/microsalt/binary analyse /path/to/microsalt_case/config.json "
+            "--input /path/to/microsalt_case/fastq"
+        )
+        mock_run.assert_called_once_with(
+            args=expected_args,
+            shell=True,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )

--- a/tests/services/analysis_starter/test_subprocess_submitter.py
+++ b/tests/services/analysis_starter/test_subprocess_submitter.py
@@ -23,9 +23,9 @@ def test_subprocess_submitter():
 
         # THEN the analysis should have been started
         expected_args = (
-            "/path/to/conda/binary run --name S_microsalt "
-            "/path/to/microsalt/binary analyse /path/to/microsalt_case/config.json "
-            "--input /path/to/microsalt_case/fastq"
+            f"{microsalt_case_config.conda_binary} run --name {microsalt_case_config.environment} "
+            f"{microsalt_case_config.binary} analyse {microsalt_case_config.config_file} "
+            f"--input {microsalt_case_config.fastq_directory}"
         )
         mock_run.assert_called_once_with(
             args=expected_args,


### PR DESCRIPTION
## Description

Closes #4215. Adds a SubProcessSubmitter intended to be used for all Slurm pipelines

### Added

- SubProcessSubmitter

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
