### PR TITLE
Patch help message for MIP-DNA

### DIFF
--- a/cg/cli/workflow/mip_dna/base.py
+++ b/cg/cli/workflow/mip_dna/base.py
@@ -86,7 +86,9 @@ def dev_run(
 ):
     """
     Run a preconfigured MIP-DNA case.
-    Assumes that the following files are in the case run directory:
+
+    \b
+    Assumes that the following files exist in the case run directory:
         - pedigree.yaml
         - gene_panels.bed
         - managed_variants.vcf
@@ -114,7 +116,10 @@ def dev_start(
     start_with: str | None,
 ):
     """
-    Start a MIP-DNA case. Configures the case and writes the following files:
+    Start a MIP-DNA case.
+
+    \b
+    Configures the case and writes the following files:
         - pedigree.yaml
         - gene_panels.bed
         - managed_variants.vcf
@@ -134,7 +139,10 @@ def dev_start(
 @click.pass_obj
 def dev_start_available(cg_config: CGConfig):
     """
-    Starts all available MIP-DNA cases. Configures the individual case and writes the following files for each case:
+    Starts all available MIP-DNA cases.
+
+    \b
+    Configures the individual case and writes the following files for each case:
         - pedigree.yaml
         - gene_panels.bed
         - managed_variants.vcf
@@ -157,7 +165,10 @@ def dev_config_case(
     panel_bed: str | None,
 ):
     """
-    Configure a MIP-DNA case so that it is ready to be run. This creates the following files:
+    Configure a MIP-DNA case so that it is ready to be run.
+
+    \b
+    This creates the following files:
         - pedigree.yaml
         - gene_panels.bed
         - managed_variants.vcf


### PR DESCRIPTION
## Description

### Changed

- The help messages for dev-mip-dna will now have new lines, just like the doc-string is structured. 


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
