### PR TITLE
Remove get_float_as_percentage for ribosomal_bases

### DIFF
--- a/cg/models/delivery_report/metadata.py
+++ b/cg/models/delivery_report/metadata.py
@@ -166,7 +166,7 @@ class WTSSampleMetadataModel(SequencingSampleMetadataModel):
     pct_surviving: Annotated[str, BeforeValidator(get_number_as_string)] = NA_FIELD
     q20_rate: Annotated[str, BeforeValidator(get_float_as_percentage)] = NA_FIELD
     q30_rate: Annotated[str, BeforeValidator(get_float_as_percentage)] = NA_FIELD
-    ribosomal_bases: Annotated[str, BeforeValidator(get_float_as_percentage)] = NA_FIELD
+    ribosomal_bases: str = NA_FIELD
     rin: Annotated[str, BeforeValidator(get_number_as_string)] = NA_FIELD
     uniquely_mapped_reads: Annotated[str, BeforeValidator(get_number_as_string)] = NA_FIELD
 


### PR DESCRIPTION
## Description

Closes https://github.com/Clinical-Genomics/cg/issues/4691.

### Fixed

- Remove get_float_as_percentage for ribosomal_bases as the value is already given as percentage.


### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Generate delivery report for an rnafusion case.

### Expected test outcome

- [X] Check that the value for ribosomal values is given without conversion.
- [X] Take a screenshot and attach or copy/paste the output.

## Review

- [x] Tests executed by BSV
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
