### PR TITLE
Two CG CI workflows exist. Pick the current pytest used with deploys to the default branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,6 @@ __________ DO NOT TOUCH ___________
 
 __________ DO NOT TOUCH ___________ -->
 
-## [x.x.x]
-### Added
-### Changed
-### Fixed
-- Stop removing trailing newlines from export managed variants and panels
-
 ## [22.26.0]
 ### Added
 - Added median target coverage to mip:s pydantic model

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # cg
-![Build Status - Github][gh-actions-badge]
+[![Build Status - Github][gh-actions-badge]][gh-actions-url]
 [![GitHub issues-closed][closed-issues-img]][closed-issues-url]
 [![Average time to resolve an issue][ismaintained-resolve-img]][ismaintained-resolve-url]
 [![Percentage of issues still open][ismaintained-open-rate-img]][ismaintained-open-rate-url]
@@ -49,10 +49,8 @@ For development, use `poetry install --all-extras` to install development depend
 
 <!-- badges -->
 
-[coveralls-url]: https://coveralls.io/github/Clinical-Genomics/cg
-[coveralls-image]: https://coveralls.io/repos/github/Clinical-Genomics/cg/badge.svg?branch=master
-
-[gh-actions-badge]: https://github.com/Clinical-Genomics/cg/workflows/CG%20CI/badge.svg
+[gh-actions-badge]: https://github.com/Clinical-Genomics/cg/actions/workflows/pytests.yml/badge.svg
+[gh-actions-url]: https://github.com/Clinical-Genomics/cg/actions/workflows/pytests.yml
 [closed-issues-img]: https://img.shields.io/github/issues-closed/Clinical-Genomics/cg.svg
 [closed-issues-url]: https://GitHub.com/Clinical-Genomics/cg/issues?q=is%3Aissue+is%3Aclosed
 [ismaintained-resolve-img]: http://isitmaintained.com/badge/resolution/Clinical-Genomics/cg.svg


### PR DESCRIPTION
Ahem, and sorry, there was a new workflow named CG CI. 😊 Using explicit workflow filename instead of alias for the badge here! 

### Fixed

- Update CG CI workflow badge. It often shows failed, though latest build on the default branch passed.

Before:
<img width="255" height="120" alt="Screenshot 2026-04-17 at 12 57 11" src="https://github.com/user-attachments/assets/8da78e7c-e635-4a2c-a0c3-5bb258018a10" />

After:
<img width="268" height="140" alt="Screenshot 2026-04-17 at 12 58 43" src="https://github.com/user-attachments/assets/3a717e41-1fea-4c81-b376-d0139fd310a6" />

### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
