### PR TITLE
patch wrong analysis set as complete in cases with multiple analyses

### DIFF
--- a/cg/meta/workflow/analysis.py
+++ b/cg/meta/workflow/analysis.py
@@ -303,10 +303,7 @@ class AnalysisAPI(MetaAPI):
             AnalysisAlreadyStoredError: If the analysis is already marked as completed.
         """
         LOG.info(f"Marking analysis as completed in StatusDB for {case_id}")
-        case: Case = self.status_db.get_case_by_internal_id(case_id)
-        analysis: Analysis | None = case.analyses[0] if case.analyses else None
-        if not analysis:
-            raise AnalysisDoesNotExistError(f"No analysis found for case {case_id}")
+        analysis: Analysis = self.status_db.get_latest_started_analysis_for_case(case_id)
         if not force and analysis.completed_at:
             raise AnalysisAlreadyStoredError(
                 f"Analysis for case {case_id} already set as completed at {analysis.completed_at}"

--- a/cg/store/crud/read.py
+++ b/cg/store/crud/read.py
@@ -15,7 +15,14 @@ from cg.constants.constants import (
     SampleType,
 )
 from cg.constants.sequencing import DNA_PREP_CATEGORIES, SeqLibraryPrepCategory
-from cg.exc import CaseNotFoundError, CgDataError, CgError, OrderNotFoundError, SampleNotFoundError
+from cg.exc import (
+    AnalysisDoesNotExistError,
+    CaseNotFoundError,
+    CgDataError,
+    CgError,
+    OrderNotFoundError,
+    SampleNotFoundError,
+)
 from cg.models.orders.constants import OrderType
 from cg.models.orders.sample_base import SexEnum
 from cg.server.dto.samples.requests import CollaboratorSamplesRequest
@@ -186,6 +193,19 @@ class ReadHandler(BaseHandler):
             case_entry_id=case_entry_id,
             completed_at_date=completed_at_date,
         ).first()
+
+    def get_latest_started_analysis_for_case(self, case_id: str) -> Analysis:
+        """Return the latest started analysis for a case.
+        Raises:
+            AnalysisDoesNotExistError if no analysis is found.
+        """
+        case: Case = self.get_case_by_internal_id(case_id)
+        analyses: list[Analysis] = case.analyses
+        if not analyses:
+            raise AnalysisDoesNotExistError(f"No analysis found for case {case_id}")
+        analyses.sort(key=lambda x: x.started_at, reverse=True)
+        analysis: Analysis | None = analyses[0]
+        return analysis
 
     def get_analysis_by_entry_id(self, entry_id: int) -> Analysis | None:
         """Return an analysis."""

--- a/cg/store/crud/read.py
+++ b/cg/store/crud/read.py
@@ -199,7 +199,7 @@ class ReadHandler(BaseHandler):
         Raises:
             AnalysisDoesNotExistError if no analysis is found.
         """
-        case: Case = self.get_case_by_internal_id(case_id)
+        case: Case | None = self.get_case_by_internal_id(case_id)
         analyses: list[Analysis] = case.analyses
         if not analyses:
             raise AnalysisDoesNotExistError(f"No analysis found for case {case_id}")


### PR DESCRIPTION
## Description
The AnalysisAPI method `update_analysis_as_completed_statusdb` used in the `store` methods picked up the analysis with the latest `completed_at` date to be stored. Still, by this point all of the analyses of the case had `completed_at = None`, making the function pick up the wrong analysis for updating. This PR changes the sorting to `started_at` instead.

### Added

- New CRUD function `get_latest_started_analysis_for_case` with tests

### Changed

- AnalysisAPI method `update_analysis_as_completed_statusdb` so that it uses the new function

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
