### PR TITLE
[BALSAMIC 18] Replace cluster-config for workflow-profile

### DIFF
--- a/cg/cli/workflow/balsamic/base.py
+++ b/cg/cli/workflow/balsamic/base.py
@@ -9,13 +9,13 @@ from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.cli.utils import CLICK_CONTEXT_SETTINGS
 from cg.cli.workflow.balsamic.options import (
     OPTION_CACHE_VERSION,
-    OPTION_CLUSTER_CONFIG,
     OPTION_GENDER,
     OPTION_GENOME_VERSION,
     OPTION_OBSERVATIONS,
     OPTION_PANEL_BED,
     OPTION_PON_CNN,
     OPTION_QOS,
+    OPTION_WORKFLOW_PROFILE,
 )
 from cg.cli.workflow.commands import ARGUMENT_CASE_ID, link, resolve_compression
 from cg.cli.workflow.utils import validate_force_store_option
@@ -91,14 +91,14 @@ def config_case(
 
 @balsamic.command("run")
 @ARGUMENT_CASE_ID
-@OPTION_CLUSTER_CONFIG
+@OPTION_WORKFLOW_PROFILE
 @DRY_RUN
 @OPTION_QOS
 @click.pass_obj
 def run(
     context: CGConfig,
     case_id: str,
-    cluster_config: click.Path,
+    workflow_profile: click.Path,
     slurm_quality_of_service: str,
     dry_run: bool,
 ):
@@ -110,7 +110,7 @@ def run(
         analysis_api.check_analysis_ongoing(case_id)
         analysis_api.run_analysis(
             case_id=case_id,
-            cluster_config=cluster_config,
+            workflow_profile=workflow_profile,
             slurm_quality_of_service=slurm_quality_of_service,
             dry_run=dry_run,
         )
@@ -194,7 +194,7 @@ def store_housekeeper(
 @OPTION_PON_CNN
 @OPTION_CACHE_VERSION
 @OPTION_OBSERVATIONS
-@OPTION_CLUSTER_CONFIG
+@OPTION_WORKFLOW_PROFILE
 @click.pass_context
 def start(
     context: click.Context,
@@ -206,7 +206,7 @@ def start(
     pon_cnn: str,
     observations: list[click.Path],
     slurm_quality_of_service: str,
-    cluster_config: click.Path,
+    workflow_profile: click.Path,
     dry_run: bool,
 ):
     """Start full workflow for case ID."""
@@ -228,7 +228,7 @@ def start(
     context.invoke(
         run,
         case_id=case_id,
-        cluster_config=cluster_config,
+        workflow_profile=workflow_profile,
         slurm_quality_of_service=slurm_quality_of_service,
         dry_run=dry_run,
     )

--- a/cg/cli/workflow/balsamic/options.py
+++ b/cg/cli/workflow/balsamic/options.py
@@ -55,5 +55,5 @@ OPTION_WORKFLOW_PROFILE = click.option(
     "--workflow-profile",
     type=click.Path(exists=True),
     required=False,
-    help="Path to directory containing config.yaml with workflow rule resources.",
+    help="Path to directory containing config.yaml.",
 )

--- a/cg/cli/workflow/balsamic/options.py
+++ b/cg/cli/workflow/balsamic/options.py
@@ -51,9 +51,9 @@ OPTION_CACHE_VERSION = click.option(
     help="Cache version to be used for init or analysis. Use 'develop' or 'X.X.X'.",
 )
 
-OPTION_CLUSTER_CONFIG = click.option(
-    "--cluster-config",
+OPTION_WORKFLOW_PROFILE = click.option(
+    "--workflow-profile",
     type=click.Path(exists=True),
     required=False,
-    help="Cluster resources configuration JSON file path used for analysis.",
+    help="Path to directory containing config.yaml with workflow rule resources.",
 )

--- a/cg/meta/workflow/balsamic.py
+++ b/cg/meta/workflow/balsamic.py
@@ -611,7 +611,7 @@ class BalsamicAnalysisAPI(AnalysisAPI):
     def run_analysis(
         self,
         case_id: str,
-        cluster_config: Path | None = None,
+        workflow_profile: Path | None = None,
         slurm_quality_of_service: str | None = None,
         dry_run: bool = False,
     ) -> None:
@@ -626,7 +626,7 @@ class BalsamicAnalysisAPI(AnalysisAPI):
                 "--mail-user": self.email,
                 "--qos": slurm_quality_of_service or self.get_slurm_qos_for_case(case_id=case_id),
                 "--sample-config": self.get_case_config_path(case_id=case_id),
-                "--cluster-config": cluster_config,
+                "--workflow-profile": workflow_profile,
             }
         )
         parameters = command + options + run_analysis + benchmark

--- a/tests/cli/workflow/balsamic/test_compound_commands.py
+++ b/tests/cli/workflow/balsamic/test_compound_commands.py
@@ -3,7 +3,9 @@ from pathlib import Path
 from unittest.mock import ANY
 
 import pytest
-from click.testing import CliRunner
+from _pytest.logging import LogCaptureFixture
+from click.testing import CliRunner, Result
+from pytest_mock import MockerFixture
 
 from cg.apps.hermes.hermes_api import HermesApi
 from cg.apps.hermes.models import CGDeliverables
@@ -53,6 +55,44 @@ def test_start(
     # THEN command should execute successfully
     assert result.exit_code == EXIT_SUCCESS
     assert case_id in caplog.text
+
+
+def test_workflow_profile_option(
+    cli_runner: CliRunner,
+    balsamic_context: CGConfig,
+    caplog: LogCaptureFixture,
+    tmp_path: Path,
+    mock_analysis_illumina_run,
+    mocker: MockerFixture,
+):
+    """Test start command with workflow-profile option."""
+    caplog.set_level(logging.INFO)
+
+    # GIVEN valid case-id
+    case_id = "balsamic_case_wgs_single"
+
+    # GIVEN that the workflow-profile path exists
+    workflow_profile = Path(tmp_path, "workflow_profile")
+    workflow_profile.mkdir(parents=True, exist_ok=True)
+
+    # WHEN dry running with the workflow-profile option specified and config case already exists
+    mocker.patch.object(BalsamicAnalysisAPI, "config_case", return_value=None)
+    result: Result = cli_runner.invoke(
+        start,
+        [
+            case_id,
+            "--dry-run",
+            "--workflow-profile",
+            workflow_profile.as_posix(),
+        ],
+        obj=balsamic_context,
+    )
+
+    # THEN command should execute successfully
+    assert result.exit_code == EXIT_SUCCESS
+
+    # THEN the workflow-profile option should be included in the run command
+    assert f"--workflow-profile {workflow_profile.as_posix()}" in caplog.text
 
 
 @pytest.mark.usefixtures("mock_config", "mock_deliverable")

--- a/tests/cli/workflow/balsamic/test_run.py
+++ b/tests/cli/workflow/balsamic/test_run.py
@@ -197,6 +197,9 @@ def test_workflow_profile_option(
     Path(balsamic_context.meta_apis["analysis_api"].get_case_config_path(case_id)).touch(
         exist_ok=True
     )
+    config_path = Path(balsamic_context.meta_apis["analysis_api"].get_case_config_path(case_id))
+    Path.mkdir(config_path.parent, exist_ok=True)
+    config_path.touch(exist_ok=True)
 
     # GIVEN that the workflow-profile path exists
     workflow_profile = Path(tmp_path, "workflow_profile")

--- a/tests/cli/workflow/balsamic/test_run.py
+++ b/tests/cli/workflow/balsamic/test_run.py
@@ -183,7 +183,7 @@ def test_workflow_profile_option(
     caplog: LogCaptureFixture,
     tmp_path: Path,
 ):
-    """Test run command with workflow-profile option"""
+    """Test run command with workflow-profile option."""
     caplog.set_level(logging.INFO)
 
     # GIVEN valid case-id

--- a/tests/cli/workflow/balsamic/test_run.py
+++ b/tests/cli/workflow/balsamic/test_run.py
@@ -4,7 +4,8 @@ import logging
 from pathlib import Path
 from unittest.mock import PropertyMock, create_autospec
 
-from click.testing import CliRunner
+from _pytest.logging import LogCaptureFixture
+from click.testing import CliRunner, Result
 
 from cg.cli.workflow.balsamic.base import run
 from cg.constants import EXIT_SUCCESS
@@ -174,3 +175,47 @@ def test_calls_on_analysis_started(cli_runner: CliRunner, balsamic_context: CGCo
 
     # THEN the on_analysis_started function has been called
     analysis_api.on_analysis_started.assert_called_with(case_id)
+
+
+def test_workflow_profile_option(
+    cli_runner: CliRunner,
+    balsamic_context: CGConfig,
+    caplog: LogCaptureFixture,
+    tmp_path: Path,
+):
+    """Test run command with workflow-profile option"""
+    caplog.set_level(logging.INFO)
+
+    # GIVEN valid case-id
+    case_id = "balsamic_case_wgs_single"
+
+    # GIVEN that the case config file exists where it should be stored
+    Path.mkdir(
+        Path(balsamic_context.meta_apis["analysis_api"].get_case_config_path(case_id)).parent,
+        exist_ok=True,
+    )
+    Path(balsamic_context.meta_apis["analysis_api"].get_case_config_path(case_id)).touch(
+        exist_ok=True
+    )
+
+    # GIVEN that the workflow-profile path exists
+    workflow_profile = Path(tmp_path, "workflow_profile")
+    workflow_profile.mkdir(parents=True, exist_ok=True)
+
+    # WHEN dry running with the workflow-profile option specified
+    result: Result = cli_runner.invoke(
+        run,
+        [
+            case_id,
+            "--dry-run",
+            "--workflow-profile",
+            workflow_profile.as_posix(),
+        ],
+        obj=balsamic_context,
+    )
+
+    # THEN command should execute successfully
+    assert result.exit_code == EXIT_SUCCESS
+
+    # THEN the workflow-profile option should be included in the run command
+    assert f"--workflow-profile {workflow_profile.as_posix()}" in caplog.text


### PR DESCRIPTION
## Description
Closes #4582 

### Added

- Argument `workflow_profile` to BalsamicAnalysisAPI method `run_analysis`
- New click decorator OPTION_WORKFLOW_PROFILE and added to BALSAMIC start and run commands
- Test decorator for start
- Test decorator for run

### Fixed

- Remove argument `cluster config` to BalsamicAnalysisAPI method `run_analysis`
- Remove click decorator OPTION_CLUSTER_CONFIG
