### PR TITLE
Feat(Pacbio) Only run post-processing if all cells are ready

### DIFF
--- a/cg/services/run_devices/pacbio/post_processing_service.py
+++ b/cg/services/run_devices/pacbio/post_processing_service.py
@@ -82,7 +82,7 @@ class PacBioPostProcessingService(PostProcessingService):
                 run_name=run_name, sequencing_dir=self.sequencing_dir
             )
             self.run_validator.validate_run_files(run_data)
-        except PostProcessingRunFileManagerError:
-            LOG.debug(f"Run {run_name} is not ready for post-processing. Missing required files.")
+        except PostProcessingRunFileManagerError as error:
+            LOG.debug(f"Run {run_name} is not ready for post-processing. {error.args[0]}.")
             return False
         return True

--- a/tests/services/run_devices/pacbio/post_processing/test_post_processing.py
+++ b/tests/services/run_devices/pacbio/post_processing/test_post_processing.py
@@ -102,7 +102,12 @@ def test_can_post_processing_start_false(
 
     # GIVEN one of them is not ready for post-processing
     pac_bio_post_processing_service.run_validator.validate_run_files = Mock(
-        side_effect=[None, PostProcessingRunFileManagerError]
+        side_effect=[
+            None,
+            PostProcessingRunFileManagerError(
+                f"No Manifest file found in {pacbio_barcoded_sequencing_run_name}"
+            ),
+        ]
     )
 
     # WHEN checking if post-processing can start


### PR DESCRIPTION
## Description
This PR changes the starting logic for the post-procesessing  of Pacbio SMRT cells. Before post-processing each SMRT cell we now also check that all other cells in the same run directory also are completed. 

This is only applies to the `post_process_all_runs command`. One can still run `post_process_run` to post-process a SMRT cell regardless of the others in the run

### Changed

- The `post_process_all_runs` now only post-pocesses SMRT cells if the entire run is completed
