### PR TITLE
Nextflow Tower allow optional revision flag upon resume

### DIFF
--- a/cg/meta/workflow/nf_handlers.py
+++ b/cg/meta/workflow/nf_handlers.py
@@ -59,6 +59,7 @@ class NfTowerHandler(NfBaseHandler):
                     "params_file",
                     "config",
                     "compute_env",
+                    "revision",
                     "stub_run",
                 )
             },


### PR DESCRIPTION
## Description
When resuming a run in tower, using `cg workflow <pipeline> run`, it generates a `tw run relaunch` command, but it does not pass the --revision flag. This is needed to allow patches to be run on existing runs.

Closes https://github.com/Clinical-Genomics/cg/issues/4408

### Added

- allow revision flag upon resuming tower runs

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b nallo-resume-new-revision
    ```

### How to test

- [ ] Do `cg workflow nallo run --revision a261c0000b87403d2e04abe58e46ceb4bf07a8a4 rightalpaca`

### Expected test outcome

- [ ] Check that the run resumes and that the tw command includes the --revision flag
- [ ] Take a screenshot and attach or copy/paste the output.
<img width="971" alt="image" src="https://github.com/user-attachments/assets/bc890d7f-1dff-4821-9066-5120f516f3c0" />

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
