### PR TITLE
Raredisease: add QC contamination check

### DIFF
--- a/cg/constants/nf_analysis.py
+++ b/cg/constants/nf_analysis.py
@@ -24,6 +24,7 @@ RAREDISEASE_METRIC_CONDITIONS_WES: dict[str, dict[str, Any]] = {
     "GC_DROPOUT": {"norm": "lt", "threshold": 10},
     RAREDISEASE_PREDICTED_SEX_METRIC: {"norm": "eq", "threshold": None},
     "gender": {"norm": "eq", "threshold": None},
+    "FREEMIX": {"norm": "lt", "threshold": 0.02},
 }
 
 RAREDISEASE_METRIC_CONDITIONS_WGS: dict[str, dict[str, Any]] = {
@@ -35,6 +36,7 @@ RAREDISEASE_METRIC_CONDITIONS_WGS: dict[str, dict[str, Any]] = {
     "GC_DROPOUT": {"norm": "lt", "threshold": 5},
     RAREDISEASE_PREDICTED_SEX_METRIC: {"norm": "eq", "threshold": None},
     "gender": {"norm": "eq", "threshold": None},
+    "FREEMIX": {"norm": "lt", "threshold": 0.02},
 }
 
 RAREDISEASE_PARENT_PEDDY_METRIC_CONDITION: dict[str, dict[str, Any]] = {

--- a/tests/fixtures/analysis/raredisease/multiqc_data.json
+++ b/tests/fixtures/analysis/raredisease/multiqc_data.json
@@ -242,7 +242,8 @@
         {
             "ADM1": {
                 "Contamination Status": "YES",
-                "Contamination Level": "ND"
+                "Contamination Level": "ND",
+                "FREEMIX": 5.68993e-05
             }
         },
         {

--- a/tests/fixtures/analysis/raredisease/raredisease_case_enough_reads_metrics_deliverables.yaml
+++ b/tests/fixtures/analysis/raredisease/raredisease_case_enough_reads_metrics_deliverables.yaml
@@ -1297,6 +1297,15 @@ metrics:
   name: Contamination Level
   step: multiqc
   value: ND
+- condition:
+    norm: lt
+    threshold: 0.02
+  header: null
+  id: ADM1
+  input: multiqc_data.json
+  name: FREEMIX
+  step: multiqc
+  value: 5.68993e-05
 - condition: null
   header: null
   id: ADM2


### PR DESCRIPTION
## Description
This PR adds a 2% contamination threshold for VerifyBamid2 for Raredisease samples.

Closes: https://github.com/Clinical-Genomics/cg/issues/4855


### Added

- Raredisease: add verifybamid2 QC contamination check

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b raredisease-add-contamination-QC
    ```

### How to test

- [ ] Using NIST case evolvedsalmon
- [ ] Do `cg workflow raredisease metrics-deliver evolvedsalmon`
- [ ] Edit the multiqc_data.json file and make the Freemix value 0.03
- [ ] Do `cg workflow raredisease metrics-deliver evolvedsalmon`

### Expected test outcome

- [ ] Check that command completes without error.
- [ ] Then, after changing the value to 0.03, check that the command fails.
- [ ] Take a screenshot and attach or copy/paste the output.
<img width="899" height="226" alt="image" src="https://github.com/user-attachments/assets/42f35b3c-0c71-4d95-85b8-267ceba9f79c" />


## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
