### PR TITLE
Speed up forms

### DIFF
--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -442,6 +442,12 @@ class CaseView(BaseView):
         "customer.internal_id",
         "tickets",
     ]
+    form_ajax_refs = {
+        "orders": {
+            "fields": ["id", "ticket_id"],
+            "page_size": 20,
+        }
+    }
     form_excluded_columns = [
         "analyses",
         "_cohorts",
@@ -556,7 +562,12 @@ class AnalysisView(BaseView):
         "case.internal_id",
         "case.name",
     ]
-    form_extra_fields = {"workflow": SelectEnumField(enum_class=Workflow)}
+    form_ajax_refs = {
+        "case": {
+            "fields": ["internal_id", "name"],
+            "page_size": 20,
+        }
+    }
 
 
 class IlluminaFlowCellView(BaseView):
@@ -644,6 +655,12 @@ class OrderView(BaseView):
     column_display_pk = True
     create_modal = True
     edit_modal = True
+    form_ajax_refs = {
+        "cases": {
+            "fields": ["internal_id", "name"],
+            "page_size": 20,
+        }
+    }
 
 
 class PanelView(BaseView):

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -1007,6 +1007,9 @@ class Order(Base):
 
     __tablename__ = "order"
 
+    def __str__(self) -> str:
+        return f"{self.id} (ticket {self.ticket_id})"
+
     id: Mapped[PrimaryKeyInt]
     cases: Mapped[list[Case]] = orm.relationship(secondary=order_case, back_populates="orders")
     customer_id: Mapped[int] = mapped_column(ForeignKey("customer.id"))


### PR DESCRIPTION
## Description

By default, relationships between tables become dropdowns in the Flask admin view forms. This quickly becomes slow. This PR adds a "search" functionality instead, so that when creating an analysis entry, you will search for the internal id or name and it will autocomplete (run a SELECT statement in the background) with the available options.

### Added

-

### Changed

-

### Fixed

- Analysis, orders and cases all have speedier forms.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
