### PR TITLE
Block retrieval of SPRING files if any file is still archiving

### DIFF
--- a/cg/exc.py
+++ b/cg/exc.py
@@ -280,6 +280,10 @@ class MissingFilesError(CgError):
     """Exception raised when there are missing files."""
 
 
+class SampleFilesCurrentlyArchivingError(CgError):
+    """Exception raised when not all of the samples' files have finished archiving."""
+
+
 class MetricsQCError(CgError):
     """Exception raised when QC metrics are not met."""
 

--- a/cg/exc.py
+++ b/cg/exc.py
@@ -281,7 +281,7 @@ class MissingFilesError(CgError):
 
 
 class SampleFilesCurrentlyArchivingError(CgError):
-    """Exception raised when not all of the samples' files have finished archiving."""
+    """Exception raised when not all of the sample files have finished archiving."""
 
 
 class MetricsQCError(CgError):

--- a/cg/meta/archive/archive.py
+++ b/cg/meta/archive/archive.py
@@ -305,6 +305,9 @@ class SpringArchiveAPI:
             except MissingFilesError as error:
                 LOG.warning(str(error))
                 continue
+            except SampleFilesCurrentlyArchivingError as error:
+                LOG.warning(f"Sample {sample.internal_id} will not be retrieved: {error}")
+                continue
 
     def retrieve_spring_files_for_sample(self, sample_id: str) -> None:
         sample: Sample = self.status_db.get_sample_by_internal_id(sample_id)

--- a/cg/meta/archive/archive.py
+++ b/cg/meta/archive/archive.py
@@ -301,7 +301,8 @@ class SpringArchiveAPI:
             except MissingFilesError as error:
                 LOG.warning(str(error))
                 continue
-            except SampleFilesCurrentlyArchivingError:
+            except SampleFilesCurrentlyArchivingError as error:
+                LOG.warning(str(error))
                 continue
 
     def retrieve_spring_files_for_sample(self, sample_id: str) -> None:

--- a/cg/meta/archive/archive.py
+++ b/cg/meta/archive/archive.py
@@ -289,11 +289,7 @@ class SpringArchiveAPI:
         else:
             order = self.status_db.get_order_by_ticket_id(id_)
         for case in order.cases:
-            try:
-                self.retrieve_spring_files_for_case(case.internal_id)
-            except MissingFilesError as error:
-                LOG.info(error)
-                continue
+            self.retrieve_spring_files_for_case(case.internal_id)
 
     def retrieve_spring_files_for_case(self, case_id: str) -> None:
         """Submits jobs to retrieve any archived files belonging to the given case, and updates the Archive entries
@@ -305,8 +301,7 @@ class SpringArchiveAPI:
             except MissingFilesError as error:
                 LOG.warning(str(error))
                 continue
-            except SampleFilesCurrentlyArchivingError as error:
-                LOG.warning(f"Sample {sample.internal_id} will not be retrieved: {error}")
+            except SampleFilesCurrentlyArchivingError:
                 continue
 
     def retrieve_spring_files_for_sample(self, sample_id: str) -> None:

--- a/tests/meta/archive/conftest.py
+++ b/tests/meta/archive/conftest.py
@@ -49,12 +49,6 @@ def ok_miria_response(ok_response: Response):
 
 
 @pytest.fixture
-def ok_miria_job_status_response(ok_response: Response):
-    ok_response._content = b'{"id": "123", "status": "Completed"}'
-    return ok_response
-
-
-@pytest.fixture
 def archive_request_json(
     remote_storage_repository: str, local_storage_repository: str, trimmed_local_path: str
 ) -> dict:
@@ -99,12 +93,6 @@ def header_with_test_auth_token() -> dict:
         "accept": "application/json",
         "Authorization": "Bearer test_auth_token",
     }
-
-
-@pytest.fixture
-def miria_auth_token_response(ok_response: Response):
-    ok_response._content = b'{"access": "test_auth_token", "expire":15, "test_refresh_token":""}'
-    return ok_response
 
 
 @pytest.fixture
@@ -211,12 +199,6 @@ def local_storage_repository() -> str:
 def remote_storage_repository() -> str:
     """Returns a remote storage repository."""
     return "archive@repository:"
-
-
-@pytest.fixture
-def full_remote_path(remote_storage_repository: str, remote_path: Path) -> str:
-    """Returns the merged remote repository and path."""
-    return remote_storage_repository + remote_path.as_posix()
 
 
 @pytest.fixture

--- a/tests/meta/archive/test_archive_api.py
+++ b/tests/meta/archive/test_archive_api.py
@@ -1,4 +1,4 @@
-import datetime as dt
+from datetime import datetime
 from pathlib import Path
 from unittest import mock
 from unittest.mock import Mock, create_autospec
@@ -302,7 +302,7 @@ def test_retrieve_case(
         spring_archive_api.housekeeper_api.add_archives(
             files=[file], archive_task_id=archival_job_id
         )
-        file.archive.archived_at = dt.datetime.now()
+        file.archive.archived_at = datetime.now()
         assert not file.archive.retrieval_task_id
         assert file.archive
 
@@ -397,7 +397,7 @@ def test_retrieve_sample(
         spring_archive_api.housekeeper_api.add_archives(
             files=[file], archive_task_id=archival_job_id
         )
-        file.archive.archived_at = dt.datetime.now()
+        file.archive.archived_at = datetime.now()
         assert not file.archive.retrieval_task_id
         assert file.archive
 
@@ -478,7 +478,7 @@ def test_retrieve_order(
         spring_archive_api.housekeeper_api.add_archives(
             files=[file], archive_task_id=archival_job_id
         )
-        file.archive.archived_at = dt.datetime.now()
+        file.archive.archived_at = datetime.now()
         assert not file.archive.retrieval_task_id
         assert file.archive
 

--- a/tests/meta/archive/test_archive_api.py
+++ b/tests/meta/archive/test_archive_api.py
@@ -1,3 +1,4 @@
+import datetime as dt
 from pathlib import Path
 from unittest import mock
 from unittest.mock import Mock, create_autospec
@@ -313,6 +314,7 @@ def test_retrieve_case(
         spring_archive_api.housekeeper_api.add_archives(
             files=[file], archive_task_id=archival_job_id
         )
+        file.archive.archived_at = dt.datetime.now()
         assert not file.archive.retrieval_task_id
         assert file.archive
 
@@ -411,6 +413,7 @@ def test_retrieve_sample(
         spring_archive_api.housekeeper_api.add_archives(
             files=[file], archive_task_id=archival_job_id
         )
+        file.archive.archived_at = dt.datetime.now()
         assert not file.archive.retrieval_task_id
         assert file.archive
 
@@ -467,6 +470,7 @@ def test_retrieve_order(
         spring_archive_api.housekeeper_api.add_archives(
             files=[file], archive_task_id=archival_job_id
         )
+        file.archive.archived_at = dt.datetime.now()
         assert not file.archive.retrieval_task_id
         assert file.archive
 

--- a/tests/meta/archive/test_archiving.py
+++ b/tests/meta/archive/test_archiving.py
@@ -23,12 +23,9 @@ from cg.meta.archive.ddn.models import MiriaObject, TransferPayload
 from cg.meta.archive.ddn.utils import get_metadata
 from cg.meta.archive.models import FileAndSample
 from cg.models.cg_config import DataFlowConfig
-from cg.store.store import Store
 
 
-def test_correct_source_root(
-    local_directory: Path, miria_file_archive: MiriaObject, trimmed_local_directory: Path
-):
+def test_correct_source_root(miria_file_archive: MiriaObject, trimmed_local_directory: Path):
     """Tests the method for trimming the source directory."""
 
     # GIVEN a MiriaObject with a source path and a destination path
@@ -319,10 +316,6 @@ def test_archive_file(
 
 def test_retrieve_files(
     ddn_dataflow_client: DDNDataFlowClient,
-    remote_storage_repository: str,
-    local_storage_repository: str,
-    archive_store: Store,
-    trimmed_local_path: str,
     file_and_sample: FileAndSample,
     ok_miria_response,
     retrieve_request_json,


### PR DESCRIPTION
## Description
The retrieval of SPRING files behaves unexpectedly when their archiving takes too long. Specifically, when retrieving files from a sample that is currently being archived, it results in unexpected behaviour, as documented in https://github.com/Clinical-Genomics/bug-reports/issues/42. For this reason, this PR implements a check that stops a retrieval process of a sample if any of its files are currently being archived, raising a `SampleFilesCurrentlyArchivingError`.

### Added

- Support for checking if any of a sample's files is being archived, and raise an error if that is the case.
- Test for this new functionality

### Changed

- Modified existing tests to account for new functionality

### Fixed

- Removed unused fixtures


### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b fix-sample-archiving -a
    ```

### How to test

1. Retrieve sample
- [x] Choose a sample with SPRING files
- [x] In Housekeeper, look for the Archive entries for the files
- [x] For one of the files, remove the `archived_at` date
- [x] Run `cg archive retrieve sample <sample_id>`

2. Retrieve case
- [x] Use the case for the previous sample
- [x] Do `cg archive retrieve case <case_id>` 

### Expected test outcome

1. Retrieve sample
- [x] Verify that the command fails with `SampleFilesCurrentlyArchivingError`
```shell
$ cg -l DEBUG archive retrieve sample ACC18107A6
Getting archived files which are not being retrieved for bundle <sample>.
Traceback (most recent call last):
  File "/home/proj/stage/bin/miniconda3/envs/S_cg/bin/cg", line 8, in <module>
    sys.exit(base())
             ^^^^^^
  File "/home/proj/stage/bin/miniconda3/envs/S_cg/lib/python3.11/site-packages/rich_click/rich_command.py", line 367, in __call__
    return super().__call__(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/proj/stage/bin/miniconda3/envs/S_cg/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/proj/stage/bin/miniconda3/envs/S_cg/lib/python3.11/site-packages/rich_click/rich_command.py", line 152, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/proj/stage/bin/miniconda3/envs/S_cg/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/proj/stage/bin/miniconda3/envs/S_cg/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/proj/stage/bin/miniconda3/envs/S_cg/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/proj/stage/bin/miniconda3/envs/S_cg/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/proj/stage/bin/miniconda3/envs/S_cg/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/proj/stage/bin/miniconda3/envs/S_cg/lib/python3.11/site-packages/click/decorators.py", line 45, in new_func
    return f(get_current_context().obj, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/proj/stage/bin/miniconda3/envs/S_cg/lib/python3.11/site-packages/cg/cli/archive.py", line 104, in retrieve_spring_files_for_sample
    spring_archive_api.retrieve_spring_files_for_sample(sample_id=sample_id)
  File "/home/proj/stage/bin/miniconda3/envs/S_cg/lib/python3.11/site-packages/cg/meta/archive/archive.py", line 309, in retrieve_spring_files_for_sample
    self._retrieve_spring_files_for_sample(sample)
  File "/home/proj/stage/bin/miniconda3/envs/S_cg/lib/python3.11/site-packages/cg/meta/archive/archive.py", line 318, in _retrieve_spring_files_for_sample
    raise SampleFilesCurrentlyArchivingError(
cg.exc.SampleFilesCurrentlyArchivingError: Not all Spring files for sample <sample> are archived - cannot retrieve files.
[js.diazboada@hasta:~] [S_base] $
```

2. Retrieve case
- [x] Verify that a warning is shown saying that the unarchived sample was not retrieved
```shell
$ cg -l DEBUG archive retrieve case <case>
Instantiating status db
Instantiating housekeeper api
Initializing Store
Getting archived files which are not being retrieved for bundle <SAMPLE>.
Not all Spring files for sample <SAMPLE> are archived - cannot retrieve files.
[js.diazboada@hasta:~] [S_base] $
```

## Review

- [x] Tests executed by SD
- [x] "Merge and deploy" approved by VJ, IO
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Deployed to stage:
```shell

```
- [ ] Deployed to production:
```shell

```
- [ ] Inform in development brief and update deviation
