### PR TITLE
Create workflow filter on unhandled sample endpoint

### DIFF
--- a/cg/server/dto/samples/requests.py
+++ b/cg/server/dto/samples/requests.py
@@ -2,6 +2,7 @@ from enum import StrEnum
 
 from pydantic import BaseModel, Field
 
+from cg.constants import Workflow
 from cg.constants.lims import LimsStatus
 from cg.models.orders.constants import OrderType
 
@@ -45,3 +46,4 @@ class UnhandledSamplesRequest(BaseModel):
     search: str | None = None
     sort_by: UnhandledSamplesSortBy | None = None
     sort_order: SortDirection | None = None
+    workflow: Workflow | None = None

--- a/cg/server/endpoints/samples.py
+++ b/cg/server/endpoints/samples.py
@@ -75,6 +75,7 @@ def get_unhandled_samples():
             page_size=req.page_size,
             sort_by=req.sort_by,
             sort_order=req.sort_order,
+            workflow=req.workflow,
         )
         response = UnhandledSamplesResponse.from_samples(samples=samples, total=total)
         return jsonify(response.model_dump())

--- a/cg/store/crud/read.py
+++ b/cg/store/crud/read.py
@@ -1926,33 +1926,40 @@ class ReadHandler(BaseHandler):
     def get_paginated_unhandled_samples(
         self,
         lims_status: LimsStatus,
-        search: str | None,
         page: int,
         page_size: int,
+        search: str | None = None,
         sort_by: UnhandledSamplesSortBy | None = None,
         sort_order: SortDirection | None = None,
+        workflow: Workflow | None = None,
     ) -> tuple[list[Sample], int]:
         unhandled_samples: Query = self._get_unhandled_samples(
-            lims_status=lims_status, search=search, sort_by=sort_by, sort_order=sort_order
+            lims_status=lims_status,
+            search=search,
+            sort_by=sort_by,
+            sort_order=sort_order,
+            workflow=workflow,
         )
         return _paginate(query=unhandled_samples, page=page, page_size=page_size)
 
     def _get_unhandled_samples(
         self,
         lims_status: LimsStatus,
-        search: str | None,
+        search: str | None = None,
         sort_by: UnhandledSamplesSortBy | None = None,
         sort_order: SortDirection | None = None,
+        workflow: Workflow | None = None,
     ) -> Query:
         """
         Return samples with the given lims_status that:
-        - Are not downsampled
-        - Are not cancelled
-        - Are not delivered
-        - Have been sequenced (last_sequenced_at is not null)
-        - Do not belong to the internal customers
-        - Ordered by last sequenced date, with the oldest first
-        - Optional filtering by search string
+            - Are not downsampled
+            - Are not cancelled
+            - Are not delivered
+            - Have been sequenced (last_sequenced_at is not null)
+            - Do not belong to the internal customers
+            - Ordered by last sequenced date, with the oldest first
+            - Optional filtering by search string
+            - Optional filtering by workflow
         """
         query = (
             self._get_query(table=Sample)

--- a/cg/store/crud/read.py
+++ b/cg/store/crud/read.py
@@ -1990,6 +1990,9 @@ class ReadHandler(BaseHandler):
                 ),
             )
 
+        if workflow:
+            query = query.filter(Sample.workflow_of_case_that_delivers.is_(workflow))
+
         return query
 
     def get_uploaded_analyses(self, trailblazer_ids: list[int]) -> list[Analysis]:

--- a/cg/store/crud/read.py
+++ b/cg/store/crud/read.py
@@ -1991,7 +1991,7 @@ class ReadHandler(BaseHandler):
             )
 
         if workflow:
-            query = query.filter(Sample.workflow_of_case_that_delivers.is_(workflow))
+            query = query.filter(Sample.workflow_of_case_that_delivers == workflow)
 
         return query
 

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -922,13 +922,28 @@ class Sample(Base, PriorityMixin):
             .label("delivering_case_internal_id")
         )
 
-    @property
+    @hybrid_property
     def workflow_of_case_that_delivers(self) -> Workflow | None:
         """Return the workflow of the original case if the case exists."""
         if case := self.case_that_delivers:
             return case.data_analysis
         else:
             return None
+
+    # noinspection PyNestedDecorators
+    @workflow_of_case_that_delivers.expression
+    @classmethod
+    def workflow_of_case_that_delivers(cls) -> SQLColumnExpression[str]:
+        return (
+            select(Case.data_analysis)
+            .join(Case.links)
+            .where(
+                CaseSample.sample_id == cls.id,
+                CaseSample.should_deliver_sample.is_(True),
+            )
+            .limit(1)
+            .label("workflow_of_case_that_delivers")
+        )
 
     @hybrid_property
     def ticket_id_from_original_order(self) -> int | None:  # pyright: ignore [reportRedeclaration]

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -923,7 +923,9 @@ class Sample(Base, PriorityMixin):
         )
 
     @hybrid_property
-    def workflow_of_case_that_delivers(self) -> Workflow | None:
+    def workflow_of_case_that_delivers(  # pyright: ignore [reportRedeclaration]
+        self,
+    ) -> Workflow | None:
         """Return the workflow of the original case if the case exists."""
         if case := self.case_that_delivers:
             return case.data_analysis
@@ -933,7 +935,7 @@ class Sample(Base, PriorityMixin):
     # noinspection PyNestedDecorators
     @workflow_of_case_that_delivers.expression
     @classmethod
-    def workflow_of_case_that_delivers(cls) -> SQLColumnExpression[str]:
+    def workflow_of_case_that_delivers(cls) -> SQLColumnExpression[Workflow]:
         return (
             select(Case.data_analysis)
             .join(Case.links)

--- a/tests/server/endpoints/test_samples_endpoint.py
+++ b/tests/server/endpoints/test_samples_endpoint.py
@@ -421,3 +421,109 @@ def test_get_unhandled_samples_sort_ticket_descending(client: FlaskClient, mocke
         sort_by=UnhandledSamplesSortBy.TICKET,
         sort_order=SortDirection.DESCENDING,
     )
+
+
+def test_get_unhandled_samples_filter_on_workflow(client: FlaskClient, mocker: MockerFixture):
+    # GIVEN a store with unhandled samples in top-up
+    status_db: TypedMock[Store] = create_typed_mock(Store)
+    date_time = datetime(2024, 12, 24, 11, 59)
+    sample_1_raredisease = create_autospec(
+        Sample,
+        customer=create_autospec(Customer, interal_id="external_customer"),
+        delivered_at=None,
+        from_sample=None,
+        internal_id="sample_1_raredisease",
+        is_cancelled=False,
+        last_sequenced_at=date_time,
+        lims_status=LimsStatus.TOP_UP,
+        delivering_case_internal_id="case_1",
+        workflow_of_case_that_delivers=Workflow.RAREDISEASE,
+        ticket_id_from_original_order=2,
+    )
+    sample_2_raredisease = create_autospec(
+        Sample,
+        customer=create_autospec(Customer, interal_id="external_customer"),
+        delivered_at=None,
+        from_sample=None,
+        internal_id="sample_2_raredisease",
+        is_cancelled=False,
+        last_sequenced_at=date_time,
+        lims_status=LimsStatus.TOP_UP,
+        delivering_case_internal_id="case_2",
+        workflow_of_case_that_delivers=Workflow.RAREDISEASE,
+        ticket_id_from_original_order=1,
+    )
+    sample_case_unkown = create_autospec(
+        Sample,
+        customer=create_autospec(Customer, interal_id="external_customer"),
+        delivered_at=None,
+        from_sample=None,
+        internal_id="sample_case_unkown",
+        is_cancelled=False,
+        last_sequenced_at=date_time,
+        lims_status=LimsStatus.TOP_UP,
+        delivering_case_internal_id=None,
+        workflow_of_case_that_delivers=None,
+        ticket_id_from_original_order=None,
+    )
+    status_db.as_type.get_paginated_unhandled_samples = Mock(
+        return_value=(
+            [sample_1_raredisease, sample_2_raredisease, sample_case_unkown],
+            3,
+        )
+    )
+    mocker.patch.object(samples, "db", status_db.as_type)
+
+    # WHEN querying the unhandled samples endpoint with workflow Raredisease
+    response = client.get(
+        path=f"/api/v1/unhandled_samples?lims_status=top-up&page=1&page_size=10&workflow={Workflow.RAREDISEASE}",
+    )
+
+    # THEN the response should be successful
+    assert response.status_code == HTTPStatus.OK
+
+    # THEN only samples with workflow raredisease should be in the response
+    assert response.json == {
+        "samples": [
+            {
+                "case_id": "case_1",
+                "sample_id": "sample_1_raredisease",
+                "last_sequenced_at": "Tue, 24 Dec 2024 11:59:00 GMT",
+                "lims_status": "top-up",
+                "ticket": 2,
+                "workflow": "raredisease",
+            },
+            {
+                "case_id": "case_2",
+                "sample_id": "sample_2_raredisease",
+                "last_sequenced_at": "Tue, 24 Dec 2024 11:59:00 GMT",
+                "lims_status": "top-up",
+                "ticket": 1,
+                "workflow": "raredisease",
+            },
+        ],
+        "total": 2,
+    }
+
+    # THEN function has been called with the correct arguments
+    status_db.as_mock.get_paginated_unhandled_samples.assert_called_once_with(
+        lims_status=LimsStatus.TOP_UP,
+        page=1,
+        page_size=10,
+        search=None,
+        sort_by=None,
+        sort_order=None,
+        workflow=Workflow.RAREDISEASE,
+    )
+
+
+def test_get_unhandled_samples_unknown_param(client: FlaskClient, mocker: MockerFixture):
+    # GIVEN an unknown param in the request
+
+    # WHEN querying the unhandled samples endpoint with descending sort on ticket
+    response = client.get(
+        path="/api/v1/unhandled_samples?lims_status=top-up&page=1&page_size=10&search=whatIsThis?",
+    )
+
+    # THEN the response should be successful
+    assert response.status_code == HTTPStatus.OK

--- a/tests/server/endpoints/test_samples_endpoint.py
+++ b/tests/server/endpoints/test_samples_endpoint.py
@@ -426,52 +426,7 @@ def test_get_unhandled_samples_sort_ticket_descending(client: FlaskClient, mocke
 def test_get_unhandled_samples_filter_on_workflow(client: FlaskClient, mocker: MockerFixture):
     # GIVEN a store with unhandled samples in top-up
     status_db: TypedMock[Store] = create_typed_mock(Store)
-    date_time = datetime(2024, 12, 24, 11, 59)
-    sample_1_raredisease = create_autospec(
-        Sample,
-        customer=create_autospec(Customer, interal_id="external_customer"),
-        delivered_at=None,
-        from_sample=None,
-        internal_id="sample_1_raredisease",
-        is_cancelled=False,
-        last_sequenced_at=date_time,
-        lims_status=LimsStatus.TOP_UP,
-        delivering_case_internal_id="case_1",
-        workflow_of_case_that_delivers=Workflow.RAREDISEASE,
-        ticket_id_from_original_order=2,
-    )
-    sample_2_raredisease = create_autospec(
-        Sample,
-        customer=create_autospec(Customer, interal_id="external_customer"),
-        delivered_at=None,
-        from_sample=None,
-        internal_id="sample_2_raredisease",
-        is_cancelled=False,
-        last_sequenced_at=date_time,
-        lims_status=LimsStatus.TOP_UP,
-        delivering_case_internal_id="case_2",
-        workflow_of_case_that_delivers=Workflow.RAREDISEASE,
-        ticket_id_from_original_order=1,
-    )
-    sample_case_unkown = create_autospec(
-        Sample,
-        customer=create_autospec(Customer, interal_id="external_customer"),
-        delivered_at=None,
-        from_sample=None,
-        internal_id="sample_case_unkown",
-        is_cancelled=False,
-        last_sequenced_at=date_time,
-        lims_status=LimsStatus.TOP_UP,
-        delivering_case_internal_id=None,
-        workflow_of_case_that_delivers=None,
-        ticket_id_from_original_order=None,
-    )
-    status_db.as_type.get_paginated_unhandled_samples = Mock(
-        return_value=(
-            [sample_1_raredisease, sample_2_raredisease, sample_case_unkown],
-            3,
-        )
-    )
+    status_db.as_type.get_paginated_unhandled_samples = Mock(return_value=([], 0))
     mocker.patch.object(samples, "db", status_db.as_type)
 
     # WHEN querying the unhandled samples endpoint with workflow Raredisease
@@ -492,29 +447,6 @@ def test_get_unhandled_samples_filter_on_workflow(client: FlaskClient, mocker: M
         sort_order=None,
         workflow=Workflow.RAREDISEASE,
     )
-
-    # THEN only samples with workflow raredisease should be in the response
-    assert response.json == {
-        "samples": [
-            {
-                "case_id": "case_1",
-                "sample_id": "sample_1_raredisease",
-                "last_sequenced_at": "Tue, 24 Dec 2024 11:59:00 GMT",
-                "lims_status": "top-up",
-                "ticket": 2,
-                "workflow": "raredisease",
-            },
-            {
-                "case_id": "case_2",
-                "sample_id": "sample_2_raredisease",
-                "last_sequenced_at": "Tue, 24 Dec 2024 11:59:00 GMT",
-                "lims_status": "top-up",
-                "ticket": 1,
-                "workflow": "raredisease",
-            },
-        ],
-        "total": 2,
-    }
 
 
 def test_get_unhandled_samples_unknown_param(client: FlaskClient, mocker: MockerFixture):

--- a/tests/server/endpoints/test_samples_endpoint.py
+++ b/tests/server/endpoints/test_samples_endpoint.py
@@ -482,6 +482,17 @@ def test_get_unhandled_samples_filter_on_workflow(client: FlaskClient, mocker: M
     # THEN the response should be successful
     assert response.status_code == HTTPStatus.OK
 
+    # THEN function has been called with the correct arguments
+    status_db.as_mock.get_paginated_unhandled_samples.assert_called_once_with(
+        lims_status=LimsStatus.TOP_UP,
+        page=1,
+        page_size=10,
+        search=None,
+        sort_by=None,
+        sort_order=None,
+        workflow=Workflow.RAREDISEASE,
+    )
+
     # THEN only samples with workflow raredisease should be in the response
     assert response.json == {
         "samples": [
@@ -504,17 +515,6 @@ def test_get_unhandled_samples_filter_on_workflow(client: FlaskClient, mocker: M
         ],
         "total": 2,
     }
-
-    # THEN function has been called with the correct arguments
-    status_db.as_mock.get_paginated_unhandled_samples.assert_called_once_with(
-        lims_status=LimsStatus.TOP_UP,
-        page=1,
-        page_size=10,
-        search=None,
-        sort_by=None,
-        sort_order=None,
-        workflow=Workflow.RAREDISEASE,
-    )
 
 
 def test_get_unhandled_samples_unknown_param(client: FlaskClient, mocker: MockerFixture):

--- a/tests/server/endpoints/test_samples_endpoint.py
+++ b/tests/server/endpoints/test_samples_endpoint.py
@@ -151,6 +151,7 @@ def test_get_unhandled_samples(client: FlaskClient, mocker: MockerFixture):
         page_size=10,
         sort_by=None,
         sort_order=None,
+        workflow=None,
     )
 
 
@@ -218,6 +219,7 @@ def test_get_unhandled_samples_sample_search(client: FlaskClient, mocker: Mocker
         page_size=10,
         sort_by=None,
         sort_order=None,
+        workflow=None,
     )
 
 
@@ -319,6 +321,7 @@ def test_get_unhandled_samples_sort_ticket_ascending(client: FlaskClient, mocker
         search=None,
         sort_by=UnhandledSamplesSortBy.TICKET,
         sort_order=SortDirection.ASCENDING,
+        workflow=None,
     )
 
 
@@ -420,6 +423,7 @@ def test_get_unhandled_samples_sort_ticket_descending(client: FlaskClient, mocke
         search=None,
         sort_by=UnhandledSamplesSortBy.TICKET,
         sort_order=SortDirection.DESCENDING,
+        workflow=None,
     )
 
 

--- a/tests/store/crud/read/test_read_sample.py
+++ b/tests/store/crud/read/test_read_sample.py
@@ -6,7 +6,7 @@ from typing import Any
 import pytest
 from sqlalchemy.orm import Query
 
-from cg.constants import SexOptions
+from cg.constants import SexOptions, Workflow
 from cg.constants.lims import LimsStatus
 from cg.constants.sequencing import DNA_PREP_CATEGORIES, SeqLibraryPrepCategory
 from cg.exc import SampleNotFoundError
@@ -831,6 +831,62 @@ def test_get_unhandled_samples_filters_out_internal_samples(store: Store, helper
 
     # THEN only the external sample is returned
     assert unhandled_samples.all() == [external_sample]
+
+
+def test_get_unhandled_samples_filters_on_workflow(store: Store, helpers: StoreHelpers):
+    # GIVEN a store with one raredisease case and a non raredisease case
+    raredisease_sample = helpers.add_sample(
+        store=store,
+        lims_status=LimsStatus.TOP_UP,
+        internal_id="raredisease_sample",
+        is_cancelled=False,
+        from_sample=None,
+        last_sequenced_at=datetime.now(),
+        delivered_at=None,
+        customer_id="cust1337",
+    )
+    non_raredisease_sample = helpers.add_sample(
+        store=store,
+        lims_status=LimsStatus.TOP_UP,
+        internal_id="non_raredisease_sample",
+        is_cancelled=False,
+        from_sample=None,
+        last_sequenced_at=datetime.now(),
+        delivered_at=None,
+        customer_id="cust1337",
+    )
+
+    raredisease_case = helpers.add_case(
+        store=store,
+        internal_id="raredisease_case",
+        name="raredisease_case",
+        data_analysis=Workflow.RAREDISEASE,
+    )
+    non_raredisease_case = helpers.add_case(
+        store=store,
+        internal_id="non_raredisease_case",
+        name="non_raredisease_case",
+        data_analysis=Workflow.MIP_DNA,
+    )
+
+    helpers.add_relationship(
+        store=store, sample=raredisease_sample, case=raredisease_case, should_deliver_sample=True
+    )
+    helpers.add_relationship(
+        store=store,
+        sample=non_raredisease_sample,
+        case=non_raredisease_case,
+        should_deliver_sample=True,
+    )
+
+    # WHEN getting the unhandled samples in top-up and workflow raredisease
+    unhandled_samples: Query = store._get_unhandled_samples(
+        lims_status=LimsStatus.TOP_UP,
+        workflow=Workflow.RAREDISEASE,
+    )
+
+    # THEN only the raredisease sample is returned
+    assert unhandled_samples.all() == [raredisease_sample]
 
 
 def test_get_paginated_unhandled_samples_sort_by_ticket(store: Store, helpers: StoreHelpers):


### PR DESCRIPTION
## Description

In the active samples view in CiGRID there is a bug when filtering on workflow. Currently, if you filter in the active samples view, you filter one page at a time. This PR aims to path this issue. 

(and patching a minor bug that makes the search section in the url mandatory)


### Added

- optional filter on workflow for unhandled samples endpoint

### Changed

- search is optional in the request to the unhandled samples endpoint, and not mandatory


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
