### PR TITLE
Fix(dragen demux) Read bashrc to source the correct path

### DIFF
--- a/cg/apps/slurm/sbatch.py
+++ b/cg/apps/slurm/sbatch.py
@@ -21,7 +21,7 @@ log() {{
 log "Running on: $(hostname)"
 """
 
-DRAGEN_SBATCH_HEADER_TEMPLATE = """#! /bin/bash
+DRAGEN_SBATCH_HEADER_TEMPLATE = """#! /bin/bash -l
 #SBATCH --job-name={job_name}
 #SBATCH --partition={partition}
 #SBATCH --account={account}


### PR DESCRIPTION
## Description
With the latest dragen version (4.4.4) which is running on cg-dragen2. The dragen installation does not add the dragen binary to the bath.

I changed the bashrc for hiseq.clinical to export it but Slurm does not load the bashrc per default. This PR adds a flag to make it source it

### Added

- Added the -l flag to the Sbatch header to run it as a login-session and thereby loading the bashrc