### PR TITLE
Add phase blocks to Nallo bundle

### DIFF
--- a/cg/resources/nallo_bundle_filenames.yaml
+++ b/cg/resources/nallo_bundle_filenames.yaml
@@ -249,6 +249,16 @@
   step: maf_depth_track
   tag: bigwig
 - format: meta
+  id: SAMPLEID
+  path: PATHTOCASE/qc/phasing_stats/SAMPLEID/SAMPLEID_stats.blocks.gtf.gz
+  step: phase_blocks
+  tag: gtf
+- format: meta
+  id: SAMPLEID
+  path: PATHTOCASE/qc/phasing_stats/SAMPLEID/SAMPLEID_stats.blocks.gtf.gz.tbi
+  step: phase_blocks
+  tag: gtf_index
+- format: meta
   id: CASEID
   path: PATHTOCASE/multiqc/multiqc_data/multiqc_data.json
   step: multiqc


### PR DESCRIPTION
## Description

This PR adds phase blocks to the Nallo file bundle, which should be made available for scout upload scout and delivered. 

### Added

- Phase blocks to Nallo bundle

### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
