### PR TITLE
Added the database id to the response of the endpoint

### DIFF
--- a/cg/server/endpoints/sequencing_run/dtos.py
+++ b/cg/server/endpoints/sequencing_run/dtos.py
@@ -29,6 +29,7 @@ class PacbioSmrtCellMetricsResponse(BaseModel):
 
 
 class PacbioSequencingRunDTO(BaseModel):
+    id: int
     run_name: str
     comment: str
     processed: bool

--- a/cg/services/run_devices/pacbio/sequencing_runs_service.py
+++ b/cg/services/run_devices/pacbio/sequencing_runs_service.py
@@ -30,6 +30,7 @@ class PacbioSequencingRunsService:
         runs: list[PacbioSequencingRunDTO] = []
         for db_run in db_runs:
             run = PacbioSequencingRunDTO(
+                id=db_run.id,
                 run_name=db_run.run_name,
                 comment=db_run.comment,
                 processed=db_run.processed,

--- a/tests/server/endpoints/test_pacbio_sequencing_runs_endpoint.py
+++ b/tests/server/endpoints/test_pacbio_sequencing_runs_endpoint.py
@@ -18,9 +18,11 @@ def test_get_pacbio_sequencing_runs(client: FlaskClient):
         return_value=PacbioSequencingRunResponse(
             pacbio_sequencing_runs=[
                 PacbioSequencingRunDTO(
-                    run_name="rudolf", comment="This one was crazy!", processed=True
+                    id=9, run_name="rudolf", comment="This one was crazy!", processed=True
                 ),
-                PacbioSequencingRunDTO(run_name="santa", comment="Ho, Ho, Ho", processed=False),
+                PacbioSequencingRunDTO(
+                    id=1, run_name="santa", comment="Ho, Ho, Ho", processed=False
+                ),
             ],
             total_count=2,
         )
@@ -36,8 +38,8 @@ def test_get_pacbio_sequencing_runs(client: FlaskClient):
     assert response.json
     assert response.json["total_count"] == 2
     assert response.json["pacbio_sequencing_runs"] == [
-        {"run_name": "rudolf", "comment": "This one was crazy!", "processed": True},
-        {"run_name": "santa", "comment": "Ho, Ho, Ho", "processed": False},
+        {"id": 9, "run_name": "rudolf", "comment": "This one was crazy!", "processed": True},
+        {"id": 1, "run_name": "santa", "comment": "Ho, Ho, Ho", "processed": False},
     ]
 
 

--- a/tests/services/run_devices/pacbio/test_pacbio_sequencing_runs_service.py
+++ b/tests/services/run_devices/pacbio/test_pacbio_sequencing_runs_service.py
@@ -57,12 +57,17 @@ def test_get_all_pacbio_sequencing_runs():
     runs = [
         create_autospec(
             PacbioSequencingRun,
+            id=6,
             run_name="santas_little_helper",
             comment="hunden i Simpsons",
             processed=True,
         ),
         create_autospec(
-            PacbioSequencingRun, run_name="Nisse", comment="Tomtens hjälpreda", processed=False
+            PacbioSequencingRun,
+            id=4,
+            run_name="Nisse",
+            comment="Tomtens hjälpreda",
+            processed=False,
         ),
     ]
     status_db: Store = create_autospec(Store)
@@ -80,9 +85,11 @@ def test_get_all_pacbio_sequencing_runs():
     assert sequencing_runs == PacbioSequencingRunResponse(
         pacbio_sequencing_runs=[
             PacbioSequencingRunDTO(
-                run_name="santas_little_helper", comment="hunden i Simpsons", processed=True
+                id=6, run_name="santas_little_helper", comment="hunden i Simpsons", processed=True
             ),
-            PacbioSequencingRunDTO(run_name="Nisse", comment="Tomtens hjälpreda", processed=False),
+            PacbioSequencingRunDTO(
+                id=4, run_name="Nisse", comment="Tomtens hjälpreda", processed=False
+            ),
         ],
         total_count=2,
     )


### PR DESCRIPTION
## Description

### Added

- The ID to the response for the endpoint called: "pacbio_sequencing_runs"
The new response:
```
{
  "pacbio_sequencing_runs": [
    {
      "comment": "Comment",
      "id": 11,
      "processed": false,
      "run_name": "THE_RUN_NAME"
    }, 
  ],
  "total_count": 1
}
```
### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
