### PR TITLE
Raredisease: change mosdepth to d4tools output in hk bundle

### DIFF
--- a/cg/resources/raredisease_bundle_filenames.yaml
+++ b/cg/resources/raredisease_bundle_filenames.yaml
@@ -25,9 +25,9 @@
   tag: tiddit_coverage
 - format: meta
   id: SAMPLEID
-  path: PATHTOCASE/qc_bam/SAMPLEID_mosdepth.per-base.d4
+  path: PATHTOCASE/qc_bam/SAMPLEID.d4
   step: qc_bam
-  tag: mosdepth_d4
+  tag: d4tools_d4
 - format: png
   id: SAMPLEID
   path: PATHTOCASE/qc_bam/SAMPLEID_chromographcov/SAMPLEID_tidditcov_1.png


### PR DESCRIPTION
## Description
For raredisease 2.5.3 we are removing the mosdepth output and instead delivering d4 files generated by d4tools. This PR updates the housekeeper bundle path to that file.

### Added

-

### Changed

- Raredisease: change mosdepth to d4tools output in hk bundle

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do cg workflow raredisease store anotheramusedmarmoset.

### Expected test outcome

- [ ] Check that the hk bundle correctly includes the d4tools d4 files.
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
