### PR TITLE
Wrap correct auth error

### DIFF
--- a/cg/server/endpoints/utils.py
+++ b/cg/server/endpoints/utils.py
@@ -55,7 +55,7 @@ def before_request():
     jwt_token = auth_header.split("Bearer ")[-1]
     try:
         user_data = verify_google_token(jwt_token)
-    except (exceptions.OAuthError, ValueError) as e:
+    except (exceptions.GoogleAuthError, ValueError) as e:
         LOG.error(f"Error {e} occurred while decoding JWT token: {jwt_token}")
         return abort(
             make_response(jsonify(message="outdated login certificate"), HTTPStatus.UNAUTHORIZED)


### PR DESCRIPTION
## Description

Closes #4402. The error we wrap is incorrect:

![image](https://github.com/user-attachments/assets/53eb512b-cc12-47fb-8aba-06c01d5288c1)


### Added

-

### Changed

-

### Fixed

- Wrap a GoogleAuthError in our endpoint


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
