### PR TITLE
Switch start commands for MIP-DNA

### DIFF
--- a/cg/cli/workflow/mip_dna/base.py
+++ b/cg/cli/workflow/mip_dna/base.py
@@ -13,14 +13,6 @@ from cg.cli.workflow.commands import (
     store,
     store_available,
 )
-from cg.cli.workflow.mip.base import (
-    config_case,
-    managed_variants,
-    panel,
-    run,
-    start,
-    start_available,
-)
 from cg.cli.workflow.mip.options import (
     ARGUMENT_CASE_ID,
     OPTION_BWA_MEM,
@@ -56,28 +48,22 @@ def mip_dna(
 
 
 for sub_cmd in [
-    config_case,
     ensure_illumina_runs_on_disk,
     link,
-    managed_variants,
-    panel,
     resolve_compression,
-    run,
-    start,
-    start_available,
     store,
     store_available,
 ]:
     mip_dna.add_command(sub_cmd)
 
 
-@mip_dna.command("dev-run")
+@mip_dna.command("run")
 @START_AFTER_PROGRAM
 @START_WITH_PROGRAM
 @OPTION_BWA_MEM
 @ARGUMENT_CASE_ID
 @click.pass_obj
-def dev_run(
+def run(
     cg_config: CGConfig,
     case_id: str,
     use_bwa_mem: bool,
@@ -98,14 +84,14 @@ def dev_run(
     )
 
 
-@mip_dna.command("dev-start")
+@mip_dna.command("start")
 @START_AFTER_PROGRAM
 @START_WITH_PROGRAM
 @OPTION_BWA_MEM
 @OPTION_PANEL_BED
 @ARGUMENT_CASE_ID
 @click.pass_obj
-def dev_start(
+def start(
     cg_config: CGConfig,
     case_id: str,
     use_bwa_mem: bool,
@@ -130,9 +116,9 @@ def dev_start(
     )
 
 
-@mip_dna.command("dev-start-available")
+@mip_dna.command("start-available")
 @click.pass_obj
-def dev_start_available(cg_config: CGConfig):
+def start_available(cg_config: CGConfig):
     """
     Starts all available MIP-DNA cases. Configures the individual case and writes the following files for each case:
         - pedigree.yaml
@@ -147,11 +133,11 @@ def dev_start_available(cg_config: CGConfig):
         raise click.Abort
 
 
-@mip_dna.command("dev-config-case")
+@mip_dna.command("config-case")
 @OPTION_PANEL_BED
 @ARGUMENT_CASE_ID
 @click.pass_obj
-def dev_config_case(
+def config_case(
     cg_config: CGConfig,
     case_id: str,
     panel_bed: str | None,

--- a/tests/cli/workflow/mip/test_cli_mip_base.py
+++ b/tests/cli/workflow/mip/test_cli_mip_base.py
@@ -7,7 +7,7 @@ from _pytest.logging import LogCaptureFixture
 from click.testing import CliRunner
 from pytest_mock import MockFixture
 
-from cg.cli.workflow.mip_dna.base import start, start_available
+from cg.cli.workflow.mip.base import start, start_available
 from cg.constants.process import EXIT_SUCCESS
 from cg.meta.workflow.prepare_fastq import PrepareFastqAPI
 from cg.models.cg_config import CGConfig

--- a/tests/cli/workflow/mip/test_cli_mip_dna.py
+++ b/tests/cli/workflow/mip/test_cli_mip_dna.py
@@ -4,7 +4,7 @@ import pytest
 from click.testing import CliRunner
 from pytest_mock import MockerFixture
 
-from cg.cli.workflow.mip_dna.base import dev_config_case, dev_run, dev_start
+from cg.cli.workflow.mip_dna.base import config_case, run, start
 from cg.constants import Workflow
 from cg.models.cg_config import CGConfig, IlluminaConfig, MipConfig, RunInstruments
 from cg.services.analysis_starter.configurator.implementations.mip_dna import MIPDNAConfigurator
@@ -56,7 +56,7 @@ def test_mip_dna_dev_run_no_flags(cg_config: CGConfig, mocker: MockerFixture):
     flags: list[str] = [case_id]
 
     # WHEN invoking cg workflow mip-dna dev-run
-    result = cli_runner.invoke(dev_run, flags, obj=cg_config)
+    result = cli_runner.invoke(run, flags, obj=cg_config)
 
     # THEN the command exits successfully
     assert result.exit_code == 0
@@ -91,7 +91,7 @@ def test_mip_dna_dev_run_all_flags(cg_config: CGConfig, mocker: MockerFixture):
     flags = ["--start-with", start_with, "--start-after", start_after, "--use-bwa-mem", case_id]
 
     # WHEN invoking cg workflow mip-dna dev-run
-    result = cli_runner.invoke(dev_run, flags, obj=cg_config)
+    result = cli_runner.invoke(run, flags, obj=cg_config)
 
     # THEN the command exits successfully
     assert result.exit_code == 0
@@ -128,7 +128,7 @@ def test_mip_dna_dev_start_no_flags(
 
     # WHEN invoking cg workflow mip-dna dev-start
     result = cli_runner.invoke(
-        dev_start,
+        start,
         flags,
         obj=cg_config,
     )
@@ -184,7 +184,7 @@ def test_mip_dna_dev_start_all_flags(
 
     # WHEN invoking cg workflow mip-dna dev-start
     result = cli_runner.invoke(
-        dev_start,
+        start,
         flags,
         obj=cg_config,
     )
@@ -219,9 +219,7 @@ def test_mip_dna_dev_config_case_all_flags(cg_config: CGConfig, mocker: MockerFi
     mock_configure = mocker.patch.object(MIPDNAConfigurator, "configure")
 
     # WHEN invoking cg workflow mip-dna dev-case-config
-    result = cli_runner.invoke(
-        dev_config_case, ["--panel-bed", "panel.bed", case_id], obj=cg_config
-    )
+    result = cli_runner.invoke(config_case, ["--panel-bed", "panel.bed", case_id], obj=cg_config)
 
     # THEN the command exits successfully
     assert result.exit_code == 0
@@ -247,7 +245,7 @@ def test_mip_dna_dev_config_case_no_flags(cg_config: CGConfig, mocker: MockerFix
     mock_configure = mocker.patch.object(MIPDNAConfigurator, "configure")
 
     # WHEN invoking cg workflow mip-dna dev-case-config
-    result = cli_runner.invoke(dev_config_case, [case_id], obj=cg_config)
+    result = cli_runner.invoke(config_case, [case_id], obj=cg_config)
 
     # THEN the command exits successfully
     assert result.exit_code == 0

--- a/tests/cli/workflow/mip/test_cli_mip_dna_config_case.py
+++ b/tests/cli/workflow/mip/test_cli_mip_dna_config_case.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from cg.cli.workflow.mip_dna.base import config_case
+from cg.cli.workflow.mip.base import config_case
 
 
 def test_cg_workflow_mip_dna_config_case_dry_run(cli_runner, caplog, case_id, mip_dna_context):
@@ -31,7 +31,7 @@ def test_cg_workflow_mip_dna_config_case(cli_runner, caplog, case_id, mip_dna_co
 
     # THEN the command should be printed
     assert result.exit_code == 0
-    assert f"Config file saved to" in caplog.text
+    assert "Config file saved to" in caplog.text
 
 
 def test_cg_workflow_mip_dna_config_case_error(cli_runner, caplog, case_id, mip_dna_context):
@@ -48,4 +48,4 @@ def test_cg_workflow_mip_dna_config_case_error(cli_runner, caplog, case_id, mip_
     assert result.exit_code == 1
 
     # THEN an error should be logged
-    assert f"could not be found in Status DB" in caplog.text
+    assert "could not be found in Status DB" in caplog.text

--- a/tests/cli/workflow/mip/test_cli_mip_dna_panel.py
+++ b/tests/cli/workflow/mip/test_cli_mip_dna_panel.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import mock
 from click.testing import CliRunner
 
-from cg.cli.workflow.mip_dna.base import panel
+from cg.cli.workflow.mip.base import panel
 from cg.constants.scout import ScoutExportFileName
 from cg.io.txt import read_txt
 from cg.meta.workflow.mip import MipAnalysisAPI

--- a/tests/cli/workflow/mip/test_cli_mip_dna_run.py
+++ b/tests/cli/workflow/mip/test_cli_mip_dna_run.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from cg.cli.workflow.mip_dna.base import run
+from cg.cli.workflow.mip.base import run
 from cg.meta.workflow.mip_dna import MipDNAAnalysisAPI
 
 

--- a/tests/cli/workflow/mip/test_cli_mip_dna_start.py
+++ b/tests/cli/workflow/mip/test_cli_mip_dna_start.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 from click.testing import CliRunner
 
-from cg.cli.workflow.mip_dna.base import start_available
+from cg.cli.workflow.mip.base import start_available
 from cg.constants import EXIT_SUCCESS, Workflow
 from cg.meta.workflow.mip_dna import MipDNAAnalysisAPI
 from cg.meta.workflow.prepare_fastq import PrepareFastqAPI

--- a/tests/cli/workflow/test_start_available.py
+++ b/tests/cli/workflow/test_start_available.py
@@ -6,7 +6,7 @@ from click.testing import CliRunner, Result
 from pytest_mock import MockerFixture
 
 from cg.cli.workflow.microsalt.base import start_available as microsalt_start_available
-from cg.cli.workflow.mip_dna.base import dev_start_available as mip_dna_start_available
+from cg.cli.workflow.mip_dna.base import start_available as mip_dna_start_available
 from cg.cli.workflow.raredisease.base import dev_start_available as raredisease_start_available
 from cg.cli.workflow.rnafusion.base import start_available as rnafusion_start_available
 from cg.cli.workflow.taxprofiler.base import start_available as taxprofiler_start_available


### PR DESCRIPTION
## Description

We have developed new start cli commands, and this PR aims to replace the older `run`,`start`, `start-available` and `config-case` cli commands.


### Changed

- The dev commands have now replaced the old start commands.

### Fixed

- Patched older tests since some of them is still in use for mip-rna


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
