### PR TITLE
Bug fix: Nallo delivery report scout38 link

### DIFF
--- a/cg/meta/delivery_report/templates/macros/uploaded_files/uploaded_files.html
+++ b/cg/meta/delivery_report/templates/macros/uploaded_files/uploaded_files.html
@@ -28,8 +28,13 @@
     <h4 class="mt-4 mb-3">Scout</h4>
     <div class="alert alert-info" role="alert">
       Varianter finns uppladdade i Scout:
-      <a href="https://scout.scilifelab.se/{{ customer_id }}/{{ case.name }}" class="alert-link">
-        https://scout.scilifelab.se/{{ customer_id }}/{{ case.name }}</a>.
+      {% if "nallo" in workflow %}
+        <a href="https://scout38.sys.scilifelab.se/{{ customer_id }}/{{ case.name }}" class="alert-link">
+          https://scout38.sys.scilifelab.se/{{ customer_id }}/{{ case.name }}</a>.
+      {% else %}
+        <a href="https://scout.scilifelab.se/{{ customer_id }}/{{ case.name }}" class="alert-link">
+          https://scout.scilifelab.se/{{ customer_id }}/{{ case.name }}</a>.
+      {% endif %}
     </div>
     {% if "balsamic" in workflow %}
       <!-- BALSAMIC Scout files -->


### PR DESCRIPTION
## Description
Closes https://github.com/Clinical-Genomics/cg/issues/4386. Nallo delivery report generates link to scout hg19 instead of scout38

### Added

-

### Changed

- Nallo delivery report link to scout38

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b bug-fix-nallo-delivery-report-correct-scout
    ```

### How to test

- [x] Do `cg generate delivery-report --force massivegopher` (Nallo)
- [x] Do `cg generate delivery-report --force fleetjay` (Balsamic)


### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.
<img width="931" alt="image" src="https://github.com/user-attachments/assets/e0741a73-f332-4195-994f-5332b10f3a3c" />

<img width="845" alt="image" src="https://github.com/user-attachments/assets/028e75b2-828e-4ac0-a480-21e2298cd48c" />


## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
