### PR TITLE
Patch CompressAPI instantiation

### DIFF
--- a/cg/services/analysis_starter/factories/starter_factory.py
+++ b/cg/services/analysis_starter/factories/starter_factory.py
@@ -3,7 +3,9 @@ import logging
 from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.constants import Workflow
 from cg.meta.archive.archive import SpringArchiveAPI
+from cg.meta.backup.backup import SpringBackupAPI
 from cg.meta.compress import CompressAPI
+from cg.meta.encryption.encryption import SpringEncryptionAPI
 from cg.models.cg_config import CGConfig
 from cg.services.analysis_starter.analysis_starter import AnalysisStarter
 from cg.services.analysis_starter.configurator.configurator import Configurator
@@ -25,6 +27,7 @@ from cg.services.analysis_starter.tracker.implementations.microsalt import Micro
 from cg.services.analysis_starter.tracker.implementations.mip_dna import MIPDNATracker
 from cg.services.analysis_starter.tracker.implementations.nextflow_tracker import NextflowTracker
 from cg.services.analysis_starter.tracker.tracker import Tracker
+from cg.services.pdc_service.pdc_service import PdcService
 from cg.store.store import Store
 
 LOG = logging.getLogger(__name__)
@@ -65,6 +68,13 @@ class AnalysisStarterFactory:
                 data_flow_config=self.cg_config.data_flow,
             )
             compress_api = CompressAPI(
+                backup_api=SpringBackupAPI(
+                    encryption_api=SpringEncryptionAPI(
+                        binary_path=self.cg_config.encryption.binary_path
+                    ),
+                    hk_api=self.cg_config.housekeeper_api,
+                    pdc_service=PdcService(self.cg_config.pdc.binary_path),
+                ),
                 hk_api=self.housekeeper_api,
                 crunchy_api=self.cg_config.crunchy_api,
                 demux_root=self.cg_config.run_instruments.illumina.demultiplexed_runs_dir,

--- a/tests/cli/workflow/balsamic/test_cli_balsamic.py
+++ b/tests/cli/workflow/balsamic/test_cli_balsamic.py
@@ -7,7 +7,14 @@ from pytest_mock import MockerFixture
 
 from cg.cli.workflow.balsamic.base import config_case, run, start
 from cg.constants import Workflow
-from cg.models.cg_config import BalsamicConfig, CGConfig, IlluminaConfig, RunInstruments
+from cg.models.cg_config import (
+    BalsamicConfig,
+    CGConfig,
+    CommonAppConfig,
+    Encryption,
+    IlluminaConfig,
+    RunInstruments,
+)
 from cg.services.analysis_starter.analysis_starter import AnalysisStarter
 from cg.services.analysis_starter.configurator.implementations.balsamic import BalsamicConfigurator
 from cg.services.analysis_starter.factories.configurator_factory import ConfiguratorFactory
@@ -20,6 +27,8 @@ def cg_config_for_balsamic_cli(cg_balsamic_config: BalsamicConfig) -> CGConfig:
         CGConfig,
         balsamic=cg_balsamic_config,
         data_flow=Mock(),
+        encryption=create_autospec(Encryption, binary_path="encryption.bin"),
+        pdc=create_autospec(CommonAppConfig, binary_path="pdc.bin"),
         run_instruments=create_autospec(
             RunInstruments,
             illumina=create_autospec(IlluminaConfig, demultiplexed_runs_dir="some_dir"),

--- a/tests/cli/workflow/mip/test_cli_mip_dna.py
+++ b/tests/cli/workflow/mip/test_cli_mip_dna.py
@@ -6,7 +6,14 @@ from pytest_mock import MockerFixture
 
 from cg.cli.workflow.mip_dna.base import config_case, run, start
 from cg.constants import Workflow
-from cg.models.cg_config import CGConfig, IlluminaConfig, MipConfig, RunInstruments
+from cg.models.cg_config import (
+    CGConfig,
+    CommonAppConfig,
+    Encryption,
+    IlluminaConfig,
+    MipConfig,
+    RunInstruments,
+)
 from cg.services.analysis_starter.analysis_starter import AnalysisStarter
 from cg.services.analysis_starter.configurator.implementations.mip_dna import MIPDNAConfigurator
 from cg.services.analysis_starter.factories.configurator_factory import ConfiguratorFactory
@@ -28,6 +35,8 @@ def cg_config() -> CGConfig:
         CGConfig,
         mip_rd_dna=mip_rd_dna_config,
         data_flow=Mock(),
+        encryption=create_autospec(Encryption, binary_path="encryption.bin"),
+        pdc=create_autospec(CommonAppConfig, binary_path="pdc.bin"),
         run_instruments=create_autospec(
             RunInstruments,
             illumina=create_autospec(IlluminaConfig, demultiplexed_runs_dir="some_dir"),

--- a/tests/services/analysis_starter/test_analysis_starter_factory.py
+++ b/tests/services/analysis_starter/test_analysis_starter_factory.py
@@ -9,6 +9,8 @@ from cg.meta.compress import CompressAPI
 from cg.models.cg_config import (
     BalsamicConfig,
     CGConfig,
+    CommonAppConfig,
+    Encryption,
     IlluminaConfig,
     MipConfig,
     NalloConfig,
@@ -49,6 +51,8 @@ def test_analysis_starter_factory_balsamic(cg_balsamic_config: BalsamicConfig):
         CGConfig,
         balsamic=cg_balsamic_config,
         data_flow=Mock(),
+        encryption=create_autospec(Encryption, binary_path="encryption.bin"),
+        pdc=create_autospec(CommonAppConfig, binary_path="pdc.bin"),
         run_instruments=create_autospec(
             RunInstruments,
             illumina=create_autospec(IlluminaConfig, demultiplexed_runs_dir="some_dir"),
@@ -104,6 +108,8 @@ def test_analysis_starter_factory_mip_dna():
         CGConfig,
         mip_rd_dna=mip_rd_dna_config,
         data_flow=Mock(),
+        encryption=create_autospec(Encryption, binary_path="encryption.bin"),
+        pdc=create_autospec(CommonAppConfig, binary_path="pdc.bin"),
         run_instruments=create_autospec(
             RunInstruments,
             illumina=create_autospec(IlluminaConfig, demultiplexed_runs_dir="some_dir"),
@@ -151,6 +157,8 @@ def test_get_analysis_starter_for_workflow_nextflow_fastq(
     cg_config: CGConfig = create_autospec(
         CGConfig,
         data_flow=Mock(),
+        encryption=create_autospec(Encryption, binary_path="encryption.bin"),
+        pdc=create_autospec(CommonAppConfig, binary_path="pdc.bin"),
         raredisease=raredisease_config_object,
         rnafusion=rnafusion_config_object,
         run_instruments=create_autospec(
@@ -195,6 +203,7 @@ def test_get_analysis_starter_for_workflow_nextflow_fastq(
     )
     mock_compress_api_init.assert_called_once_with(
         ANY,
+        backup_api=ANY,
         hk_api=cg_config.housekeeper_api,
         crunchy_api=cg_config.crunchy_api,
         demux_root=cg_config.run_instruments.illumina.demultiplexed_runs_dir,


### PR DESCRIPTION
## Description

The instantiation of the CompressAPI in the AnalysisStarterFactory has been broken for a couple of months. No SpringBackupAPI is injected. This PR addresses that.

### Added

-

### Changed

-

### Fixed

- The CompressAPI gets a SpringBackupAPI injected in the AnalysisStarterFactory


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b patch-compress-api-instantiation
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
