### PR TITLE
Proposed changes to fix filtering and add test to catch errors we missed

### DIFF
--- a/cg/store/crud/read.py
+++ b/cg/store/crud/read.py
@@ -1906,11 +1906,13 @@ class ReadHandler(BaseHandler):
         """
         return (
             self._get_query(table=Sample)
-            .filter_by(
-                lims_status=lims_status, from_sample=None, is_cancelled=False, delivered_at=None
-            )
+            .join(Customer, Sample.customer_id == Customer.id)
             .filter(
-                Sample.last_sequenced_at.is_not(None),
+                Sample.delivered_at.is_(None),
+                Sample.from_sample.is_(None),
+                Sample.is_cancelled.is_(False),
+                Sample.last_sequenced_at.isnot(None),
+                Sample.lims_status == lims_status,
                 Customer.internal_id != "cust000",
                 Customer.internal_id.not_like("cust9%"),
             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import gzip
 import http
 import logging
 import os
+import re
 import shutil
 from copy import deepcopy
 from datetime import datetime
@@ -15,6 +16,7 @@ import pytest
 from housekeeper.store.models import File, Version
 from pytest_mock import MockFixture
 from requests import Response
+from sqlalchemy import event
 
 from cg.apps.crunchy import CrunchyAPI
 from cg.apps.demultiplex.demultiplex_api import DemultiplexingAPI
@@ -61,7 +63,7 @@ from cg.services.deliver_files.rsync.service import DeliveryRsyncService
 from cg.services.illumina.backup.encrypt_service import IlluminaRunEncryptionService
 from cg.services.illumina.data_transfer.data_transfer_service import IlluminaDataTransferService
 from cg.services.orders.storing.constants import MAF_ORDER_ID
-from cg.store.database import create_all_tables, drop_all_tables, initialize_database
+from cg.store.database import create_all_tables, drop_all_tables, get_engine, initialize_database
 from cg.store.models import (
     Application,
     ApplicationVersion,
@@ -1460,11 +1462,22 @@ def wgs_long_read_application_tag() -> str:
     return "LWPBELB070"
 
 
+def add_mysql_compat_guard(engine):
+    @event.listens_for(engine, "before_cursor_execute")
+    def check_sql(conn, cursor, statement, parameters, context, executemany):
+        # IS NOT with a string, invalid MySQL but will be a false positive in Sqlite
+        if re.search(r"IS NOT '[^']*'", statement):
+            raise RuntimeError(
+                f"Not compatible with mysql: IS NOT/IS with string value.\n{statement}"
+            )
+
+
 @pytest.fixture
 def store() -> Generator[Store, None, None]:
     """Return a CG store."""
     initialize_database("sqlite:///")
     _store = Store()
+    add_mysql_compat_guard(get_engine())
     create_all_tables()
     yield _store
     drop_all_tables()

--- a/tests/store/crud/read/test_read_sample.py
+++ b/tests/store/crud/read/test_read_sample.py
@@ -750,7 +750,18 @@ def test_get_unhandled_samples_filters_out_delivered_samples(store: Store, helpe
 
 
 def test_get_unhandled_samples_filters_out_internal_samples(store: Store, helpers: StoreHelpers):
-    # GIVEN a store with an internal sample
+    # GIVEN a store with one external and two internal samples
+    external_sample = helpers.add_sample(
+        store=store,
+        lims_status=LimsStatus.TOP_UP,
+        internal_id="perfect_unhandled_sample_1",
+        is_cancelled=False,
+        from_sample=None,
+        last_sequenced_at=datetime.now(),
+        delivered_at=None,
+        customer_id="cust1337",
+    )
+
     helpers.add_sample(
         store=store,
         lims_status=LimsStatus.TOP_UP,
@@ -775,8 +786,8 @@ def test_get_unhandled_samples_filters_out_internal_samples(store: Store, helper
     # WHEN getting the unhandled samples in top-up
     unhandled_samples: Query = store._get_unhandled_samples(lims_status=LimsStatus.TOP_UP)
 
-    # THEN no sample is returned
-    assert unhandled_samples.all() == []
+    # THEN only the external sample is returned
+    assert unhandled_samples.all() == [external_sample]
 
 
 def test_get_paginated_unhandled_samples(store: Store, helpers: StoreHelpers):


### PR DESCRIPTION
## Description

Some quick notes - the reason we didn't catch the error with the customer filtering is because we were testing with a database that only included customers to be filtered out - without a join we got the cartesian product of the tables but all rows where filtered out because they still only contained invalid customers. 

The contest addition is a small event hook that will look at any generated sql string during testing and see that it does not contain `IS NOT 'string'` because that is allowed in sqlite but not mysql - only `IS NOT NULL`, `IS NOT 1` and so on is allowed in mysql

### Added

-

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
