### PR TITLE
Make bed version shortname non-nullable

### DIFF
--- a/alembic/versions/2025_10_23_2d63ba0d1154_make_short_name_non_nullable.py
+++ b/alembic/versions/2025_10_23_2d63ba0d1154_make_short_name_non_nullable.py
@@ -1,0 +1,36 @@
+"""Make short name non-nullable
+
+Revision ID: 2d63ba0d1154
+Revises: e0a3e31ed84e
+Create Date: 2025-10-23 14:24:48.182207
+
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "2d63ba0d1154"
+down_revision = "e0a3e31ed84e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        table_name="bed_version",
+        column_name="shortname",
+        existing_type=mysql.VARCHAR(length=64),
+        nullable=False,
+    )
+
+
+def downgrade():
+    op.alter_column(
+        table_name="bed_version",
+        column_name="shortname",
+        existing_type=mysql.VARCHAR(length=64),
+        nullable=True,
+    )

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -324,7 +324,7 @@ class BedVersion(Base):
     __table_args__ = (UniqueConstraint("bed_id", "version", name="_app_version_uc"),)
 
     id: Mapped[PrimaryKeyInt]
-    shortname: Mapped[Str64 | None]
+    shortname: Mapped[Str64]
     version: Mapped[int]
     filename: Mapped[Str256]
     checksum: Mapped[Str32 | None]


### PR DESCRIPTION
## Description

The shortname should be mandatory for all bed versions and we see no entries with it being null. This PR migrates the database to enforce this.

### Added

-

### Changed

- shortname is a non-nullable field on bed_version

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
