### PR TITLE
Rewrite microsalt tests

### DIFF
--- a/tests/services/analysis_starter/tracker/test_microsalt_tracker.py
+++ b/tests/services/analysis_starter/tracker/test_microsalt_tracker.py
@@ -71,7 +71,7 @@ def test_microsalt_tracker_successful(
         fastq_directory="fastq/dir",
     )
 
-    # GIVEN an order, sample and case
+    # GIVEN an order, sample and case in StatusDB
     order: Order = create_autospec(Order, id=567, ticket_id=ticket_id)
     sample: Sample = create_autospec(Sample, internal_id="microsalt_sample")
 


### PR DESCRIPTION
## Description

Rewrite microSALT tracker tests to not use in memory database or the `cg_context` fixture
Closes [#64](https://github.com/Clinical-Genomics/pipeline-integration/issues/64)

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


