### PR TITLE
Feat(taxprofiler):Remove _pe suffix from deliverables

### DIFF
--- a/cg/resources/taxprofiler_bundle_filenames.yaml
+++ b/cg/resources/taxprofiler_bundle_filenames.yaml
@@ -5,7 +5,7 @@
   tag: kraken2_combined_report
 - format: txt
   id: SAMPLEID
-  path: PATHTOCASE/kraken2/k2_pluspf/SAMPLENAME_k2_pluspf.kraken2.kraken2.report.txtt
+  path: PATHTOCASE/kraken2/k2_pluspf/SAMPLENAME_k2_pluspf.kraken2.kraken2.report.txt
   step: kraken2
   tag: kraken2_report
 - format: txt


### PR DESCRIPTION
## Description
This PR removes `_pe` from taxprofiler deliverables. To be tested together with [Hermes PR](https://github.com/Clinical-Genomics/hermes/pull/155)

### Changed

- Removes` _pe` from taxprofiler deliverables.



### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b fix_deliverables_taxprofiler -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
