### PR TITLE
Fix microSALT single sample tracking

### DIFF
--- a/cg/services/analysis_starter/tracker/implementations/microsalt.py
+++ b/cg/services/analysis_starter/tracker/implementations/microsalt.py
@@ -12,7 +12,7 @@ class MicrosaltTracker(Tracker):
         return WorkflowManager.Slurm
 
     def _get_job_ids_path(self, case_id: str) -> Path:
-        project_id: str = self._get_lims_project_id(case_id)
+        project_id: str = self._get_file_name_start(case_id)
         job_ids_path = Path(
             self.workflow_root,
             "results",
@@ -24,9 +24,12 @@ class MicrosaltTracker(Tracker):
         self._ensure_old_job_ids_are_removed(job_ids_path)
         return job_ids_path
 
-    def _get_lims_project_id(self, case_id: str) -> str:
+    def _get_file_name_start(self, case_id: str) -> str:
+        """Returns the LIMS project if the case contains multiple samples, else the sample id."""
         case: Case = self.store.get_case_by_internal_id(case_id)
-        sample_id: str = case.links[0].sample.internal_id
+        sample_id: str = case.samples[0].internal_id
+        if len(case.samples) == 1:
+            return sample_id
         return self._extract_project_id(sample_id)
 
     @staticmethod

--- a/cg/services/analysis_starter/tracker/implementations/microsalt.py
+++ b/cg/services/analysis_starter/tracker/implementations/microsalt.py
@@ -25,7 +25,7 @@ class MicrosaltTracker(Tracker):
         return job_ids_path
 
     def _get_file_name_start(self, case_id: str) -> str:
-        """Returns the LIMS project ID if the case contains multiple samples, else the sample id."""
+        """Returns the LIMS project id if the case contains multiple samples, else the sample id."""
         case: Case = self.store.get_case_by_internal_id(case_id)
         sample_id: str = case.samples[0].internal_id
         if len(case.samples) == 1:

--- a/cg/services/analysis_starter/tracker/implementations/microsalt.py
+++ b/cg/services/analysis_starter/tracker/implementations/microsalt.py
@@ -25,7 +25,7 @@ class MicrosaltTracker(Tracker):
         return job_ids_path
 
     def _get_file_name_start(self, case_id: str) -> str:
-        """Returns the LIMS project if the case contains multiple samples, else the sample id."""
+        """Returns the LIMS project ID if the case contains multiple samples, else the sample id."""
         case: Case = self.store.get_case_by_internal_id(case_id)
         sample_id: str = case.samples[0].internal_id
         if len(case.samples) == 1:

--- a/tests/services/analysis_starter/test_microsalt_tracker.py
+++ b/tests/services/analysis_starter/test_microsalt_tracker.py
@@ -91,7 +91,7 @@ def test_get_job_ids_path_multiple_samples(microsalt_tracker: MicrosaltTracker):
     microsalt_tracker.store = store
 
     # WHEN getting the job_ids_path
-    job_id_path = microsalt_tracker._get_job_ids_path(internal_id)
+    job_id_path: Path = microsalt_tracker._get_job_ids_path(internal_id)
 
     # THEN the file name should use the LIMS project ID
     assert job_id_path.name == "ACC123_slurm_ids.yaml"
@@ -111,9 +111,9 @@ def test_get_job_ids_path_single_sample(microsalt_tracker: MicrosaltTracker):
     microsalt_tracker.store = store
 
     # WHEN getting the job_ids_path
-    job_id_path = microsalt_tracker._get_job_ids_path(internal_id)
+    job_id_path: Path = microsalt_tracker._get_job_ids_path(internal_id)
 
-    # THEN the file name should use the LIMS project ID
+    # THEN the file name should use the sample ID
     assert job_id_path.name == "ACC123A1_slurm_ids.yaml"
 
 


### PR DESCRIPTION
## Description

The slurm job file has a different name when cases with only one sample are run. This PR makes sure Trailblazer gets the correct path.

### Added

-

### Changed

-

### Fixed

- Single sample cases gets a slurm job id file name with the whole sample id.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b fix-microsalt-single-sample-tracking -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
