### PR TITLE
Make RNAFUSION samples be always tumour

### DIFF
--- a/cg/services/orders/validation/models/existing_sample.py
+++ b/cg/services/orders/validation/models/existing_sample.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from cg.models.orders.sample_base import NAME_PATTERN, StatusEnum
 
@@ -12,3 +12,22 @@ class ExistingSample(BaseModel):
     @property
     def is_new(self) -> bool:
         return False
+
+
+class ExistingRNAFusionSample(ExistingSample):
+    """Model with special tumour validation for existing RNAFUSION samples."""
+
+    tumour: bool = True
+
+    @field_validator("tumour", mode="before")
+    @classmethod
+    def default_and_validate_tumour(cls, v) -> bool:
+        """Ensure that the tumour field is always set to True.
+        If it is not provided, it defaults to True.
+        If it is provided and not True, raise a ValueError.
+        """
+        if v is None:
+            return True
+        if v is not True:
+            raise ValueError("Can't perform RNAFUSION analysis on non-tumour samples")
+        return v

--- a/cg/services/orders/validation/order_types/rna_fusion/models/case.py
+++ b/cg/services/orders/validation/order_types/rna_fusion/models/case.py
@@ -3,11 +3,11 @@ from typing_extensions import Annotated
 
 from cg.services.orders.validation.models.case import Case
 from cg.services.orders.validation.models.discriminators import has_internal_id
-from cg.services.orders.validation.models.existing_sample import ExistingSample
+from cg.services.orders.validation.models.existing_sample import ExistingRNAFusionSample
 from cg.services.orders.validation.order_types.rna_fusion.models.sample import RNAFusionSample
 
 NewSample = Annotated[RNAFusionSample, Tag("new")]
-OldSample = Annotated[ExistingSample, Tag("existing")]
+OldSample = Annotated[ExistingRNAFusionSample, Tag("existing")]
 
 
 class RNAFusionCase(Case):

--- a/cg/services/orders/validation/order_types/rna_fusion/models/sample.py
+++ b/cg/services/orders/validation/order_types/rna_fusion/models/sample.py
@@ -6,6 +6,8 @@ from cg.services.orders.validation.constants import ElutionBuffer, TissueBlockEn
 from cg.services.orders.validation.models.sample import Sample
 from cg.services.orders.validation.utils import parse_buffer, parse_control
 
+TUMOUR_ERROR_MESSAGE: str = "RNAFUSION samples must always be tumour samples"
+
 
 class RNAFusionSample(Sample):
     age_at_sampling: float | None = None
@@ -27,15 +29,15 @@ class RNAFusionSample(Sample):
     @classmethod
     def validate_tumour_is_true(cls, v):
         if v is not True:
-            raise ValueError("RNAFUSION samples must always be tumour samples")
+            raise ValueError(TUMOUR_ERROR_MESSAGE)
         return v
 
     def __setattr__(self, name, value):
         if name == "tumour" and hasattr(self, name):
-            raise ValueError("RNAFUSION samples must always be tumour samples")
+            raise ValueError(TUMOUR_ERROR_MESSAGE)
         super().__setattr__(name, value)
 
     def model_copy(self, *args, update=None, **kwargs):
         if update and "tumour" in update and update["tumour"] is not True:
-            raise ValueError("RNAFUSION samples must always be tumour samples")
+            raise ValueError(TUMOUR_ERROR_MESSAGE)
         return super().model_copy(*args, update=update, **kwargs)

--- a/cg/services/orders/validation/order_types/rna_fusion/models/sample.py
+++ b/cg/services/orders/validation/order_types/rna_fusion/models/sample.py
@@ -25,9 +25,15 @@ class RNAFusionSample(Sample):
     tissue_block_size: TissueBlockEnum | None = None
     tumour: bool = True
 
-    @field_validator("tumour")
+    @field_validator("tumour", mode="before")
     @classmethod
-    def validate_tumour_is_true(cls, v):
+    def default_and_validate_tumour(cls, v) -> bool:
+        """Ensure that the tumour field is always set to True.
+        If it is not provided, it defaults to True.
+        If it is provided and not True, raise a ValueError.
+        """
+        if v is None:
+            return True
         if v is not True:
             raise ValueError(TUMOUR_ERROR_MESSAGE)
         return v

--- a/cg/services/orders/validation/order_types/rna_fusion/models/sample.py
+++ b/cg/services/orders/validation/order_types/rna_fusion/models/sample.py
@@ -1,4 +1,4 @@
-from pydantic import BeforeValidator, Field
+from pydantic import BeforeValidator, Field, field_validator
 from typing_extensions import Annotated
 
 from cg.models.orders.sample_base import NAME_PATTERN, ControlEnum, SexEnum
@@ -21,3 +21,21 @@ class RNAFusionSample(Sample):
     source: str
     subject_id: str = Field(pattern=NAME_PATTERN, min_length=1, max_length=128)
     tissue_block_size: TissueBlockEnum | None = None
+    tumour: bool = True
+
+    @field_validator("tumour")
+    @classmethod
+    def validate_tumour_is_true(cls, v):
+        if v is not True:
+            raise ValueError("RNAFUSION samples must always be tumour samples")
+        return v
+
+    def __setattr__(self, name, value):
+        if name == "tumour" and hasattr(self, name):
+            raise ValueError("RNAFUSION samples must always be tumour samples")
+        super().__setattr__(name, value)
+
+    def model_copy(self, *args, update=None, **kwargs):
+        if update and "tumour" in update and update["tumour"] is not True:
+            raise ValueError("RNAFUSION samples must always be tumour samples")
+        return super().model_copy(*args, update=update, **kwargs)

--- a/cg/services/orders/validation/service.py
+++ b/cg/services/orders/validation/service.py
@@ -51,7 +51,7 @@ class OrderValidationService:
             )
         if not errors.is_empty:
             LOG.error(errors.get_error_message())
-            raise OrderValidationError(message="Order contained errors")
+            raise OrderValidationError(message=errors.get_error_message())
         return parsed_order
 
     def _get_errors(

--- a/tests/fixture_plugins/orders_fixtures/order_to_submit_fixtures.py
+++ b/tests/fixture_plugins/orders_fixtures/order_to_submit_fixtures.py
@@ -98,7 +98,7 @@ def rml_order_to_submit(cgweb_orders_dir: Path) -> dict:
     )
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def rnafusion_order_to_submit(cgweb_orders_dir: Path) -> dict:
     """Load an example RNA Fusion order."""
     return ReadFile.get_content_from_file(

--- a/tests/fixtures/cgweb_orders/rnafusion.json
+++ b/tests/fixtures/cgweb_orders/rnafusion.json
@@ -29,6 +29,7 @@
                     "source": "tissue (fresh frozen)",
                     "synopsis": "",
                     "subject_id": "subject-sample1-rna-t1",
+                    "tumour": null,
                     "volume": "120",
                     "well_position": "A:1"
                 }
@@ -60,6 +61,7 @@
                     "source": "tissue (fresh frozen)",
                     "synopsis": "",
                     "subject_id": "subject-sample1-rna-t2",
+                    "tumour": null,
                     "volume": "20",
                     "well_position": "B:1"
                 }

--- a/tests/services/orders/store_service/test_generic_order_store_service.py
+++ b/tests/services/orders/store_service/test_generic_order_store_service.py
@@ -140,7 +140,7 @@ def test_store_rna_fusion_order(
     assert first_case.data_delivery == str(DataDelivery.FASTQ_ANALYSIS)
     assert new_link.sample.name == "sample1-rna-t1"
     assert new_link.sample.application_version.application.tag == "RNAPOAR025"
-    assert new_link
+    assert new_link.sample.is_tumour is True
 
 
 def test_store_tomte_order(

--- a/tests/services/orders/validation_service/conftest.py
+++ b/tests/services/orders/validation_service/conftest.py
@@ -293,3 +293,50 @@ def application_tgs(base_store: Store) -> Application:
 @pytest.fixture
 def tomte_rule_set() -> RuleSet:
     return ORDER_TYPE_RULE_SET_MAP[OrderType.TOMTE]
+
+
+@pytest.fixture
+def rnafusion_order_with_existing_sample() -> dict:
+    """Return a Tomte order with an existing sample."""
+    return {
+        "name": "RNAfusion-order",
+        "customer": "cust000",
+        "delivery_type": "fastq-analysis",
+        "project_type": "rnafusion",
+        "comment": "",
+        "cases": [
+            {
+                "cohorts": None,
+                "name": "RnaFusionCase3",
+                "panels": None,
+                "priority": "standard",
+                "samples": [
+                    {
+                        "application": "RNAPOAR025",
+                        "cohorts": [""],
+                        "comment": "this is a sample comment",
+                        "container": "96 well plate",
+                        "container_name": "CMMS",
+                        "data_analysis": None,
+                        "data_delivery": None,
+                        "family_name": "RnaFusionCase3",
+                        "internal_id": "ACC123A1",
+                        "name": "sample1-rna-t3",
+                        "phenotype_groups": [""],
+                        "phenotype_terms": [""],
+                        "priority": "standard",
+                        "quantity": "220",
+                        "require_qc_ok": False,
+                        "sex": "female",
+                        "source": "tissue (fresh frozen)",
+                        "synopsis": "",
+                        "subject_id": "subject-sample1-rna-t3",
+                        "tumour": False,
+                        "volume": "20",
+                        "well_position": "B:1",
+                    }
+                ],
+                "synopsis": "A synopsis",
+            }
+        ],
+    }

--- a/tests/services/orders/validation_service/test_model_validator.py
+++ b/tests/services/orders/validation_service/test_model_validator.py
@@ -101,7 +101,7 @@ def test_set_tumour_to_false_fails_rnafusion_sample(rnafusion_order_to_submit: d
     # THEN it should raise a ValueError saying that RNAFUSION samples must be tumour samples
     with pytest.raises(ValueError) as exc_info:
         order.cases[0].samples[0].tumour = False
-        assert str(exc_info.value) == "RNAFUSION samples must always be tumour samples"
+    assert str(exc_info.value) == "RNAFUSION samples must always be tumour samples"
 
 
 def test_order_field_error(valid_order: TomteOrder, model_validator: ModelValidator):

--- a/tests/services/orders/validation_service/test_model_validator.py
+++ b/tests/services/orders/validation_service/test_model_validator.py
@@ -76,7 +76,7 @@ def test_rnafusion_with_normal_sample_fails(rnafusion_order_to_submit: dict):
     rnafusion_order_to_submit["cases"][0]["samples"][0]["tumour"] = False
 
     # WHEN validating the order
-    order, errors = ModelValidator.validate(order=rnafusion_order_to_submit, model=RNAFusionOrder)
+    _, errors = ModelValidator.validate(order=rnafusion_order_to_submit, model=RNAFusionOrder)
 
     # THEN there should be a sample validation error
     assert errors.case_sample_errors


### PR DESCRIPTION
## Description
Closes #4528 
Closes #4530 
This PR adds validation to RNAFUSION samples so that they are always tumour

### Added

- Boolean `tumour` field in the `RNAFusionSample` defaulting to `True`
- Field validator over "tumour" that verifies that it is always true
- Overriding of `__setattr__` method of the `RNAFusionSample` so that it raises an error if tumour is set to False
- Overriding of `model_copy ` method of the `RNAFusionSample` so that it raises an error if tumour is set to False when updating
- Tests for above scenarios


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b tumor-validation-rnafusion -a
    ```

### How to test

- [x] Submit an RNAFUSION order using the order form with samples without specifying tumour value -> verify that is persisted as True in StatusDB

<img width="1811" height="269" alt="Screenshot 2025-08-01 at 13 53 16" src="https://github.com/user-attachments/assets/658fa0d3-91de-494a-8674-d51b1138b1b7" />

- [ ] Submit an RNAFUSION order through the order portal using an existing normal (non-tumour) sample -> verify that it raises an error with a meaningful message 

- [x] Submit an RNAFUSION order using the order form specifying false as tumour status -> verify that it raises an error with a meaningful message (not very meaningful message, is there something we can do about this? @islean )

<img width="1213" height="529" alt="Screenshot 2025-08-01 at 13 57 39" src="https://github.com/user-attachments/assets/62fbffd9-10a8-4740-b1bc-0fcbae699ce4" />

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Deployed to stage:
```shell

```
- [ ] Deployed to production:
```shell

```
