### PR TITLE
Add customer case display name to gens load

### DIFF
--- a/cg/apps/gens.py
+++ b/cg/apps/gens.py
@@ -32,6 +32,7 @@ class GensAPI:
         self,
         baf_path: str,
         case_id: str,
+        case_name: str,
         coverage_path: str,
         genome_build: str,
         sample_id: str,
@@ -44,6 +45,7 @@ class GensAPI:
             "--baf": baf_path,
             "--coverage": coverage_path,
             "--case-id": case_id,
+            "--display-case-id": case_name,
         }
         command: list[str] = args + get_list_from_dictionary(kw_args)
 

--- a/cg/cli/upload/gens.py
+++ b/cg/cli/upload/gens.py
@@ -53,6 +53,7 @@ def upload_to_gens(context: CGConfig, case_id: str | None, dry_run: bool):
             gens_api.load(
                 baf_path=hk_fracsnp.full_path,
                 case_id=case_id,
+                case_name=case.name,
                 coverage_path=hk_coverage.full_path,
                 genome_build=genome_build,
                 sample_id=sample.internal_id,

--- a/tests/apps/gens/test_gens_api.py
+++ b/tests/apps/gens/test_gens_api.py
@@ -27,6 +27,7 @@ def test_instantiate(gens_config: GENSConfig):
 
 def test_gens_api_load(
     case_id: str,
+    case_name: str,
     gens_config: dict[str, dict[str, str]],
     gens_coverage_path: Path,
     gens_fracsnp_path: Path,
@@ -48,6 +49,7 @@ def test_gens_api_load(
         baf_path=gens_fracsnp_path.as_posix(),
         coverage_path=gens_coverage_path.as_posix(),
         case_id=case_id,
+        case_name=case_name,
     )
 
     # THEN the subprocess.run() should be called with
@@ -67,6 +69,8 @@ def test_gens_api_load(
             gens_coverage_path.as_posix(),
             "--case-id",
             case_id,
+            "--display-case-id",
+            case_name,
         ],
         check=False,
         env=ANY,

--- a/tests/cli/upload/test_cli_upload_gens.py
+++ b/tests/cli/upload/test_cli_upload_gens.py
@@ -47,7 +47,10 @@ def test_upload_gens_genome_build(
     sample1: Sample = create_autospec(Sample, internal_id="sample_id1")
     sample2: Sample = create_autospec(Sample, internal_id="sample_id2")
 
-    case: Case = create_autospec(Case, data_analysis=workflow, samples=[sample1, sample2])
+    case: Case = create_autospec(
+        Case, data_analysis=workflow, samples=[sample1, sample2], name="case_name"
+    )
+    case.name = "case_name"
     upload_gens_context.status_db.get_case_by_internal_id_strict = Mock(return_value=case)
 
     # GIVEN a HousekeeperAPI
@@ -65,6 +68,7 @@ def test_upload_gens_genome_build(
             call(
                 baf_path=ANY,
                 case_id="some_case",
+                case_name="case_name",
                 coverage_path=ANY,
                 genome_build=genome_build,
                 sample_id="sample_id1",
@@ -72,6 +76,7 @@ def test_upload_gens_genome_build(
             call(
                 baf_path=ANY,
                 case_id="some_case",
+                case_name="case_name",
                 coverage_path=ANY,
                 genome_build=genome_build,
                 sample_id="sample_id2",


### PR DESCRIPTION
## Description

Closes https://github.com/Clinical-Genomics/cg/issues/5097

### Added

- Customer case name is passed as parameter to gens load command

### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b gens-load-cust-name -a
    ```

### How to test

- [x] Run `cg upload gens <case_id>`

### Expected test outcome

- [x] Gens command is invoked correctly
- [x] Gens command runs successfully
- [x] Take a screenshot and attach or copy/paste the output.

## Review

- [x] Tests executed by AKE
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in NA
- [ ] Deploy this branch on master
- [ ] Inform to DN
