### PR TITLE
Fix(Cleaning) Remove analysis based on completion instead of start

### DIFF
--- a/cg/store/crud/read.py
+++ b/cg/store/crud/read.py
@@ -1199,14 +1199,14 @@ class ReadHandler(BaseHandler):
         ).all()
 
     def get_analyses_to_clean(
-        self, before: datetime = datetime.now(), workflow: Workflow | None = None
+        self, before: datetime, workflow: Workflow | None = None
     ) -> list[Analysis]:
         """Return analyses that haven't been cleaned."""
         filter_functions: list[Callable] = [
             AnalysisFilter.COMPLETED,
             AnalysisFilter.IS_UPLOADED,
             AnalysisFilter.IS_NOT_CLEANED,
-            AnalysisFilter.STARTED_AT_BEFORE,
+            AnalysisFilter.COMPLETED_AT_BEFORE,
             AnalysisFilter.CASE_ACTION_IS_NONE,
         ]
         if workflow:
@@ -1215,7 +1215,7 @@ class ReadHandler(BaseHandler):
             filter_functions=filter_functions,
             analyses=self._get_latest_analyses_for_cases_query(),
             workflow=workflow,
-            started_at_date=before,
+            completed_at_date=before,
         ).all()
 
     def get_completed_analyses_for_workflow_started_at_before(

--- a/cg/store/filters/status_analysis_filters.py
+++ b/cg/store/filters/status_analysis_filters.py
@@ -71,6 +71,18 @@ def filter_analyses_started_before(analyses: Query, started_at_date: datetime, *
     return analyses.filter(Analysis.started_at < started_at_date)
 
 
+def filter_analyses_completed_before(
+    analyses: Query, completed_at_date: datetime, **kwargs
+) -> Query:
+    """Return a query of analyses completed before a certain date."""
+    return analyses.filter(
+        and_(
+            Analysis.completed_at.isnot(None),
+            Analysis.completed_at < completed_at_date,
+        )
+    )
+
+
 def filter_analyses_not_cleaned(analyses: Query, **kwargs) -> Query:
     """Return a query of analyses that have not been cleaned."""
     return analyses.filter(Analysis.cleaned_at.is_(None))
@@ -122,6 +134,7 @@ class AnalysisFilter(Enum):
     REPORT_BY_WORKFLOW: Callable = filter_report_analyses_by_workflow
     IS_NOT_CLEANED: Callable = filter_analyses_not_cleaned
     STARTED_AT_BEFORE: Callable = filter_analyses_started_before
+    COMPLETED_AT_BEFORE: Callable = filter_analyses_completed_before
     CASE_ACTION_IS_NONE: Callable = filter_analysis_case_action_is_none
     ORDER_BY_UPLOADED_AT: Callable = order_analyses_by_uploaded_at_asc
     ORDER_BY_COMPLETED_AT: Callable = order_analyses_by_completed_at_asc

--- a/tests/cli/clean/test_balsamic_clean.py
+++ b/tests/cli/clean/test_balsamic_clean.py
@@ -106,7 +106,9 @@ def test_dry_run(
     assert result.exit_code == EXIT_SUCCESS
     assert "Would have deleted" in caplog.text
     assert balsamic_case_clean in caplog.text
-    assert analysis_to_clean in base_store.get_analyses_to_clean(workflow=Workflow.BALSAMIC)
+    assert analysis_to_clean in base_store.get_analyses_to_clean(
+        before=dt.datetime.now(), workflow=Workflow.BALSAMIC
+    )
 
 
 def test_cleaned_at_valid(

--- a/tests/cli/clean/test_microbial_clean.py
+++ b/tests/cli/clean/test_microbial_clean.py
@@ -52,7 +52,9 @@ def test_dry_run(
 
     # THEN the analysis should still be in the analyses_to_clean query since this is a dry-ryn
     assert analysis_to_clean.cleaned_at is None
-    assert analysis_to_clean in base_store.get_analyses_to_clean(workflow=Workflow.MICROSALT)
+    assert analysis_to_clean in base_store.get_analyses_to_clean(
+        before=dt.datetime.now(), workflow=Workflow.MICROSALT
+    )
 
 
 def test_clean_run(
@@ -102,4 +104,6 @@ def test_clean_run(
 
     # THEN the analysis should no longer be in the analyses_to_clean query
     assert isinstance(analysis_to_clean.cleaned_at, dt.datetime)
-    assert analysis_to_clean not in base_store.get_analyses_to_clean(workflow=Workflow.MICROSALT)
+    assert analysis_to_clean not in base_store.get_analyses_to_clean(
+        before=dt.datetime.now(), workflow=Workflow.MICROSALT
+    )

--- a/tests/store/crud/read/test_read_analyses_to_clean.py
+++ b/tests/store/crud/read/test_read_analyses_to_clean.py
@@ -48,7 +48,7 @@ def test_analysis_excluded(analysis_store: Store, helpers, timestamp_now: dateti
     analysis_store.session.add(link)
 
     # WHEN calling the analyses_to_clean
-    analyses_to_clean = analysis_store.get_analyses_to_clean()
+    analyses_to_clean = analysis_store.get_analyses_to_clean(datetime.now())
 
     # THEN this analysis should be returned
     assert analysis not in analyses_to_clean
@@ -106,7 +106,9 @@ def test_workflow_excluded(analysis_store: Store, helpers, timestamp_now: dateti
     analysis_store.session.add(link)
 
     # WHEN calling the analyses_to_clean specifying another workflow
-    analyses_to_clean = analysis_store.get_analyses_to_clean(workflow=wrong_workflow)
+    analyses_to_clean = analysis_store.get_analyses_to_clean(
+        before=datetime.now(), workflow=wrong_workflow
+    )
 
     # THEN this analysis should not be returned
     assert analysis not in analyses_to_clean
@@ -157,7 +159,7 @@ def test_cleaned_excluded(analysis_store: Store, helpers, timestamp_now: datetim
     analysis_store.session.add(link)
 
     # WHEN calling the analyses_to_clean
-    analyses_to_clean = analysis_store.get_analyses_to_clean()
+    analyses_to_clean = analysis_store.get_analyses_to_clean(before=datetime.now())
 
     # THEN this analysis should not be returned
     assert analysis not in analyses_to_clean


### PR DESCRIPTION
## Description
This PR changes the cleaning logic to start counting from the completion timestamp rather than the starting timestamp. This is more intuitive since analysis completion times vary significantly.

Additionally removes the default argument for

### Changed
- Changed analysis cleaning logic to be base on completion timestamp
- Removed default value for XXXX

