### PR TITLE
Change Taxprofiler Sequencing QC

### DIFF
--- a/cg/services/sequencing_qc_service/quality_checks/checks.py
+++ b/cg/services/sequencing_qc_service/quality_checks/checks.py
@@ -3,10 +3,10 @@ from typing import Callable
 
 from cg.constants import Workflow
 from cg.services.sequencing_qc_service.quality_checks.utils import (
+    all_samples_in_case_have_reads,
     any_sample_in_case_has_reads,
     case_pass_sequencing_qc,
     sample_pass_sequencing_qc,
-    all_samples_in_case_have_reads,
 )
 from cg.store.models import Case
 
@@ -41,7 +41,7 @@ def get_sequencing_quality_check_for_case(case: Case) -> Callable:
         Workflow.RAW_DATA: SequencingQCCheck.ANY_SAMPLE_IN_CASE_HAS_READS,
         Workflow.MICROSALT: SequencingQCCheck.ANY_SAMPLE_IN_CASE_HAS_READS,
         Workflow.MUTANT: SequencingQCCheck.ANY_SAMPLE_IN_CASE_HAS_READS,
-        Workflow.TAXPROFILER: SequencingQCCheck.ANY_SAMPLE_IN_CASE_HAS_READS,
+        Workflow.TAXPROFILER: SequencingQCCheck.ALL_SAMPLES_IN_CASE_HAVE_READS,
         Workflow.NALLO: SequencingQCCheck.ALL_SAMPLES_IN_CASE_HAVE_READS,
     }
 


### PR DESCRIPTION
## Description

We should change the Sequencing QC run for Taxprofiler to be stricter. Right now, cases are picked up where not all samples have been sequenced

### Added

-

### Changed

- Taxprofiler Sequencing QC is that all samples should have reads.

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b change-taxprofiler-sequencing-qc -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
