### PR TITLE
Refactor most "cg store" commands to be called "cg prepare"

### DIFF
--- a/cg/cli/base.py
+++ b/cg/cli/base.py
@@ -21,6 +21,7 @@ from cg.cli.downsample import downsample
 from cg.cli.generate.base import generate as generate_cmd
 from cg.cli.get import get
 from cg.cli.post_process.post_process import post_process_group as post_processing
+from cg.cli.prepare.base import prepare
 from cg.cli.sequencing_qc.sequencing_qc import sequencing_qc
 from cg.cli.set.base import set_cmd
 from cg.cli.store.base import store as store_cmd
@@ -120,6 +121,7 @@ base.add_command(set_cmd)
 base.add_command(transfer_group)
 base.add_command(upload)
 base.add_command(workflow_cmd)
+base.add_command(prepare)
 base.add_command(store_cmd)
 base.add_command(deliver_cmd)
 base.add_command(demultiplex_cmd)

--- a/cg/cli/prepare/base.py
+++ b/cg/cli/prepare/base.py
@@ -1,0 +1,46 @@
+"""Code for store part of CLI."""
+
+import logging
+
+import rich_click as click
+
+from cg.apps.crunchy.crunchy import CrunchyAPI
+from cg.apps.housekeeper.hk import HousekeeperAPI
+from cg.cli.prepare.prepare import (
+    prepare_case,
+    prepare_demultiplexed_illumina_run,
+    prepare_illumina_run,
+    prepare_sample,
+    prepare_ticket,
+)
+from cg.cli.utils import CLICK_CONTEXT_SETTINGS
+from cg.meta.compress.compress import CompressAPI
+from cg.models.cg_config import CGConfig
+
+LOG = logging.getLogger(__name__)
+
+
+@click.group(context_settings=CLICK_CONTEXT_SETTINGS)
+@click.pass_obj
+def prepare(context: CGConfig):
+    """Command for preparing files for analysis."""
+    LOG.info("Running CG prepare command")
+    housekeeper_api: HousekeeperAPI = context.housekeeper_api
+    crunchy_api: CrunchyAPI = context.crunchy_api
+
+    compress_api = CompressAPI(
+        hk_api=housekeeper_api,
+        crunchy_api=crunchy_api,
+        demux_root=context.run_instruments.illumina.sequencing_runs_dir,
+    )
+    context.meta_apis["compress_api"] = compress_api
+
+
+for sub_cmd in [
+    prepare_case,
+    prepare_demultiplexed_illumina_run,
+    prepare_illumina_run,
+    prepare_sample,
+    prepare_ticket,
+]:
+    prepare.add_command(sub_cmd)

--- a/cg/cli/prepare/prepare.py
+++ b/cg/cli/prepare/prepare.py
@@ -1,0 +1,135 @@
+import logging
+from pathlib import Path
+from typing import Iterable
+
+import rich_click as click
+from housekeeper.store.models import File
+
+from cg.apps.crunchy.files import update_metadata_paths
+from cg.cli.compress.helpers import update_compress_api
+from cg.constants import SequencingFileTag
+from cg.constants.cli_options import DRY_RUN
+from cg.exc import CaseNotFoundError
+from cg.meta.compress import CompressAPI
+from cg.models.cg_config import CGConfig
+from cg.store.models import Sample
+from cg.store.store import Store
+
+LOG = logging.getLogger(__name__)
+
+
+@click.command("sample")
+@click.argument("sample-id", type=str)
+@DRY_RUN
+@click.pass_obj
+def prepare_sample(context: CGConfig, sample_id: str, dry_run: bool) -> int:
+    """Include links to decompressed FASTQ files belonging to this sample in Housekeeper."""
+    compress_api: CompressAPI = context.meta_apis["compress_api"]
+    status_db: Store = context.status_db
+    update_compress_api(compress_api, dry_run=dry_run)
+    sample = status_db.get_sample_by_internal_id(internal_id=sample_id)
+    if not sample:
+        LOG.warning(f"Could not find {sample_id}")
+        return 0
+    was_decompressed: bool = compress_api.add_decompressed_fastq(sample)
+    if not was_decompressed:
+        LOG.info(f"Skipping sample {sample_id}")
+        return 0
+    LOG.info(f"Stored fastq files for {sample_id}")
+    return 1
+
+
+def invoke_prepare_samples(context: click.Context, sample_ids: list[str], dry_run: bool) -> int:
+    """Invoke prepare sample for sample ids."""
+    prepared_individuals: int = 0
+    for sample_id in sample_ids:
+        prepared_count: int = context.invoke(prepare_sample, sample_id=sample_id, dry_run=dry_run)
+        prepared_individuals += prepared_count
+    return prepared_individuals
+
+
+@click.command("case")
+@click.argument("case-id", type=str)
+@DRY_RUN
+@click.pass_context
+def prepare_case(context: click.Context, case_id: str, dry_run: bool) -> None:
+    """Include links to decompressed FASTQ files belonging to this case in Housekeeper."""
+
+    status_db: Store = context.obj.status_db
+    try:
+        sample_ids: Iterable[str] = status_db.get_sample_ids_by_case_id(case_id=case_id)
+        prepared_individuals: int = invoke_prepare_samples(
+            context=context, dry_run=dry_run, sample_ids=sample_ids
+        )
+    except CaseNotFoundError:
+        return
+    LOG.info(f"Stored fastq files for {prepared_individuals} samples")
+
+
+@click.command("illumina-run")
+@click.argument("flow-cell-id", type=str)
+@DRY_RUN
+@click.pass_context
+def prepare_illumina_run(context: click.Context, flow_cell_id: str, dry_run: bool) -> None:
+    """Include links to decompressed FASTQ files belonging to this Illumina run to Housekeeper."""
+    status_db: Store = context.obj.status_db
+    samples: list[Sample] = status_db.get_samples_by_illumina_flow_cell(flow_cell_id)
+    prepared_individuals: int = invoke_prepare_samples(
+        context=context, dry_run=dry_run, sample_ids=[sample.internal_id for sample in samples]
+    )
+    LOG.info(f"Stored fastq files for {prepared_individuals} samples")
+
+
+@click.command("ticket")
+@click.argument("ticket", type=str)
+@DRY_RUN
+@click.pass_context
+def prepare_ticket(context: click.Context, ticket: str, dry_run: bool) -> None:
+    """Include links to decompressed FASTQ files belonging to a ticket in Housekeeper."""
+    status_db: Store = context.obj.status_db
+    samples: list[Sample] = status_db.get_samples_from_ticket(ticket=ticket)
+    prepared_individuals: int = invoke_prepare_samples(
+        context=context, dry_run=dry_run, sample_ids=[sample.internal_id for sample in samples]
+    )
+    LOG.info(f"Stored fastq files for {prepared_individuals} samples")
+
+
+@click.command("demultiplexed-run")
+@click.argument("flow-cell-id", type=str)
+@DRY_RUN
+@click.pass_obj
+def prepare_demultiplexed_illumina_run(
+    context: click.Context, flow_cell_id: str, dry_run: bool
+) -> None:
+    """
+    Include all flow cell bundle and sequencing files to Housekeeper. Updates SPRING metadata file.
+    """
+    compress_api: CompressAPI = context.meta_apis["compress_api"]
+    status_db: Store = context.status_db
+    update_compress_api(compress_api, dry_run=dry_run)
+
+    samples: list[Sample] = status_db.get_samples_by_illumina_flow_cell(flow_cell_id)
+    bundle_names: list[str] = (
+        [sample.internal_id for sample in samples if sample.internal_id] + [flow_cell_id]
+        if samples
+        else [flow_cell_id]
+    )
+    for bundle_name in bundle_names:
+        compress_api.hk_api.include_files_to_latest_version(bundle_name=bundle_name)
+
+    if not samples:
+        LOG.info(f"No samples found for flow cell {flow_cell_id} in the database")
+        return
+    for sample in samples:
+        spring_metadata_files: list[File] = compress_api.hk_api.get_files_from_latest_version(
+            bundle_name=sample.internal_id, tags=[SequencingFileTag.SPRING_METADATA]
+        )
+        if spring_metadata_files:
+            for spring_metadata_file in spring_metadata_files:
+                LOG.info(
+                    f"Updating file paths in SPRING metadata file {spring_metadata_file.full_path}: for sample: {sample.internal_id}"
+                )
+                update_metadata_paths(
+                    spring_metadata_path=spring_metadata_file.full_path,
+                    new_parent_path=Path(spring_metadata_file.full_path).parent,
+                )

--- a/cg/cli/store/base.py
+++ b/cg/cli/store/base.py
@@ -4,18 +4,8 @@ import logging
 
 import rich_click as click
 
-from cg.apps.crunchy.crunchy import CrunchyAPI
-from cg.apps.housekeeper.hk import HousekeeperAPI
-from cg.cli.store.store import (
-    store_case,
-    store_demultiplexed_illumina_run,
-    store_illumina_run,
-    store_qc_metrics,
-    store_sample,
-    store_ticket,
-)
+from cg.cli.store.store import store_qc_metrics
 from cg.cli.utils import CLICK_CONTEXT_SETTINGS
-from cg.meta.compress.compress import CompressAPI
 from cg.models.cg_config import CGConfig
 
 LOG = logging.getLogger(__name__)
@@ -26,23 +16,6 @@ LOG = logging.getLogger(__name__)
 def store(context: CGConfig):
     """Command for storing files."""
     LOG.info("Running CG store command")
-    housekeeper_api: HousekeeperAPI = context.housekeeper_api
-    crunchy_api: CrunchyAPI = context.crunchy_api
-
-    compress_api = CompressAPI(
-        hk_api=housekeeper_api,
-        crunchy_api=crunchy_api,
-        demux_root=context.run_instruments.illumina.sequencing_runs_dir,
-    )
-    context.meta_apis["compress_api"] = compress_api
 
 
-for sub_cmd in [
-    store_case,
-    store_demultiplexed_illumina_run,
-    store_illumina_run,
-    store_sample,
-    store_ticket,
-    store_qc_metrics,
-]:
-    store.add_command(sub_cmd)
+store.add_command(store_qc_metrics)

--- a/cg/cli/store/store.py
+++ b/cg/cli/store/store.py
@@ -1,141 +1,14 @@
 import logging
-from pathlib import Path
-from typing import Iterable
 
 import rich_click as click
-from housekeeper.store.models import File
 
-from cg.apps.crunchy.files import update_metadata_paths
-from cg.cli.compress.helpers import update_compress_api
 from cg.clients.arnold.exceptions import ArnoldClientError, ArnoldServerError
 from cg.clients.janus.exceptions import JanusClientError, JanusServerError
-from cg.constants import SequencingFileTag
 from cg.constants.cli_options import DRY_RUN
-from cg.exc import CaseNotFoundError
-from cg.meta.compress import CompressAPI
 from cg.meta.qc_metrics.collect_qc_metrics import CollectQCMetricsAPI
 from cg.models.cg_config import CGConfig
-from cg.store.models import Sample
-from cg.store.store import Store
 
 LOG = logging.getLogger(__name__)
-
-
-@click.command("sample")
-@click.argument("sample-id", type=str)
-@DRY_RUN
-@click.pass_obj
-def store_sample(context: CGConfig, sample_id: str, dry_run: bool) -> int:
-    """Include links to decompressed FASTQ files belonging to this sample in Housekeeper."""
-    compress_api: CompressAPI = context.meta_apis["compress_api"]
-    status_db: Store = context.status_db
-    update_compress_api(compress_api, dry_run=dry_run)
-    sample = status_db.get_sample_by_internal_id(internal_id=sample_id)
-    if not sample:
-        LOG.warning(f"Could not find {sample_id}")
-        return 0
-    was_decompressed: bool = compress_api.add_decompressed_fastq(sample)
-    if not was_decompressed:
-        LOG.info(f"Skipping sample {sample_id}")
-        return 0
-    LOG.info(f"Stored fastq files for {sample_id}")
-    return 1
-
-
-def invoke_store_samples(context: click.Context, sample_ids: list[str], dry_run: bool) -> int:
-    """Invoke store sample for sample ids."""
-    stored_individuals: int = 0
-    for sample_id in sample_ids:
-        stored_count: int = context.invoke(store_sample, sample_id=sample_id, dry_run=dry_run)
-        stored_individuals += stored_count
-    return stored_individuals
-
-
-@click.command("case")
-@click.argument("case-id", type=str)
-@DRY_RUN
-@click.pass_context
-def store_case(context: click.Context, case_id: str, dry_run: bool) -> None:
-    """Include links to decompressed FASTQ files belonging to this case in Housekeeper."""
-
-    status_db: Store = context.obj.status_db
-    try:
-        sample_ids: Iterable[str] = status_db.get_sample_ids_by_case_id(case_id=case_id)
-        stored_individuals: int = invoke_store_samples(
-            context=context, dry_run=dry_run, sample_ids=sample_ids
-        )
-    except CaseNotFoundError:
-        return
-    LOG.info(f"Stored fastq files for {stored_individuals} samples")
-
-
-@click.command("illumina-run")
-@click.argument("flow-cell-id", type=str)
-@DRY_RUN
-@click.pass_context
-def store_illumina_run(context: click.Context, flow_cell_id: str, dry_run: bool) -> None:
-    """Include links to decompressed FASTQ files belonging to this Illumina run to Housekeeper."""
-    status_db: Store = context.obj.status_db
-    samples: list[Sample] = status_db.get_samples_by_illumina_flow_cell(flow_cell_id)
-    stored_individuals: int = invoke_store_samples(
-        context=context, dry_run=dry_run, sample_ids=[sample.internal_id for sample in samples]
-    )
-    LOG.info(f"Stored fastq files for {stored_individuals} samples")
-
-
-@click.command("ticket")
-@click.argument("ticket", type=str)
-@DRY_RUN
-@click.pass_context
-def store_ticket(context: click.Context, ticket: str, dry_run: bool) -> None:
-    """Include links to decompressed FASTQ files belonging to a ticket in Housekeeper."""
-    status_db: Store = context.obj.status_db
-    samples: list[Sample] = status_db.get_samples_from_ticket(ticket=ticket)
-    stored_individuals: int = invoke_store_samples(
-        context=context, dry_run=dry_run, sample_ids=[sample.internal_id for sample in samples]
-    )
-    LOG.info(f"Stored fastq files for {stored_individuals} samples")
-
-
-@click.command("demultiplexed-run")
-@click.argument("flow-cell-id", type=str)
-@DRY_RUN
-@click.pass_obj
-def store_demultiplexed_illumina_run(
-    context: click.Context, flow_cell_id: str, dry_run: bool
-) -> None:
-    """
-    Include all flow cell bundle and sequencing files to Housekeeper. Updates SPRING metadata file.
-    """
-    compress_api: CompressAPI = context.meta_apis["compress_api"]
-    status_db: Store = context.status_db
-    update_compress_api(compress_api, dry_run=dry_run)
-
-    samples: list[Sample] = status_db.get_samples_by_illumina_flow_cell(flow_cell_id)
-    bundle_names: list[str] = (
-        [sample.internal_id for sample in samples if sample.internal_id] + [flow_cell_id]
-        if samples
-        else [flow_cell_id]
-    )
-    for bundle_name in bundle_names:
-        compress_api.hk_api.include_files_to_latest_version(bundle_name=bundle_name)
-
-    if not samples:
-        LOG.info(f"No samples found for flow cell {flow_cell_id} in the database")
-        return
-    for sample in samples:
-        spring_metadata_files: list[File] = compress_api.hk_api.get_files_from_latest_version(
-            bundle_name=sample.internal_id, tags=[SequencingFileTag.SPRING_METADATA]
-        )
-        if spring_metadata_files:
-            for spring_metadata_file in spring_metadata_files:
-                LOG.info(
-                    f"Updating file paths in SPRING metadata file {spring_metadata_file.full_path}: for sample: {sample.internal_id}"
-                )
-                update_metadata_paths(
-                    spring_metadata_path=spring_metadata_file.full_path,
-                    new_parent_path=Path(spring_metadata_file.full_path).parent,
-                )
 
 
 @click.command("qc-metrics")

--- a/tests/cli/prepare/test_prepare.py
+++ b/tests/cli/prepare/test_prepare.py
@@ -2,12 +2,12 @@ import logging
 
 from click.testing import CliRunner
 
-from cg.cli.store.store import (
-    store_case,
-    store_demultiplexed_illumina_run,
-    store_illumina_run,
-    store_sample,
-    store_ticket,
+from cg.cli.prepare.prepare import (
+    prepare_case,
+    prepare_demultiplexed_illumina_run,
+    prepare_illumina_run,
+    prepare_sample,
+    prepare_ticket,
 )
 from cg.constants import EXIT_SUCCESS
 from cg.meta.compress import CompressAPI
@@ -16,15 +16,15 @@ from cg.store.models import Sample
 from cg.store.store import Store
 
 
-def test_store_sample_when_no_samples(
+def test_prepare_sample_when_no_samples(
     caplog, cli_runner: CliRunner, compress_context: CGConfig, sample_id: str
 ):
-    """Test to run store samples command with a database without samples."""
+    """Test to run prepare samples command with a database without samples."""
     caplog.set_level(logging.DEBUG)
     # GIVEN a context without samples
 
-    # WHEN running the store sample command
-    res = cli_runner.invoke(store_sample, [sample_id], obj=compress_context)
+    # WHEN running the prepare sample command
+    res = cli_runner.invoke(prepare_sample, [sample_id], obj=compress_context)
 
     # THEN assert the command exits successfully
     assert res.exit_code == EXIT_SUCCESS
@@ -33,10 +33,10 @@ def test_store_sample_when_no_samples(
     assert f"Could not find {sample_id}" in caplog.text
 
 
-def test_store_sample_when_decompression_not_finished(
+def test_prepare_sample_when_decompression_not_finished(
     cli_runner: CliRunner, caplog, mocker, populated_compress_context: CGConfig, sample_id: str
 ):
-    """Test to run store samples command when decompression is not finished."""
+    """Test to run prepare samples command when decompression is not finished."""
     caplog.set_level(logging.DEBUG)
     # GIVEN a context with a sample
 
@@ -44,8 +44,8 @@ def test_store_sample_when_decompression_not_finished(
     mocker.patch.object(CompressAPI, "add_decompressed_fastq")
     CompressAPI.add_decompressed_fastq.return_value = False
 
-    # WHEN running the store samples command
-    res = cli_runner.invoke(store_sample, [sample_id], obj=populated_compress_context)
+    # WHEN running the prepare samples command
+    res = cli_runner.invoke(prepare_sample, [sample_id], obj=populated_compress_context)
 
     # THEN assert that the command exits successfully
     assert res.exit_code == EXIT_SUCCESS
@@ -54,10 +54,10 @@ def test_store_sample_when_decompression_not_finished(
     assert f"Skipping sample {sample_id}" in caplog.text
 
 
-def test_store_sample_when_decompression_finished(
+def test_prepare_sample_when_decompression_finished(
     caplog, cli_runner: CliRunner, mocker, populated_compress_context: CGConfig, sample_id: str
 ):
-    """Test to run store samples command when decompression is finished."""
+    """Test to run prepare samples command when decompression is finished."""
     caplog.set_level(logging.DEBUG)
     # GIVEN a context with a sample
 
@@ -65,25 +65,25 @@ def test_store_sample_when_decompression_finished(
     mocker.patch.object(CompressAPI, "add_decompressed_fastq")
     CompressAPI.add_decompressed_fastq.return_value = True
 
-    # WHEN running the store sample command
-    res = cli_runner.invoke(store_sample, [sample_id], obj=populated_compress_context)
+    # WHEN running the prepare sample command
+    res = cli_runner.invoke(prepare_sample, [sample_id], obj=populated_compress_context)
 
     # THEN assert that the command exits successfully
     assert res.exit_code == EXIT_SUCCESS
 
-    # THEN assert that we log that we stored FASTQ files
+    # THEN assert that we log that we prepared FASTQ files
     assert f"Stored fastq files for {sample_id}" in caplog.text
 
 
-def test_store_case_when_no_case(
+def test_prepare_case_when_no_case(
     caplog, case_id: str, cli_runner: CliRunner, compress_context: CGConfig
 ):
-    """Test to run store case command when no case in database."""
+    """Test to run prepare case command when no case in database."""
     caplog.set_level(logging.DEBUG)
     # GIVEN a context with no case
 
-    # WHEN running the store case command
-    res = cli_runner.invoke(store_case, [case_id], obj=compress_context)
+    # WHEN running the prepare case command
+    res = cli_runner.invoke(prepare_case, [case_id], obj=compress_context)
 
     # THEN assert that the command exits successfully
     assert res.exit_code == EXIT_SUCCESS
@@ -92,7 +92,7 @@ def test_store_case_when_no_case(
     assert f"Could not find case {case_id}" in caplog.text
 
 
-def test_store_case(
+def test_prepare_case(
     caplog,
     cli_runner: CliRunner,
     case_id: str,
@@ -100,7 +100,7 @@ def test_store_case(
     populated_compress_context: CGConfig,
     sample_id: str,
 ):
-    """Test to run store case command."""
+    """Test to run prepare case command."""
     caplog.set_level(logging.DEBUG)
     # GIVEN a context with a case and a sample
 
@@ -108,17 +108,17 @@ def test_store_case(
     mocker.patch.object(CompressAPI, "add_decompressed_fastq")
     CompressAPI.add_decompressed_fastq.return_value = True
 
-    # WHEN running the store case command
-    res = cli_runner.invoke(store_case, [case_id], obj=populated_compress_context)
+    # WHEN running the prepare case command
+    res = cli_runner.invoke(prepare_case, [case_id], obj=populated_compress_context)
 
     # THEN assert that the command exits successfully
     assert res.exit_code == EXIT_SUCCESS
 
-    # THEN assert that we log that we stored FASTQ files
+    # THEN assert that we log that we prepared FASTQ files
     assert f"Stored fastq files for {sample_id}" in caplog.text
 
 
-def test_store_flow_cell(
+def test_prepare_flow_cell(
     caplog,
     cli_runner: CliRunner,
     novaseq_6000_pre_1_5_kits_flow_cell_id: str,
@@ -126,7 +126,7 @@ def test_store_flow_cell(
     populated_compress_context: CGConfig,
     sample_id: str,
 ):
-    """Test to run store flow cell command."""
+    """Test to run prepare flow cell command."""
     caplog.set_level(logging.DEBUG)
     # GIVEN a context with a sample
     sample: Sample = populated_compress_context.status_db.get_sample_by_internal_id(sample_id)
@@ -137,9 +137,9 @@ def test_store_flow_cell(
         mocker.patch.object(Store, "get_samples_by_illumina_flow_cell", return_value=[sample]),
         mocker.patch.object(CompressAPI, "add_decompressed_fastq", return_value=True),
     ):
-        # WHEN running the store flow cell command
+        # WHEN running the prepare flow cell command
         res = cli_runner.invoke(
-            store_illumina_run,
+            prepare_illumina_run,
             [novaseq_6000_pre_1_5_kits_flow_cell_id],
             obj=populated_compress_context,
         )
@@ -147,11 +147,11 @@ def test_store_flow_cell(
         # THEN assert that the command exits successfully
         assert res.exit_code == EXIT_SUCCESS
 
-        # THEN assert that we log that we stored FASTQ files
+        # THEN assert that we log that we prepared FASTQ files
         assert f"Stored fastq files for {sample_id}" in caplog.text
 
 
-def test_store_ticket(
+def test_prepare_ticket(
     caplog,
     cli_runner: CliRunner,
     mocker,
@@ -159,7 +159,7 @@ def test_store_ticket(
     sample_id: str,
     ticket_id: str,
 ):
-    """Test to run store ticket command."""
+    """Test to run prepare ticket command."""
     caplog.set_level(logging.DEBUG)
     # GIVEN a context with a sample
 
@@ -167,17 +167,17 @@ def test_store_ticket(
     mocker.patch.object(CompressAPI, "add_decompressed_fastq")
     CompressAPI.add_decompressed_fastq.return_value = True
 
-    # WHEN running the store ticket command
-    res = cli_runner.invoke(store_ticket, [ticket_id], obj=populated_compress_context)
+    # WHEN running the prepare ticket command
+    res = cli_runner.invoke(prepare_ticket, [ticket_id], obj=populated_compress_context)
 
     # THEN assert that the command exits successfully
     assert res.exit_code == EXIT_SUCCESS
 
-    # THEN assert that we log that we stored FASTQ files
+    # THEN assert that we log that we prepared FASTQ files
     assert f"Stored fastq files for {sample_id}" in caplog.text
 
 
-def test_store_demultiplexed_flow_cell(
+def test_prepare_demultiplexed_flow_cell(
     caplog,
     cli_runner: CliRunner,
     novaseq_6000_pre_1_5_kits_flow_cell_id: str,
@@ -186,7 +186,7 @@ def test_store_demultiplexed_flow_cell(
     real_populated_compress_context: CGConfig,
     sample_id: str,
 ):
-    """Test to run store demultiplexed flow cell command."""
+    """Test to run prepare demultiplexed flow cell command."""
     caplog.set_level(logging.DEBUG)
     # GIVEN a context with a sample
     sample: Sample = real_populated_compress_context.status_db.get_sample_by_internal_id(sample_id)
@@ -196,11 +196,11 @@ def test_store_demultiplexed_flow_cell(
     Store.get_samples_by_illumina_flow_cell.return_value = [sample]
 
     # GIVEN an updated metadata file
-    mocker.patch("cg.cli.store.store.update_metadata_paths", return_value=None)
+    mocker.patch("cg.cli.prepare.prepare.update_metadata_paths", return_value=None)
 
-    # WHEN running the store demultiplexed flow cell command
+    # WHEN running the prepare demultiplexed flow cell command
     res = cli_runner.invoke(
-        store_demultiplexed_illumina_run,
+        prepare_demultiplexed_illumina_run,
         [novaseq_6000_pre_1_5_kits_flow_cell_id],
         obj=real_populated_compress_context,
     )

--- a/tests/cli/prepare/test_store_fastq.py
+++ b/tests/cli/prepare/test_store_fastq.py
@@ -4,32 +4,34 @@ import logging
 
 from click.testing import CliRunner
 
-from cg.cli.store.store import store_case
+from cg.cli.prepare.prepare import prepare_case
 from cg.models.cg_config import CGConfig
 
 
-def test_store_fastq_cli_no_family(compress_context: CGConfig, cli_runner: CliRunner, caplog):
-    """Test to run the compress command without providing any case id"""
+def test_prepare_case_fastq_cli_no_family(
+    compress_context: CGConfig, cli_runner: CliRunner, caplog
+):
+    """Test to run the prepare command without providing any case id"""
     caplog.set_level(logging.DEBUG)
     # GIVEN a context
 
     # WHEN running the store fastq command
-    res = cli_runner.invoke(store_case, [], obj=compress_context)
+    res = cli_runner.invoke(prepare_case, [], obj=compress_context)
 
     # THEN assert the program exits with 2 since no argument was provided
     assert res.exit_code == 2
 
 
-def test_store_fastq_cli_non_existing_family(
+def test_prepare_case_fastq_cli_non_existing_family(
     compress_context: CGConfig, cli_runner: CliRunner, caplog
 ):
-    """Test to run the compress command with a non-existing case"""
+    """Test to run the prepare command with a non-existing case"""
     caplog.set_level(logging.DEBUG)
     # GIVEN a context and a non existing case id
     case_id = "happychap"
 
     # WHEN running the store fastq command
-    res = cli_runner.invoke(store_case, [case_id], obj=compress_context)
+    res = cli_runner.invoke(prepare_case, [case_id], obj=compress_context)
 
     # THEN assert the program exits without a problem
     assert res.exit_code == 0


### PR DESCRIPTION
## Description

Proposed changes for the commands currently named `cg store` to be renamed to avoid confusion with the `cg workflow <workflow> store`. The purpose of the command is (mostly) to make decompressed Fastq files available for analysis by updating Housekeeper. My suggestion for the new name is `prepare` because:

- Not all files are FASTQs ( demultiplexed-run includes all bundle files)
- The command never starts decompression — so "decompress" would be misleading
- "link" already means filesystem linking in other cg commands, not Housekeeper registration
- "ingest" implies raw data, but the files are already compressed/demultiplexed in the system
- "stage" conflicts with the staging environment terminology used by the team
- "prepare" might be to general but at least covers the shared intent: making files ready for analysis, regardless of the specific mechanism

But the name needs to be discussed - this PR is just to illustrate what changes are needed, less than I anticipated. 

`cg store qc-metrics` is left untouched since it has a very different purpose from the others