### PR TITLE
Fix flag behaviour for MIP-DNA

### DIFF
--- a/cg/services/analysis_starter/configurator/models/mip_dna.py
+++ b/cg/services/analysis_starter/configurator/models/mip_dna.py
@@ -1,5 +1,3 @@
-from pydantic import Field
-
 from cg.constants.constants import Workflow
 from cg.constants.priority import SlurmQos
 from cg.services.analysis_starter.configurator.abstract_model import CaseConfig
@@ -13,8 +11,8 @@ class MIPDNACaseConfig(CaseConfig):
     pipeline_command: str
     pipeline_config_path: str
     slurm_qos: SlurmQos
-    start_after_recipe: str | None = Field(default=None, alias="start_after")
-    start_with_recipe: str | None = Field(default=None, alias="start_with")
+    start_after: str | None = None
+    start_with: str | None = None
     workflow: Workflow = Workflow.MIP_DNA
     use_bwa_mem: bool
 
@@ -25,11 +23,11 @@ class MIPDNACaseConfig(CaseConfig):
             "{slurm_qos} --email {email}"
         ).format(**self.model_dump())
 
-        if self.start_after_recipe:
-            start_command += f" --start_after_recipe {self.start_after_recipe}"
+        if self.start_after:
+            start_command += f" --start_after_recipe {self.start_after}"
 
-        if self.start_with_recipe:
-            start_command += f" --start_with_recipe {self.start_with_recipe}"
+        if self.start_with:
+            start_command += f" --start_with_recipe {self.start_with}"
 
         if self.use_bwa_mem:
             start_command += " --bwa_mem 1 --bwa_mem2 0"

--- a/tests/services/analysis_starter/test_case_configs.py
+++ b/tests/services/analysis_starter/test_case_configs.py
@@ -83,8 +83,8 @@ def test_mip_dna_get_start_command_all_flags_set():
         f"{mip_case_config.conda_binary} run --name {mip_case_config.conda_environment} {mip_case_config.pipeline_binary} analyse rd_dna"
         f" --config {mip_case_config.pipeline_config_path} {case_id} --slurm_quality_of_service "
         f"{mip_case_config.slurm_qos} --email {mip_case_config.email} "
-        f"--start_after_recipe {mip_case_config.start_after_recipe} "
-        f"--start_with_recipe {mip_case_config.start_with_recipe} "
+        f"--start_after_recipe {mip_case_config.start_after} "
+        f"--start_with_recipe {mip_case_config.start_with} "
         f"--bwa_mem 1 "
         f"--bwa_mem2 0"
     )

--- a/tests/services/analysis_starter/test_mip_dna_configurator.py
+++ b/tests/services/analysis_starter/test_mip_dna_configurator.py
@@ -133,8 +133,8 @@ def test_get_config(mock_cg_config_mip: MipConfig, mock_status_db: Store, mocker
     assert case_config.case_id == "test_case"
     assert case_config.slurm_qos == SlurmQos.NORMAL
     assert case_config.email == "test@scilifelab.se"
-    assert case_config.start_after_recipe is None
-    assert case_config.start_with_recipe is None
+    assert case_config.start_after is None
+    assert case_config.start_with is None
 
 
 def test_get_config_all_flags_set(
@@ -161,16 +161,16 @@ def test_get_config_all_flags_set(
     # WHEN getting the case config
     case_config: MIPDNACaseConfig = configurator.get_config(
         case_id=case_id,
-        start_after_recipe="banana_bread",
-        start_with_recipe="short_bread",
+        start_after="banana_bread",
+        start_with="short_bread",
         use_bwa_mem=True,
     )
 
     # THEN we should run the analysis with bwa_mem instead of bwa_mem2
     assert case_config.use_bwa_mem
 
-    assert case_config.start_after_recipe == "banana_bread"
-    assert case_config.start_with_recipe == "short_bread"
+    assert case_config.start_after == "banana_bread"
+    assert case_config.start_with == "short_bread"
 
 
 def test_get_config_validation(mock_cg_config_mip: MipConfig, mock_status_db: Store):


### PR DESCRIPTION
## Description

We introduced some aliases for the flags in #4658 which do not work well with our flag handling (model_update do not take aliases into account). This PR fixes current behaviour by not relying on aliases.

### Added

-

### Changed

-

### Fixed

- Removed aliases from the MIP-DNA case config


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b patch-mip-flags -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
