### PR TITLE
Make unknown sex use female gens coverage pon file

### DIFF
--- a/cg/meta/workflow/balsamic.py
+++ b/cg/meta/workflow/balsamic.py
@@ -410,9 +410,7 @@ class BalsamicAnalysisAPI(AnalysisAPI):
             "genome_interval": self.genome_interval_path,
             "gnomad_min_af5": self.gnomad_af5_path,
             "gens_coverage_pon": (
-                self.gens_coverage_female_path
-                if sex == Sex.FEMALE
-                else self.gens_coverage_male_path
+                self.gens_coverage_male_path if sex == Sex.MALE else self.gens_coverage_female_path
             ),
         }
 


### PR DESCRIPTION
## Description
The logic for choosing a gens coverage pon file for a Balsamic case was (Balsamic 17 and earlier) set to:
- Choose the gens female coverage file for samples with sex set to female
- Choose the gens male coverage file for samples with sex set to male or unknown.

Previously, the sex for samples with unknown sex was set to female for Balsamic, which made all samples originally with sex == Unknown use the female gens coverage file. However, now Balsamic v18 allows sample to have unknwon sex. This means that unkwnon-sex samples previously using the female coverage file would use the male coverge file, which is an unexpected change of behavior. This PR changes that.

### Changed

The logic for choosing a gens coverage pon file is now set to:
- Choose the gens male coverage file for samples with sex set to male
- Choose the gens female coverage file for samples with sex set to female or unknown.



### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
