### PR TITLE
Value sent to write_yaml should always be str and not StrEnum

### DIFF
--- a/cg/services/analysis_starter/configurator/file_creators/mip_dna_config.py
+++ b/cg/services/analysis_starter/configurator/file_creators/mip_dna_config.py
@@ -45,7 +45,7 @@ class MIPDNAConfigFileCreator:
 
         phenotype = case_sample.status
         if len(case.links) == 1 and case_sample.status == StatusOptions.UNKNOWN:
-            phenotype = StatusOptions.UNAFFECTED
+            phenotype = StatusOptions.UNAFFECTED.value
 
         return {
             "analysis_type": sample.prep_category,
@@ -53,7 +53,7 @@ class MIPDNAConfigFileCreator:
             "expected_coverage": sample.application_version.application.min_sequencing_depth,
             "father": father,
             "mother": mother,
-            "phenotype": phenotype.value,  # YAML serialisation does not handle Enums properly
+            "phenotype": phenotype,
             "sample_display_name": sample.name,
             "sample_id": sample.internal_id,
             "sex": sample.sex,

--- a/tests/services/analysis_starter/file_creators/mip_dna_config_file_creator/test_mip_dna_config_file_creator.py
+++ b/tests/services/analysis_starter/file_creators/mip_dna_config_file_creator/test_mip_dna_config_file_creator.py
@@ -173,6 +173,10 @@ def test_create_wgs_only_one_sample_phenotype_unknown(
         content=expected_content_wgs, file_path=Path("pedigree.yaml")
     )
 
+    # THEN the type of the phenotype value should be str
+    # (not StrEnum since they don't serialize properly when using write_yaml)
+    assert type(mock_write.call_args.kwargs["content"]["samples"][0]["phenotype"]) is str
+
 
 def test_create_wes_no_bed_flag(
     case_id: str, expected_content_wes: dict, wes_mock_store: Store, mocker: MockerFixture


### PR DESCRIPTION
## Description

### Added

-

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
