### PR TITLE
Implement error handling to manual deliver commands

### DIFF
--- a/cg/services/deliver_service.py
+++ b/cg/services/deliver_service.py
@@ -32,36 +32,15 @@ class DeliverService:
         self.freshdesk_client = freshdesk_client
 
     def deliver_all_available(self) -> bool:
-        success: bool = True
         order_dict: dict[Order, list[Analysis]] = self._get_order_analyses_dictionary()
         if len(order_dict) == 0:
             LOG.warning("No analyses found to deliver.")
-            return success
+            return True
+        are_all_orders_delivered: list[bool] = []
         for order, analyses in order_dict.items():
-            try:
-                self._deliver_order(order=order, analyses=analyses)
-            except TrailblazerAnalysisDeliveryError as error:
-                self.status_db.rollback()
-                success = False
-                LOG.error(
-                    f"Failed to mark analyses as delivered in Trailblazer for order {order.id}"
-                )
-                LOG.exception(error)
-            except (TrailblazerFailedToGetAnalysesError, FreshdeskDeliveryMessageError) as error:
-                self.status_db.rollback()
-                self.mark_as_delivered_service.unmark_analyses(analyses)
-                success = False
-                LOG.error(f"Failed to send delivery message for ticket {order.ticket_id}")
-                LOG.exception(error)
-            except (FreshdeskGetTicketError, FreshdeskUpdateTicketError) as error:
-                order.is_open = True
-                self.status_db.commit_to_store()
-                success = False
-                LOG.error(f"Failed to close ticket {order.ticket_id} in Freshdesk")
-                LOG.exception(error)
-            else:
-                self.status_db.commit_to_store()
-        return success
+            order_successful: bool = self._deliver(order=order, analyses=analyses, signature=None)
+            are_all_orders_delivered.append(order_successful)
+        return all(are_all_orders_delivered)
 
     def deliver_case(self, case_id: str, signature: str):
         analyses_to_deliver: list[Analysis] = self._get_undelivered_analyses_for_case(case_id)
@@ -70,13 +49,12 @@ class DeliverService:
                 LOG.warning(f"No analysis found to deliver for case {case_id}.")
             case 1:
                 order: Order = analyses_to_deliver[0].order
-                self._deliver_order(order=order, analyses=analyses_to_deliver, signature=signature)
+                self._deliver(order=order, analyses=analyses_to_deliver, signature=signature)
             case _:
                 raise MultipleAnalysesToDeliverError(f"Multiple analyses found for case {case_id}")
 
     def deliver_order(self, ticket_id: int, signature: str):
         order: Order = self.status_db.get_order_by_ticket_id_strict(ticket_id)
-
         undelivered_trailblazer_analyses = self.trailblazer_api.get_analyses_to_deliver_for_order(
             order.id
         )
@@ -84,11 +62,35 @@ class DeliverService:
             [analysis.id for analysis in undelivered_trailblazer_analyses]
         )
         if uploaded_analyses_to_deliver:
-            self._deliver_order(
-                order=order, analyses=uploaded_analyses_to_deliver, signature=signature
-            )
+            self._deliver(order=order, analyses=uploaded_analyses_to_deliver, signature=signature)
         else:
             LOG.warning("No analysis in the order ready to deliver")
+
+    def _deliver(
+        self, order: Order, analyses: list[Analysis], signature: str | None = None
+    ) -> bool:
+        try:
+            self._deliver_order(order=order, analyses=analyses, signature=signature)
+        except TrailblazerAnalysisDeliveryError as error:
+            self.status_db.rollback()
+            LOG.error(f"Failed to mark analyses as delivered in Trailblazer for order {order.id}")
+            LOG.exception(error)
+            return False
+        except (TrailblazerFailedToGetAnalysesError, FreshdeskDeliveryMessageError) as error:
+            self.status_db.rollback()
+            self.mark_as_delivered_service.unmark_analyses(analyses)
+            LOG.error(f"Failed to send delivery message for ticket {order.ticket_id}")
+            LOG.exception(error)
+            return False
+        except (FreshdeskGetTicketError, FreshdeskUpdateTicketError) as error:
+            order.is_open = True
+            self.status_db.commit_to_store()
+            LOG.error(f"Failed to close ticket {order.ticket_id} in Freshdesk")
+            LOG.exception(error)
+            return False
+        else:
+            self.status_db.commit_to_store()
+            return True
 
     def _deliver_order(
         self, order: Order, analyses: list[Analysis], signature: str | None = None

--- a/cg/services/deliver_service.py
+++ b/cg/services/deliver_service.py
@@ -69,8 +69,12 @@ class DeliverService:
     def _deliver(
         self, order: Order, analyses: list[Analysis], signature: str | None = None
     ) -> bool:
+        LOG.info(f"Delivering {len(analyses)} analyses of ticket {order.ticket_id}.")
         try:
-            self._deliver_order(order=order, analyses=analyses, signature=signature)
+            self.mark_as_delivered_service.mark_analyses(analyses=analyses, signature=signature)
+            self.mark_as_delivered_service.close_order_in_status_db_if_closable(order)
+            self._freshdesk_send_delivery_message(order=order, analyses=analyses)
+            self._freshdesk_close_ticket_if_open(order=order)
         except TrailblazerAnalysisDeliveryError as error:
             self.status_db.rollback()
             LOG.error(f"Failed to mark analyses as delivered in Trailblazer for order {order.id}")
@@ -91,15 +95,6 @@ class DeliverService:
         else:
             self.status_db.commit_to_store()
             return True
-
-    def _deliver_order(
-        self, order: Order, analyses: list[Analysis], signature: str | None = None
-    ) -> None:
-        LOG.info(f"Delivering {len(analyses)} analyses of ticket {order.ticket_id}.")
-        self.mark_as_delivered_service.mark_analyses(analyses=analyses, signature=signature)
-        self.mark_as_delivered_service.close_order_in_status_db_if_closable(order)
-        self._freshdesk_send_delivery_message(order=order, analyses=analyses)
-        self._freshdesk_close_ticket_if_open(order=order)
 
     def _get_undelivered_analyses_for_case(self, case_id: str) -> list[Analysis]:
         undelivered_trailblazer_analyses: list[TrailblazerAnalysis] = (

--- a/tests/cli/deliver/test_dev_deliver.py
+++ b/tests/cli/deliver/test_dev_deliver.py
@@ -13,14 +13,8 @@ from cg.cli.deliver.base import (
     deliver_dev_order,
 )
 from cg.constants.process import EXIT_FAIL, EXIT_PARSE_ERROR, EXIT_SUCCESS
-from cg.exc import (
-    FreshdeskDeliveryMessageError,
-    FreshdeskUpdateTicketError,
-    TrailblazerAnalysisDeliveryError,
-    TrailblazerFailedToGetAnalysesError,
-)
 from cg.models.cg_config import CGConfig, FreshdeskConfig
-from cg.services.deliver_service import DeliverService, MarkAsDeliveredService
+from cg.services.deliver_service import DeliverService
 from cg.store.models import Order
 from cg.store.store import Store
 from tests.typed_mock import TypedMock, create_typed_mock
@@ -150,18 +144,7 @@ def test_deliver_dev_all_available_command_success(mocker: MockerFixture):
     deliver_all_command.assert_called_once_with(ANY)
 
 
-@pytest.mark.parametrize(
-    "caught_error",
-    [
-        TrailblazerAnalysisDeliveryError,
-        TrailblazerFailedToGetAnalysesError,
-        FreshdeskDeliveryMessageError,
-        FreshdeskUpdateTicketError,
-    ],
-)
-def test_deliver_dev_all_available_service_caught_error(
-    caught_error: Exception, mocker: MockerFixture
-):
+def test_deliver_dev_all_available_service_caught_error(mocker: MockerFixture):
     # GIVEN a store and a CG config
     cli_runner = CliRunner()
     freshdesk_config = FreshdeskConfig(api_key="some_key", base_url="some_url")
@@ -178,8 +161,7 @@ def test_deliver_dev_all_available_service_caught_error(
         "_get_order_analyses_dictionary",
         return_value={create_autospec(Order, id=1, ticket_id=1234567): "analyses"},
     )
-    mocker.patch.object(MarkAsDeliveredService, "unmark_analyses")
-    mocker.patch.object(DeliverService, "_deliver_order", side_effect=caught_error)
+    mocker.patch.object(DeliverService, "_deliver", return_value=False)
 
     # WHEN calling the deliver all available cases command
     result = cli_runner.invoke(deliver_dev_all_available, obj=cg_config, standalone_mode=False)


### PR DESCRIPTION
## Description

Implement error handling and rollback in the manual commands deliver_case and deliver_order

### Added

-

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
