### PR TITLE
(Pipeline Implementation) Add MIP-DNA submitter

### DIFF
--- a/cg/services/analysis_starter/configurator/implementations/mip_dna.py
+++ b/cg/services/analysis_starter/configurator/implementations/mip_dna.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from cg.apps.environ import environ_email
 from cg.exc import MissingConfigFilesError
 from cg.meta.workflow.fastq import MipFastqHandler
+from cg.models.cg_config import MipConfig
 from cg.services.analysis_starter.configurator.configurator import Configurator
 from cg.services.analysis_starter.configurator.file_creators.gene_panel import GenePanelFileCreator
 from cg.services.analysis_starter.configurator.file_creators.managed_variants import (
@@ -26,6 +27,7 @@ MIP_DNA_MANAGED_VARIANTS_FILE_NAME = "managed_variants.vcf"
 class MIPDNAConfigurator(Configurator):
     def __init__(
         self,
+        config: MipConfig,
         config_file_creator: MIPDNAConfigFileCreator,
         fastq_handler: MipFastqHandler,
         gene_panel_file_creator: GenePanelFileCreator,
@@ -33,9 +35,13 @@ class MIPDNAConfigurator(Configurator):
         root: Path,
         store: Store,
     ):
+        self.conda_binary = config.conda_binary
+        self.conda_environment = config.conda_env
+        self.pipeline_binary = f"{config.script} {config.workflow}"
         self.config_file_creator = config_file_creator
         self.fastq_handler = fastq_handler
         self.gene_panel_file_creator = gene_panel_file_creator
+
         self.managed_variants_file_creator = managed_variants_file_creator
         self.root = root
         self.store = store
@@ -61,6 +67,10 @@ class MIPDNAConfigurator(Configurator):
         case: Case = self.store.get_case_by_internal_id_strict(case_id)
         config = MIPDNACaseConfig(
             case_id=case_id,
+            conda_binary=self.con,
+            conda_environment="",
+            pipeline_binary="",
+            pipeline_config_path="",
             email=environ_email(),
             slurm_qos=case.slurm_priority,
         )

--- a/cg/services/analysis_starter/configurator/implementations/mip_dna.py
+++ b/cg/services/analysis_starter/configurator/implementations/mip_dna.py
@@ -73,6 +73,7 @@ class MIPDNAConfigurator(Configurator):
             pipeline_config_path=self.pipeline_config_path,
             email=environ_email(),
             slurm_qos=case.slurm_priority,
+            use_bwa_mem=flags.get("use_bwa_mem", False),
         )
         config = self._set_flags(config=config, **flags)
         self._ensure_required_config_files_exist(case_id)
@@ -115,8 +116,4 @@ class MIPDNAConfigurator(Configurator):
 
     @staticmethod
     def _set_flags(config: MIPDNACaseConfig, **flags) -> MIPDNACaseConfig:
-        if flags.get("use_bwa_mem"):
-            flags["bwa_mem"] = 1
-            flags["bwa_mem2"] = 0
-            flags.pop("use_bwa_mem")
         return Configurator._set_flags(config=config, **flags)

--- a/cg/services/analysis_starter/configurator/implementations/mip_dna.py
+++ b/cg/services/analysis_starter/configurator/implementations/mip_dna.py
@@ -27,23 +27,23 @@ MIP_DNA_MANAGED_VARIANTS_FILE_NAME = "managed_variants.vcf"
 class MIPDNAConfigurator(Configurator):
     def __init__(
         self,
-        config: MipConfig,
+        config: MipConfig,  # TODO: Consider a better name for this config
         config_file_creator: MIPDNAConfigFileCreator,
         fastq_handler: MipFastqHandler,
         gene_panel_file_creator: GenePanelFileCreator,
         managed_variants_file_creator: ManagedVariantsFileCreator,
-        root: Path,
         store: Store,
     ):
         self.conda_binary = config.conda_binary
         self.conda_environment = config.conda_env
         self.pipeline_binary = f"{config.script} {config.workflow}"
+        self.pipeline_config_path = config.mip_config
+        self.root = config.root
+
         self.config_file_creator = config_file_creator
         self.fastq_handler = fastq_handler
         self.gene_panel_file_creator = gene_panel_file_creator
-
         self.managed_variants_file_creator = managed_variants_file_creator
-        self.root = root
         self.store = store
 
     def configure(self, case_id: str, **flags) -> MIPDNACaseConfig:
@@ -67,10 +67,10 @@ class MIPDNAConfigurator(Configurator):
         case: Case = self.store.get_case_by_internal_id_strict(case_id)
         config = MIPDNACaseConfig(
             case_id=case_id,
-            conda_binary=self.con,
-            conda_environment="",
-            pipeline_binary="",
-            pipeline_config_path="",
+            conda_binary=self.conda_binary,
+            conda_environment=self.conda_environment,
+            pipeline_binary=self.pipeline_binary,
+            pipeline_config_path=self.pipeline_config_path,
             email=environ_email(),
             slurm_qos=case.slurm_priority,
         )

--- a/cg/services/analysis_starter/configurator/models/mip_dna.py
+++ b/cg/services/analysis_starter/configurator/models/mip_dna.py
@@ -27,4 +27,13 @@ class MIPDNACaseConfig(CaseConfig):
         if self.start_after_recipe:
             start_command += f" --start_after_recipe {self.start_after_recipe}"
 
+        if self.start_with_recipe:
+            start_command += f" --start_with_recipe {self.start_with_recipe}"
+
+        if self.bwa_mem is not None:
+            start_command += f" --bwa_mem {self.bwa_mem}"
+
+        if self.bwa_mem2 is not None:
+            start_command += f" --bwa_mem2 {self.bwa_mem2}"
+
         return start_command

--- a/cg/services/analysis_starter/configurator/models/mip_dna.py
+++ b/cg/services/analysis_starter/configurator/models/mip_dna.py
@@ -1,6 +1,7 @@
 from pydantic import Field
 
 from cg.constants.constants import Workflow
+from cg.constants.priority import SlurmQos
 from cg.services.analysis_starter.configurator.abstract_model import CaseConfig
 
 
@@ -10,7 +11,7 @@ class MIPDNACaseConfig(CaseConfig):
     email: str
     pipeline_binary: str
     pipeline_config_path: str
-    slurm_qos: str
+    slurm_qos: SlurmQos
     start_after_recipe: str | None = Field(default=None, alias="start_after")
     start_with_recipe: str | None = Field(default=None, alias="start_with")
     workflow: Workflow = Workflow.MIP_DNA

--- a/cg/services/analysis_starter/configurator/models/mip_dna.py
+++ b/cg/services/analysis_starter/configurator/models/mip_dna.py
@@ -12,3 +12,6 @@ class MIPDNACaseConfig(CaseConfig):
     start_after_recipe: str | None = Field(default=None, alias="start_after")
     start_with_recipe: str | None = Field(default=None, alias="start_with")
     workflow: Workflow = Workflow.MIP_DNA
+
+    def get_start_command(self) -> str:
+        return ""

--- a/cg/services/analysis_starter/configurator/models/mip_dna.py
+++ b/cg/services/analysis_starter/configurator/models/mip_dna.py
@@ -5,8 +5,6 @@ from cg.services.analysis_starter.configurator.abstract_model import CaseConfig
 
 
 class MIPDNACaseConfig(CaseConfig):
-    bwa_mem: int | None = None
-    bwa_mem2: int | None = None
     conda_binary: str
     conda_environment: str
     email: str
@@ -31,10 +29,7 @@ class MIPDNACaseConfig(CaseConfig):
         if self.start_with_recipe:
             start_command += f" --start_with_recipe {self.start_with_recipe}"
 
-        if self.bwa_mem is not None:
-            start_command += f" --bwa_mem {self.bwa_mem}"
-
-        if self.bwa_mem2 is not None:
-            start_command += f" --bwa_mem2 {self.bwa_mem2}"
+        if self.use_bwa_mem:
+            start_command += " --bwa_mem 1 --bwa_mem2 0"
 
         return start_command

--- a/cg/services/analysis_starter/configurator/models/mip_dna.py
+++ b/cg/services/analysis_starter/configurator/models/mip_dna.py
@@ -16,6 +16,7 @@ class MIPDNACaseConfig(CaseConfig):
     start_after_recipe: str | None = Field(default=None, alias="start_after")
     start_with_recipe: str | None = Field(default=None, alias="start_with")
     workflow: Workflow = Workflow.MIP_DNA
+    use_bwa_mem: bool
 
     def get_start_command(self) -> str:
         start_command = (

--- a/cg/services/analysis_starter/configurator/models/mip_dna.py
+++ b/cg/services/analysis_starter/configurator/models/mip_dna.py
@@ -18,8 +18,13 @@ class MIPDNACaseConfig(CaseConfig):
     workflow: Workflow = Workflow.MIP_DNA
 
     def get_start_command(self) -> str:
-        return (
+        start_command = (
             "{conda_binary} run --name {conda_environment} {pipeline_binary} analyse rd_dna"
             " --config {pipeline_config_path} {case_id} --slurm_quality_of_service "
             "{slurm_qos} --email {email}"
         ).format(**self.model_dump())
+
+        if self.start_after_recipe:
+            start_command += f" --start_after_recipe {self.start_after_recipe}"
+
+        return start_command

--- a/cg/services/analysis_starter/configurator/models/mip_dna.py
+++ b/cg/services/analysis_starter/configurator/models/mip_dna.py
@@ -7,11 +7,19 @@ from cg.services.analysis_starter.configurator.abstract_model import CaseConfig
 class MIPDNACaseConfig(CaseConfig):
     bwa_mem: int | None = None
     bwa_mem2: int | None = None
+    conda_binary: str
+    conda_environment: str
     email: str
+    pipeline_binary: str
+    pipeline_config_path: str
     slurm_qos: str
     start_after_recipe: str | None = Field(default=None, alias="start_after")
     start_with_recipe: str | None = Field(default=None, alias="start_with")
     workflow: Workflow = Workflow.MIP_DNA
 
     def get_start_command(self) -> str:
-        return ""
+        return (
+            "{conda_binary} run --name {conda_environment} {pipeline_binary} analyse rd_dna"
+            " --config {pipeline_config_path} {case_id} --slurm_quality_of_service "
+            "{slurm_qos} --email {email}"
+        ).format(**self.model_dump())

--- a/cg/services/analysis_starter/factories/configurator_factory.py
+++ b/cg/services/analysis_starter/factories/configurator_factory.py
@@ -174,13 +174,13 @@ class ConfiguratorFactory:
     def _get_mip_dna_configurator(self) -> MIPDNAConfigurator:
         root: str = self.cg_config.mip_rd_dna.root
         return MIPDNAConfigurator(
+            config=self.cg_config.mip_rd_dna,
             config_file_creator=self._get_mip_dna_config_file_creator(root=root),
             fastq_handler=MipFastqHandler(
                 self.housekeeper_api, root_dir=Path(root), status_db=self.store
             ),
             gene_panel_file_creator=self._get_gene_panel_file_creator(Workflow.MIP_DNA),
             managed_variants_file_creator=self._get_managed_variants_file_creator(Workflow.MIP_DNA),
-            root=Path(root),
             store=self.store,
         )
 

--- a/cg/services/analysis_starter/submitters/subprocess/submitter.py
+++ b/cg/services/analysis_starter/submitters/subprocess/submitter.py
@@ -2,12 +2,13 @@ import logging
 import subprocess
 
 from cg.services.analysis_starter.configurator.models.microsalt import MicrosaltCaseConfig
+from cg.services.analysis_starter.configurator.models.mip_dna import MIPDNACaseConfig
 from cg.services.analysis_starter.submitters.submitter import Submitter
 from cg.services.analysis_starter.submitters.subprocess.commands import WORKFLOW_VERSION_COMMAND_MAP
 
 LOG = logging.getLogger(__name__)
 
-SubprocessCaseConfig = MicrosaltCaseConfig
+SubprocessCaseConfig = MicrosaltCaseConfig | MIPDNACaseConfig
 
 
 class SubprocessSubmitter(Submitter):

--- a/tests/services/analysis_starter/test_case_configs.py
+++ b/tests/services/analysis_starter/test_case_configs.py
@@ -1,4 +1,5 @@
 from cg.services.analysis_starter.configurator.models.microsalt import MicrosaltCaseConfig
+from cg.services.analysis_starter.configurator.models.mip_dna import MIPDNACaseConfig
 
 
 def test_microsalt_get_start_command():
@@ -23,3 +24,13 @@ def test_microsalt_get_start_command():
     )
 
     assert start_command == expected_command
+
+
+def test_mip_dna_get_start_command():
+    # GIVEN a MIP-DNA case config
+    mip_case_config = MIPDNACaseConfig(
+        case_id="case_id", email="email@scilifelab.se", slurm_qos="normal"
+    )
+    # WHEN getting the slurm command
+    mip_case_config.get_start_command()
+    # THEN the command is as expected

--- a/tests/services/analysis_starter/test_case_configs.py
+++ b/tests/services/analysis_starter/test_case_configs.py
@@ -32,6 +32,8 @@ def test_mip_dna_get_start_command():
 
     # GIVEN a MIP-DNA case config
     mip_case_config = MIPDNACaseConfig(
+        bwa_mem=1,
+        bwa_mem2=0,
         conda_binary="/path/to/conda",
         conda_environment="environment",
         case_id=case_id,
@@ -39,6 +41,8 @@ def test_mip_dna_get_start_command():
         pipeline_binary="/path/to/pipeline/binary",
         pipeline_config_path="/path/to/pipeline/config.yaml",
         slurm_qos="normal",
+        start_after="retroseq_bread",
+        start_with="smile_bread",
     )
     # WHEN getting the slurm command
     start_command: str = mip_case_config.get_start_command()
@@ -46,8 +50,12 @@ def test_mip_dna_get_start_command():
     # THEN the command is as expected
 
     expected_command = (
-        f"{conda_binary} run --name {environment} {pipeline_binary} analyse rd_dna"
-        f" --config {pipeline_config_path} {case_id} --slurm_quality_of_service "
-        f"{mip_case_config.slurm_qos} --email {mip_case_config.email}"
+        f"{mip_case_config.conda_binary} run --name {mip_case_config.conda_environment} {mip_case_config.pipeline_binary} analyse rd_dna"
+        f" --config {mip_case_config.pipeline_config_path} {case_id} --slurm_quality_of_service "
+        f"{mip_case_config.slurm_qos} --email {mip_case_config.email} "
+        f"--start_after_recipe {mip_case_config.start_after_recipe} "
+        f"--start_with_recipe {mip_case_config.start_with_recipe} "
+        f"--bwa_mem {mip_case_config.bwa_mem} "
+        f"--bwa_mem2 {mip_case_config.bwa_mem2} "
     )
     assert start_command == expected_command

--- a/tests/services/analysis_starter/test_case_configs.py
+++ b/tests/services/analysis_starter/test_case_configs.py
@@ -56,6 +56,6 @@ def test_mip_dna_get_start_command():
         f"--start_after_recipe {mip_case_config.start_after_recipe} "
         f"--start_with_recipe {mip_case_config.start_with_recipe} "
         f"--bwa_mem {mip_case_config.bwa_mem} "
-        f"--bwa_mem2 {mip_case_config.bwa_mem2} "
+        f"--bwa_mem2 {mip_case_config.bwa_mem2}"
     )
     assert start_command == expected_command

--- a/tests/services/analysis_starter/test_case_configs.py
+++ b/tests/services/analysis_starter/test_case_configs.py
@@ -26,14 +26,40 @@ def test_microsalt_get_start_command():
     assert start_command == expected_command
 
 
-def test_mip_dna_get_start_command():
+def test_mip_dna_get_start_command_no_flags_set():
     # GIVEN a case id
     case_id = "case_id"
 
     # GIVEN a MIP-DNA case config
     mip_case_config = MIPDNACaseConfig(
-        bwa_mem=1,
-        bwa_mem2=0,
+        conda_binary="/path/to/conda",
+        conda_environment="environment",
+        case_id=case_id,
+        email="email@scilifelab.se",
+        pipeline_binary="/path/to/pipeline/binary",
+        pipeline_config_path="/path/to/pipeline/config.yaml",
+        slurm_qos="normal",
+        use_bwa_mem=False,
+    )
+
+    # WHEN getting the slurm command
+    start_command: str = mip_case_config.get_start_command()
+
+    # THEN the command is as expected
+    expected_command = (
+        f"{mip_case_config.conda_binary} run --name {mip_case_config.conda_environment} {mip_case_config.pipeline_binary} analyse rd_dna"
+        f" --config {mip_case_config.pipeline_config_path} {case_id} --slurm_quality_of_service "
+        f"{mip_case_config.slurm_qos} --email {mip_case_config.email}"
+    )
+    assert start_command == expected_command
+
+
+def test_mip_dna_get_start_command_all_flags_set():
+    # GIVEN a case id
+    case_id = "case_id"
+
+    # GIVEN a MIP-DNA case config
+    mip_case_config = MIPDNACaseConfig(
         conda_binary="/path/to/conda",
         conda_environment="environment",
         case_id=case_id,
@@ -43,19 +69,20 @@ def test_mip_dna_get_start_command():
         slurm_qos="normal",
         start_after="retroseq_bread",
         start_with="smile_bread",
+        use_bwa_mem=True,
     )
+
     # WHEN getting the slurm command
     start_command: str = mip_case_config.get_start_command()
 
     # THEN the command is as expected
-
     expected_command = (
         f"{mip_case_config.conda_binary} run --name {mip_case_config.conda_environment} {mip_case_config.pipeline_binary} analyse rd_dna"
         f" --config {mip_case_config.pipeline_config_path} {case_id} --slurm_quality_of_service "
         f"{mip_case_config.slurm_qos} --email {mip_case_config.email} "
         f"--start_after_recipe {mip_case_config.start_after_recipe} "
         f"--start_with_recipe {mip_case_config.start_with_recipe} "
-        f"--bwa_mem {mip_case_config.bwa_mem} "
-        f"--bwa_mem2 {mip_case_config.bwa_mem2}"
+        f"--bwa_mem 1 "
+        f"--bwa_mem2 0"
     )
     assert start_command == expected_command

--- a/tests/services/analysis_starter/test_case_configs.py
+++ b/tests/services/analysis_starter/test_case_configs.py
@@ -1,3 +1,4 @@
+from cg.constants.priority import SlurmQos
 from cg.services.analysis_starter.configurator.models.microsalt import MicrosaltCaseConfig
 from cg.services.analysis_starter.configurator.models.mip_dna import MIPDNACaseConfig
 
@@ -38,7 +39,7 @@ def test_mip_dna_get_start_command_no_flags_set():
         email="email@scilifelab.se",
         pipeline_binary="/path/to/pipeline/binary",
         pipeline_config_path="/path/to/pipeline/config.yaml",
-        slurm_qos="normal",
+        slurm_qos=SlurmQos.NORMAL,
         use_bwa_mem=False,
     )
 
@@ -66,7 +67,7 @@ def test_mip_dna_get_start_command_all_flags_set():
         email="email@scilifelab.se",
         pipeline_binary="/path/to/pipeline/binary",
         pipeline_config_path="/path/to/pipeline/config.yaml",
-        slurm_qos="normal",
+        slurm_qos=SlurmQos.NORMAL,
         start_after="retroseq_bread",
         start_with="smile_bread",
         use_bwa_mem=True,

--- a/tests/services/analysis_starter/test_case_configs.py
+++ b/tests/services/analysis_starter/test_case_configs.py
@@ -32,5 +32,8 @@ def test_mip_dna_get_start_command():
         case_id="case_id", email="email@scilifelab.se", slurm_qos="normal"
     )
     # WHEN getting the slurm command
-    mip_case_config.get_start_command()
+    start_command: str = mip_case_config.get_start_command()
+
     # THEN the command is as expected
+    expected_command = "{conda_binary} run --name {environment} {binary} analyse"
+    assert start_command == expected_command

--- a/tests/services/analysis_starter/test_case_configs.py
+++ b/tests/services/analysis_starter/test_case_configs.py
@@ -27,13 +27,27 @@ def test_microsalt_get_start_command():
 
 
 def test_mip_dna_get_start_command():
+    # GIVEN a case id
+    case_id = "case_id"
+
     # GIVEN a MIP-DNA case config
     mip_case_config = MIPDNACaseConfig(
-        case_id="case_id", email="email@scilifelab.se", slurm_qos="normal"
+        conda_binary="/path/to/conda",
+        conda_environment="environment",
+        case_id=case_id,
+        email="email@scilifelab.se",
+        pipeline_binary="/path/to/pipeline/binary",
+        pipeline_config_path="/path/to/pipeline/config.yaml",
+        slurm_qos="normal",
     )
     # WHEN getting the slurm command
     start_command: str = mip_case_config.get_start_command()
 
     # THEN the command is as expected
-    expected_command = "{conda_binary} run --name {environment} {binary} analyse"
+
+    expected_command = (
+        f"{conda_binary} run --name {environment} {pipeline_binary} analyse rd_dna"
+        f" --config {pipeline_config_path} {case_id} --slurm_quality_of_service "
+        f"{mip_case_config.slurm_qos} --email {mip_case_config.email}"
+    )
     assert start_command == expected_command

--- a/tests/services/analysis_starter/test_configurator_factory.py
+++ b/tests/services/analysis_starter/test_configurator_factory.py
@@ -1,5 +1,5 @@
 from typing import cast
-from unittest.mock import Mock, create_autospec
+from unittest.mock import create_autospec
 
 import pytest
 
@@ -73,7 +73,15 @@ def test_nextflow_configurator_factory_success(
 
 
 def test_get_mip_dna_configurator():
-    mip_config = create_autospec(MipConfig, root="mip_root")
+    mip_config = create_autospec(
+        MipConfig,
+        root="mip_root",
+        conda_binary="conda_binary",
+        conda_env="S_mip_dna",
+        mip_config="mip_config",
+        workflow="analyse rd_dna",
+        script="script",
+    )
     cg_config = create_autospec(CGConfig, mip_rd_dna=mip_config)
 
     # GIVEN a configurator factory

--- a/tests/services/analysis_starter/test_mip_dna_configurator.py
+++ b/tests/services/analysis_starter/test_mip_dna_configurator.py
@@ -167,9 +167,7 @@ def test_get_config_all_flags_set(
     )
 
     # THEN we should run the analysis with bwa_mem instead of bwa_mem2
-    assert case_config.bwa_mem == 1
-    assert case_config.bwa_mem2 == 0
-    assert getattr(case_config, "use_bwa_mem", None) is None
+    assert case_config.use_bwa_mem
 
     assert case_config.start_after_recipe == "banana_bread"
     assert case_config.start_with_recipe == "short_bread"

--- a/tests/services/analysis_starter/test_mip_dna_configurator.py
+++ b/tests/services/analysis_starter/test_mip_dna_configurator.py
@@ -6,6 +6,7 @@ from pytest_mock import MockerFixture
 
 from cg.constants.priority import SlurmQos
 from cg.exc import MissingConfigFilesError
+from cg.models.cg_config import MipConfig
 from cg.services.analysis_starter.configurator.file_creators.gene_panel import GenePanelFileCreator
 from cg.services.analysis_starter.configurator.file_creators.managed_variants import (
     ManagedVariantsFileCreator,
@@ -33,7 +34,20 @@ def mock_status_db() -> Store:
     return mock_store
 
 
-def test_configure(mocker: MockerFixture):
+@pytest.fixture
+def mock_cg_config_mip() -> MipConfig:
+    return create_autospec(
+        MipConfig,
+        root="root_dir",
+        conda_binary="conda_binary",
+        conda_env="S_mip_dna",
+        mip_config="mip_config",
+        workflow="analyse rd_dna",
+        script="script",
+    )
+
+
+def test_configure(mock_cg_config_mip: MipConfig, mocker: MockerFixture):
     # GIVEN a case id
     case_id = "test_case"
 
@@ -45,11 +59,11 @@ def test_configure(mocker: MockerFixture):
     # GIVEN a MIP DNA configurator
     root_dir = Path("root_dir")
     configurator = MIPDNAConfigurator(
+        config=mock_cg_config_mip,
         config_file_creator=create_autospec(MIPDNAConfigFileCreator),
         fastq_handler=Mock(),
         gene_panel_file_creator=create_autospec(GenePanelFileCreator),
         managed_variants_file_creator=create_autospec(ManagedVariantsFileCreator),
-        root=root_dir,
         store=store,
     )
 

--- a/tests/services/analysis_starter/test_mip_dna_configurator.py
+++ b/tests/services/analysis_starter/test_mip_dna_configurator.py
@@ -104,7 +104,7 @@ def test_configure(mock_cg_config_mip: MipConfig, mocker: MockerFixture):
     )
 
 
-def test_get_config(mock_status_db: Store, mocker: MockerFixture):
+def test_get_config(mock_cg_config_mip: MipConfig, mock_status_db: Store, mocker: MockerFixture):
     """Test that the MIP DNA configurator can get a case config."""
 
     # GIVEN an email address in the environment
@@ -112,11 +112,11 @@ def test_get_config(mock_status_db: Store, mocker: MockerFixture):
 
     # GIVEN a MIP DNA configurator
     configurator = MIPDNAConfigurator(
+        config=mock_cg_config_mip,
         config_file_creator=Mock(),
         fastq_handler=Mock(),
         gene_panel_file_creator=Mock(),
         managed_variants_file_creator=Mock(),
-        root=Path("root_dir"),
         store=mock_status_db,
     )
 
@@ -137,16 +137,18 @@ def test_get_config(mock_status_db: Store, mocker: MockerFixture):
     assert case_config.start_with_recipe is None
 
 
-def test_get_config_all_flags_set(mock_status_db: Store, mocker: MockerFixture):
+def test_get_config_all_flags_set(
+    mock_cg_config_mip: MipConfig, mock_status_db: Store, mocker: MockerFixture
+):
     """Test that the MIP DNA configurator can get a case config."""
 
     # GIVEN a MIP DNA configurator
     configurator = MIPDNAConfigurator(
+        config=mock_cg_config_mip,
         config_file_creator=Mock(),
         fastq_handler=Mock(),
         gene_panel_file_creator=Mock(),
         managed_variants_file_creator=Mock(),
-        root=Path("root_dir"),
         store=mock_status_db,
     )
 
@@ -173,18 +175,18 @@ def test_get_config_all_flags_set(mock_status_db: Store, mocker: MockerFixture):
     assert case_config.start_with_recipe == "short_bread"
 
 
-def test_get_config_validation(mock_status_db: Store):
+def test_get_config_validation(mock_cg_config_mip: MipConfig, mock_status_db: Store):
     # GIVEN at least one file creator that returns a path which does not exist
     gene_panel_file_creator: GenePanelFileCreator = create_autospec(GenePanelFileCreator)
     gene_panel_file_creator.get_file_path = Mock(return_value=Path("fake_path"))
 
     # GIVEN a configurator
     configurator = MIPDNAConfigurator(
+        config=mock_cg_config_mip,
         config_file_creator=Mock(),
         fastq_handler=Mock(),
         gene_panel_file_creator=gene_panel_file_creator,
         managed_variants_file_creator=Mock(),
-        root=Path("root_dir"),
         store=mock_status_db,
     )
 

--- a/tests/services/analysis_starter/test_subprocess_submitter.py
+++ b/tests/services/analysis_starter/test_subprocess_submitter.py
@@ -1,9 +1,9 @@
 import subprocess
-from unittest.mock import Mock, create_autospec
 
 import pytest
 from pytest_mock import MockerFixture
 
+from cg.constants.priority import SlurmQos
 from cg.services.analysis_starter.configurator.models.microsalt import MicrosaltCaseConfig
 from cg.services.analysis_starter.configurator.models.mip_dna import MIPDNACaseConfig
 from cg.services.analysis_starter.submitters.subprocess.submitter import (
@@ -12,14 +12,35 @@ from cg.services.analysis_starter.submitters.subprocess.submitter import (
 )
 
 
-@pytest.mark.parametrize("case_config_class", [MicrosaltCaseConfig, MIPDNACaseConfig])
-def test_subprocess_submitter(case_config_class: type[SubprocessCaseConfig], mocker: MockerFixture):
+@pytest.mark.parametrize(
+    "case_config",
+    [
+        MicrosaltCaseConfig(
+            case_id="case_id",
+            binary="binary",
+            conda_binary="conda_binary",
+            config_file="config_file",
+            environment="environment",
+            fastq_directory="fastq_directory",
+        ),
+        MIPDNACaseConfig(
+            case_id="case_id",
+            pipeline_binary="pipeline_binary",
+            conda_binary="conda_binary",
+            pipeline_config_path="pipeline_config_path",
+            conda_environment="conda_environment",
+            slurm_qos=SlurmQos.NORMAL,
+            use_bwa_mem=False,
+            email="my@email.se",
+        ),
+    ],
+    ids=["microSALT", "MIP-DNA"],
+)
+def test_subprocess_submitter(case_config: SubprocessCaseConfig, mocker: MockerFixture):
     # GIVEN a SubProcessSubmitter
     subprocess_submitter = SubprocessSubmitter()
 
     # GIVEN a case config with a get_start_command method
-    case_config = create_autospec(case_config_class)
-    case_config.get_start_command = Mock(return_value="start command")
 
     # WHEN submitting a case using a valid case config
     mock_run = mocker.patch.object(subprocess, "run")

--- a/tests/services/analysis_starter/test_subprocess_submitter.py
+++ b/tests/services/analysis_starter/test_subprocess_submitter.py
@@ -1,36 +1,35 @@
 import subprocess
-from unittest import mock
-from unittest.mock import create_autospec
+from unittest.mock import Mock, create_autospec
 
 import pytest
+from pytest_mock import MockerFixture
 
-from cg.services.analysis_starter.configurator.abstract_model import CaseConfig
 from cg.services.analysis_starter.configurator.models.microsalt import MicrosaltCaseConfig
 from cg.services.analysis_starter.configurator.models.mip_dna import MIPDNACaseConfig
-from cg.services.analysis_starter.submitters.subprocess.submitter import SubprocessSubmitter
+from cg.services.analysis_starter.submitters.subprocess.submitter import (
+    SubprocessCaseConfig,
+    SubprocessSubmitter,
+)
 
 
 @pytest.mark.parametrize("case_config_class", [MicrosaltCaseConfig, MIPDNACaseConfig])
-def test_subprocess_submitter(case_config_class: type[SubprocessCaseConfig]):
+def test_subprocess_submitter(case_config_class: type[SubprocessCaseConfig], mocker: MockerFixture):
     # GIVEN a SubProcessSubmitter
     subprocess_submitter = SubprocessSubmitter()
 
-    # WHEN submitting a case using a valid case config
+    # GIVEN a case config with a get_start_command method
     case_config = create_autospec(case_config_class)
-    case_config.get_workflow
-    with mock.patch.object(subprocess, "run") as mock_run:
-        subprocess_submitter.submit(microsalt_case_config)
+    case_config.get_start_command = Mock(return_value="start command")
 
-        # THEN the analysis should have been started
-        expected_args = (
-            f"{microsalt_case_config.conda_binary} run --name {microsalt_case_config.environment} "
-            f"{microsalt_case_config.binary} analyse {microsalt_case_config.config_file} "
-            f"--input {microsalt_case_config.fastq_directory}"
-        )
-        mock_run.assert_called_once_with(
-            args=expected_args,
-            shell=True,
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
+    # WHEN submitting a case using a valid case config
+    mock_run = mocker.patch.object(subprocess, "run")
+    subprocess_submitter.submit(case_config)
+
+    # THEN the analysis should have been started
+    mock_run.assert_called_once_with(
+        args=case_config.get_start_command(),
+        shell=True,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )

--- a/tests/services/analysis_starter/test_subprocess_submitter.py
+++ b/tests/services/analysis_starter/test_subprocess_submitter.py
@@ -1,23 +1,23 @@
 import subprocess
 from unittest import mock
+from unittest.mock import create_autospec
 
+import pytest
+
+from cg.services.analysis_starter.configurator.abstract_model import CaseConfig
 from cg.services.analysis_starter.configurator.models.microsalt import MicrosaltCaseConfig
+from cg.services.analysis_starter.configurator.models.mip_dna import MIPDNACaseConfig
 from cg.services.analysis_starter.submitters.subprocess.submitter import SubprocessSubmitter
 
 
-def test_subprocess_submitter():
+@pytest.mark.parametrize("case_config_class", [MicrosaltCaseConfig, MIPDNACaseConfig])
+def test_subprocess_submitter(case_config_class: type[SubprocessCaseConfig]):
     # GIVEN a SubProcessSubmitter
     subprocess_submitter = SubprocessSubmitter()
 
     # WHEN submitting a case using a valid case config
-    microsalt_case_config = MicrosaltCaseConfig(
-        binary="/path/to/microsalt/binary",
-        case_id="microsalt_case",
-        conda_binary="/path/to/conda/binary",
-        config_file="/path/to/microsalt_case/config.json",
-        environment="S_microsalt",
-        fastq_directory="/path/to/microsalt_case/fastq",
-    )
+    case_config = create_autospec(case_config_class)
+    case_config.get_workflow
     with mock.patch.object(subprocess, "run") as mock_run:
         subprocess_submitter.submit(microsalt_case_config)
 


### PR DESCRIPTION
## Description

This PR adds a `get_start_command` method to the `MIPDNACaseConfig` class and adds support for submitting a MIP-DNA analysis

### Added

-

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
