### PR TITLE
Patch case latest analysed ensuring dates are not None

### DIFF
--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -517,9 +517,7 @@ class Case(Base, PriorityMixin):
 
     @property
     def latest_analyzed(self) -> datetime | None:
-        valid_analyses: list[Analysis] | None = [
-            a for a in self.analyses if a.completed_at is not None
-        ]
+        valid_analyses: list[Analysis] = [a for a in self.analyses if a.completed_at is not None]
         if not valid_analyses:
             return None
         sorted_analyses: list[Analysis] = sorted(

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -517,10 +517,13 @@ class Case(Base, PriorityMixin):
 
     @property
     def latest_analyzed(self) -> datetime | None:
-        if not self.analyses:
+        valid_analyses: list[Analysis] | None = [
+            a for a in self.analyses if a.completed_at is not None
+        ]
+        if not valid_analyses:
             return None
         sorted_analyses: list[Analysis] = sorted(
-            self.analyses, key=lambda analysis: analysis.completed_at, reverse=True
+            valid_analyses, key=lambda analysis: analysis.completed_at, reverse=True
         )
         return sorted_analyses[0].completed_at
 


### PR DESCRIPTION
## Description
**Hot patch**
The `Case.latest_analysed` sorts the `completed_at` dates of a case's analyses. This fails when dates are None. This PR filters out analyses that have `completed_at` equal to None.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
