### PR TITLE
add support for starting microsalt case without all samples sequenced

### DIFF
--- a/cg/meta/compress/compress.py
+++ b/cg/meta/compress/compress.py
@@ -2,9 +2,9 @@
 API for compressing files. Functionality to compress FASTQ, decompress SPRING and clean files
 """
 
-from datetime import datetime, timedelta
 import logging
 import re
+from datetime import datetime, timedelta
 from pathlib import Path
 
 from housekeeper.store.models import File, Version
@@ -13,6 +13,7 @@ from cg.apps.crunchy import CrunchyAPI
 from cg.apps.crunchy.files import update_metadata_date
 from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.constants import SequencingFileTag
+from cg.constants.constants import PIPELINES_USING_PARTIAL_ANALYSES
 from cg.exc import DecompressionCouldNotStartError
 from cg.meta.backup.backup import SpringBackupAPI
 from cg.meta.compress import files
@@ -401,6 +402,9 @@ class CompressAPI:
         """Return an object containing compression data for a case."""
         sample_compressions: list[SampleCompressionData] = []
         for sample in case.samples:
+            if self._should_skip_sample(case=case, sample=sample):
+                LOG.warning(f"Skipping sample {sample.internal_id} - it has no reads.")
+                continue
             sample_compression_data: SampleCompressionData = self.get_sample_compression_data(
                 sample.internal_id
             )
@@ -414,3 +418,13 @@ class CompressAPI:
         version: Version = self.hk_api.get_latest_bundle_version(sample_id)
         compression_objects.extend(files.get_spring_paths(version))
         return SampleCompressionData(sample_id=sample_id, compression_objects=compression_objects)
+
+    @staticmethod
+    def _should_skip_sample(case: Case, sample: Sample):
+        """
+        For some workflows, we want to start a partial analysis skipping the samples with no reads.
+        This method returns true if we should skip the sample.
+        """
+        if case.data_analysis in PIPELINES_USING_PARTIAL_ANALYSES and not sample.has_reads:
+            return True
+        return False

--- a/cg/meta/compress/compress.py
+++ b/cg/meta/compress/compress.py
@@ -403,7 +403,7 @@ class CompressAPI:
         sample_compressions: list[SampleCompressionData] = []
         for sample in case.samples:
             if self._should_skip_sample(case=case, sample=sample):
-                LOG.warning(f"Skipping sample {sample.internal_id} - it has no reads.")
+                LOG.debug(f"Skipping sample {sample.internal_id} - it has no reads.")
                 continue
             sample_compression_data: SampleCompressionData = self.get_sample_compression_data(
                 sample.internal_id

--- a/cg/meta/compress/compress.py
+++ b/cg/meta/compress/compress.py
@@ -420,7 +420,7 @@ class CompressAPI:
         return SampleCompressionData(sample_id=sample_id, compression_objects=compression_objects)
 
     @staticmethod
-    def _should_skip_sample(case: Case, sample: Sample):
+    def _should_skip_sample(case: Case, sample: Sample) -> bool:
         """
         For some workflows, we want to start a partial analysis skipping the samples with no reads.
         This method returns true if we should skip the sample.

--- a/tests/meta/compress/conftest.py
+++ b/tests/meta/compress/conftest.py
@@ -5,6 +5,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Generator
+from unittest.mock import Mock, create_autospec
 
 import pytest
 
@@ -14,6 +15,7 @@ from cg.constants import SequencingFileTag
 from cg.constants.constants import FileFormat
 from cg.io.controller import WriteFile
 from cg.meta.compress import CompressAPI
+from cg.models.compression_data import CompressionData, SampleCompressionData
 from tests.cli.compress.conftest import MockCompressAPI
 from tests.store_helpers import StoreHelpers
 
@@ -228,3 +230,13 @@ def decompress_hk_spring_bundle(
 
     hk_spring_bundle["files"].extend([spring_file_info, spring_meta_info])
     return hk_spring_bundle
+
+
+@pytest.fixture
+def sample_compression_data() -> SampleCompressionData:
+    """Return a SampleCompressionData object for a sample."""
+    compression_data: Mock[CompressionData] = create_autospec(CompressionData)
+    return SampleCompressionData(
+        sample_id="sample_1",
+        compression_objects=[compression_data],
+    )

--- a/tests/meta/compress/test_compress_meta_fastq.py
+++ b/tests/meta/compress/test_compress_meta_fastq.py
@@ -2,8 +2,15 @@
 
 import logging
 from unittest import mock
+from unittest.mock import Mock, create_autospec
 
+import pytest
+from pytest_mock import MockerFixture
+
+from cg.constants import Workflow
 from cg.meta.compress import CompressAPI
+from cg.models.compression_data import CaseCompressionData, SampleCompressionData
+from cg.store.models import Case, Sample
 
 
 def test_compress_case_fastq_one_sample(populated_compress_fastq_api, sample, caplog):
@@ -90,3 +97,64 @@ def test_compress_sample_fastq_archived_spring_file(
         assert result is False
         # THEN assert that the correct information is communicated
         assert f"FASTQ to SPRING not possible for {sample}" in caplog.text
+
+
+def test_get_microsalt_case_compression_data(
+    compress_api: CompressAPI, sample_compression_data: SampleCompressionData, mocker: MockerFixture
+):
+    """
+    Test that the case compression data from a microSALT case with samples, some of which don't
+    have reads, only contains the sample compression data of the samples that have reads.
+    """
+    # GIVEN a CompressAPI instance
+
+    # GIVEN a microSALT case with 3 samples, only one of them has reads
+    sample_with_reads: Mock[Sample] = create_autospec(Sample)
+    sample_with_reads.has_reads = True
+    sample_with_reads.internal_id = "sample_with_reads"
+
+    sample_without_reads: Mock[Sample] = create_autospec(Sample)
+    sample_without_reads.has_reads = False
+    sample_without_reads.internal_id = "sample_without_reads"
+
+    case: Mock[Case] = create_autospec(Case)
+    case.data_analysis = Workflow.MICROSALT
+    case.samples = [sample_with_reads, sample_without_reads, sample_without_reads]
+    case.internal_id = "case_with_samples"
+
+    # GIVEN a sample compression data for the sample with reads
+    mocker.patch.object(
+        compress_api, "get_sample_compression_data", return_value=sample_compression_data
+    )
+
+    # WHEN getting the case compression data
+    case_compression_data: CaseCompressionData = compress_api.get_case_compression_data(case)
+
+    # THEN the case compression data should only contain data for the sample that has reads
+    assert case_compression_data.sample_compression_data == [sample_compression_data]
+
+
+@pytest.mark.parametrize(
+    "workflow, has_reads, expected",
+    [
+        (Workflow.MICROSALT, False, True),
+        (Workflow.MUTANT, True, False),
+        (Workflow.RNAFUSION, False, False),
+        (Workflow.RNAFUSION, True, False),
+    ],
+)
+def test_should_skip_sample(
+    workflow: Workflow, has_reads: bool, expected: bool, compress_api: CompressAPI
+):
+    """Test that the skip sample function returns the expected value."""
+    # GIVEN a case and a sample and a CompressAPI instance
+    case: Mock[Case] = create_autospec(Case)
+    case.data_analysis = workflow
+    sample: Mock[Sample] = create_autospec(Sample)
+    sample.has_reads = has_reads
+
+    # WHEN checking if the sample should be skipped
+    result: bool = compress_api._should_skip_sample(case=case, sample=sample)
+
+    # THEN assert that the result is as expected
+    assert result == expected


### PR DESCRIPTION
## Description
Closes #4519 

### Added

- Function that checks if sample is microSALT or Mutant to skip it if it has no reads and do not block the analysis
- tests for new functionality


### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b fix-start-microsalt -a
    ```

### How to test

- [x] Find a microSALT case on stage with some samples without reads
- [x] Run `cg -l DEBUG workflow microsalt start climbingalien `

### Expected test outcome

- [x] Check that the case has started
```shell
[js.diazboada@hasta:~] [S_base] $ cg -l DEBUG workflow microsalt start climbingalien
Starting microSALT workflow for climbingalien
Getting a microsalt analysis starter
Starting case climbingalien
Making request: POST https://oauth2.googleapis.com/token
...
Ensuring Fastq files are ready for analysis
Getting archived files for bundle <>
...
Skipping sample <> - it has no reads.
Fetch latest version from bundle <>
<terminated by user>
```

## Review

- [x] Tests executed by SD
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Deployed to stage:
```shell

```
- [ ] Deployed to production:
```shell

```
- [ ] Inform to prodbioinfo that the bug has been patched
