### PR TITLE
Fix(microSALT) Don't delete Slurm file

### DIFF
--- a/cg/meta/workflow/microsalt/microsalt.py
+++ b/cg/meta/workflow/microsalt/microsalt.py
@@ -17,9 +17,7 @@ from cg.meta.workflow.microsalt.quality_controller import MicroSALTQualityContro
 from cg.meta.workflow.microsalt.quality_controller.models import QualityResult
 from cg.meta.workflow.microsalt.utils import get_most_recent_project_directory
 from cg.models.cg_config import CGConfig
-from cg.services.sequencing_qc_service.sequencing_qc_service import (
-    SequencingQCService,
-)
+from cg.services.sequencing_qc_service.sequencing_qc_service import SequencingQCService
 from cg.store.models import Case, Sample
 from cg.utils import Process
 
@@ -91,21 +89,13 @@ class MicrosaltAnalysisAPI(AnalysisAPI):
 
     def get_job_ids_path(self, case_id: str) -> Path:
         project_id: str = self.get_project_id(case_id)
-        job_ids_path = Path(
+        return Path(
             self.root_dir,
             "results",
             "reports",
             "trailblazer",
             f"{project_id}_slurm_ids{FileExtensions.YAML}",
         )
-        # Necessary due to how microsalt structures its output
-        self._ensure_old_job_ids_are_removed(job_ids_path)
-        return job_ids_path
-
-    def _ensure_old_job_ids_are_removed(self, job_ids_path: Path) -> None:
-        is_yaml_file: bool = job_ids_path.suffix == FileExtensions.YAML
-        if job_ids_path.exists() and is_yaml_file:
-            job_ids_path.unlink()
 
     def get_deliverables_file_path(self, case_id: str) -> Path:
         """Returns a path where the microSALT deliverables file for the order_id should be

--- a/cg/services/analysis_starter/tracker/implementations/microsalt.py
+++ b/cg/services/analysis_starter/tracker/implementations/microsalt.py
@@ -26,16 +26,13 @@ class MicrosaltTracker(Tracker):
 
     def _get_job_ids_path(self, case_id: str) -> Path:
         project_id: str = self._get_file_name_start(case_id)
-        job_ids_path = Path(
+        return Path(
             self.workflow_root,
             "results",
             "reports",
             "trailblazer",
             f"{project_id}_slurm_ids{FileExtensions.YAML}",
         )
-        # Necessary due to how microsalt structures its output
-        self._ensure_old_job_ids_are_removed(job_ids_path)
-        return job_ids_path
 
     def _get_file_name_start(self, case_id: str) -> str:
         """Returns the LIMS project id if the case contains multiple samples, else the sample id."""
@@ -48,12 +45,6 @@ class MicrosaltTracker(Tracker):
     @staticmethod
     def _extract_project_id(sample_id: str) -> str:
         return sample_id.rsplit("A", maxsplit=1)[0]
-
-    @staticmethod
-    def _ensure_old_job_ids_are_removed(job_ids_path: Path) -> None:
-        is_yaml_file: bool = job_ids_path.suffix == FileExtensions.YAML
-        if job_ids_path.exists() and is_yaml_file:
-            job_ids_path.unlink()
 
     def _get_workflow_version(self, case_config: MicrosaltCaseConfig) -> str:
         return self.subprocess_submitter.get_workflow_version(case_config)


### PR DESCRIPTION
## Description
See #4527 for issue description.

This PR removes the method which was mean to purge a file from previous runs, but instead removed the file that was relevant for the run just starting

### Changed
- Remove the method removing the microSALT Slurm IDs file
