### PR TITLE
Patch subprocess check

### DIFF
--- a/cg/services/analysis_starter/submitters/subprocess/submitter.py
+++ b/cg/services/analysis_starter/submitters/subprocess/submitter.py
@@ -17,7 +17,7 @@ class SubprocessSubmitter(Submitter):
         subprocess.run(
             args=command,
             shell=True,
-            check=True,
+            check=False,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )

--- a/tests/services/analysis_starter/test_subprocess_submitter.py
+++ b/tests/services/analysis_starter/test_subprocess_submitter.py
@@ -30,7 +30,7 @@ def test_subprocess_submitter():
         mock_run.assert_called_once_with(
             args=expected_args,
             shell=True,
-            check=True,
+            check=False,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )


### PR DESCRIPTION
## Description

The SubprocessSubmitter unintentionally runs analyses with check=True instead of check=False, as it was prior to the pipeline integration project. This PR fixes it.

### Added

-

### Changed

-

### Fixed

- The SubprocessSubmitter runs analyses with check False


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
