### PR TITLE
Change --should-deliver-sample into -d/-nd --delivery/--no-delivery (patch)

### DIFF
--- a/cg/cli/add.py
+++ b/cg/cli/add.py
@@ -305,10 +305,12 @@ def add_case(
 @click.option("-f", "--father-id", help="Sample ID for father of sample")
 @click.option("-s", "--status", type=EnumChoice(StatusOptions), required=True)
 @click.option(
-    "--should-deliver-sample",
-    type=bool,
+    "-d/-nd",
+    "--delivery/--no-delivery",
+    "should_deliver_sample",
+    is_flag=True,
     required=True,
-    help="Set the value for should_deliver_sample. Can be True or False.",
+    help="Toggle whether case delivery should trigger sample delivery.",
 )
 @click.argument("case-id")
 @click.argument("sample-id")

--- a/tests/cli/add/test_cli_add_relationship.py
+++ b/tests/cli/add/test_cli_add_relationship.py
@@ -25,7 +25,7 @@ def test_add_relationship_required(cli_runner: CliRunner, base_context: CGConfig
     # WHEN adding a relationship
     result = cli_runner.invoke(
         add,
-        ["relationship", case_id, sample_id, "-s", status, "--should-deliver-sample", True],
+        ["relationship", case_id, sample_id, "-s", status, "-d"],
         obj=base_context,
     )
 
@@ -49,7 +49,7 @@ def test_add_relationship_bad_sample(cli_runner: CliRunner, base_context: CGConf
     status = "affected"
     result = cli_runner.invoke(
         add,
-        ["relationship", case_id, sample_id, "-s", status, "--should-deliver-sample", True],
+        ["relationship", case_id, sample_id, "-s", status, "-d"],
         obj=base_context,
     )
 
@@ -70,7 +70,7 @@ def test_add_relationship_bad_family(cli_runner: CliRunner, base_context: CGConf
     status = "affected"
     result = cli_runner.invoke(
         add,
-        ["relationship", case_id, sample_id, "-s", status, "--should-deliver-sample", True],
+        ["relationship", case_id, sample_id, "-s", status, "-d"],
         obj=base_context,
     )
 
@@ -93,7 +93,7 @@ def test_add_relationship_bad_status(cli_runner: CliRunner, base_context: CGConf
 
     result = cli_runner.invoke(
         add,
-        ["relationship", case_id, sample_id, "-s", status, "--should-deliver-sample", True],
+        ["relationship", case_id, sample_id, "-s", status, "-d"],
         obj=base_context,
     )
 
@@ -127,8 +127,7 @@ def test_add_relationship_mother(
             status,
             "-m",
             mother_id,
-            "--should-deliver-sample",
-            False,
+            "-nd",
         ],
         obj=base_context,
     )
@@ -164,8 +163,7 @@ def test_add_relationship_bad_mother(
             status,
             "-m",
             mother_id,
-            "--should-deliver-sample",
-            False,
+            "-nd",
         ],
         obj=base_context,
     )
@@ -203,8 +201,7 @@ def test_add_relationship_father(
             status,
             "-f",
             father_id,
-            "--should-deliver-sample",
-            False,
+            "-nd",
         ],
         obj=base_context,
     )
@@ -242,8 +239,7 @@ def test_add_relationship_bad_father(
             status,
             "-f",
             father_id,
-            "--should-deliver-sample",
-            False,
+            "-nd",
         ],
         obj=base_context,
     )
@@ -280,8 +276,7 @@ def test_add_relationship_mother_not_female(
             status,
             "-m",
             male_mother_id,
-            "--should-deliver-sample",
-            False,
+            "-nd",
         ],
         obj=base_context,
     )
@@ -318,8 +313,7 @@ def test_add_relationship_father_not_male(
             status,
             "-f",
             female_father_id,
-            "--should-deliver-sample",
-            False,
+            "-nd",
         ],
         obj=base_context,
     )


### PR DESCRIPTION
## Description

Closes https://github.com/Clinical-Genomics/cg/issues/5012

### Changed

- CLI option for `cg add relationship`

### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b change-should-deliver-sample-option -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
