### PR TITLE
Fix naming of cgh file

### DIFF
--- a/cg/resources/raredisease_bundle_filenames.yaml
+++ b/cg/resources/raredisease_bundle_filenames.yaml
@@ -195,7 +195,7 @@
   tag: str_alignment_index
 - format: meta
   id: SAMPLEID
-  path: PATHTOCASE/vcf2cytosure/SAMPLEID.cgh
+  path: PATHTOCASE/vcf2cytosure/SAMPLENAME.cgh
   step: vcf2cytosure
   tag: vcf2cytosure
 - format: bed


### PR DESCRIPTION
## Description

Closes https://github.com/Clinical-Genomics/MTP-RAREDISEASE/issues/110.

When storing an RD case, the code is looking for the vcf2cytosure file using the sample_id while it is in fact named using the sample name. This PR changes the lookup so that the cgh file is added to the Housekeeper bundle and subsequently uploaded to Scout.

### Added

-

### Changed

-

### Fixed

- Reference the cgh file using the sample name in the Raredisease Deliverables file


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b patch-raredisease-cgh-naming -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
