### PR TITLE
Set Balsamic default workflow profile

### DIFF
--- a/cg/cli/workflow/balsamic/base.py
+++ b/cg/cli/workflow/balsamic/base.py
@@ -18,7 +18,9 @@ from cg.meta.workflow.analysis import AnalysisAPI
 from cg.meta.workflow.balsamic import BalsamicAnalysisAPI
 from cg.models.cg_config import CGConfig
 from cg.services.analysis_starter.analysis_starter import AnalysisStarter
-from cg.services.analysis_starter.configurator.implementations.balsamic import BalsamicConfigurator
+from cg.services.analysis_starter.configurator.implementations.balsamic_configurator import (
+    BalsamicConfigurator,
+)
 from cg.services.analysis_starter.factories.configurator_factory import ConfiguratorFactory
 from cg.services.analysis_starter.factories.starter_factory import AnalysisStarterFactory
 from cg.store.store import Store

--- a/cg/cli/workflow/balsamic/umi.py
+++ b/cg/cli/workflow/balsamic/umi.py
@@ -13,7 +13,9 @@ from cg.constants.constants import Workflow
 from cg.meta.workflow.balsamic_umi import BalsamicUmiAnalysisAPI
 from cg.models.cg_config import CGConfig
 from cg.services.analysis_starter.analysis_starter import AnalysisStarter
-from cg.services.analysis_starter.configurator.implementations.balsamic import BalsamicConfigurator
+from cg.services.analysis_starter.configurator.implementations.balsamic_configurator import (
+    BalsamicConfigurator,
+)
 from cg.services.analysis_starter.factories.configurator_factory import ConfiguratorFactory
 from cg.services.analysis_starter.factories.starter_factory import AnalysisStarterFactory
 

--- a/cg/models/cg_config.py
+++ b/cg/models/cg_config.py
@@ -235,6 +235,7 @@ class BalsamicConfig(CommonAppConfig):
     swegen_path: Path
     swegen_snv: Path
     swegen_sv: Path
+    workflow_profile: Path
 
 
 class MutantConfig(BaseModel):

--- a/cg/services/analysis_starter/configurator/implementations/balsamic_configurator.py
+++ b/cg/services/analysis_starter/configurator/implementations/balsamic_configurator.py
@@ -33,6 +33,7 @@ class BalsamicConfigurator(Configurator):
         self.head_job_partition: str = config.head_job_partition
         self.root_dir: Path = config.root
         self.slurm_account: str = config.slurm.account
+        self.workflow_profile = config.workflow_profile
 
         self.fastq_handler: BalsamicFastqHandler = fastq_handler
         self.config_file_creator: BalsamicConfigFileCreator = config_file_creator
@@ -57,6 +58,7 @@ class BalsamicConfigurator(Configurator):
             qos=self.store.get_case_by_internal_id_strict(case_id).slurm_priority,
             sample_config=self._get_sample_config_path(case_id),
             workflow=self.store.get_case_workflow(case_id),
+            workflow_profile=self.workflow_profile,
         )
         balsamic_config: BalsamicCaseConfig = self._set_flags(config=balsamic_config, **flags)
         self._ensure_required_config_files_exist(balsamic_config)

--- a/cg/services/analysis_starter/configurator/models/balsamic.py
+++ b/cg/services/analysis_starter/configurator/models/balsamic.py
@@ -150,14 +150,12 @@ class BalsamicCaseConfig(CaseConfig):
     qos: SlurmQos
     sample_config: Path
     workflow: Workflow
-    workflow_profile: Path | None = None
+    workflow_profile: Path
 
     def get_start_command(self) -> str:
         command = (
             "{conda_binary} run --name {environment} {binary} run analysis --account {account} "
             "--qos {qos} --sample-config {sample_config} --headjob-partition {head_job_partition} "
-            "--run-analysis".format(**self.model_dump())
+            "--run-analysis --workflow-profile {workflow_profile}".format(**self.model_dump())
         )
-        if self.workflow_profile:
-            command += f" --workflow-profile {self.workflow_profile}"
         return command

--- a/cg/services/analysis_starter/factories/configurator_factory.py
+++ b/cg/services/analysis_starter/factories/configurator_factory.py
@@ -66,7 +66,9 @@ from cg.services.analysis_starter.configurator.file_creators.nextflow.sample_she
 from cg.services.analysis_starter.configurator.file_creators.nextflow.sample_sheet.tomte_sample_sheet_creator import (
     TomteSampleSheetCreator,
 )
-from cg.services.analysis_starter.configurator.implementations.balsamic import BalsamicConfigurator
+from cg.services.analysis_starter.configurator.implementations.balsamic_configurator import (
+    BalsamicConfigurator,
+)
 from cg.services.analysis_starter.configurator.implementations.microsalt import (
     MicrosaltConfigurator,
 )

--- a/cg/services/analysis_starter/submitters/subprocess/submitter.py
+++ b/cg/services/analysis_starter/submitters/subprocess/submitter.py
@@ -1,6 +1,7 @@
 import logging
 import subprocess
 
+from cg.services.analysis_starter.configurator.models.balsamic import BalsamicCaseConfig
 from cg.services.analysis_starter.configurator.models.microsalt import MicrosaltCaseConfig
 from cg.services.analysis_starter.configurator.models.mip_dna import MIPDNACaseConfig
 from cg.services.analysis_starter.submitters.submitter import Submitter
@@ -8,7 +9,7 @@ from cg.services.analysis_starter.submitters.subprocess.commands import WORKFLOW
 
 LOG = logging.getLogger(__name__)
 
-SubprocessCaseConfig = MicrosaltCaseConfig | MIPDNACaseConfig
+SubprocessCaseConfig = BalsamicCaseConfig | MicrosaltCaseConfig | MIPDNACaseConfig
 
 
 class SubprocessSubmitter(Submitter):

--- a/tests/cli/workflow/balsamic/test_cli_balsamic.py
+++ b/tests/cli/workflow/balsamic/test_cli_balsamic.py
@@ -16,7 +16,9 @@ from cg.models.cg_config import (
     RunInstruments,
 )
 from cg.services.analysis_starter.analysis_starter import AnalysisStarter
-from cg.services.analysis_starter.configurator.implementations.balsamic import BalsamicConfigurator
+from cg.services.analysis_starter.configurator.implementations.balsamic_configurator import (
+    BalsamicConfigurator,
+)
 from cg.services.analysis_starter.factories.configurator_factory import ConfiguratorFactory
 from cg.services.analysis_starter.factories.starter_factory import AnalysisStarterFactory
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2088,6 +2088,7 @@ def context_config(
             "swegen_path": str(cg_dir),
             "swegen_snv": str(cg_dir),
             "swegen_sv": str(cg_dir),
+            "workflow_profile": str(balsamic_dir),
         },
         "chanjo": {"binary_path": "echo", "config_path": "chanjo-stage-hg19.yaml"},
         "chanjo_38": {"binary_path": "echo", "config_path": "chanjo-stage-hg38.yaml"},

--- a/tests/fixture_plugins/analysis_starter/configurator_fixtures.py
+++ b/tests/fixture_plugins/analysis_starter/configurator_fixtures.py
@@ -14,16 +14,15 @@ from cg.services.analysis_starter.configurator.file_creators.microsalt_config im
 from cg.services.analysis_starter.configurator.file_creators.nextflow.config_file import (
     NextflowConfigFileCreator,
 )
-from cg.services.analysis_starter.configurator.file_creators.nextflow.params_file.nallo import (
-    NalloParamsFileCreator,
-)
 from cg.services.analysis_starter.configurator.file_creators.nextflow.params_file.raredisease_params_file_creator import (
     RarediseaseParamsFileCreator,
 )
 from cg.services.analysis_starter.configurator.file_creators.nextflow.sample_sheet.raredisease_sample_sheet_creator import (
     RarediseaseSampleSheetCreator,
 )
-from cg.services.analysis_starter.configurator.implementations.balsamic import BalsamicConfigurator
+from cg.services.analysis_starter.configurator.implementations.balsamic_configurator import (
+    BalsamicConfigurator,
+)
 from cg.services.analysis_starter.configurator.implementations.microsalt import (
     MicrosaltConfigurator,
 )

--- a/tests/fixture_plugins/analysis_starter/pipeline_config_fixtures.py
+++ b/tests/fixture_plugins/analysis_starter/pipeline_config_fixtures.py
@@ -141,6 +141,7 @@ def cg_balsamic_config(tmp_path) -> BalsamicConfig:
         swegen_path="swegen",
         swegen_snv=tmp_path / "swegen_snv.vcf",
         swegen_sv=tmp_path / "swegen_sv.vcf",
+        workflow_profile=tmp_path / "workflow_profile_dir",
     )
 
 

--- a/tests/integration/config/cg-test.yaml
+++ b/tests/integration/config/cg-test.yaml
@@ -105,6 +105,7 @@ balsamic:
     account: "balsamic_slurm_account"
     mail_user: "balsamic_mail_user@scilifelab.se"
     qos: "low"
+  workflow_profile: "{test_root_dir}/balsamic"
 crunchy:
   conda_binary: "{test_root_dir}/crunchy_conda_binary"
   cram_reference: "{test_root_dir}/crunchy_cram_reference"

--- a/tests/integration/workflows/test_balsamic.py
+++ b/tests/integration/workflows/test_balsamic.py
@@ -257,7 +257,8 @@ def test_start_available_tgs_tumour_only(
         f"--qos normal "
         f"--sample-config {balsamic_root_dir}/{case_id}/{case_id}.json "
         f"--headjob-partition head-jobs "
-        f"--run-analysis"
+        f"--run-analysis "
+        f"--workflow-profile {test_root_dir}/balsamic"
     )
     run_analysis_call = run_analysis_subprocess_mock.run.mock_calls[0]
     assert run_analysis_call == call(
@@ -409,7 +410,8 @@ def test_start_available_wgs_paired(
         f"--qos normal "
         f"--sample-config {balsamic_root_dir}/{case_id}/{case_id}.json "
         f"--headjob-partition head-jobs "
-        f"--run-analysis"
+        f"--run-analysis "
+        f"--workflow-profile {test_root_dir}/balsamic"
     )
     run_analysis_call = run_analysis_subprocess_mock.run.mock_calls[0]
 

--- a/tests/services/analysis_starter/test_analysis_starter.py
+++ b/tests/services/analysis_starter/test_analysis_starter.py
@@ -20,7 +20,9 @@ from cg.services.analysis_starter.configurator.file_creators.nextflow.sample_she
 from cg.services.analysis_starter.configurator.file_creators.nextflow.sample_sheet.rnafusion_sample_sheet_creator import (
     RNAFusionSampleSheetCreator,
 )
-from cg.services.analysis_starter.configurator.implementations.balsamic import BalsamicConfigurator
+from cg.services.analysis_starter.configurator.implementations.balsamic_configurator import (
+    BalsamicConfigurator,
+)
 from cg.services.analysis_starter.configurator.implementations.microsalt import (
     MicrosaltConfigurator,
 )

--- a/tests/services/analysis_starter/test_analysis_starter_factory.py
+++ b/tests/services/analysis_starter/test_analysis_starter_factory.py
@@ -22,7 +22,9 @@ from cg.models.cg_config import (
     TomteConfig,
 )
 from cg.services.analysis_starter.analysis_starter import AnalysisStarter
-from cg.services.analysis_starter.configurator.implementations.balsamic import BalsamicConfigurator
+from cg.services.analysis_starter.configurator.implementations.balsamic_configurator import (
+    BalsamicConfigurator,
+)
 from cg.services.analysis_starter.configurator.implementations.microsalt import (
     MicrosaltConfigurator,
 )

--- a/tests/services/analysis_starter/test_balsamic_configurator.py
+++ b/tests/services/analysis_starter/test_balsamic_configurator.py
@@ -14,7 +14,9 @@ from cg.models.cg_config import BalsamicConfig
 from cg.services.analysis_starter.configurator.file_creators.balsamic_config import (
     BalsamicConfigFileCreator,
 )
-from cg.services.analysis_starter.configurator.implementations.balsamic import BalsamicConfigurator
+from cg.services.analysis_starter.configurator.implementations.balsamic_configurator import (
+    BalsamicConfigurator,
+)
 from cg.services.analysis_starter.configurator.models.balsamic import BalsamicCaseConfig
 from cg.store.models import Case, Sample
 from cg.store.store import Store
@@ -33,7 +35,53 @@ def case_with_sample() -> Case:
 
 @pytest.mark.parametrize("workflow", [Workflow.BALSAMIC, Workflow.BALSAMIC_UMI])
 def test_get_config(
-    balsamic_configurator: BalsamicConfigurator, case_id: str, tmp_path: Path, workflow: Workflow
+    balsamic_configurator: BalsamicConfigurator,
+    case_id: str,
+    tmp_path: Path,
+    workflow: Workflow,
+    cg_balsamic_config: BalsamicConfig,
+):
+    """Tests that the get_config method returns a BalsamicCaseConfig and that fields can be overridden with flags."""
+    # GIVEN a Balsamic configurator with an existing config file
+    balsamic_configurator.root_dir = tmp_path
+    Path(balsamic_configurator.root_dir, case_id).mkdir()
+    Path(balsamic_configurator.root_dir, case_id, f"{case_id}.json").touch()
+
+    # GIVEN that the database returns a case with the provided case_id
+    case_to_configure: Case = create_autospec(
+        Case, internal_id=case_id, slurm_priority=SlurmQos.NORMAL
+    )
+    balsamic_configurator.store.get_case_by_internal_id_strict = Mock(
+        return_value=case_to_configure
+    )
+    balsamic_configurator.store.get_case_workflow = Mock(return_value=workflow)
+
+    # WHEN getting the config
+    config: BalsamicCaseConfig = balsamic_configurator.get_config(case_id=case_id)
+
+    # THEN the config should look as expected
+    expected_balsamic_case_config = BalsamicCaseConfig(
+        case_id=case_id,
+        account=cg_balsamic_config.slurm.account,
+        binary=cg_balsamic_config.binary_path,
+        conda_binary=cg_balsamic_config.conda_binary,
+        environment=cg_balsamic_config.conda_env,
+        head_job_partition=cg_balsamic_config.head_job_partition,
+        qos=SlurmQos.NORMAL,
+        sample_config=Path(balsamic_configurator.root_dir, case_id, f"{case_id}.json"),
+        workflow=workflow,
+        workflow_profile=cg_balsamic_config.workflow_profile,
+    )
+    assert config == expected_balsamic_case_config
+
+
+@pytest.mark.parametrize("workflow", [Workflow.BALSAMIC, Workflow.BALSAMIC_UMI])
+def test_get_config_with_flag(
+    balsamic_configurator: BalsamicConfigurator,
+    case_id: str,
+    tmp_path: Path,
+    workflow: Workflow,
+    cg_balsamic_config: BalsamicConfig,
 ):
     """Tests that the get_config method returns a BalsamicCaseConfig and that fields can be overridden with flags."""
     # GIVEN a Balsamic configurator with an existing config file
@@ -55,11 +103,20 @@ def test_get_config(
         case_id=case_id, qos=SlurmQos.EXPRESS
     )
 
-    # THEN the config should be a BalsamicCaseConfig
-    assert isinstance(config, BalsamicCaseConfig)
-
-    # THEN the qos should be set to the provided value
-    assert config.qos == SlurmQos.EXPRESS
+    # THEN the config should look as expected
+    expected_balsamic_case_config = BalsamicCaseConfig(
+        case_id=case_id,
+        account=cg_balsamic_config.slurm.account,
+        binary=cg_balsamic_config.binary_path,
+        conda_binary=cg_balsamic_config.conda_binary,
+        environment=cg_balsamic_config.conda_env,
+        head_job_partition=cg_balsamic_config.head_job_partition,
+        qos=SlurmQos.EXPRESS,
+        sample_config=Path(balsamic_configurator.root_dir, case_id, f"{case_id}.json"),
+        workflow=workflow,
+        workflow_profile=cg_balsamic_config.workflow_profile,
+    )
+    assert config == expected_balsamic_case_config
 
 
 def test_get_config_missing_config_file(
@@ -136,6 +193,7 @@ def test_configure(cg_balsamic_config: BalsamicConfig, workflow: Workflow, mocke
         qos=SlurmQos.NORMAL,
         sample_config=Path(cg_balsamic_config.root, "case_id", "case_id.json"),
         workflow=workflow,
+        workflow_profile=cg_balsamic_config.workflow_profile,
     )
 
 

--- a/tests/services/analysis_starter/test_case_configs.py
+++ b/tests/services/analysis_starter/test_case_configs.py
@@ -107,6 +107,7 @@ def test_balsamic_get_start_command_no_flags_set():
         sample_config=Path("/path/to/sample/config"),
         qos=SlurmQos.NORMAL,
         workflow=Workflow.BALSAMIC,
+        workflow_profile=Path("/path/to/balsamic"),
     )
 
     # WHEN getting the start command
@@ -121,7 +122,8 @@ def test_balsamic_get_start_command_no_flags_set():
         "--qos normal "
         "--sample-config /path/to/sample/config "
         "--headjob-partition head_job_partition "
-        "--run-analysis"
+        "--run-analysis "
+        "--workflow-profile /path/to/balsamic"
     )
     assert start_command == expected_command
 

--- a/tests/services/analysis_starter/test_configurator_factory.py
+++ b/tests/services/analysis_starter/test_configurator_factory.py
@@ -39,7 +39,9 @@ from cg.services.analysis_starter.configurator.file_creators.nextflow.sample_she
 from cg.services.analysis_starter.configurator.file_creators.nextflow.sample_sheet.raredisease_sample_sheet_creator import (
     RarediseaseSampleSheetCreator,
 )
-from cg.services.analysis_starter.configurator.implementations.balsamic import BalsamicConfigurator
+from cg.services.analysis_starter.configurator.implementations.balsamic_configurator import (
+    BalsamicConfigurator,
+)
 from cg.services.analysis_starter.configurator.implementations.microsalt import (
     MicrosaltConfigurator,
 )

--- a/tests/services/analysis_starter/test_subprocess_submitter.py
+++ b/tests/services/analysis_starter/test_subprocess_submitter.py
@@ -48,6 +48,7 @@ from cg.services.analysis_starter.submitters.subprocess.submitter import (
             qos=SlurmQos.LOW,
             sample_config=Path("sample_config"),
             workflow=Workflow.BALSAMIC,
+            workflow_profile=Path("/path/to/balsamic"),
         ),
     ],
     ids=["microSALT", "MIP-DNA", "BALSAMIC"],

--- a/tests/services/analysis_starter/tracker/test_tracker_mip_dna_and_balsamic.py
+++ b/tests/services/analysis_starter/tracker/test_tracker_mip_dna_and_balsamic.py
@@ -60,6 +60,7 @@ def balsamic_case_config(case_id: str) -> BalsamicCaseConfig:
         qos=SlurmQos.NORMAL,
         sample_config=Path("tmp_path", case_id, f"{case_id}.json"),
         workflow=Workflow.BALSAMIC,
+        workflow_profile=Path("/path/to/balsamic"),
     )
 
 


### PR DESCRIPTION
## Description

Closes #5133. Needs to be merged with https://github.com/Clinical-Genomics/servers/pull/1912. When running balsamic, one can provide the option `--workflow-profile`. Previously this was only a CLI option, but now the default value will be provided explicitly as well, using the path specified in the CGConfig.

### Added

-

### Changed

- workflow-profile is always provided when running balsamic, with the default value being the one in CGConfig.

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b 5133-set-balsamic-workflow-profile -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
