### PR TITLE
Add endpoint for updating lims status

### DIFF
--- a/cg/server/dto/samples/requests.py
+++ b/cg/server/dto/samples/requests.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel, Field
 
+from cg.constants.lims import LimsStatus
 from cg.models.orders.constants import OrderType
 
 
@@ -15,3 +16,12 @@ class SamplesRequest(BaseModel):
     enquiry: str | None = None
     page: int = 1
     page_size: int | None = Field(50, alias="pageSize")
+
+
+class SampleUpdate(BaseModel):
+    internal_id: str
+    lims_status: LimsStatus
+
+
+class SamplesUpdateRequest(BaseModel):
+    samples: list[SampleUpdate]

--- a/cg/server/endpoints/samples.py
+++ b/cg/server/endpoints/samples.py
@@ -1,6 +1,6 @@
 from http import HTTPStatus
 
-from flask import Blueprint, abort, g, jsonify, request
+from flask import Blueprint, Response, abort, g, jsonify, request
 
 from cg.exc import AuthorisationError
 from cg.server.dto.samples.requests import CollaboratorSamplesRequest, SamplesRequest
@@ -55,4 +55,8 @@ def get_samples():
 
 @SAMPLES_BLUEPRINT.route("/samples", methods=["PATCH"])
 def update_samples():
-    return "", HTTPStatus.OK
+    samples_request = request.json
+    for sample in samples_request["samples"]:
+        db_sample = db.get_sample_by_internal_id_strict(sample["internal_id"])
+        db_sample.lims_status = sample["lims_status"]
+    return Response(status=HTTPStatus.NO_CONTENT)

--- a/cg/server/endpoints/samples.py
+++ b/cg/server/endpoints/samples.py
@@ -42,7 +42,7 @@ def parse_sample_in_collaboration(sample_id):
     return jsonify(**sample.to_dict(links=True))
 
 
-@SAMPLES_BLUEPRINT.route("/samples")
+@SAMPLES_BLUEPRINT.route("/samples", methods=["GET"])
 def get_samples():
     """Return samples."""
     samples_request = SamplesRequest.model_validate(request.args.to_dict())
@@ -51,3 +51,8 @@ def get_samples():
     except AuthorisationError:
         return abort(HTTPStatus.FORBIDDEN)
     return jsonify(samples=samples, total=total)
+
+
+@SAMPLES_BLUEPRINT.route("/samples", methods=["PATCH"])
+def update_samples():
+    return "", HTTPStatus.OK

--- a/cg/server/endpoints/samples.py
+++ b/cg/server/endpoints/samples.py
@@ -60,6 +60,7 @@ def get_samples():
 
 @SAMPLES_BLUEPRINT.route("/samples", methods=["PATCH"])
 def update_samples():
+    """Update the lims_status attribute of a list of samples."""
     try:
         samples_request = SamplesUpdateRequest.model_validate(request.json)
         for sample in samples_request.samples:

--- a/cg/server/endpoints/samples.py
+++ b/cg/server/endpoints/samples.py
@@ -1,9 +1,14 @@
 from http import HTTPStatus
 
 from flask import Blueprint, Response, abort, g, jsonify, request
+from pydantic import ValidationError
 
 from cg.exc import AuthorisationError, SampleNotFoundError
-from cg.server.dto.samples.requests import CollaboratorSamplesRequest, SamplesRequest
+from cg.server.dto.samples.requests import (
+    CollaboratorSamplesRequest,
+    SamplesRequest,
+    SamplesUpdateRequest,
+)
 from cg.server.dto.samples.samples_response import SamplesResponse
 from cg.server.endpoints.utils import before_request
 from cg.server.ext import db, sample_service
@@ -55,12 +60,13 @@ def get_samples():
 
 @SAMPLES_BLUEPRINT.route("/samples", methods=["PATCH"])
 def update_samples():
-    samples_request = request.json
     try:
-        for sample in samples_request["samples"]:
-            db_sample = db.get_sample_by_internal_id_strict(sample["internal_id"])
-            db_sample.lims_status = sample["lims_status"]
-    except SampleNotFoundError:
+        samples_request = SamplesUpdateRequest.model_validate(request.json)
+        for sample in samples_request.samples:
+            db.update_sample_lims_status(
+                internal_id=sample.internal_id, lims_status=sample.lims_status
+            )
+    except (SampleNotFoundError, ValidationError):
         return abort(HTTPStatus.BAD_REQUEST)
     db.commit_to_store()
     return Response(status=HTTPStatus.NO_CONTENT)

--- a/cg/server/endpoints/samples.py
+++ b/cg/server/endpoints/samples.py
@@ -2,7 +2,7 @@ from http import HTTPStatus
 
 from flask import Blueprint, Response, abort, g, jsonify, request
 
-from cg.exc import AuthorisationError
+from cg.exc import AuthorisationError, SampleNotFoundError
 from cg.server.dto.samples.requests import CollaboratorSamplesRequest, SamplesRequest
 from cg.server.dto.samples.samples_response import SamplesResponse
 from cg.server.endpoints.utils import before_request
@@ -56,7 +56,11 @@ def get_samples():
 @SAMPLES_BLUEPRINT.route("/samples", methods=["PATCH"])
 def update_samples():
     samples_request = request.json
-    for sample in samples_request["samples"]:
-        db_sample = db.get_sample_by_internal_id_strict(sample["internal_id"])
-        db_sample.lims_status = sample["lims_status"]
+    try:
+        for sample in samples_request["samples"]:
+            db_sample = db.get_sample_by_internal_id_strict(sample["internal_id"])
+            db_sample.lims_status = sample["lims_status"]
+    except SampleNotFoundError:
+        return abort(HTTPStatus.BAD_REQUEST)
+    db.commit_to_store()
     return Response(status=HTTPStatus.NO_CONTENT)

--- a/cg/store/crud/update.py
+++ b/cg/store/crud/update.py
@@ -145,6 +145,7 @@ class UpdateMixin(ReadHandler):
         sequencing_run.processed = processed
         self.commit_to_store()
 
-    def update_sample_lims_status(self, internal_id: str, lims_status: LimsStatus):
-        db_sample = self.get_sample_by_internal_id_strict(internal_id)
-        db_sample.lims_status = lims_status
+    def update_sample_lims_status(self, internal_id: str, lims_status: LimsStatus) -> Sample:
+        sample: Sample = self.get_sample_by_internal_id_strict(internal_id)
+        sample.lims_status = lims_status
+        return sample

--- a/cg/store/crud/update.py
+++ b/cg/store/crud/update.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 from cg.constants import SequencingRunDataAvailability
 from cg.constants.constants import CaseActions, SequencingQCStatus
+from cg.constants.lims import LimsStatus
 from cg.constants.sequencing import Sequencers
 from cg.services.illumina.post_processing.utils import get_q30_threshold
 from cg.store.crud.read import ReadHandler
@@ -143,3 +144,7 @@ class UpdateMixin(ReadHandler):
         sequencing_run: PacbioSequencingRun = self.get_pacbio_sequencing_run_by_id(id)
         sequencing_run.processed = processed
         self.commit_to_store()
+
+    def update_sample_lims_status(self, internal_id: str, lims_status: LimsStatus):
+        db_sample = self.get_sample_by_internal_id_strict(internal_id)
+        db_sample.lims_status = lims_status

--- a/tests/server/endpoints/test_samples_endpoint.py
+++ b/tests/server/endpoints/test_samples_endpoint.py
@@ -19,4 +19,4 @@ def test_update_samples(client: FlaskClient):
     )
 
     # THEN the samples were updated in the database
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.NO_CONTENT

--- a/tests/server/endpoints/test_samples_endpoint.py
+++ b/tests/server/endpoints/test_samples_endpoint.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from unittest.mock import Mock, create_autospec
+from unittest.mock import Mock, call
 
 from flask.testing import FlaskClient
 from pytest_mock import MockerFixture
@@ -7,7 +7,6 @@ from pytest_mock import MockerFixture
 from cg.constants.lims import LimsStatus
 from cg.exc import SampleNotFoundError
 from cg.server.endpoints import samples
-from cg.store.models import Sample
 from cg.store.store import Store
 from tests.typed_mock import TypedMock, create_typed_mock
 
@@ -15,11 +14,6 @@ from tests.typed_mock import TypedMock, create_typed_mock
 def test_update_samples(client: FlaskClient, mocker: MockerFixture):
     # GIVEN a store
     status_db: TypedMock[Store] = create_typed_mock(Store)
-    sample_1 = create_autospec(Sample, internal_id="sample_1", lims_status=LimsStatus.PENDING)
-    sample_2 = create_autospec(Sample, internal_id="sample_2", lims_status=LimsStatus.PENDING)
-    status_db.as_type.get_sample_by_internal_id_strict = lambda internal_id: (
-        sample_1 if internal_id == "sample_1" else sample_2
-    )
     mocker.patch.object(samples, "db", status_db.as_type)
 
     # GIVEN a request body with two sample internal ids and a lims status
@@ -40,15 +34,19 @@ def test_update_samples(client: FlaskClient, mocker: MockerFixture):
     assert response.status_code == HTTPStatus.NO_CONTENT
 
     # THEN the samples were updated in the database
-    assert sample_1.lims_status == LimsStatus.TOP_UP
-    assert sample_2.lims_status == LimsStatus.RE_PREP
+    status_db.as_mock.update_sample_lims_status.assert_has_calls(
+        [
+            call(internal_id="sample_1", lims_status=LimsStatus.TOP_UP),
+            call(internal_id="sample_2", lims_status=LimsStatus.RE_PREP),
+        ]
+    )
     status_db.as_mock.commit_to_store.assert_called_once()
 
 
 def test_update_samples_sample_not_found(client: FlaskClient, mocker: MockerFixture):
     # GIVEN a store that raises an error when trying to get a sample
     status_db: TypedMock[Store] = create_typed_mock(Store)
-    status_db.as_type.get_sample_by_internal_id_strict = Mock(side_effect=SampleNotFoundError())
+    status_db.as_type.update_sample_lims_status = Mock(side_effect=SampleNotFoundError())
     mocker.patch.object(samples, "db", status_db.as_type)
 
     # GIVEN a request body with a sample internal id and a lims status

--- a/tests/server/endpoints/test_samples_endpoint.py
+++ b/tests/server/endpoints/test_samples_endpoint.py
@@ -3,13 +3,13 @@ from unittest.mock import Mock, create_autospec
 
 from flask.testing import FlaskClient
 from pytest_mock import MockerFixture
-from typed_mock import TypedMock, create_typed_mock
 
 from cg.constants.lims import LimsStatus
 from cg.exc import SampleNotFoundError
 from cg.server.endpoints import samples
 from cg.store.models import Sample
 from cg.store.store import Store
+from tests.typed_mock import TypedMock, create_typed_mock
 
 
 def test_update_samples(client: FlaskClient, mocker: MockerFixture):
@@ -55,6 +55,31 @@ def test_update_samples_sample_not_found(client: FlaskClient, mocker: MockerFixt
     request_body = {
         "samples": [
             {"internal_id": "sample_1", "lims_status": "top-up"},
+        ]
+    }
+
+    # WHEN calling the endpoint to update the lims status of the sample
+    response = client.patch(
+        path="/api/v1/samples",
+        json=request_body,
+    )
+
+    # THEN the response should indicate that the sample was not found
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+
+    # THEN the database was not updated
+    status_db.as_mock.commit_to_store.assert_not_called()
+
+
+def test_update_sample_invalid_request_structure(client: FlaskClient, mocker: MockerFixture):
+    # GIVEN a store that raises an error when trying to get a sample
+    status_db: TypedMock[Store] = create_typed_mock(Store)
+    mocker.patch.object(samples, "db", status_db.as_type)
+
+    # GIVEN a request body with an invalid structure
+    request_body = {
+        "not_samples_keys": [
+            {},
         ]
     }
 

--- a/tests/server/endpoints/test_samples_endpoint.py
+++ b/tests/server/endpoints/test_samples_endpoint.py
@@ -1,0 +1,22 @@
+from http import HTTPStatus
+
+from flask.testing import FlaskClient
+
+
+def test_update_samples(client: FlaskClient):
+    # GIVEN a request body with two sample internal ids and a lims status
+    request_body = {
+        "samples": [
+            {"internal_id": "sample_1", "lims_status": "top-up"},
+            {"internal_id": "sample_2", "lims_status": "re-prep"},
+        ]
+    }
+
+    # WHEN calling the endpoint to update the lims statuses of the samples
+    response = client.patch(
+        path="/api/v1/samples",
+        json=request_body,
+    )
+
+    # THEN the samples were updated in the database
+    assert response.status_code == HTTPStatus.OK

--- a/tests/server/endpoints/test_samples_endpoint.py
+++ b/tests/server/endpoints/test_samples_endpoint.py
@@ -1,9 +1,27 @@
 from http import HTTPStatus
+from unittest.mock import Mock, create_autospec
 
 from flask.testing import FlaskClient
+from pytest_mock import MockerFixture
+from typed_mock import TypedMock, create_typed_mock
+
+from cg.constants.lims import LimsStatus
+from cg.exc import SampleNotFoundError
+from cg.server.endpoints import samples
+from cg.store.models import Sample
+from cg.store.store import Store
 
 
-def test_update_samples(client: FlaskClient):
+def test_update_samples(client: FlaskClient, mocker: MockerFixture):
+    # GIVEN a store
+    status_db: TypedMock[Store] = create_typed_mock(Store)
+    sample_1 = create_autospec(Sample, internal_id="sample_1", lims_status=LimsStatus.PENDING)
+    sample_2 = create_autospec(Sample, internal_id="sample_2", lims_status=LimsStatus.PENDING)
+    status_db.as_type.get_sample_by_internal_id_strict = lambda internal_id: (
+        sample_1 if internal_id == "sample_1" else sample_2
+    )
+    mocker.patch.object(samples, "db", status_db.as_type)
+
     # GIVEN a request body with two sample internal ids and a lims status
     request_body = {
         "samples": [
@@ -18,5 +36,36 @@ def test_update_samples(client: FlaskClient):
         json=request_body,
     )
 
-    # THEN the samples were updated in the database
+    # THEN the response should be successful
     assert response.status_code == HTTPStatus.NO_CONTENT
+
+    # THEN the samples were updated in the database
+    assert sample_1.lims_status == LimsStatus.TOP_UP
+    assert sample_2.lims_status == LimsStatus.RE_PREP
+    status_db.as_mock.commit_to_store.assert_called_once()
+
+
+def test_update_samples_sample_not_found(client: FlaskClient, mocker: MockerFixture):
+    # GIVEN a store that raises an error when trying to get a sample
+    status_db: TypedMock[Store] = create_typed_mock(Store)
+    status_db.as_type.get_sample_by_internal_id_strict = Mock(side_effect=SampleNotFoundError())
+    mocker.patch.object(samples, "db", status_db.as_type)
+
+    # GIVEN a request body with a sample internal id and a lims status
+    request_body = {
+        "samples": [
+            {"internal_id": "sample_1", "lims_status": "top-up"},
+        ]
+    }
+
+    # WHEN calling the endpoint to update the lims status of the sample
+    response = client.patch(
+        path="/api/v1/samples",
+        json=request_body,
+    )
+
+    # THEN the response should indicate that the sample was not found
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+
+    # THEN the database was not updated
+    status_db.as_mock.commit_to_store.assert_not_called()

--- a/tests/store/crud/update/test_update.py
+++ b/tests/store/crud/update/test_update.py
@@ -333,10 +333,13 @@ def test_update_sample_lims_status(store: Store, helpers: StoreHelpers, mocker: 
     commit_spy = mocker.spy(store, "commit_to_store")
 
     # WHEN updating the LIMS status of the sample
-    store.update_sample_lims_status(internal_id=sample_1.internal_id, lims_status=LimsStatus.TOP_UP)
+    updated_sample: Sample = store.update_sample_lims_status(
+        internal_id=sample_1.internal_id, lims_status=LimsStatus.TOP_UP
+    )
 
     # THEN the sample should have been updated
     assert sample_1.lims_status == LimsStatus.TOP_UP
+    assert updated_sample.lims_status == LimsStatus.TOP_UP
 
     # THEN the commit should not have been called
     commit_spy.assert_not_called()

--- a/tests/store/crud/update/test_update.py
+++ b/tests/store/crud/update/test_update.py
@@ -338,7 +338,7 @@ def test_update_sample_lims_status(store: Store, helpers: StoreHelpers, mocker: 
     )
 
     # THEN the sample should have been updated
-    assert sample_1.lims_status == LimsStatus.TOP_UP
+    assert sample_1 == updated_sample
     assert updated_sample.lims_status == LimsStatus.TOP_UP
 
     # THEN the commit should not have been called

--- a/tests/store/crud/update/test_update.py
+++ b/tests/store/crud/update/test_update.py
@@ -1,10 +1,12 @@
 from datetime import datetime
 
 import pytest
+from pytest_mock import MockerFixture
 
 from cg.constants import SequencingRunDataAvailability
 from cg.constants.constants import CaseActions, ControlOptions
 from cg.constants.devices import RevioNames
+from cg.constants.lims import LimsStatus
 from cg.constants.sequencing import Sequencers
 from cg.services.run_devices.pacbio.data_transfer_service.dto import PacBioSequencingRunDTO
 from cg.store.models import Analysis, IlluminaSampleSequencingMetrics, IlluminaSequencingRun, Sample
@@ -321,3 +323,20 @@ def test_update_pacbio_sequencing_run_processed(store: Store):
     # THEN the processed field should have been updated
     updated_sequencing_run = store.get_pacbio_sequencing_run_by_id(sequencing_run.id)
     assert updated_sequencing_run.processed is True
+
+
+def test_update_sample_lims_status(store: Store, helpers: StoreHelpers, mocker: MockerFixture):
+    # GIVEN a store with a sample
+    sample_1 = helpers.add_sample(
+        store=store, internal_id="sample_1", lims_status=LimsStatus.PENDING
+    )
+    commit_spy = mocker.spy(store, "commit_to_store")
+
+    # WHEN updating the LIMS status of the sample
+    store.update_sample_lims_status(internal_id=sample_1.internal_id, lims_status=LimsStatus.TOP_UP)
+
+    # THEN the sample should have been updated
+    assert sample_1.lims_status == LimsStatus.TOP_UP
+
+    # THEN the commit should not have been called
+    commit_spy.assert_not_called()


### PR DESCRIPTION
## Description

### Added

- a PATCH endpoint called `samples`, which allows you to update the `lims_status` for a list of samples.   


Request body should look like this:
```json
{
  "samples": [
    {
      "internal_id": "sample1",
      "lims_status": "pending"
    },
    {
      "internal_id": "sample2",
      "lims_status": "top-up"
    },
    {
      "internal_id": "sample3",
      "lims_status": "re-prep"
    },
    {
      "internal_id": "sample4",
      "lims_status": "done"
    }
  ]
}
```

### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
