### PR TITLE
Allow missing mutant (Original lab address) and (region code)

### DIFF
--- a/cg/services/orders/validation/order_types/mutant/models/sample.py
+++ b/cg/services/orders/validation/order_types/mutant/models/sample.py
@@ -26,7 +26,7 @@ class MutantSample(Sample):
     _lab_code: str = PrivateAttr(default="SE100 Karolinska")
     organism: str
     organism_other: str | None = None
-    original_lab: OriginalLab | None = None
+    original_lab: OriginalLab
     original_lab_address: str | None = None
     pre_processing_method: PreProcessingMethod
     primer: Primer
@@ -34,7 +34,7 @@ class MutantSample(Sample):
     quantity: int | None = None
     reference_genome: str
     region: Region
-    region_code: str
+    region_code: str | None = None
     selection_criteria: SelectionCriteria
     _verified_organism: bool | None = PrivateAttr(default=None)
 

--- a/cg/services/orders/validation/order_types/mutant/models/sample.py
+++ b/cg/services/orders/validation/order_types/mutant/models/sample.py
@@ -26,8 +26,8 @@ class MutantSample(Sample):
     _lab_code: str = PrivateAttr(default="SE100 Karolinska")
     organism: str
     organism_other: str | None = None
-    original_lab: OriginalLab
-    original_lab_address: str
+    original_lab: OriginalLab | None = None
+    original_lab_address: str | None = None
     pre_processing_method: PreProcessingMethod
     primer: Primer
     priority: PriorityEnum


### PR DESCRIPTION
## Description

Make `original_lab_address` and `region_code` optional for Mutant/SARS-CoV-2 sample validation.

These fields do not exist in the order portal and are not visible or editable by users. They are derived from `original_lab` and `region` when possible, so missing values should not block order validation or return validation errors to the frontend.

This change is required because the frontend includes errors for fields that are hidden in the UI. Showing validation errors for `original_lab_address` or `region_code` would confuse users, since they cannot fix those fields in the order portal.

## Added

None

## Changed

- Allow `original_lab_address` to be `None`
- Allow `region_code` to be `None`
- Keep the existing auto-fill behavior from `original_lab` and `region`


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...

Issue: https://github.com/Clinical-Genomics/cg/issues/5120
