### PR TITLE
Patch race condition in demultiplexing

### DIFF
--- a/cg/cli/demultiplex/copy_novaseqx_demultiplex_data.py
+++ b/cg/cli/demultiplex/copy_novaseqx_demultiplex_data.py
@@ -122,7 +122,9 @@ def are_all_files_synced(files_at_source: list[Path], target_directory: Path) ->
     """Checks if all relevant files in the source are present in the target directory."""
     for file in files_at_source:
         target_file_path = Path(target_directory, file)
-        if is_file_relevant_for_demultiplexing(file) and not target_file_path.exists():
+        if (
+            is_file_relevant_for_demultiplexing(file) or is_file_relevant_for_post_processing(file)
+        ) and not target_file_path.exists():
             LOG.info(f"File: {file}, has not been transferred from source to {target_directory}")
             return False
     return True
@@ -214,6 +216,16 @@ def is_file_relevant_for_demultiplexing(file: Path) -> bool:
         if relevant_directory in file.parts:
             return True
     return False
+
+
+def is_file_relevant_for_post_processing(file: Path) -> bool:
+    """Returns whether a file is relevant for post-processing."""
+    relevant_files = [
+        DemultiplexingDirsAndFiles.RUN_COMPLETION_STATUS,
+        DemultiplexingDirsAndFiles.RUN_PARAMETERS_PASCAL_CASE,
+        DemultiplexingDirsAndFiles.RUN_PARAMETERS_CAMEL_CASE,
+    ]
+    return file.name in relevant_files
 
 
 def link_onboard_demultiplexed_flow_cell(


### PR DESCRIPTION
## Description
Aim to address bug: https://github.com/Clinical-Genomics/bug-reports/issues/75

### Added

- func is_file_relevant_for_post_processing

### Changed

- demultiplexing will only start when all relevant files are on hasta, files needed for demultiplexing and post processing.

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
