### PR TITLE
Patch error message for decompression

### DIFF
--- a/cg/meta/compress/compress.py
+++ b/cg/meta/compress/compress.py
@@ -258,7 +258,9 @@ class CompressAPI:
             LOG.warning(f"Could not find any spring paths for {sample.internal_id}")
         for compression in spring_paths:
             if not compression.is_spring_decompression_done:
-                LOG.info(f"SPRING to FASTQ decompression not finished {sample.internal_id}")
+                LOG.info(
+                    f"SPRING to FASTQ decompression has not completed or was never started for {sample.internal_id}"
+                )
                 return False
 
             fastq_first: Path = compression.fastq_first


### PR DESCRIPTION
## Description

Message makes the user think that CG has checked that a decompression slurm job is running, but this is not the case. 
"SPRING to FASTQ decompression not finished {sample.internal_id}"

### Changed

- f"SPRING to FASTQ decompression has not completed or was never started for {sample.internal_id}"

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
