### PR TITLE
patch raredisease base command

### DIFF
--- a/cg/cli/workflow/raredisease/base.py
+++ b/cg/cli/workflow/raredisease/base.py
@@ -16,7 +16,9 @@ from cg.cli.workflow.nf_analysis import (
     store_available,
     store_housekeeper,
 )
-from cg.constants.constants import Workflow
+from cg.constants.constants import MetaApis, Workflow
+from cg.meta.workflow.analysis import AnalysisAPI
+from cg.meta.workflow.raredisease import RarediseaseAnalysisAPI
 from cg.models.cg_config import CGConfig
 from cg.services.analysis_starter.analysis_starter import AnalysisStarter
 from cg.services.analysis_starter.configurator.implementations.nextflow import NextflowConfigurator
@@ -30,8 +32,8 @@ LOG = logging.getLogger(__name__)
 @click.pass_context
 def raredisease(context: click.Context) -> None:
     """NF-core/raredisease analysis workflow."""
-    if context.invoked_subcommand is None:
-        click.echo(context.get_help())
+    AnalysisAPI.get_help(context)
+    context.obj.meta_apis[MetaApis.ANALYSIS_API] = RarediseaseAnalysisAPI(config=context.obj)
 
 
 raredisease.add_command(metrics_deliver)


### PR DESCRIPTION
## Description
On the pipeline integration project, the base command `cg workflow raredisease` was modified to exclude the AnalysisAPI. This was incorrect, as it is still needed for the storing commands. This PR rolls back that change

### Added

-

### Changed

-

### Fixed

-


### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b patch-raredisease-base-command -a
    ```

### How to test

- [x] Do `cg workflow raredisease store-available` 

### Expected test outcome

- [x] Check that the command does not fail
- [ ] Take a screenshot and attach or copy/paste the output. (no output when command is succesful)

## Review

- [x] Tests executed by SD
- [x] "Merge and deploy" approved by IO
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Deployed to stage:
```shell

```
- [ ] Deployed to production:
```shell

```
