### PR TITLE
fix nextflow store available

### DIFF
--- a/cg/cli/workflow/balsamic/base.py
+++ b/cg/cli/workflow/balsamic/base.py
@@ -279,13 +279,13 @@ def store_available(context: click.Context, dry_run: bool) -> None:
 
     analysis_api: AnalysisAPI = context.obj.meta_apis["analysis_api"]
 
-    exit_code: int = EXIT_SUCCESS
+    was_successful: bool = True
     for case_obj in analysis_api.get_cases_to_store():
         LOG.info(f"Storing deliverables for {case_obj.internal_id}")
         try:
             context.invoke(store, case_id=case_obj.internal_id, dry_run=dry_run)
         except Exception as exception_object:
             LOG.error(f"Error storing {case_obj.internal_id}: {exception_object}")
-            exit_code = EXIT_FAIL
-    if exit_code:
-        raise click.Abort
+            was_successful = False
+    if not was_successful:
+        raise click.Abort()

--- a/cg/cli/workflow/commands.py
+++ b/cg/cli/workflow/commands.py
@@ -135,16 +135,16 @@ def store_available(context: click.Context, dry_run: bool) -> None:
 
     analysis_api: AnalysisAPI = context.obj.meta_apis["analysis_api"]
 
-    exit_code: int = EXIT_SUCCESS
+    was_successful: bool = True
     for case_obj in analysis_api.get_cases_to_store():
         LOG.info(f"Storing deliverables for {case_obj.internal_id}")
         try:
             context.invoke(store, case_id=case_obj.internal_id, dry_run=dry_run)
         except Exception as exception_object:
             LOG.error(f"Error storing {case_obj.internal_id}: {exception_object}")
-            exit_code = EXIT_FAIL
-    if exit_code:
-        raise click.Abort
+            was_successful = False
+    if not was_successful:
+        raise click.Abort()
 
 
 @click.command("rsync-past-run-dirs")

--- a/cg/cli/workflow/mutant/base.py
+++ b/cg/cli/workflow/mutant/base.py
@@ -109,7 +109,7 @@ def store_available(context: click.Context, dry_run: bool) -> None:
 
     analysis_api: MutantAnalysisAPI = context.obj.meta_apis["analysis_api"]
 
-    exit_code: int = EXIT_SUCCESS
+    was_successful: bool = True
 
     cases_ready_for_qc: list[Case] = analysis_api.get_cases_to_perform_qc_on()
     LOG.info(f"Found {len(cases_ready_for_qc)} cases to perform QC on!")
@@ -128,10 +128,10 @@ def store_available(context: click.Context, dry_run: bool) -> None:
             context.invoke(store, case_id=case.internal_id, dry_run=dry_run)
         except Exception as exception_object:
             LOG.error(f"Error storingc {case.internal_id}: {exception_object}")
-            exit_code = EXIT_FAIL
+            was_successful = False
 
-    if exit_code:
-        raise click.Abort
+    if not was_successful:
+        raise click.Abort()
 
 
 @mutant.command("run-qc")

--- a/cg/cli/workflow/nf_analysis.py
+++ b/cg/cli/workflow/nf_analysis.py
@@ -321,13 +321,13 @@ def store_available(context: click.Context, dry_run: bool) -> None:
     """
 
     analysis_api: NfAnalysisAPI = context.obj.meta_apis[MetaApis.ANALYSIS_API]
-    exit_code: int = EXIT_SUCCESS
+    was_successful: bool = True
     for case in analysis_api.get_cases_to_store():
         LOG.info(f"Storing deliverables for {case.internal_id}")
         try:
             analysis_api.store(case_id=case.internal_id, dry_run=dry_run)
         except Exception as error:
             LOG.error(f"Error storing {case.internal_id}: {repr(error)}")
-            exit_code = EXIT_FAIL
-    if exit_code:
+            was_successful = False
+    if not was_successful:
         raise click.Abort()


### PR DESCRIPTION
## Description
 The CLI command `store-available` for nextflow pipelines exited before all cases were evaluating for storing. This PR makes sure that `click.abort` is invoked only after all cases have been assesed and at least one got an exception caught.

### Added

-

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
