### PR TITLE
fix delivery report creation with completed_at date

### DIFF
--- a/cg/cli/generate/delivery_report/base.py
+++ b/cg/cli/generate/delivery_report/base.py
@@ -10,11 +10,11 @@ from housekeeper.store.models import Version
 
 from cg.cli.generate.delivery_report.options import (
     ARGUMENT_CASE_ID,
-    OPTION_STARTED_AT,
+    OPTION_COMPLETED_AT,
     OPTION_WORKFLOW,
 )
 from cg.cli.generate.delivery_report.utils import (
-    get_report_analysis_started_at,
+    get_report_analysis_completed_at,
     get_report_api,
     get_report_api_workflow,
     get_report_case,
@@ -32,20 +32,22 @@ LOG = logging.getLogger(__name__)
 @ARGUMENT_CASE_ID
 @FORCE
 @DRY_RUN
-@OPTION_STARTED_AT
+@OPTION_COMPLETED_AT
 @click.pass_context
 def generate_delivery_report(
     context: click.Context,
     case_id: str,
     force: bool,
     dry_run: bool,
-    analysis_started_at: str = None,
+    analysis_completed_at: str = None,
 ) -> None:
     """Creates a delivery report for the provided case."""
     click.echo(click.style("--------------- DELIVERY REPORT ---------------"))
     case: Case = get_report_case(context, case_id)
     report_api: DeliveryReportAPI = get_report_api(context, case)
-    analysis_date: datetime = get_report_analysis_started_at(case, report_api, analysis_started_at)
+    analysis_date: datetime = get_report_analysis_completed_at(
+        case=case, report_api=report_api, analysis_completed_at=analysis_completed_at
+    )
 
     # Dry run: prints the HTML report to console
     if dry_run:

--- a/cg/cli/generate/delivery_report/options.py
+++ b/cg/cli/generate/delivery_report/options.py
@@ -16,7 +16,7 @@ OPTION_WORKFLOW = click.option(
     help="Limit delivery report generation to a specific workflow",
 )
 
-OPTION_STARTED_AT = click.option(
-    "--analysis-started-at",
-    help="Retrieve analysis started at a specific date (i.e. '2020-05-28  12:00:46')",
+OPTION_COMPLETED_AT = click.option(
+    "--analysis-completed-at",
+    help="Retrieve analysis completed at a specific date (i.e. '2020-05-28  12:00:46')",
 )

--- a/cg/cli/generate/delivery_report/utils.py
+++ b/cg/cli/generate/delivery_report/utils.py
@@ -108,21 +108,21 @@ def get_report_api_workflow(context: click.Context, workflow: Workflow) -> Deliv
     return dispatch_report_api.get(workflow)
 
 
-def get_report_analysis_started_at(
-    case: Case, report_api: DeliveryReportAPI, analysis_started_at: str | None
+def get_report_analysis_completed_at(
+    case: Case, report_api: DeliveryReportAPI, analysis_completed_at: str | None
 ) -> datetime:
-    """Resolves and returns a valid analysis date."""
-    if not analysis_started_at:
-        analysis_started_at: datetime = (
+    """Resolves and returns a valid analysis completed date."""
+    if not analysis_completed_at:
+        analysis_completed_at: datetime = (
             report_api.status_db.get_case_by_internal_id(internal_id=case.internal_id)
             .analyses[0]
-            .started_at
+            .completed_at
         )
     # If there is no analysis for the provided date
-    if not report_api.status_db.get_completed_analysis_by_case_entry_id_and_started_at(
-        case_entry_id=case.id, started_at_date=analysis_started_at
+    if not report_api.status_db.get_analysis_by_case_entry_id_and_completed_at(
+        case_entry_id=case.id, completed_at_date=analysis_completed_at
     ):
-        LOG.error(f"There is no analysis started at {analysis_started_at}")
+        LOG.error(f"There is no analysis completed at {analysis_completed_at}")
         raise click.Abort
-    LOG.info(f"Using analysis started at: {analysis_started_at}")
-    return analysis_started_at
+    LOG.info(f"Using analysis completed at: {analysis_completed_at}")
+    return analysis_completed_at

--- a/cg/meta/clean/api.py
+++ b/cg/meta/clean/api.py
@@ -35,14 +35,14 @@ class CleanAPI:
             bundle_name = analysis.case.internal_id
 
             hk_bundle_version: Version | None = self.housekeeper_api.version(
-                bundle=bundle_name, date=analysis.started_at
+                bundle=bundle_name, date=analysis.completed_at
             )
             if not hk_bundle_version:
                 LOG.warning(
                     f"Version not found for "
                     f"bundle:{bundle_name}; "
                     f"workflow: {workflow}; "
-                    f"date {analysis.started_at}"
+                    f"date {analysis.completed_at}"
                 )
                 continue
 
@@ -50,7 +50,7 @@ class CleanAPI:
                 f"Version found for "
                 f"bundle:{bundle_name}; "
                 f"workflow: {workflow}; "
-                f"date {analysis.started_at}"
+                f"date {analysis.completed_at}"
             )
             yield self.housekeeper_api.get_files(
                 bundle=bundle_name, version=hk_bundle_version.id

--- a/cg/meta/delivery_report/delivery_report_api.py
+++ b/cg/meta/delivery_report/delivery_report_api.py
@@ -164,8 +164,8 @@ class DeliveryReportAPI:
 
     def update_delivery_report_date(self, case: Case, analysis_date: datetime) -> None:
         """Updates the date when a delivery report was created."""
-        analysis: Analysis = self.status_db.get_completed_analysis_by_case_entry_id_and_started_at(
-            case_entry_id=case.id, started_at_date=analysis_date
+        analysis: Analysis = self.status_db.get_analysis_by_case_entry_id_and_completed_at(
+            case_entry_id=case.id, completed_at_date=analysis_date
         )
         analysis.delivery_report_created_at = datetime.now()
         self.status_db.session.commit()
@@ -173,8 +173,8 @@ class DeliveryReportAPI:
     def get_report_data(self, case_id: str, analysis_date: datetime) -> ReportModel:
         """Fetches all the data needed to generate a delivery report."""
         case: Case = self.status_db.get_case_by_internal_id(internal_id=case_id)
-        analysis: Analysis = self.status_db.get_completed_analysis_by_case_entry_id_and_started_at(
-            case_entry_id=case.id, started_at_date=analysis_date
+        analysis: Analysis = self.status_db.get_analysis_by_case_entry_id_and_completed_at(
+            case_entry_id=case.id, completed_at_date=analysis_date
         )
         analysis_metadata: AnalysisModel = self.analysis_api.get_latest_metadata(case.internal_id)
         case_model: CaseModel = self.get_case_data(case, analysis, analysis_metadata)

--- a/cg/meta/observations/observations_api.py
+++ b/cg/meta/observations/observations_api.py
@@ -64,7 +64,7 @@ class ObservationsAPI:
     ):
         """Return input files from a case to upload to Loqusdb."""
         analysis: Analysis = case.analyses[0]
-        analysis_date: datetime = analysis.started_at or analysis.completed_at
+        analysis_date: datetime = analysis.completed_at
         hk_version: Version = self.housekeeper_api.version(analysis.case.internal_id, analysis_date)
         return self.get_observations_files_from_hk(hk_version=hk_version, case_id=case.internal_id)
 

--- a/cg/meta/upload/coverage.py
+++ b/cg/meta/upload/coverage.py
@@ -23,8 +23,7 @@ class UploadCoverageApi:
         family_id = analysis.case.internal_id
         data = {"family": family_id, "family_name": analysis.case.name, "samples": []}
         for link_obj in analysis.case.links:
-            analysis_date = analysis.started_at or analysis.completed_at
-            hk_version = self.hk_api.version(family_id, analysis_date)
+            hk_version = self.hk_api.version(family_id, analysis.completed_at)
             hk_coverage = self.hk_api.files(
                 version=hk_version.id, tags=[link_obj.sample.internal_id, "coverage"]
             ).first()

--- a/cg/meta/workflow/analysis.py
+++ b/cg/meta/workflow/analysis.py
@@ -315,7 +315,7 @@ class AnalysisAPI(MetaAPI):
             LOG.info("Dry-run: StatusDB changes will not be commited")
             return
         self.status_db.update_analysis_completed_at(
-            analysis_id=analysis.id, completed_at=datetime.now()
+            analysis_id=analysis.id, completed_at=self.get_bundle_created_date(case_id)
         )
         self.status_db.update_analysis_comment(analysis_id=analysis.id, comment=comment)
 

--- a/cg/store/crud/read.py
+++ b/cg/store/crud/read.py
@@ -174,21 +174,20 @@ class ReadHandler(BaseHandler):
             workflow=workflow,
         ).all()
 
-    def get_completed_analysis_by_case_entry_id_and_started_at(
-        self, case_entry_id: int, started_at_date: dt.datetime
+    def get_analysis_by_case_entry_id_and_completed_at(
+        self, case_entry_id: int, completed_at_date: dt.datetime
     ) -> Analysis | None:
         """Fetch an analysis."""
         filter_functions: list[Callable] = [
-            AnalysisFilter.COMPLETED,
             AnalysisFilter.BY_CASE_ENTRY_ID,
-            AnalysisFilter.BY_STARTED_AT,
+            AnalysisFilter.BY_COMPLETED_AT,
         ]
 
         return apply_analysis_filter(
             filter_functions=filter_functions,
             analyses=self._get_query(Analysis),
             case_entry_id=case_entry_id,
-            started_at_date=started_at_date,
+            completed_at_date=completed_at_date,
         ).first()
 
     def get_analysis_by_entry_id(self, entry_id: int) -> Analysis | None:

--- a/cg/store/filters/status_analysis_filters.py
+++ b/cg/store/filters/status_analysis_filters.py
@@ -80,6 +80,13 @@ def filter_analyses_by_started_at(analyses: Query, started_at_date: datetime, **
     return analyses.filter(Analysis.started_at == started_at_date)
 
 
+def filter_analyses_by_completed_at(
+    analyses: Query, completed_at_date: datetime, **kwargs
+) -> Query:
+    """Return a query of analyses completed at a certain date."""
+    return analyses.filter(Analysis.completed_at == completed_at_date)
+
+
 def filter_analyses_not_cleaned(analyses: Query, **kwargs) -> Query:
     """Return a query of analyses that have not been cleaned."""
     return analyses.filter(Analysis.cleaned_at.is_(None))
@@ -133,6 +140,7 @@ class AnalysisFilter(Enum):
     IS_NOT_CLEANED: Callable = filter_analyses_not_cleaned
     STARTED_AT_BEFORE: Callable = filter_analyses_started_before
     BY_STARTED_AT: Callable = filter_analyses_by_started_at
+    BY_COMPLETED_AT: Callable = filter_analyses_by_completed_at
     CASE_ACTION_IS_NONE: Callable = filter_analysis_case_action_is_none
     ORDER_BY_UPLOADED_AT: Callable = order_analyses_by_uploaded_at_asc
     ORDER_BY_COMPLETED_AT: Callable = order_analyses_by_completed_at_asc

--- a/cg/store/filters/status_analysis_filters.py
+++ b/cg/store/filters/status_analysis_filters.py
@@ -75,11 +75,6 @@ def filter_analyses_started_before(analyses: Query, started_at_date: datetime, *
     return analyses.filter(Analysis.started_at < started_at_date)
 
 
-def filter_analyses_by_started_at(analyses: Query, started_at_date: datetime, **kwargs) -> Query:
-    """Return a query of analyses started at a certain date."""
-    return analyses.filter(Analysis.started_at == started_at_date)
-
-
 def filter_analyses_by_completed_at(
     analyses: Query, completed_at_date: datetime, **kwargs
 ) -> Query:
@@ -139,7 +134,6 @@ class AnalysisFilter(Enum):
     BY_CASE_ENTRY_ID: Callable = filter_analyses_by_case_entry_id
     IS_NOT_CLEANED: Callable = filter_analyses_not_cleaned
     STARTED_AT_BEFORE: Callable = filter_analyses_started_before
-    BY_STARTED_AT: Callable = filter_analyses_by_started_at
     BY_COMPLETED_AT: Callable = filter_analyses_by_completed_at
     CASE_ACTION_IS_NONE: Callable = filter_analysis_case_action_is_none
     ORDER_BY_UPLOADED_AT: Callable = order_analyses_by_uploaded_at_asc

--- a/tests/cli/generate/delivery_report/test_utils.py
+++ b/tests/cli/generate/delivery_report/test_utils.py
@@ -6,10 +6,10 @@ import click.exceptions
 import pytest
 
 from cg.cli.generate.delivery_report.utils import (
-    get_report_case,
+    get_report_analysis_completed_at,
     get_report_api,
     get_report_api_workflow,
-    get_report_analysis_started_at,
+    get_report_case,
 )
 from cg.constants import Workflow
 from cg.meta.delivery_report.delivery_report_api import DeliveryReportAPI
@@ -84,10 +84,10 @@ def test_get_report_api_workflow(raredisease_delivery_report_click_context: clic
     assert isinstance(report_api, RarediseaseDeliveryReportAPI)
 
 
-def test_get_report_analysis_started_at(
+def test_get_report_analysis_completed_at(
     raredisease_delivery_report_click_context: click.Context, raredisease_case_id: str
 ):
-    """Tests retrieval of analysis started at field"""
+    """Tests retrieval of analysis completed at field"""
 
     # GIVEN a case and a report api
     case: Case = get_report_case(
@@ -97,11 +97,11 @@ def test_get_report_analysis_started_at(
         context=raredisease_delivery_report_click_context, case=case
     )
 
-    # WHEN resolving the analysis started at field
-    started_at = get_report_analysis_started_at(
-        case=case, report_api=report_api, analysis_started_at=None
+    # WHEN resolving the analysis completed at field
+    completed_at = get_report_analysis_completed_at(
+        case=case, report_api=report_api, analysis_completed_at=None
     )
 
     # THEN check if the verified value has been correctly extracted and formatted
-    assert started_at
-    assert isinstance(started_at, datetime)
+    assert completed_at
+    assert isinstance(completed_at, datetime)

--- a/tests/meta/delivery_report/test_api.py
+++ b/tests/meta/delivery_report/test_api.py
@@ -13,18 +13,18 @@ from cg.meta.delivery_report.delivery_report_api import DeliveryReportAPI
 from cg.models.analysis import AnalysisModel
 from cg.models.delivery_report.metadata import SampleMetadataModel
 from cg.models.delivery_report.report import (
-    ReportModel,
-    CustomerModel,
     CaseModel,
+    CustomerModel,
     DataAnalysisModel,
+    ReportModel,
 )
 from cg.models.delivery_report.sample import (
-    SampleModel,
     ApplicationModel,
     MethodsModel,
+    SampleModel,
     TimestampModel,
 )
-from cg.store.models import Case, Analysis, Sample
+from cg.store.models import Analysis, Case, Sample
 
 
 @pytest.mark.parametrize("workflow", [Workflow.RAREDISEASE, Workflow.RNAFUSION])
@@ -42,7 +42,7 @@ def test_get_delivery_report_html(request: FixtureRequest, workflow: Workflow):
 
     # WHEN generating the delivery report HTML
     delivery_report_html: str = delivery_report_api.get_delivery_report_html(
-        case_id=case_id, analysis_date=case.analyses[0].started_at, force=False
+        case_id=case_id, analysis_date=case.analyses[0].completed_at, force=False
     )
 
     # THEN it should generate a valid HTML string
@@ -51,7 +51,7 @@ def test_get_delivery_report_html(request: FixtureRequest, workflow: Workflow):
 
 
 @pytest.mark.parametrize("workflow", [Workflow.RAREDISEASE, Workflow.RNAFUSION])
-def write_delivery_report_file(request: FixtureRequest, workflow: Workflow, tmp_path: Path):
+def test_write_delivery_report_file(request: FixtureRequest, workflow: Workflow, tmp_path: Path):
     """Test writing of the delivery report for different workflows."""
 
     # GIVEN a delivery report API
@@ -63,10 +63,11 @@ def write_delivery_report_file(request: FixtureRequest, workflow: Workflow, tmp_
     case_id: str = request.getfixturevalue(f"{workflow}_case_id")
     case: Case = delivery_report_api.analysis_api.status_db.get_case_by_internal_id(case_id)
 
+    # WHEN writing the delivery report file
     delivery_report_file: Path = delivery_report_api.write_delivery_report_file(
         case_id=case.internal_id,
         directory=tmp_path,
-        analysis_date=case.analyses[0].started_at,
+        analysis_date=case.analyses[0].completed_at,
         force=False,
     )
 
@@ -89,7 +90,7 @@ def test_render_delivery_report(request: FixtureRequest, workflow: Workflow):
 
     # GIVEN some report data
     report_data: ReportModel = delivery_report_api.get_report_data(
-        case_id=case_id, analysis_date=case.analyses[0].started_at
+        case_id=case_id, analysis_date=case.analyses[0].completed_at
     )
 
     # WHEN rendering the report
@@ -115,7 +116,7 @@ def test_get_report_data(request: FixtureRequest, workflow: Workflow):
 
     # WHEN extracting the report data
     report_data: ReportModel = delivery_report_api.get_report_data(
-        case_id=case_id, analysis_date=case.analyses[0].started_at
+        case_id=case_id, analysis_date=case.analyses[0].completed_at
     )
 
     # THEN the report model should have been populated and the data validated
@@ -138,7 +139,7 @@ def test_validate_report_data(request: FixtureRequest, workflow: Workflow):
 
     # GIVEN a report data model
     report_data: ReportModel = delivery_report_api.get_report_data(
-        case_id=case_id, analysis_date=case.analyses[0].started_at
+        case_id=case_id, analysis_date=case.analyses[0].completed_at
     )
 
     # WHEN validating the delivery report data
@@ -168,7 +169,7 @@ def test_validate_report_data_empty_optional_fields(
 
     # GIVEN a delivery report data model
     report_data: ReportModel = delivery_report_api.get_report_data(
-        case_id, case.analyses[0].started_at
+        case_id, case.analyses[0].completed_at
     )
 
     # GIVEN empty optional delivery report fields
@@ -208,7 +209,7 @@ def test_validate_report_data_empty_required_fields(
 
     # GIVEN a delivery report data model
     report_data: ReportModel = delivery_report_api.get_report_data(
-        case_id, case.analyses[0].started_at
+        case_id, case.analyses[0].completed_at
     )
 
     # GIVEN empty required delivery report fields
@@ -246,7 +247,7 @@ def test_validate_report_data_empty_required_fields_force(
 
     # GIVEN a delivery report data model
     report_data: ReportModel = delivery_report_api.get_report_data(
-        case_id, case.analyses[0].started_at
+        case_id, case.analyses[0].completed_at
     )
 
     # GIVEN empty required delivery report fields
@@ -279,7 +280,7 @@ def test_validate_report_data_external_sample(request: FixtureRequest, workflow:
 
     # GIVEN a delivery report data model
     report_data: ReportModel = delivery_report_api.get_report_data(
-        case_id, case.analyses[0].started_at
+        case_id, case.analyses[0].completed_at
     )
 
     # GIVEN a case with an external sample

--- a/tests/meta/delivery_report/test_data_validators.py
+++ b/tests/meta/delivery_report/test_data_validators.py
@@ -5,8 +5,8 @@ import math
 from cg.constants import NA_FIELD
 from cg.meta.delivery_report.data_validators import (
     get_empty_report_data,
-    get_missing_report_data,
     get_million_read_pairs,
+    get_missing_report_data,
 )
 from cg.meta.delivery_report.raredisease import RarediseaseDeliveryReportAPI
 from cg.models.delivery_report.report import ReportModel
@@ -31,7 +31,7 @@ def test_get_empty_report_data(
 
     # GIVEN a delivery report data model
     report_data: ReportModel = raredisease_delivery_report_api.get_report_data(
-        case_id=raredisease_case_id, analysis_date=case.analyses[0].started_at
+        case_id=raredisease_case_id, analysis_date=case.analyses[0].completed_at
     )
 
     # GIVEN empty fields
@@ -74,7 +74,7 @@ def test_get_missing_report_data(
 
     # GIVEN a report data model
     report_data: ReportModel = raredisease_delivery_report_api.get_report_data(
-        raredisease_case_id, case.analyses[0].started_at
+        raredisease_case_id, case.analyses[0].completed_at
     )
 
     # GIVEN a dictionary of report empty fields and a list of required MIP DNA report fields

--- a/tests/meta/upload/test_meta_upload_coverage.py
+++ b/tests/meta/upload/test_meta_upload_coverage.py
@@ -12,10 +12,10 @@ from cg.store.store import Store
 class MockAnalysis:
     """Mock Analysis object"""
 
-    def __init__(self, case_obj: Case, started_at: datetime):
+    def __init__(self, case_obj: Case, completed_at: datetime):
         self.case_obj = case_obj
         self.case = case_obj
-        self.started_at = started_at
+        self.completed_at = completed_at
 
     @property
     def family(self):
@@ -34,7 +34,7 @@ def test_data(
     coverage_api = coverage_upload_api
     case_name = case_id
     case_obj = analysis_store.get_case_by_internal_id(internal_id=case_name)
-    analysis = MockAnalysis(case_obj=case_obj, started_at=timestamp_yesterday)
+    analysis = MockAnalysis(case_obj=case_obj, completed_at=timestamp_yesterday)
 
     # WHEN using the data method
     results = coverage_api.data(analysis=analysis)
@@ -63,7 +63,7 @@ def test_upload(
     coverage_api = UploadCoverageApi(status_api=None, hk_api=hk_api, chanjo_api=chanjo_api)
     family_name = case_id
     case_obj = analysis_store.get_case_by_internal_id(family_name)
-    analysis = MockAnalysis(case_obj=case_obj, started_at=timestamp_yesterday)
+    analysis = MockAnalysis(case_obj=case_obj, completed_at=timestamp_yesterday)
     data = coverage_api.data(analysis=analysis)
 
     # WHEN uploading samples in data dictionary

--- a/tests/meta/workflow/test_analysis.py
+++ b/tests/meta/workflow/test_analysis.py
@@ -891,8 +891,15 @@ def test_update_analysis_as_completed_statusdb_succeeds(
     analysis.completed_at = None
     case_mock.analyses = [analysis]
 
-    # WHEN update_analysis_as_completed_statusdb is called
-    analysis_api.update_analysis_as_completed_statusdb(case_id=case_mock.internal_id, force=False)
+    # GIVEN that the bundle deliverables file has been created
+    with mock.patch(
+        "cg.meta.workflow.analysis.AnalysisAPI.get_bundle_created_date",
+        return_value=datetime.now(),
+    ):
+        # WHEN update_analysis_as_completed_statusdb is called
+        analysis_api.update_analysis_as_completed_statusdb(
+            case_id=case_mock.internal_id, force=False
+        )
 
     # THEN it updates the analysis completed_at date in StatusDB
     status_db_mock.update_analysis_completed_at.assert_called_with(

--- a/tests/store/crud/read/test_read.py
+++ b/tests/store/crud/read/test_read.py
@@ -515,19 +515,19 @@ def test_get_user_when_email_is_none_returns_none(store_with_users: Store):
     assert filtered_user is None
 
 
-def test_get_analysis_by_case_entry_id_and_started_at(
+def test_get_analysis_by_case_entry_id_and_completed_at(
     sample_store: Store, helpers: StoreHelpers, timestamp_now: datetime
 ):
     """Test returning an analysis using a date."""
-    # GIVEN a case with an analysis with a start date in the database
+    # GIVEN a case with an analysis with a completed date in the database
     analysis = helpers.add_analysis(
         store=sample_store, started_at=timestamp_now, completed_at=timestamp_now
     )
-    assert analysis.started_at
+    assert analysis.completed_at
 
-    # WHEN getting analysis via case_id and start date
-    db_analysis = sample_store.get_completed_analysis_by_case_entry_id_and_started_at(
-        case_entry_id=analysis.case.id, started_at_date=analysis.started_at
+    # WHEN getting analysis via case_id and completed date
+    db_analysis = sample_store.get_analysis_by_case_entry_id_and_completed_at(
+        case_entry_id=analysis.case.id, completed_at_date=analysis.completed_at
     )
 
     # THEN the analysis should have been retrieved

--- a/tests/store/filters/test_status_analyses_filters.py
+++ b/tests/store/filters/test_status_analyses_filters.py
@@ -5,12 +5,13 @@ from sqlalchemy.orm import Query
 from cg.constants.constants import Workflow
 from cg.store.filters.status_analysis_filters import (
     filter_analyses_by_case_entry_id,
-    filter_analyses_by_started_at,
+    filter_analyses_by_completed_at,
     filter_analyses_not_cleaned,
     filter_analyses_started_before,
     filter_analyses_with_delivery_report,
     filter_analyses_with_workflow,
     filter_analyses_without_delivery_report,
+    filter_analysis_by_entry_id,
     filter_completed_analyses,
     filter_not_uploaded_analyses,
     filter_report_analyses_by_workflow,
@@ -18,7 +19,6 @@ from cg.store.filters.status_analysis_filters import (
     filter_valid_analyses_in_production,
     order_analyses_by_completed_at_asc,
     order_analyses_by_uploaded_at_asc,
-    filter_analysis_by_entry_id,
 )
 from cg.store.models import Analysis, Case
 from cg.store.store import Store
@@ -301,30 +301,30 @@ def test_filter_analysis_not_cleaned(
     assert analysis_cleaned not in analyses
 
 
-def test_filter_analyses_by_started_at(
+def test_filter_analyses_by_completed_at(
     base_store: Store, helpers: StoreHelpers, timestamp_now: datetime, timestamp_yesterday: datetime
 ):
-    """Test filtering of analyses by started at."""
+    """Test filtering of analyses by completed at."""
 
     # GIVEN a set of mock analyses
-    analysis_started_now: Analysis = helpers.add_analysis(
-        store=base_store, started_at=timestamp_now
+    analysis_completed_now: Analysis = helpers.add_analysis(
+        store=base_store, completed_at=timestamp_now
     )
-    analysis_started_old: Analysis = helpers.add_analysis(
-        store=base_store, case=analysis_started_now.case, started_at=timestamp_yesterday
+    analysis_completed_old: Analysis = helpers.add_analysis(
+        store=base_store, case=analysis_completed_now.case, completed_at=timestamp_yesterday
     )
 
-    # WHEN filtering the analyses by started_at
-    analyses: Query = filter_analyses_by_started_at(
-        analyses=base_store._get_query(table=Analysis), started_at_date=timestamp_yesterday
+    # WHEN filtering the analyses by completed_at
+    analyses: Query = filter_analyses_by_completed_at(
+        analyses=base_store._get_query(table=Analysis), completed_at_date=timestamp_yesterday
     )
 
     # ASSERT that analyses is a query
     assert isinstance(analyses, Query)
 
-    # THEN only the analysis that have been started after the given date should be retrieved
-    assert analysis_started_now not in analyses
-    assert analysis_started_old in analyses
+    # THEN only the analysis that have been completed after the given date should be retrieved
+    assert analysis_completed_now not in analyses
+    assert analysis_completed_old in analyses
 
 
 def test_filter_by_analysis_entry_id(base_store: Store, helpers: StoreHelpers):


### PR DESCRIPTION
## Description
Fix a current bug in production in which the delivery report generation tries to get a HK bundle version with a wrong datetime

### Fixed

- The version would be fetched through `completed_at` instead of `started_at` of the Analysis object
- The `completed_at` date of teh Analysis object will be the timestamp of the bundle generated by HermesAPI


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
