### PR TITLE
Add order ID to analysis and raw data service

### DIFF
--- a/cg/cli/workflow/raw_data/raw_data_service.py
+++ b/cg/cli/workflow/raw_data/raw_data_service.py
@@ -33,6 +33,7 @@ class RawDataAnalysisService:
             started_at=dt.datetime.now(),
             case_id=case.id,
             trailblazer_id=trailblazer_id,
+            order_id=case.latest_order.id,
         )
         self.store.add_item_to_store(new_analysis)
         self.store.commit_to_store()

--- a/cg/meta/workflow/analysis.py
+++ b/cg/meta/workflow/analysis.py
@@ -241,6 +241,7 @@ class AnalysisAPI(MetaAPI):
             primary=is_primary,
             started_at=analysis_start,
             trailblazer_id=trailblazer_id,
+            order_id=case.latest_order.id,
         )
         new_analysis.case = case
         self.status_db.add_item_to_store(new_analysis)

--- a/tests/cli/workflow/raw_data/test_raw_data_service.py
+++ b/tests/cli/workflow/raw_data/test_raw_data_service.py
@@ -9,16 +9,17 @@ from cg.apps.tb.models import TrailblazerAnalysis
 from cg.cli.workflow.raw_data.raw_data_service import RawDataAnalysisService
 from cg.constants import Priority
 from cg.constants.constants import Workflow
-from cg.store.models import Case
+from cg.store.models import Case, Order
 from cg.store.store import Store
 from tests.typed_mock import TypedMock, create_typed_mock
 
 
 @pytest.mark.freeze_time
 def test_store_analysis():
-    # GIVEN a raw data case
+    # GIVEN a raw data case linked to an order
+    order: Order = create_autospec(Order, id=42)
     case: Case = create_autospec(
-        Case, id=666, priority=Priority.express, internal_id="the_best_case"
+        Case, id=666, priority=Priority.express, internal_id="the_best_case", latest_order=order
     )
 
     # GIVEN that a pending analysis can be created in trailblazer
@@ -56,6 +57,7 @@ def test_store_analysis():
         started_at=datetime.now(),
         case_id=666,
         trailblazer_id=67,
+        order_id=case.latest_order.id,
     )
     store.as_mock.add_item_to_store.assert_called_once()
     store.as_mock.commit_to_store.assert_called_once()

--- a/tests/meta/workflow/test_analysis.py
+++ b/tests/meta/workflow/test_analysis.py
@@ -8,6 +8,7 @@ from unittest.mock import ANY, Mock, create_autospec
 import mock
 import pytest
 from housekeeper.store.models import Version
+from typed_mock import TypedMock, create_typed_mock
 
 from cg.apps.tb.api import TrailblazerAPI
 from cg.apps.tb.models import TrailblazerAnalysis
@@ -671,9 +672,9 @@ def case_mock() -> Case:
 
 
 @pytest.fixture
-def status_db_mock(case_mock: Case) -> Store:
-    store: Store = create_autospec(Store)
-    store.get_case_by_internal_id = lambda internal_id: case_mock
+def status_db_mock(case_mock: Case) -> TypedMock[Store]:
+    store: TypedMock[Store] = create_typed_mock(Store)
+    store.as_type.get_case_by_internal_id = lambda internal_id: case_mock
     return store
 
 
@@ -686,10 +687,10 @@ def trailblazer_api_mock() -> TrailblazerAPI:
 
 @pytest.fixture()
 def analysis_config(
-    context_config: dict, status_db_mock: Store, trailblazer_api_mock: TrailblazerAPI
+    context_config: dict, status_db_mock: TypedMock[Store], trailblazer_api_mock: TrailblazerAPI
 ) -> CGConfig:
     cg_config = CGConfig(**context_config)
-    cg_config.status_db_ = status_db_mock
+    cg_config.status_db_ = status_db_mock.as_type
     cg_config.trailblazer_api_ = trailblazer_api_mock
     return cg_config
 
@@ -730,7 +731,7 @@ def test_on_analysis_started_adds_a_pending_analysis_to_trailblazer(
 def test_on_analysis_started_creates_an_analysis_in_status_db(
     analysis_config: CGConfig,
     case_mock: Case,
-    status_db_mock: Store,
+    status_db_mock: TypedMock[Store],
     trailblazer_api_mock: TrailblazerAPI,
 ):
     # GIVEN an analysis api can successfully create a trailblazer analysis
@@ -742,7 +743,7 @@ def test_on_analysis_started_creates_an_analysis_in_status_db(
     trailblazer_api_mock.add_pending_analysis = Mock(return_value=new_trailblazer_analysis)
 
     new_analysis: Analysis = create_autospec(Analysis)
-    status_db_mock.add_analysis = Mock(return_value=new_analysis)
+    status_db_mock.as_type.add_analysis = Mock(return_value=new_analysis)
 
     # WHEN on_analysis_started is called
     analysis_api.on_analysis_started(case_mock.internal_id)
@@ -751,7 +752,7 @@ def test_on_analysis_started_creates_an_analysis_in_status_db(
     #   - the trailblazer analysis id
     #   - the given case
     #   - the latest order id for the case
-    status_db_mock.add_analysis.assert_called_with(
+    status_db_mock.as_mock.add_analysis.assert_called_with(
         workflow=Workflow.BALSAMIC,
         trailblazer_id=new_trailblazer_analysis.id,
         completed_at=None,
@@ -760,16 +761,17 @@ def test_on_analysis_started_creates_an_analysis_in_status_db(
         version=ANY,
         order_id=case_mock.latest_order.id,
     )
-    status_db_mock.add_item_to_store.assert_called_with(new_analysis)
+    status_db_mock.as_mock.add_item_to_store.assert_called_with(new_analysis)
     assert new_analysis.case == case_mock
 
 
 @pytest.mark.usefixtures("patch_abstract_methods")
 def test_on_analysis_started_throws_when_case_was_not_found(
-    analysis_config: CGConfig, case_mock: Case, status_db_mock: Store
+    analysis_config: CGConfig, case_mock: Case, status_db_mock: TypedMock[Store]
 ):
     # GIVEN the case can't be found in StatusDB
-    status_db_mock.get_case_by_internal_id = Mock(return_value=None)
+    status_db_mock.as_type.get_case_by_internal_id = Mock(return_value=None)
+
     # GIVEN an analysis api
     analysis_api: AnalysisAPI = AnalysisAPI(workflow=Workflow.BALSAMIC, config=analysis_config)
 
@@ -781,7 +783,7 @@ def test_on_analysis_started_throws_when_case_was_not_found(
 
 @pytest.mark.usefixtures("patch_abstract_methods")
 def test_on_analysis_started_sets_the_case_action_to_running(
-    analysis_config: CGConfig, case_mock: Case, status_db_mock: Store
+    analysis_config: CGConfig, case_mock: Case, status_db_mock: TypedMock[Store]
 ):
     # GIVEN an analysis api and a case with action = None
     analysis_api = AnalysisAPI(workflow=Workflow.BALSAMIC, config=analysis_config)
@@ -791,13 +793,13 @@ def test_on_analysis_started_sets_the_case_action_to_running(
     analysis_api.on_analysis_started(case_mock.internal_id)
 
     # THEN the case action is set to RUNNING
-    status_db_mock.update_case_action.assert_called_with(
+    status_db_mock.as_mock.update_case_action.assert_called_with(
         action=CaseActions.RUNNING, case_internal_id=case_mock.internal_id
     )
 
 
 def test_update_analysis_as_completed_statusdb_analysis_already_completed(
-    analysis_config: CGConfig, case_mock: Case, status_db_mock: Store
+    analysis_config: CGConfig, case_mock: Case
 ):
     """Test that update_analysis_as_completed_statusdb fails if the analysis is already completed."""
     # GIVEN an analysis api and a case with an analysis in StatusDB
@@ -818,7 +820,7 @@ def test_update_analysis_as_completed_statusdb_analysis_already_completed(
 def test_update_analysis_as_completed_statusdb_succeeds(
     analysis_config: CGConfig,
     case_mock: Case,
-    status_db_mock: Store,
+    status_db_mock: TypedMock[Store],
 ):
     """Test that update_analysis_as_completed_statusdb succeeds if the analysis is not completed."""
     # GIVEN an analysis api and a case with an analysis in StatusDB
@@ -829,7 +831,7 @@ def test_update_analysis_as_completed_statusdb_succeeds(
     analysis.housekeeper_version_id = None
     hk_version: Version = create_autospec(Version)
     hk_version.id = 1234
-    status_db_mock.get_latest_started_analysis_for_case.return_value = analysis
+    status_db_mock.as_type.get_latest_started_analysis_for_case.return_value = analysis
 
     # GIVEN that the bundle has a completed_at date of now
     with (
@@ -844,17 +846,19 @@ def test_update_analysis_as_completed_statusdb_succeeds(
         )
 
     # THEN it updates the analysis completed_at date in StatusDB
-    status_db_mock.update_analysis_completed_at.assert_called_with(
+    status_db_mock.as_mock.update_analysis_completed_at.assert_called_with(
         analysis_id=123456, completed_at=datetime.now()
     )
 
     # THEN it updates the analysis housekeeper version id
-    status_db_mock.update_analysis_housekeeper_version_id.assert_called_with(
+    status_db_mock.as_mock.update_analysis_housekeeper_version_id.assert_called_with(
         analysis_id=123456, version_id=1234
     )
 
     # THEN it updates the analysis comment
-    status_db_mock.update_analysis_comment.assert_called_with(analysis_id=123456, comment=ANY)
+    status_db_mock.as_mock.update_analysis_comment.assert_called_with(
+        analysis_id=123456, comment=ANY
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/meta/workflow/test_analysis.py
+++ b/tests/meta/workflow/test_analysis.py
@@ -23,7 +23,7 @@ from cg.meta.workflow.mip_dna import MipDNAAnalysisAPI
 from cg.meta.workflow.prepare_fastq import PrepareFastqAPI
 from cg.models.cg_config import CGConfig
 from cg.models.fastq import FastqFileMeta
-from cg.store.models import Analysis, Case, CaseSample, IlluminaSequencingRun, Sample
+from cg.store.models import Analysis, Case, CaseSample, IlluminaSequencingRun, Order, Sample
 from cg.store.store import Store
 from tests.store_helpers import StoreHelpers
 
@@ -662,8 +662,8 @@ def patch_abstract_methods(mocker):
 def case_mock() -> Case:
     case_sample: CaseSample = create_autospec(CaseSample)
     case_sample.sample = create_autospec(Sample)
-
-    case: Case = create_autospec(Case)
+    order: Order = create_autospec(Order, id=1)
+    case: Case = create_autospec(Case, latest_order=order)
     case.internal_id = "some_case_id"
     case.links = [case_sample]
     case.priority = Priority.standard
@@ -750,6 +750,7 @@ def test_on_analysis_started_creates_an_analysis_in_status_db(
     # THEN it creates an Analysis row in status db connected with:
     #   - the trailblazer analysis id
     #   - the given case
+    #   - the latest order id for the case
     status_db_mock.add_analysis.assert_called_with(
         workflow=Workflow.BALSAMIC,
         trailblazer_id=new_trailblazer_analysis.id,
@@ -757,6 +758,7 @@ def test_on_analysis_started_creates_an_analysis_in_status_db(
         primary=True,
         started_at=datetime.now(),
         version=ANY,
+        order_id=case_mock.latest_order.id,
     )
     status_db_mock.add_item_to_store.assert_called_with(new_analysis)
     assert new_analysis.case == case_mock

--- a/tests/meta/workflow/test_analysis.py
+++ b/tests/meta/workflow/test_analysis.py
@@ -8,7 +8,6 @@ from unittest.mock import ANY, Mock, create_autospec
 import mock
 import pytest
 from housekeeper.store.models import Version
-from typed_mock import TypedMock, create_typed_mock
 
 from cg.apps.tb.api import TrailblazerAPI
 from cg.apps.tb.models import TrailblazerAnalysis
@@ -27,6 +26,7 @@ from cg.models.fastq import FastqFileMeta
 from cg.store.models import Analysis, Case, CaseSample, IlluminaSequencingRun, Order, Sample
 from cg.store.store import Store
 from tests.store_helpers import StoreHelpers
+from tests.typed_mock import TypedMock, create_typed_mock
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

### Added

- The id of the latest order to the Analysis object when starting MUTANT, Fluffy, raw-data and MIP-RNA analyses

### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b add-order-id-to-analysis -a
    ```

### How to test

- [x] Do `cg workflow raw-data store` with a raw-data case ready to be stored
- [x] Do `cg workflow mip-rna run` with a MIP-RNA case ready to run

### Expected test outcome

- [x] Check that the created analysis object has order_id set

## Review

- [x] Tests executed by SD
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
