### PR TITLE
Make sure that a failure in the HK storing of Pacbio files does not add entries to StatusDB

### DIFF
--- a/cg/services/run_devices/pacbio/post_processing_service.py
+++ b/cg/services/run_devices/pacbio/post_processing_service.py
@@ -57,8 +57,8 @@ class PacBioPostProcessingService(PostProcessingService):
             run_name=run_name, sequencing_dir=self.sequencing_dir
         )
         self.run_validator.ensure_post_processing_can_start(run_data)
-        self.store_service.store_post_processing_data(run_data=run_data, dry_run=dry_run)
         self.hk_service.store_files_in_housekeeper(run_data=run_data, dry_run=dry_run)
+        self.store_service.store_post_processing_data(run_data=run_data, dry_run=dry_run)
         self._touch_post_processing_complete(run_data=run_data, dry_run=dry_run)
 
     def is_run_processed(self, run_name: str) -> bool:


### PR DESCRIPTION
## Description
(SEMI-HOT PATCH)

This patch comes as a consequence of some PacBio cases having their post-processing failing in the Housekeeper's storage of files but post-processing being successful in StatusDB. In these cases, all StatusDB changes were commited to the database as if the post-processing would have been successful when in reality it failed. This made StatusDB look as if the post-processing was successful, which caused some analyses being started without `.bam` files in Housekeeper. 

This patch changes the order of the services called, storing first in Housekeeper and then in StatusDB, so that a failure in Housekeeper does not add any entry in StatusDB.

NOTE: This PR makes the opposite scenario possible, when a failure in StatusDB storage would cause Housekeeper look like the post-processing was successful. This, however and under our judgement, is not critical as Housekeeper is not consulted to start analyses nor any critical operation in our system, as StatusDB is.

### Changed

- The order of calling storage services in the PacBio post-processing: `hk_service.store_files_in_housekeeper` is called before `store_service.store_post_processing_data`
- Change tests so that it ensures StatusDB service was not called when HK fails



### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
