### PR TITLE
remove `workflow_bin_path` for taxprofiler 

### DIFF
--- a/cg/meta/workflow/nf_analysis.py
+++ b/cg/meta/workflow/nf_analysis.py
@@ -57,7 +57,6 @@ class NfAnalysisAPI(AnalysisAPI):
         super().__init__(workflow=workflow, config=config)
         self.workflow: Workflow = workflow
         self.root_dir: str | None = None
-        self.workflow_bin_path: str | None = None
         self.references: str | None = None
         self.profile: str | None = None
         self.conda_env: str | None = None

--- a/cg/meta/workflow/taxprofiler.py
+++ b/cg/meta/workflow/taxprofiler.py
@@ -33,7 +33,6 @@ class TaxprofilerAnalysisAPI(NfAnalysisAPI):
     ):
         super().__init__(config=config, workflow=workflow)
         self.root_dir: str = config.taxprofiler.root
-        self.workflow_bin_path: str = config.taxprofiler.workflow_bin_path
         self.profile: str = config.taxprofiler.profile
         self.conda_env: str = config.taxprofiler.conda_env
         self.conda_binary: str = config.taxprofiler.conda_binary

--- a/cg/models/cg_config.py
+++ b/cg/models/cg_config.py
@@ -314,7 +314,6 @@ class TaxprofilerConfig(CommonAppConfig):
     params: str
     config: str
     resources: str
-    workflow_bin_path: str
     pre_run_script: str = ""
     profile: str
     repository: str

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2246,7 +2246,6 @@ def context_config(
             "config": str(nf_analysis_pipeline_config_path),
             "resources": str(nf_analysis_pipeline_resource_optimisation_path),
             "launch_directory": Path("path", "to", "launchdir").as_posix(),
-            "workflow_bin_path": Path("workflow", "path").as_posix(),
             "pre_run_script": "",
             "profile": "myprofile",
             "repository": "https://some_url",

--- a/tests/fixture_plugins/analysis_starter/pipeline_config_fixtures.py
+++ b/tests/fixture_plugins/analysis_starter/pipeline_config_fixtures.py
@@ -48,7 +48,6 @@ def get_nextflow_config_dict(
             "config": str(nf_analysis_pipeline_config_path),
             "resources": str(nf_analysis_pipeline_resource_optimisation_path),
             "launch_directory": Path("path", "to", "launchdir").as_posix(),
-            "workflow_bin_path": Path("workflow", "path").as_posix(),
             "profile": "myprofile",
             "references": Path("path", "to", "references").as_posix(),
             "repository": nextflow_repository,


### PR DESCRIPTION
## Description

### Added

-

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b test-taxprofiler -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
