### PR TITLE
Rename sample ID add case

### DIFF
--- a/cg/server/dto/samples/samples_response.py
+++ b/cg/server/dto/samples/samples_response.py
@@ -104,6 +104,7 @@ class SamplesResponse(BaseModel):
 
 
 class UnhandledSample(BaseModel):
+    case_id: str | Literal["unknown"]
     sample_id: str
     last_sequenced_at: datetime
     lims_status: LimsStatus
@@ -126,6 +127,7 @@ class UnhandledSamplesResponse(BaseModel):
         for sample in samples:
             unhandled_samples.append(
                 UnhandledSample(
+                    case_id=sample.original_case.internal_id if sample.original_case else "unknown",
                     sample_id=sample.internal_id,
                     last_sequenced_at=sample.last_sequenced_at,  # type: ignore
                     lims_status=sample.lims_status,

--- a/cg/server/dto/samples/samples_response.py
+++ b/cg/server/dto/samples/samples_response.py
@@ -104,7 +104,7 @@ class SamplesResponse(BaseModel):
 
 
 class UnhandledSample(BaseModel):
-    internal_id: str
+    sample_id: str
     last_sequenced_at: datetime
     lims_status: LimsStatus
     ticket: int | Literal["unknown"]
@@ -126,7 +126,7 @@ class UnhandledSamplesResponse(BaseModel):
         for sample in samples:
             unhandled_samples.append(
                 UnhandledSample(
-                    internal_id=sample.internal_id,
+                    sample_id=sample.internal_id,
                     last_sequenced_at=sample.last_sequenced_at,  # type: ignore
                     lims_status=sample.lims_status,
                     ticket=sample.ticket_id_from_original_order or "unknown",

--- a/tests/server/dto/samples/test_samples_response.py
+++ b/tests/server/dto/samples/test_samples_response.py
@@ -35,14 +35,14 @@ def test_unhandled_samples_response_from_samples():
     assert response == UnhandledSamplesResponse(
         samples=[
             UnhandledSample(
-                internal_id="sample_1",
+                sample_id="sample_1",
                 last_sequenced_at=datetime.now(),
                 lims_status=LimsStatus.TOP_UP,
                 workflow=Workflow.RAREDISEASE,
                 ticket=123456,
             ),
             UnhandledSample(
-                internal_id="sample_2",
+                sample_id="sample_2",
                 last_sequenced_at=datetime.now(),
                 lims_status=LimsStatus.TOP_UP,
                 workflow=Workflow.RAREDISEASE,
@@ -72,7 +72,7 @@ def test_unhandled_samples_response_from_samples_without_ticket_id_and_workflow(
     assert unhandled_samples_response == UnhandledSamplesResponse(
         samples=[
             UnhandledSample(
-                internal_id="sample_1",
+                sample_id="sample_1",
                 last_sequenced_at=datetime.now(),
                 lims_status=LimsStatus.TOP_UP,
                 workflow="unknown",

--- a/tests/server/dto/samples/test_samples_response.py
+++ b/tests/server/dto/samples/test_samples_response.py
@@ -6,7 +6,7 @@ import pytest
 from cg.constants.constants import Workflow
 from cg.constants.lims import LimsStatus
 from cg.server.dto.samples.samples_response import UnhandledSample, UnhandledSamplesResponse
-from cg.store.models import Sample
+from cg.store.models import Case, Sample
 
 
 @pytest.mark.freeze_time
@@ -14,6 +14,7 @@ def test_unhandled_samples_response_from_samples():
     # GIVEN a list of database samples
     sample_1 = create_autospec(
         Sample,
+        original_case=create_autospec(Case, internal_id="case_1"),
         internal_id="sample_1",
         last_sequenced_at=datetime.now(),
         lims_status=LimsStatus.TOP_UP,
@@ -22,6 +23,7 @@ def test_unhandled_samples_response_from_samples():
     )
     sample_2 = create_autospec(
         Sample,
+        original_case=create_autospec(Case, internal_id="case_2"),
         internal_id="sample_2",
         last_sequenced_at=datetime.now(),
         lims_status=LimsStatus.TOP_UP,
@@ -35,6 +37,7 @@ def test_unhandled_samples_response_from_samples():
     assert response == UnhandledSamplesResponse(
         samples=[
             UnhandledSample(
+                case_id="case_1",
                 sample_id="sample_1",
                 last_sequenced_at=datetime.now(),
                 lims_status=LimsStatus.TOP_UP,
@@ -42,6 +45,7 @@ def test_unhandled_samples_response_from_samples():
                 ticket=123456,
             ),
             UnhandledSample(
+                case_id="case_2",
                 sample_id="sample_2",
                 last_sequenced_at=datetime.now(),
                 lims_status=LimsStatus.TOP_UP,
@@ -58,6 +62,7 @@ def test_unhandled_samples_response_from_samples_without_ticket_id_and_workflow(
     # GIVEN a sample with no original workflow nor ticket id
     sample_1 = create_autospec(
         Sample,
+        original_case=create_autospec(Case, internal_id="case_1"),
         internal_id="sample_1",
         last_sequenced_at=datetime.now(),
         lims_status=LimsStatus.TOP_UP,
@@ -72,6 +77,7 @@ def test_unhandled_samples_response_from_samples_without_ticket_id_and_workflow(
     assert unhandled_samples_response == UnhandledSamplesResponse(
         samples=[
             UnhandledSample(
+                case_id="case_1",
                 sample_id="sample_1",
                 last_sequenced_at=datetime.now(),
                 lims_status=LimsStatus.TOP_UP,

--- a/tests/server/endpoints/test_samples_endpoint.py
+++ b/tests/server/endpoints/test_samples_endpoint.py
@@ -9,7 +9,7 @@ from cg.constants import Workflow
 from cg.constants.lims import LimsStatus
 from cg.exc import SampleNotFoundError
 from cg.server.endpoints import samples
-from cg.store.models import Customer, Sample
+from cg.store.models import Case, Customer, Sample
 from cg.store.store import Store
 from tests.typed_mock import TypedMock, create_typed_mock
 
@@ -110,6 +110,7 @@ def test_get_unhandled_samples(client: FlaskClient, mocker: MockerFixture):
         is_cancelled=False,
         last_sequenced_at=date_time,
         lims_status=LimsStatus.TOP_UP,
+        original_case=create_autospec(Case, internal_id="case_1"),
         original_workflow=Workflow.RAREDISEASE,
         ticket_id_from_original_order=123456,
     )
@@ -130,6 +131,7 @@ def test_get_unhandled_samples(client: FlaskClient, mocker: MockerFixture):
     assert response.json == {
         "samples": [
             {
+                "case_id": "case_1",
                 "sample_id": "sample_1",
                 "last_sequenced_at": "Tue, 24 Dec 2024 11:59:00 GMT",
                 "lims_status": "top-up",

--- a/tests/server/endpoints/test_samples_endpoint.py
+++ b/tests/server/endpoints/test_samples_endpoint.py
@@ -130,7 +130,7 @@ def test_get_unhandled_samples(client: FlaskClient, mocker: MockerFixture):
     assert response.json == {
         "samples": [
             {
-                "internal_id": "sample_1",
+                "sample_id": "sample_1",
                 "last_sequenced_at": "Tue, 24 Dec 2024 11:59:00 GMT",
                 "lims_status": "top-up",
                 "ticket": 123456,


### PR DESCRIPTION
## Description

Closes https://github.com/Clinical-Genomics/production-automation/issues/50

### Added

- Case ID to response from unhandled samples endpoint

### Changed

- Renamed `internal_id` --> `sample_id` in response from unhandled samples endpoint

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions