### PR TITLE
Fix raredisease capture kit fetching

### DIFF
--- a/cg/services/analysis_starter/configurator/file_creators/nextflow/params_file/raredisease.py
+++ b/cg/services/analysis_starter/configurator/file_creators/nextflow/params_file/raredisease.py
@@ -84,13 +84,16 @@ class RarediseaseParamsFileCreator(ParamsFileCreator):
         """
         case: Case = self.store.get_case_by_internal_id_strict(internal_id=case_id)
         sample: Sample = case.samples[0]
-        target_bed_shortname: str = self.lims.capture_kit(sample.from_sample or sample.internal_id)
-        if not target_bed_shortname:
-            return ""
-        bed_version: BedVersion = self.store.get_bed_version_by_short_name_strict(
-            target_bed_shortname
+        target_bed_shortname: str | None = self.lims.capture_kit(
+            sample.from_sample or sample.internal_id
         )
-        return bed_version.filename
+        if target_bed_shortname:
+            bed_version: BedVersion = self.store.get_bed_version_by_short_name_strict(
+                target_bed_shortname
+            )
+            return bed_version.filename
+        else:
+            return ""
 
     def _create_sample_mapping_file(self, case_id: str, case_path: Path) -> Path:
         """Create a sample mapping file for the case and returns its path."""

--- a/tests/services/analysis_starter/file_creators/params_file/test_params_file_creator.py
+++ b/tests/services/analysis_starter/file_creators/params_file/test_params_file_creator.py
@@ -18,7 +18,14 @@ from cg.store.models import BedVersion, Case, Sample
 from cg.store.store import Store
 
 
-def test_raredisease_params_file_creator(mocker: MockerFixture):
+@pytest.mark.parametrize(
+    "expected_bed_short_name, lims_capture_kit",
+    [("bed_version.bed", "target_bed_shortname_123"), ("", None)],
+    ids=["Capture kit is in LIMS", "Capture kit not in LIMS"],
+)
+def test_raredisease_params_file_creator(
+    lims_capture_kit: str | None, expected_bed_short_name: str, mocker: MockerFixture
+):
     # GIVEN a file path
     file_path = Path("some_path", "file_name.yaml")
 
@@ -42,7 +49,7 @@ def test_raredisease_params_file_creator(mocker: MockerFixture):
 
     # GIVEN that Lims returns a bed shortname
     lims = create_autospec(LimsAPI)
-    lims.capture_kit = Mock(return_value="target_bed_shortname_123")
+    lims.capture_kit = Mock(return_value=lims_capture_kit)
 
     # GIVEN a params file creator
     file_creator = RarediseaseParamsFileCreator(
@@ -77,7 +84,7 @@ def test_raredisease_params_file_creator(mocker: MockerFixture):
             "outdir": Path("some_path"),
             "sample_id_map": Path("some_path/case_id_customer_internal_mapping.csv"),
             "save_mapped_as_cram": True,
-            "target_bed_file": "bed_version.bed",
+            "target_bed_file": expected_bed_short_name,
             "vcfanno_extra_resources": "some_path/managed_variants.vcf",
             "vep_filters_scout_fmt": "some_path/gene_panels.bed",
         },


### PR DESCRIPTION
## Description
Fixes the generation of the params file in raredisease new pipeline starting

### Fixed

- Use non-strict version of lims capture kit
- Use default value of `""` if capture kit returns None


### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b patch-raredisease-capture-kit -a
    ```

### How to test

- [x] Do `cg -l DEBUG workflow raredisease dev-config-case amusingmarmoset`

### Expected test outcome

- [x] Check that the command finishes without errors
- [x] The params file has an empty str in the key `target_capture_kit`

## Review

- [x] Tests executed by SD
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [x] Deployed to stage:
```shell
Getting deployer... done.
Getting last commit message and SHA... done.
Getting version of deploy scripts... /home/hiseq.clinical
done.
Log deploy... done.
cg, version 78.2.1
[13:58] [hiseq.clinical@hasta:~] [S_base]  $
```
- [ ] Deployed to production:
```shell

```
