### PR TITLE
Add balsamic umi commands

### DIFF
--- a/cg/cli/workflow/balsamic/umi.py
+++ b/cg/cli/workflow/balsamic/umi.py
@@ -97,7 +97,7 @@ def config_case(
     cache_version: str,
     dry_run: bool,
 ):
-    """Create config file for BALSAMIC analysis for a given CASE_ID."""
+    """Create config file for BALSAMIC UMI analysis for a given CASE_ID."""
 
     analysis_api: BalsamicUmiAnalysisAPI = context.meta_apis["analysis_api"]
     try:
@@ -136,7 +136,7 @@ def run(
     slurm_quality_of_service: str,
     dry_run: bool,
 ):
-    """Run balsamic analysis for given CASE ID"""
+    """Run Balsamic UMI analysis for given CASE ID"""
     analysis_api: BalsamicUmiAnalysisAPI = context.meta_apis["analysis_api"]
     try:
         analysis_api.status_db.verify_case_exists(case_internal_id=case_id)
@@ -217,7 +217,7 @@ def start_available(context: click.Context, dry_run: bool = False, limit: int | 
     analysis_api: BalsamicUmiAnalysisAPI = context.obj.meta_apis["analysis_api"]
 
     cases: list[Case] = analysis_api.get_cases_to_analyze(limit=limit)
-    LOG.info(f"Starting {len(cases)} available Balsamic cases")
+    LOG.info(f"Starting {len(cases)} available Balsamic UMI cases")
 
     exit_code: int = EXIT_SUCCESS
     for case in cases:


### PR DESCRIPTION
## Description

We accidentally removed balsamic umi commands when refactoring the start logic (#4732). This PR aims to implement balsamic umi again, and restore previous functionality.

### Added

Balsamic umi commands:

- Run
- Config
- Start
- Start-available

### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b enable-balsamic-umi
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
