### PR TITLE
Separate Balsamic and Balsamic-UMI

### DIFF
--- a/cg/cli/workflow/balsamic/umi.py
+++ b/cg/cli/workflow/balsamic/umi.py
@@ -1,22 +1,21 @@
 """CLI support to create config and/or start BALSAMIC """
 
 import logging
+from typing import cast
 
 import rich_click as click
 
 from cg.cli.utils import CLICK_CONTEXT_SETTINGS
-from cg.cli.workflow.balsamic.base import (
-    config_case,
-    report_deliver,
-    run,
-    start,
-    start_available,
-    store,
-    store_available,
-    store_housekeeper,
-)
-from cg.cli.workflow.commands import link, resolve_compression
+from cg.cli.workflow.balsamic.base import report_deliver, store, store_available, store_housekeeper
+from cg.cli.workflow.balsamic.options import OPTION_PANEL_BED, OPTION_WORKFLOW_PROFILE
+from cg.cli.workflow.commands import ARGUMENT_CASE_ID, link, resolve_compression
+from cg.constants import Workflow
 from cg.meta.workflow.balsamic_umi import BalsamicUmiAnalysisAPI
+from cg.models.cg_config import CGConfig
+from cg.services.analysis_starter.analysis_starter import AnalysisStarter
+from cg.services.analysis_starter.configurator.implementations.balsamic import BalsamicConfigurator
+from cg.services.analysis_starter.factories.configurator_factory import ConfiguratorFactory
+from cg.services.analysis_starter.factories.starter_factory import AnalysisStarterFactory
 
 LOG = logging.getLogger(__name__)
 
@@ -38,11 +37,62 @@ def balsamic_umi(context: click.Context):
 
 balsamic_umi.add_command(resolve_compression)
 balsamic_umi.add_command(link)
-balsamic_umi.add_command(config_case)
-balsamic_umi.add_command(run)
 balsamic_umi.add_command(report_deliver)
 balsamic_umi.add_command(store_housekeeper)
-balsamic_umi.add_command(start)
-balsamic_umi.add_command(start_available)
 balsamic_umi.add_command(store)
 balsamic_umi.add_command(store_available)
+
+
+@balsamic_umi.command("config-case")
+@OPTION_PANEL_BED
+@ARGUMENT_CASE_ID
+@click.pass_obj
+def config_case(cg_config: CGConfig, case_id: str, panel_bed: str | None):
+    """Configure a Balsamic case so that it is ready to be run."""
+    factory = ConfiguratorFactory(cg_config)
+    configurator = cast(BalsamicConfigurator, factory.get_configurator(Workflow.BALSAMIC_UMI))
+    configurator.configure(case_id=case_id, panel_bed=panel_bed)
+
+
+@balsamic_umi.command("run")
+@OPTION_WORKFLOW_PROFILE
+@ARGUMENT_CASE_ID
+@click.pass_obj
+def run(cg_config: CGConfig, case_id: str, workflow_profile: click.Path | None):
+    """Run a preconfigured Balsamic case."""
+    factory = AnalysisStarterFactory(cg_config)
+    analysis_starter: AnalysisStarter = factory.get_analysis_starter_for_workflow(
+        Workflow.BALSAMIC_UMI
+    )
+    analysis_starter.run(case_id=case_id, workflow_profile=workflow_profile)
+
+
+@balsamic_umi.command("start")
+@OPTION_PANEL_BED
+@OPTION_WORKFLOW_PROFILE
+@ARGUMENT_CASE_ID
+@click.pass_obj
+def start(
+    cg_config: CGConfig,
+    case_id: str,
+    panel_bed: str | None,
+    workflow_profile: click.Path | None,
+):
+    """Start a Balsamic case. Configures the case if needed."""
+    factory = AnalysisStarterFactory(cg_config)
+    analysis_starter: AnalysisStarter = factory.get_analysis_starter_for_workflow(
+        Workflow.BALSAMIC_UMI
+    )
+    analysis_starter.start(case_id=case_id, workflow_profile=workflow_profile, panel_bed=panel_bed)
+
+
+@balsamic_umi.command("start-available")
+@click.pass_obj
+def start_available(cg_config: CGConfig):
+    """Starts all available raredisease cases."""
+    LOG.info("Starting Balsamic workflow for all available cases.")
+    factory = AnalysisStarterFactory(cg_config)
+    analysis_starter = factory.get_analysis_starter_for_workflow(Workflow.BALSAMIC_UMI)
+    succeeded: bool = analysis_starter.start_available()
+    if not succeeded:
+        raise click.Abort


### PR DESCRIPTION
## Description

The commands for Balsamic-UMI are imported from the Balsamic commands, meaning that they are currently starting balsamic cases. This PR makes sure that `cg workflow balsamic-umi config-case`, `cg workflow balsamic-umi run`, `cg workflow balsamic-umi start` and `cg workflow balsamic-umi start-available` handles balsamic cases.

### Added

-

### Changed

-

### Fixed

- Balsamic-UMI handles balsamic-umi cases


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
