### PR TITLE
Handle Nones for original ticket and original order in db models

### DIFF
--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -521,8 +521,11 @@ class Case(Base, PriorityMixin):
         return self.tickets.split(sep=",")[-1] if self.tickets else None
 
     @property
-    def original_order(self) -> "Order":
-        return min(self.orders, key=lambda order: order.order_date)
+    def original_order(self) -> "Order | None":
+        if not self.orders:
+            return None
+        else:
+            return min(self.orders, key=lambda order: order.order_date)
 
     @property
     def latest_order(self) -> "Order":
@@ -899,8 +902,8 @@ class Sample(Base, PriorityMixin):
     @property
     def ticket_id_from_original_order(self) -> int | None:
         """Return the original ticket id of the sample if it is linked to any ticket."""
-        if original_case := self.original_case:
-            return original_case.original_order.ticket_id
+        if self.original_case and self.original_case.original_order:
+            return self.original_case.original_order.ticket_id
         else:
             return None
 

--- a/tests/store/test_store_models.py
+++ b/tests/store/test_store_models.py
@@ -28,6 +28,18 @@ def test_application_version_has_application(store: Store, helpers: StoreHelpers
     assert application_version.application == application
 
 
+def test_case_original_order_no_orders():
+    """Test that a case without orders returns None for original order."""
+    # GIVEN a case without orders
+    case = Case()
+
+    # WHEN getting the original order
+    original_order = case.original_order
+
+    # THEN the original order should be None
+    assert original_order is None
+
+
 def test_microbial_sample_to_dict(microbial_store: Store, helpers):
     # GIVEN a store with a Microbial sample
     sample_obj = helpers.add_microbial_sample(microbial_store)
@@ -124,6 +136,18 @@ def test_multiple_collaborations(base_store, customer_id):
         collaborator.internal_id in ["cust001", new_customer_id, "cust002", "cust003", customer_id]
         for collaborator in collaborators
     )
+
+
+def test_sample_ticket_id_from_original_order_no_order():
+    """Tests that a sample without an original order returns None for ticket id."""
+    # GIVEN a sample without an original order
+    sample = Sample(links=[CaseSample(case=Case())])
+
+    # WHEN getting the ticket id from the original order
+    ticket_id = sample.ticket_id_from_original_order
+
+    # THEN the ticket id should be None
+    assert ticket_id is None
 
 
 def test_case_samples_all_control(analysis_store: Store, case_id: str) -> None:


### PR DESCRIPTION
## Description

Some cases are not tied to any orders prompting issues in the case.original_order property and the sample.ticket_id_from_original_order.

### Fixed

- case.original_order returns None if the case is tied to no Order
- sample.ticket_id_from_original_order returns None if the original case has no order.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
