### PR TITLE
add d4 file to scout case config load

### DIFF
--- a/cg/constants/scout.py
+++ b/cg/constants/scout.py
@@ -161,12 +161,14 @@ MIP_SAMPLE_TAGS: dict[str, set[str]] = dict(
 )
 
 BALSAMIC_SAMPLE_TAGS = dict(
+    d4_file={"d4"},
     bam_file={"bam"},
     alignment_file={"cram"},
     vcf2cytosure={"vcf2cytosure"},
 )
 
 BALSAMIC_UMI_SAMPLE_TAGS = dict(
+    d4_file={"umi-d4"},
     bam_file={"umi-bam"},
     alignment_file={"umi-cram"},
 )

--- a/cg/meta/upload/scout/balsamic_config_builder.py
+++ b/cg/meta/upload/scout/balsamic_config_builder.py
@@ -52,6 +52,9 @@ class BalsamicConfigBuilder(ScoutConfigBuilder):
             sample_id=sample_id,
             hk_version=hk_version,
         )
+        config_sample.d4_file = self.get_sample_file(
+            hk_tags=self.sample_tags.d4_file, sample_id=sample_id, hk_version=hk_version
+        )
 
     def build_config_sample(
         self, case_sample: CaseSample, hk_version: Version

--- a/cg/models/scout/scout_load_config.py
+++ b/cg/models/scout/scout_load_config.py
@@ -141,6 +141,7 @@ class ScoutLoadConfig(BaseModel):
 
 
 class BalsamicLoadConfig(ScoutLoadConfig):
+    d4_file: str | None = None
     madeline: str | None = None
     vcf_cancer: Annotated[str | None, AfterValidator(field_not_none)] = None
     vcf_cancer_sv: str | None = None

--- a/cg/models/scout/scout_load_config.py
+++ b/cg/models/scout/scout_load_config.py
@@ -110,6 +110,7 @@ class ScoutCancerIndividual(ScoutIndividual):
     msi: str | None = None
     tumor_purity: float = 0
     vcf2cytosure: str | None = None
+    d4_file: str | None = None
 
 
 class ScoutLoadConfig(BaseModel):


### PR DESCRIPTION
## Description

This PR adds the d4 file generated in balsamic to the scout config yaml. However currently this file is not produced in Balsamic: https://github.com/Clinical-Genomics/BALSAMIC/pull/1592 

Adding the d4 file to the scout load activates Chanjo for balsamic.

### Added

-

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
