### PR TITLE
Exclude VCF-str file for WES Raredisease cases

### DIFF
--- a/cg/meta/delivery_report/raredisease.py
+++ b/cg/meta/delivery_report/raredisease.py
@@ -14,6 +14,7 @@ from cg.constants.report import (
     REQUIRED_SAMPLE_RAREDISEASE_FIELDS,
     REQUIRED_SAMPLE_TIMESTAMP_FIELDS,
 )
+from cg.constants.scout import ScoutUploadKey
 from cg.constants.sequencing import SeqLibraryPrepCategory
 from cg.meta.delivery_report.data_validators import get_million_read_pairs
 from cg.meta.delivery_report.delivery_report_api import DeliveryReportAPI
@@ -63,38 +64,23 @@ class RarediseaseDeliveryReportAPI(DeliveryReportAPI):
 
     def get_scout_variants_files(self, case_id: str) -> ScoutVariantsFiles:
         """Return Raredisease files that will be uploaded to Scout."""
+        snv_vcf: str | None = self.get_scout_uploaded_file_from_hk(
+            case_id=case_id, scout_key=ScoutUploadKey.VCF_SNV
+        )
+        sv_vcf: str | None = self.get_scout_uploaded_file_from_hk(
+            case_id=case_id, scout_key=ScoutUploadKey.VCF_SV
+        )
+        vcf_str: str | None = self.get_scout_uploaded_file_from_hk(
+            case_id=case_id, scout_key=ScoutUploadKey.VCF_STR
+        )
+        smn_tsv: str | None = self.get_scout_uploaded_file_from_hk(
+            case_id=case_id, scout_key=ScoutUploadKey.SMN_TSV
+        )
         return ScoutVariantsFiles(
-            snv_vcf=self.housekeeper_api.get_file_by_exact_tags(
-                bundle=case_id,
-                tags=[
-                    AnalysisTag.VCF_SNV_CLINICAL,
-                    case_id,
-                    HermesFileTag.CLINICAL_DELIVERY,
-                    HermesFileTag.LONG_TERM_STORAGE,
-                    HermesFileTag.SCOUT,
-                ],
-            ).full_path,
-            sv_vcf=self.housekeeper_api.get_file_by_exact_tags(
-                bundle=case_id,
-                tags=[
-                    AnalysisTag.VCF_SV_CLINICAL,
-                    case_id,
-                    HermesFileTag.CLINICAL_DELIVERY,
-                    HermesFileTag.LONG_TERM_STORAGE,
-                    HermesFileTag.SCOUT,
-                ],
-            ).full_path,
-            vcf_str=self._get_vcf_str_file(case_id),
-            smn_tsv=self.housekeeper_api.get_file_by_exact_tags(
-                bundle=case_id,
-                tags=[
-                    AnalysisTag.SMN_CALLING,
-                    case_id,
-                    HermesFileTag.CLINICAL_DELIVERY,
-                    HermesFileTag.LONG_TERM_STORAGE,
-                    HermesFileTag.SCOUT,
-                ],
-            ).full_path,
+            snv_vcf=snv_vcf,
+            sv_vcf=sv_vcf,
+            vcf_str=vcf_str,
+            smn_tsv=smn_tsv,
         )
 
     def _get_vcf_str_file(self, case_id: str) -> str:

--- a/cg/meta/delivery_report/raredisease.py
+++ b/cg/meta/delivery_report/raredisease.py
@@ -1,7 +1,6 @@
 """Raredisease Delivery Report API."""
 
 from cg.clients.chanjo2.models import CoverageMetrics
-from cg.constants.housekeeper_tags import AnalysisTag, HermesFileTag
 from cg.constants.report import (
     REQUIRED_APPLICATION_FIELDS,
     REQUIRED_CASE_FIELDS,
@@ -81,27 +80,6 @@ class RarediseaseDeliveryReportAPI(DeliveryReportAPI):
             sv_vcf=sv_vcf,
             vcf_str=vcf_str,
             smn_tsv=smn_tsv,
-        )
-
-    def _get_vcf_str_file(self, case_id: str) -> str:
-        """Gets the VCF STR file. If the case is not WGS, returns None, since the file
-        will not have been generated."""
-        case: Case = self.status_db.get_case_by_internal_id(case_id)
-        analysis_type: str = case.samples[0].application_version.application.analysis_type
-        should_have_vcf_str: bool = analysis_type == SeqLibraryPrepCategory.WHOLE_GENOME_SEQUENCING
-        return (
-            self.housekeeper_api.get_file_by_exact_tags(
-                bundle=case_id,
-                tags=[
-                    AnalysisTag.VCF_STR,
-                    case_id,
-                    HermesFileTag.CLINICAL_DELIVERY,
-                    HermesFileTag.LONG_TERM_STORAGE,
-                    HermesFileTag.SCOUT,
-                ],
-            ).full_path
-            if should_have_vcf_str
-            else None
         )
 
     @staticmethod


### PR DESCRIPTION
## Description

Uploads for WES cases to Scout fails for Raredisease at the moment. The cause is that the vcf-str files are not, and should not be, generated for WES cases, yet we expect them in the Scout upload. This is a hot patch intended to get the data to the customers, although we should probably have a think about how this _should_ be done.

### Added

-

### Changed

-

### Fixed

- WES Raredisease cases are not expected to have a vcf-str file in the Scout upload


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b patch-raredisease-wes-uploads -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
