### PR TITLE
fix order of uploads for Nallo

### DIFF
--- a/cg/meta/upload/nallo/nallo_upload_api.py
+++ b/cg/meta/upload/nallo/nallo_upload_api.py
@@ -31,6 +31,13 @@ class NalloUploadAPI(UploadAPI):
         """Uploads NALLO analysis data and files."""
         analysis: Analysis = self.status_db.get_latest_completed_analysis_for_case(case.internal_id)
         self.update_upload_started_at(analysis=analysis)
+
+        # Main upload
+        genome_version: GenomeBuild = WORKFLOW_TO_GENOME_VERSION_MAP[Workflow.NALLO]
+        ctx.invoke(upload_coverage, family_id=case.internal_id, genome_version=genome_version.name)
+        ctx.invoke(upload_observations_to_loqusdb, case_id=case.internal_id)
+        ctx.invoke(upload_to_gens, case_id=case.internal_id)
+
         # Delivery report generation
         if case.data_delivery in REPORT_SUPPORTED_DATA_DELIVERY:
             ctx.invoke(generate_delivery_report, case_id=case.internal_id)
@@ -41,12 +48,6 @@ class NalloUploadAPI(UploadAPI):
         LOG.info(
             f"Upload of case {case.internal_id} was successful. Uploaded at {dt.datetime.now()} in StatusDB"
         )
-
-        genome_version: GenomeBuild = WORKFLOW_TO_GENOME_VERSION_MAP[Workflow.NALLO]
-
-        ctx.invoke(upload_observations_to_loqusdb, case_id=case.internal_id)
-        ctx.invoke(upload_to_gens, case_id=case.internal_id)
-        ctx.invoke(upload_coverage, family_id=case.internal_id, genome_version=genome_version.name)
 
         # Clinical delivery upload
         self.upload_files_to_customer_inbox(case)

--- a/tests/meta/upload/nallo/test_nallo_upload_api.py
+++ b/tests/meta/upload/nallo/test_nallo_upload_api.py
@@ -94,11 +94,11 @@ def test_upload_succeeds():
 
     # THEN a delivery report has been generated and the case has been uploaded to scout and loqusdb
     invoke_calls = [
-        call(generate_delivery_report, case_id="case_id"),
-        call(upload_to_scout, case_id="case_id", re_upload=False),
+        call(upload_coverage, family_id="case_id", genome_version="hg38"),
         call(upload_observations_to_loqusdb, case_id="case_id"),
         call(upload_to_gens, case_id="case_id"),
-        call(upload_coverage, family_id="case_id", genome_version="hg38"),
+        call(generate_delivery_report, case_id="case_id"),
+        call(upload_to_scout, case_id="case_id", re_upload=False),
     ]
 
     click_context.as_mock.invoke.assert_has_calls(invoke_calls)


### PR DESCRIPTION
## Description
The delivery report generation needs the case to be uploaded to Chanjo first. This PR ensures that a Nallo case uploads to Chanjo before attempting the generation of the delivery report.

### Changed

- The order of the upload commands for Nallo. Specifically, put `upload_coverage` before `generate_delivery_report`. Follows the same order as MIP-DNA


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b fix-upload-order-nallo -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [x] "Merge and deploy" approved by LL
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [x] Deployed to stage:
```shell
Logging deploy ...
Getting deployer... done.
Getting last commit message and SHA... done.
Getting version of deploy scripts... /home/hiseq.clinical
done.
Log deploy... done.
cg, version 84.7.1
[10:56] [hiseq.clinical@hasta:~] [S_base]  $ up
```
- [x] Deployed to production:
```shell
Getting deployer... done.
Getting last commit message and SHA... done.
Getting version of deploy scripts... /home/hiseq.clinical
done.
Log deploy... done.
cg, version 84.7.1
```
