### PR TITLE
Reduce spamming in PacBio post-processing logs

### DIFF
--- a/cg/services/run_devices/pacbio/post_processing_service.py
+++ b/cg/services/run_devices/pacbio/post_processing_service.py
@@ -67,7 +67,7 @@ class PacBioPostProcessingService(PostProcessingService):
         return processing_complete_file.exists()
 
     def can_post_processing_start(self, run_name: str) -> bool:
-        LOG.info(f"Checking if Pacbio post-processing can start for run: {run_name}")
+        LOG.debug(f"Checking if Pacbio post-processing can start for run: {run_name}")
         parent_directory: Path = Path(self.sequencing_dir, run_name).parent
         all_smrt_cells_are_ready: bool = all(
             self.is_smrt_cell_ready_for_post_processing(f"{parent_directory.name}/{smrt_cell.name}")
@@ -76,7 +76,7 @@ class PacBioPostProcessingService(PostProcessingService):
         return all_smrt_cells_are_ready
 
     def is_smrt_cell_ready_for_post_processing(self, run_name: str) -> bool:
-        LOG.info(f"Checking if Pacbio SMRT-cell {run_name} is ready for postprocessing")
+        LOG.debug(f"Checking if Pacbio SMRT-cell {run_name} is ready for postprocessing")
         try:
             run_data: PacBioRunData = self.run_data_generator.get_run_data(
                 run_name=run_name, sequencing_dir=self.sequencing_dir


### PR DESCRIPTION
## Description
The logs for pacbio post-processing has too many lines of monitoring runs for its post-processing status. What is really important to have in the logs is the cases when it fails. This PR makes the useless lines not be in the logs

### Changed

- Some INFO logs to DEBUG

- [x] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Deployed to stage
- [x] Deployed to prod
