### PR TITLE
Use should deliver sample in the unhandled samples endpoint

### DIFF
--- a/cg/server/dto/samples/samples_response.py
+++ b/cg/server/dto/samples/samples_response.py
@@ -136,7 +136,7 @@ class UnhandledSamplesResponse(BaseModel):
                     last_sequenced_at=sample.last_sequenced_at,  # type: ignore
                     lims_status=sample.lims_status,
                     ticket=sample.ticket_id_from_original_order or "unknown",
-                    workflow=sample.original_workflow or "unknown",
+                    workflow=sample.workflow_of_case_that_delivers or "unknown",
                 )
             )
         return cls(samples=unhandled_samples, total=total)

--- a/cg/server/dto/samples/samples_response.py
+++ b/cg/server/dto/samples/samples_response.py
@@ -127,7 +127,11 @@ class UnhandledSamplesResponse(BaseModel):
         for sample in samples:
             unhandled_samples.append(
                 UnhandledSample(
-                    case_id=sample.original_case.internal_id if sample.original_case else "unknown",
+                    case_id=(
+                        sample.case_that_delivers.internal_id
+                        if sample.case_that_delivers
+                        else "unknown"
+                    ),
                     sample_id=sample.internal_id,
                     last_sequenced_at=sample.last_sequenced_at,  # type: ignore
                     lims_status=sample.lims_status,

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -897,7 +897,7 @@ class Sample(Base, PriorityMixin):
             return None
 
     @property
-    def original_workflow(self) -> Workflow | None:
+    def workflow_of_case_that_delivers(self) -> Workflow | None:
         """Return the workflow of the original case if the case exists."""
         if case := self.case_that_delivers:
             return case.data_analysis

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -13,9 +13,11 @@ from sqlalchemy import (
     Numeric,
     String,
     Table,
+    UniqueConstraint,
+    orm,
+    types,
 )
 from sqlalchemy import Text as SLQText
-from sqlalchemy import UniqueConstraint, orm, types
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 from sqlalchemy.orm.attributes import InstrumentedAttribute
 
@@ -888,17 +890,15 @@ class Sample(Base, PriorityMixin):
         return None
 
     @property
-    def original_case(self) -> Case | None:
-        """Return the original case of the sample if it exists."""
-        if cases := [link.case for link in self.links]:
-            return min(cases, key=lambda case: case.created_at)
-        else:
-            return None
+    def case_that_delivers(self) -> Case | None:
+        """TODO"""
+        if self.links:
+            return [link for link in self.links if link.should_deliver_sample][0].case
 
     @property
     def original_workflow(self) -> Workflow | None:
         """Return the workflow of the original case if the case exists."""
-        if case := self.original_case:
+        if case := self.case_that_delivers:
             return case.data_analysis
         else:
             return None
@@ -906,8 +906,8 @@ class Sample(Base, PriorityMixin):
     @property
     def ticket_id_from_original_order(self) -> int | None:
         """Return the original ticket id of the sample if it is linked to any ticket."""
-        if self.original_case and self.original_case.original_order:
-            return self.original_case.original_order.ticket_id
+        if self.case_that_delivers and self.case_that_delivers.original_order:
+            return self.case_that_delivers.original_order.ticket_id
         else:
             return None
 

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -891,9 +891,8 @@ class Sample(Base, PriorityMixin):
     def case_that_delivers(self) -> Case | None:
         """Returns the case that should deliver this sample."""
         if case_samples_that_deliver := [link for link in self.links if link.should_deliver_sample]:
-            return min(
-                case_samples_that_deliver, key=lambda case_sample: case_sample.case.created_at
-            ).case
+            # we only expect one of these
+            return case_samples_that_deliver[0].case
         else:
             return None
 

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -13,11 +13,9 @@ from sqlalchemy import (
     Numeric,
     String,
     Table,
-    UniqueConstraint,
-    orm,
-    types,
 )
 from sqlalchemy import Text as SLQText
+from sqlalchemy import UniqueConstraint, orm, types
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 from sqlalchemy.orm.attributes import InstrumentedAttribute
 
@@ -891,9 +889,13 @@ class Sample(Base, PriorityMixin):
 
     @property
     def case_that_delivers(self) -> Case | None:
-        """TODO"""
-        if self.links:
-            return [link for link in self.links if link.should_deliver_sample][0].case
+        """Returns the case that should deliver this sample."""
+        if case_samples_that_deliver := [link for link in self.links if link.should_deliver_sample]:
+            return min(
+                case_samples_that_deliver, key=lambda case_sample: case_sample.case.created_at
+            ).case
+        else:
+            return None
 
     @property
     def original_workflow(self) -> Workflow | None:

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -906,7 +906,7 @@ class Sample(Base, PriorityMixin):
 
     @property
     def ticket_id_from_original_order(self) -> int | None:
-        """Return the original ticket id of the sample if it is linked to any ticket."""
+        """Return the original ticket id of the delivering case if it is linked to any ticket."""
         if self.case_that_delivers and self.case_that_delivers.original_order:
             return self.case_that_delivers.original_order.ticket_id
         else:

--- a/tests/server/dto/samples/test_samples_response.py
+++ b/tests/server/dto/samples/test_samples_response.py
@@ -18,7 +18,7 @@ def test_unhandled_samples_response_from_samples():
         internal_id="sample_1",
         last_sequenced_at=datetime.now(),
         lims_status=LimsStatus.TOP_UP,
-        original_workflow=Workflow.RAREDISEASE,
+        workflow_of_case_that_delivers=Workflow.RAREDISEASE,
         ticket_id_from_original_order=123456,
     )
     sample_2 = create_autospec(
@@ -27,7 +27,7 @@ def test_unhandled_samples_response_from_samples():
         internal_id="sample_2",
         last_sequenced_at=datetime.now(),
         lims_status=LimsStatus.TOP_UP,
-        original_workflow=Workflow.RAREDISEASE,
+        workflow_of_case_that_delivers=Workflow.RAREDISEASE,
         ticket_id_from_original_order=123456,
     )
     # WHEN creating an UnhandledSampleResponse from samples

--- a/tests/server/dto/samples/test_samples_response.py
+++ b/tests/server/dto/samples/test_samples_response.py
@@ -66,7 +66,7 @@ def test_unhandled_samples_response_from_samples_without_ticket_id_and_workflow(
         internal_id="sample_1",
         last_sequenced_at=datetime.now(),
         lims_status=LimsStatus.TOP_UP,
-        original_workflow=None,
+        workflow_of_case_that_delivers=None,
         ticket_id_from_original_order=None,
     )
 

--- a/tests/server/dto/samples/test_samples_response.py
+++ b/tests/server/dto/samples/test_samples_response.py
@@ -14,7 +14,7 @@ def test_unhandled_samples_response_from_samples():
     # GIVEN a list of database samples
     sample_1 = create_autospec(
         Sample,
-        original_case=create_autospec(Case, internal_id="case_1"),
+        case_that_delivers=create_autospec(Case, internal_id="case_1"),
         internal_id="sample_1",
         last_sequenced_at=datetime.now(),
         lims_status=LimsStatus.TOP_UP,
@@ -23,7 +23,7 @@ def test_unhandled_samples_response_from_samples():
     )
     sample_2 = create_autospec(
         Sample,
-        original_case=create_autospec(Case, internal_id="case_2"),
+        case_that_delivers=create_autospec(Case, internal_id="case_2"),
         internal_id="sample_2",
         last_sequenced_at=datetime.now(),
         lims_status=LimsStatus.TOP_UP,
@@ -62,7 +62,7 @@ def test_unhandled_samples_response_from_samples_without_ticket_id_and_workflow(
     # GIVEN a sample with no original workflow nor ticket id
     sample_1 = create_autospec(
         Sample,
-        original_case=create_autospec(Case, internal_id="case_1"),
+        case_that_delivers=create_autospec(Case, internal_id="case_1"),
         internal_id="sample_1",
         last_sequenced_at=datetime.now(),
         lims_status=LimsStatus.TOP_UP,

--- a/tests/server/endpoints/test_samples_endpoint.py
+++ b/tests/server/endpoints/test_samples_endpoint.py
@@ -111,7 +111,7 @@ def test_get_unhandled_samples(client: FlaskClient, mocker: MockerFixture):
         last_sequenced_at=date_time,
         lims_status=LimsStatus.TOP_UP,
         case_that_delivers=create_autospec(Case, internal_id="case_1"),
-        original_workflow=Workflow.RAREDISEASE,
+        workflow_of_case_that_delivers=Workflow.RAREDISEASE,
         ticket_id_from_original_order=123456,
     )
     status_db.as_type.get_paginated_unhandled_samples = Mock(return_value=([sample_1], 1))

--- a/tests/server/endpoints/test_samples_endpoint.py
+++ b/tests/server/endpoints/test_samples_endpoint.py
@@ -110,7 +110,7 @@ def test_get_unhandled_samples(client: FlaskClient, mocker: MockerFixture):
         is_cancelled=False,
         last_sequenced_at=date_time,
         lims_status=LimsStatus.TOP_UP,
-        original_case=create_autospec(Case, internal_id="case_1"),
+        case_that_delivers=create_autospec(Case, internal_id="case_1"),
         original_workflow=Workflow.RAREDISEASE,
         ticket_id_from_original_order=123456,
     )

--- a/tests/store/test_store_models.py
+++ b/tests/store/test_store_models.py
@@ -138,6 +138,20 @@ def test_multiple_collaborations(base_store, customer_id):
     )
 
 
+def test_sample_case_that_delivers():
+    case_that_delivers = Case(created_at="1980-01-01")
+    case_that_does_not_deliver = Case(created_at="1970-01-01")
+    sample = Sample(
+        links=[
+            CaseSample(case=case_that_delivers, should_deliver_sample=True),
+            CaseSample(case=case_that_does_not_deliver, should_deliver_sample=False),
+        ]
+    )
+    case = sample.case_that_delivers
+
+    assert case == case_that_delivers
+
+
 def test_sample_ticket_id_from_original_order_no_order():
     """Tests that a sample without an original order returns None for ticket id."""
     # GIVEN a sample without an original order

--- a/tests/store/test_store_models.py
+++ b/tests/store/test_store_models.py
@@ -139,17 +139,48 @@ def test_multiple_collaborations(base_store, customer_id):
 
 
 def test_sample_case_that_delivers():
-    case_that_delivers = Case(created_at="1980-01-01")
-    case_that_does_not_deliver = Case(created_at="1970-01-01")
+    # GIVEN a sample with a relationship that delivers the sample
+    case_that_delivers = Case()
+    case_that_does_not_deliver = Case()
     sample = Sample(
         links=[
             CaseSample(case=case_that_delivers, should_deliver_sample=True),
             CaseSample(case=case_that_does_not_deliver, should_deliver_sample=False),
         ]
     )
+
+    # WHEN getting the case that delivers
     case = sample.case_that_delivers
 
+    # THEN the result is the expected case
     assert case == case_that_delivers
+
+
+def test_sample_case_that_delivers_no_links():
+    # GIVEN a sample without relationships
+    sample = Sample(links=[])
+
+    # WHEN getting the case that delivers
+    case = sample.case_that_delivers
+
+    # THEN the property returns None
+    assert case is None
+
+
+def test_sample_case_that_delivers_no_case_that_delivers():
+    # GIVEN a sample with only relationships having should_deliver_sample False
+    case = Case()
+    sample = Sample(
+        links=[
+            CaseSample(case=case, should_deliver_sample=False),
+        ]
+    )
+
+    # WHEN getting the case that delivers
+    case = sample.case_that_delivers
+
+    # THEN the property should return None
+    assert case is None
 
 
 def test_sample_ticket_id_from_original_order_no_order():


### PR DESCRIPTION
## Description

### Changed

- Use the CaseSample `should_deliver_sample` property to choose the case for a sample in the `/unhandled_samples` endpoint
- Rename Sample properties accordingly


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
