### PR TITLE
Toggle on DB changes in upload_handler and update TB

### DIFF
--- a/cg/cli/events.py
+++ b/cg/cli/events.py
@@ -3,6 +3,7 @@ import os
 
 import rich_click as click
 
+from cg.apps.tb import TrailblazerAPI
 from cg.models.cg_config import CGConfig
 from cg.services.events import upload_handler
 from cg.services.events.event_listener import EventListener
@@ -19,8 +20,20 @@ def listen(config: CGConfig):
     initialize_database(os.environ["CG_SQL_DATABASE_URI"])
     status_db = Store()
 
+    trailblazer_api = TrailblazerAPI(config=_trailblazer_config_from_env())
+
     listener.register(
         f"{config.nats.stream}.{ANALYSIS_UPLOADED_SUBJECT}",
-        upload_handler.completed(status_db),
+        upload_handler.completed(store=status_db, trailblazer_api=trailblazer_api),
     )
     asyncio.run(listener.listen())
+
+
+def _trailblazer_config_from_env() -> dict[str, dict[str, str]]:
+    return {
+        "trailblazer": {
+            "host": os.environ["TRAILBLAZER_HOST"],
+            "service_account": os.environ["TRAILBLAZER_SERVICE_ACCOUNT"],
+            "service_account_auth_file": os.environ["TRAILBLAZER_SERVICE_ACCOUNT_AUTH_FILE"],
+        }
+    }

--- a/cg/cli/events.py
+++ b/cg/cli/events.py
@@ -24,7 +24,7 @@ def listen(config: CGConfig):
 
     listener.register(
         f"{config.nats.stream}.{ANALYSIS_UPLOADED_SUBJECT}",
-        upload_handler.completed(store=status_db, trailblazer_api=trailblazer_api),
+        upload_handler.completed(status_db=status_db, trailblazer_api=trailblazer_api),
     )
     asyncio.run(listener.listen())
 

--- a/cg/services/events/event_listener.py
+++ b/cg/services/events/event_listener.py
@@ -8,6 +8,7 @@ from ssl import Purpose, SSLContext, TLSVersion
 
 import nats
 from nats.aio.client import Client
+from nats.aio.msg import Msg
 from nats.js import JetStreamContext
 
 from cg.models.cg_config import NatsConfig
@@ -46,8 +47,11 @@ class EventListener:
                     handler(json.loads(msg.data))
                     await msg.ack()
                 except Exception:
-                    LOG.exception(f"Failed to handle {msg.subject}")
-                    await msg.nak()
+                    delay: int = _exponential_backoff_delay(msg)
+                    LOG.exception(
+                        f"Failed to handle {msg.subject}, will retry in: {delay} seconds."
+                    )
+                    await msg.nak(delay=delay)
             else:
                 LOG.warning(f"No handler registered for {msg.subject}")
                 await msg.ack()
@@ -58,3 +62,14 @@ class EventListener:
         ctx.load_verify_locations(self.ca_cert_path)
         ctx.load_cert_chain(certfile=self.client_cert, keyfile=self.client_key)
         return ctx
+
+
+def _exponential_backoff_delay(msg: Msg) -> int:
+    """
+    Increase the delay for each attempt:
+    30s, 60s, 120s etc. until a maximum of 1hr
+    """
+    max_backoff_seconds: int = 3600
+    base_delay: int = 30
+    previous_attempts: int = msg.metadata.num_delivered - 1
+    return min(base_delay * (2**previous_attempts), max_backoff_seconds)

--- a/cg/services/events/upload_handler.py
+++ b/cg/services/events/upload_handler.py
@@ -9,17 +9,17 @@ LOG = logging.getLogger(__name__)
 ANALYSIS_UPLOADED_SUBJECT = "analysis.upload_completed"
 
 
-def completed(store: Store, trailblazer_api: TrailblazerAPI):
+def completed(status_db: Store, trailblazer_api: TrailblazerAPI):
     def handler(message: dict):
         analysis_id = message["cg.analysis_id"]
         uploaded_at = message["uploaded_at"]
         try:
             uploaded_at_datetime = datetime.strptime(uploaded_at, "%Y-%m-%dT%H:%M:%SZ")
-            store.update_analysis_uploaded_at(
+            status_db.update_analysis_uploaded_at(
                 analysis_id=analysis_id,
                 uploaded_at=uploaded_at_datetime,
             )
-            if analysis := store.get_analysis_by_entry_id(analysis_id):
+            if analysis := status_db.get_analysis_by_entry_id(analysis_id):
                 trailblazer_api.set_analysis_uploaded(
                     analysis.case.internal_id, uploaded_at=uploaded_at_datetime
                 )

--- a/cg/services/events/upload_handler.py
+++ b/cg/services/events/upload_handler.py
@@ -1,6 +1,7 @@
 import logging
 from datetime import datetime
 
+from cg.apps.tb.api import TrailblazerAPI
 from cg.store.store import Store
 
 LOG = logging.getLogger(__name__)
@@ -8,22 +9,24 @@ LOG = logging.getLogger(__name__)
 ANALYSIS_UPLOADED_SUBJECT = "analysis.upload_completed"
 
 
-def completed(store: Store):
+def completed(store: Store, trailblazer_api: TrailblazerAPI):
     def handler(message: dict):
         analysis_id = message["cg.analysis_id"]
         uploaded_at = message["uploaded_at"]
         try:
-            # store.update_analysis_uploaded_at(
-            #     analysis_id=analysis_id,
-            #     uploaded_at=datetime.strptime(uploaded_at, "%Y-%m-%dT%H:%M:%SZ"),
-            # )
-            LOG.info("DB changes toggled off. Would process event by running:")
-            LOG.info(
-                f"store.update_analysis_uploaded_at(analysis_id={analysis_id}, uploaded_at={datetime.strptime(uploaded_at, '%Y-%m-%dT%H:%M:%SZ')})"
+            uploaded_at_datetime = datetime.strptime(uploaded_at, "%Y-%m-%dT%H:%M:%SZ")
+            store.update_analysis_uploaded_at(
+                analysis_id=analysis_id,
+                uploaded_at=uploaded_at_datetime,
             )
+            if analysis := store.get_analysis_by_entry_id(analysis_id):
+                trailblazer_api.set_analysis_uploaded(
+                    analysis.case.internal_id, uploaded_at=uploaded_at_datetime
+                )
         except Exception as error:
             LOG.error(f"Failed to update analysis uploaded_at for analysis with id {analysis_id}")
             LOG.error(f"Failed to handle message {message}.")
             LOG.exception(error)
+            raise error
 
     return handler

--- a/tests/cli/test_events.py
+++ b/tests/cli/test_events.py
@@ -7,10 +7,12 @@ from click.testing import CliRunner, Result
 from pytest_mock import MockerFixture
 
 import cg.cli.events as events_cli
+from cg.apps.tb.api import TrailblazerAPI
 from cg.cli.events import listen
 from cg.models.cg_config import CGConfig, NatsAuthentication, NatsConfig
 from cg.services.events import upload_handler
 from cg.services.events.event_listener import EventListener
+from cg.store.store import Store
 from tests.typed_mock import TypedMock, create_typed_mock
 
 
@@ -59,6 +61,13 @@ def mock_store_and_db(mocker: MockerFixture):
     mocker.patch.dict(os.environ, {"CG_SQL_DATABASE_URI": "sqlite:///test.db"})
 
 
+@pytest.fixture(autouse=True)
+def mock_trailblazer_config(mocker: MockerFixture):
+    mocker.patch.dict(os.environ, {"TRAILBLAZER_HOST": "https://tb.scilifelab.se"})
+    mocker.patch.dict(os.environ, {"TRAILBLAZER_SERVICE_ACCOUNT": "tb-service-account"})
+    mocker.patch.dict(os.environ, {"TRAILBLAZER_SERVICE_ACCOUNT_AUTH_FILE": "auth.json"})
+
+
 def test_listen(
     mocker: MockerFixture,
     cli_runner: CliRunner,
@@ -67,17 +76,40 @@ def test_listen(
 ):
     # GIVEN a configured listener, store, and database URI in the environment
     initialize_database: Mock = mocker.patch.object(events_cli, "initialize_database")
+
+    status_db = create_autospec(Store)
+    mocker.patch.object(events_cli, "Store", return_value=status_db)
+
+    trailblazer_api = create_autospec(TrailblazerAPI)
+    trailblazer_constructor = mocker.patch.object(
+        events_cli, "TrailblazerAPI", return_value=trailblazer_api
+    )
+
     handler: Mock = Mock()
-    mocker.patch.object(upload_handler, "completed", return_value=handler)
+    handler_creator = mocker.patch.object(upload_handler, "completed", return_value=handler)
 
     # WHEN the listen command is invoked
-    result: Result = cli_runner.invoke(listen, obj=config)
+    result: Result = cli_runner.invoke(listen, obj=config, catch_exceptions=False)
 
     # THEN the command exits without error
     assert result.exit_code == 0
 
     # THEN the database is initialized with the URI from the environment
     initialize_database.assert_called_once_with("sqlite:///test.db")
+
+    # THEN the trailblazer api is initialized with a config from the environment
+    trailblazer_constructor.assert_called_once_with(
+        config={
+            "trailblazer": {
+                "host": "https://tb.scilifelab.se",
+                "service_account": "tb-service-account",
+                "service_account_auth_file": "auth.json",
+            }
+        }
+    )
+
+    # THEN the handler was created with the correct dependencies
+    handler_creator.assert_called_once_with(store=status_db, trailblazer_api=trailblazer_api)
 
     # THEN the listener is registered with the upload.completed subject
     event_listener.as_mock.register.assert_called_once_with(

--- a/tests/cli/test_events.py
+++ b/tests/cli/test_events.py
@@ -109,7 +109,7 @@ def test_listen(
     )
 
     # THEN the handler was created with the correct dependencies
-    handler_creator.assert_called_once_with(store=status_db, trailblazer_api=trailblazer_api)
+    handler_creator.assert_called_once_with(status_db=status_db, trailblazer_api=trailblazer_api)
 
     # THEN the listener is registered with the upload.completed subject
     event_listener.as_mock.register.assert_called_once_with(

--- a/tests/services/events/test_event_listener.py
+++ b/tests/services/events/test_event_listener.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 from pathlib import Path
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, create_autospec
 
 import nats
 import pytest
@@ -44,8 +44,16 @@ async def message_stream(*messages):
         yield message
 
 
-def make_mock_message(subject: str, data: dict) -> TypedMock[Msg]:
-    return create_typed_mock(Msg, subject=subject, data=json.dumps(data).encode())
+def make_mock_message(subject: str, data: dict, num_delivered: int = 1) -> TypedMock[Msg]:
+    return create_typed_mock(
+        Msg,
+        subject=subject,
+        data=json.dumps(data).encode(),
+        metadata=create_autospec(
+            Msg.Metadata,
+            num_delivered=num_delivered,
+        ),
+    )
 
 
 def make_mock_nats(mocker: MockerFixture, subscription: TypedMock[JSC.PushSubscription]) -> None:
@@ -97,14 +105,26 @@ def test_listen_acks_message_with_no_handler(mocker: MockerFixture, event_listen
     message.as_mock.nak.assert_not_called()
 
 
-def test_listen_naks_message_when_handler_raises(
+def test_listen_naks_message_with_a_backoff_delay_when_handler_raises(
     mocker: MockerFixture, event_listener: EventListener
 ):
-    # GIVEN a message on a subject whose handler raises an exception
-    message: TypedMock[Msg] = make_mock_message("stream-name.my_subject", {"x": 1})
+    # GIVEN three message on a subject whose handler raises an exception
+    first_attempt_message: TypedMock[Msg] = make_mock_message(
+        "stream-name.my_subject", {"x": 1}, num_delivered=1
+    )
+    third_attempt_message: TypedMock[Msg] = make_mock_message(
+        "stream-name.my_subject", {"y": 3}, num_delivered=3
+    )
+    twentieth_attempt_message: TypedMock[Msg] = make_mock_message(
+        "stream-name.my_subject", {"never": "give up"}, num_delivered=20
+    )
 
     subscription: TypedMock[JSC.PushSubscription] = create_typed_mock(JSC.PushSubscription)
-    subscription.as_mock.messages = message_stream(message.as_type)
+    subscription.as_mock.messages = message_stream(
+        first_attempt_message.as_type,
+        third_attempt_message.as_type,
+        twentieth_attempt_message.as_type,
+    )
     make_mock_nats(mocker, subscription)
 
     handler: Mock = Mock(side_effect=RuntimeError("boom"))
@@ -113,6 +133,12 @@ def test_listen_naks_message_when_handler_raises(
     # WHEN listening for events
     asyncio.run(event_listener.listen())
 
-    # THEN the message is nacked instead of acked
-    message.as_mock.nak.assert_called_once()
-    message.as_mock.ack.assert_not_called()
+    # THEN the message is nacked instead of acked and a delay is applied
+    first_attempt_message.as_mock.nak.assert_called_once_with(delay=30)
+    first_attempt_message.as_mock.ack.assert_not_called()
+
+    third_attempt_message.as_mock.nak.assert_called_once_with(delay=120)
+    third_attempt_message.as_mock.ack.assert_not_called()
+
+    twentieth_attempt_message.as_mock.nak.assert_called_once_with(delay=3600)
+    twentieth_attempt_message.as_mock.ack.assert_not_called()

--- a/tests/services/events/test_upload_handler.py
+++ b/tests/services/events/test_upload_handler.py
@@ -3,26 +3,40 @@ from unittest.mock import Mock, create_autospec
 
 import pytest
 
+from cg.apps.tb.api import TrailblazerAPI
 from cg.services.events.upload_handler import completed
+from cg.store.models import Analysis, Case
 from cg.store.store import Store
+from tests.typed_mock import TypedMock, create_typed_mock
 
 
-@pytest.mark.xfail(reason="DB updates are toggled off", strict=True)
 def test_completed_success():
     # GIVEN a message with an existing analysis id and a date
     message = {"cg.analysis_id": 1, "uploaded_at": "2026-06-02T11:14:52Z"}
 
     # GIVEN a store with an analysis
-    store = create_autospec(Store)
+    store: TypedMock[Store] = create_typed_mock(Store)
+    case: Case = create_autospec(Case, internal_id="case_1")
+    analysis: Analysis = create_autospec(Analysis, case=case)
+
+    store.as_type.get_analysis_by_entry_id = Mock(return_value=analysis)
+
+    # GIVEN the trailblazer api is available
+    trailblazer_api = create_autospec(TrailblazerAPI)
 
     # WHEN a completed message is received
-    completed_handler = completed(store)
+    completed_handler = completed(store=store.as_type, trailblazer_api=trailblazer_api)
     completed_handler(message)
 
     # THEN the analysis uploaded_at should have been updated
     expected_date = datetime(year=2026, month=6, day=2, hour=11, minute=14, second=52)
-    store.update_analysis_uploaded_at.assert_called_once_with(
+    store.as_mock.update_analysis_uploaded_at.assert_called_once_with(
         analysis_id=1, uploaded_at=expected_date
+    )
+
+    # THEN the analysis should have been set as uploaded in Trailblazer
+    trailblazer_api.set_analysis_uploaded.assert_called_once_with(
+        case_id="case_1", uploaded_at=expected_date
     )
 
 
@@ -35,7 +49,7 @@ def test_completed_missing_analysis():
     store.update_analysis_uploaded_at = Mock(side_effect=Exception)
 
     # WHEN a completed message is received
-    completed_handler = completed(store)
-    completed_handler(message)
-
-    # THEN it should not raise an exception
+    # THEN it let's the exception propagate
+    completed_handler = completed(store=store, trailblazer_api=create_autospec(TrailblazerAPI))
+    with pytest.raises(Exception):
+        completed_handler(message)

--- a/tests/services/events/test_upload_handler.py
+++ b/tests/services/events/test_upload_handler.py
@@ -49,7 +49,7 @@ def test_completed_missing_analysis():
     store.update_analysis_uploaded_at = Mock(side_effect=Exception)
 
     # WHEN a completed message is received
-    # THEN it let's the exception propagate
+    # THEN it lets the exception propagate
     completed_handler = completed(store=store, trailblazer_api=create_autospec(TrailblazerAPI))
     with pytest.raises(Exception):
         completed_handler(message)

--- a/tests/services/events/test_upload_handler.py
+++ b/tests/services/events/test_upload_handler.py
@@ -25,7 +25,7 @@ def test_completed_success():
     trailblazer_api = create_autospec(TrailblazerAPI)
 
     # WHEN a completed message is received
-    completed_handler = completed(store=store.as_type, trailblazer_api=trailblazer_api)
+    completed_handler = completed(status_db=store.as_type, trailblazer_api=trailblazer_api)
     completed_handler(message)
 
     # THEN the analysis uploaded_at should have been updated
@@ -50,6 +50,6 @@ def test_completed_missing_analysis():
 
     # WHEN a completed message is received
     # THEN it lets the exception propagate
-    completed_handler = completed(store=store, trailblazer_api=create_autospec(TrailblazerAPI))
+    completed_handler = completed(status_db=store, trailblazer_api=create_autospec(TrailblazerAPI))
     with pytest.raises(Exception):
         completed_handler(message)


### PR DESCRIPTION
## Description

To be deployed together with https://github.com/Clinical-Genomics/servers/pull/1913 


### Added

- upload_handler.completed sets analysis as uploaded in Trailblazer
- Use backoff delay when sending a not acknowledget to nats

### Changed

- Toggle on DB changes in upload_handler

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
