### PR TITLE
Skip Freshdesk interactions when data delivery is NO_DELIVERY

### DIFF
--- a/cg/services/deliver_service.py
+++ b/cg/services/deliver_service.py
@@ -4,6 +4,7 @@ from cg.apps.tb.api import TrailblazerAPI
 from cg.apps.tb.models import TrailblazerAnalysis
 from cg.clients.freshdesk.constants import Status
 from cg.clients.freshdesk.freshdesk_client import FreshdeskClient
+from cg.constants import DataDelivery
 from cg.exc import (
     FreshdeskDeliveryMessageError,
     FreshdeskGetTicketError,
@@ -43,7 +44,7 @@ class DeliverService:
         return all(are_all_orders_delivered)
 
     def deliver_case(self, case_id: str, signature: str):
-        analyses_to_deliver: list[Analysis] = self._get_undelivered_analyses_for_case(case_id)
+        analyses_to_deliver: list[Analysis] = self._get_analyses_to_deliver_for_case(case_id)
         match len(analyses_to_deliver):
             case 0:
                 LOG.warning(f"No analysis found to deliver for case {case_id}.")
@@ -55,14 +56,9 @@ class DeliverService:
 
     def deliver_order(self, ticket_id: int, signature: str):
         order: Order = self.status_db.get_order_by_ticket_id_strict(ticket_id)
-        undelivered_trailblazer_analyses = self.trailblazer_api.get_analyses_to_deliver_for_order(
-            order.id
-        )
-        uploaded_analyses_to_deliver = self.status_db.get_uploaded_analyses(
-            [analysis.id for analysis in undelivered_trailblazer_analyses]
-        )
-        if uploaded_analyses_to_deliver:
-            self._deliver(order=order, analyses=uploaded_analyses_to_deliver, signature=signature)
+        analyses_to_deliver: list[Analysis] = self._get_analyses_to_deliver_for_order(order)
+        if analyses_to_deliver:
+            self._deliver(order=order, analyses=analyses_to_deliver, signature=signature)
         else:
             LOG.warning("No analysis in the order ready to deliver")
 
@@ -73,8 +69,9 @@ class DeliverService:
         try:
             self.mark_as_delivered_service.mark_analyses(analyses=analyses, signature=signature)
             self.mark_as_delivered_service.close_order_in_status_db_if_closable(order)
-            self._freshdesk_send_delivery_message(order=order, analyses=analyses)
-            self._freshdesk_close_ticket_if_open(order=order)
+            if not self._is_order_no_delivery(order):
+                self._freshdesk_send_delivery_message(order=order, analyses=analyses)
+                self._freshdesk_close_ticket_if_open(order=order)
         except TrailblazerAnalysisDeliveryError as error:
             self.status_db.rollback()
             LOG.error(f"Failed to mark analyses as delivered in Trailblazer for order {order.id}")
@@ -96,7 +93,7 @@ class DeliverService:
             self.status_db.commit_to_store()
             return True
 
-    def _get_undelivered_analyses_for_case(self, case_id: str) -> list[Analysis]:
+    def _get_analyses_to_deliver_for_case(self, case_id: str) -> list[Analysis]:
         undelivered_trailblazer_analyses: list[TrailblazerAnalysis] = (
             self.trailblazer_api.get_analyses_to_deliver_for_case(case_id)
         )
@@ -105,6 +102,15 @@ class DeliverService:
             undelivered_trailblazer_ids
         )
         return analyses_to_deliver
+
+    def _get_analyses_to_deliver_for_order(self, order: Order) -> list[Analysis]:
+        undelivered_trailblazer_analyses = self.trailblazer_api.get_analyses_to_deliver_for_order(
+            order.id
+        )
+        uploaded_analyses_to_deliver = self.status_db.get_uploaded_analyses(
+            [analysis.id for analysis in undelivered_trailblazer_analyses]
+        )
+        return uploaded_analyses_to_deliver
 
     def _get_order_analyses_dictionary(self) -> dict[Order, list[Analysis]]:
         """
@@ -125,6 +131,10 @@ class DeliverService:
             else:
                 order_analyses[analysis.order] = [analysis]
         return order_analyses
+
+    @staticmethod
+    def _is_order_no_delivery(order: Order) -> bool:
+        return order.cases[0].data_delivery == DataDelivery.NO_DELIVERY
 
     def _freshdesk_send_delivery_message(self, order: Order, analyses: list[Analysis]):
         cases: list[Case] = [analysis.case for analysis in analyses]

--- a/tests/services/test_deliver_service.py
+++ b/tests/services/test_deliver_service.py
@@ -36,6 +36,7 @@ def test_deliver_case_closes_order(mocker: MockerFixture):
         Case,
         analyses=[analysis],
         internal_id="case_id",
+        data_delivery=DataDelivery.FASTQ_ANALYSIS_SCOUT,
     )
     analysis.case = case
 
@@ -109,6 +110,7 @@ def test_deliver_case_order_is_not_closed(mocker: MockerFixture):
         Case,
         analyses=[uploaded_analysis],
         internal_id="case_ready",
+        data_delivery=DataDelivery.FASTQ_ANALYSIS_SCOUT,
     )
     uploaded_analysis.case = case_ready
 
@@ -123,6 +125,7 @@ def test_deliver_case_order_is_not_closed(mocker: MockerFixture):
         Case,
         analyses=[not_uploaded_analysis],
         internal_id="case_not_ready",
+        data_delivery=DataDelivery.FASTQ_ANALYSIS_SCOUT,
     )
 
     # GIVEN an open order with the two cases
@@ -186,6 +189,61 @@ def test_deliver_case_order_is_not_closed(mocker: MockerFixture):
 
     # THEN the ticket is not closed in freshdesk
     freshdesk_client.as_mock.update_ticket.assert_not_called()
+
+
+def test_deliver_case_no_delivery(mocker: MockerFixture):
+    # GIVEN a case with an analysis ready to be delivered but with NO_DELIVERY as data delivery type
+    analysis = create_autospec(
+        Analysis,
+        trailblazer_id=1,
+        uploaded_at=datetime.now(),
+    )
+    case: Case = create_autospec(
+        Case,
+        analyses=[analysis],
+        internal_id="case_id",
+        data_delivery=DataDelivery.NO_DELIVERY,
+    )
+    analysis.case = case
+
+    # GIVEN an open order with the case
+    order: Order = create_autospec(Order, id=1, is_open=True, cases=[case], ticket_id=123)
+    analysis.order = order
+    status_db: Store = create_autospec(Store)
+    status_db.get_uploaded_analyses = Mock(return_value=[analysis])
+
+    # GIVEN a Trailblazer API with the analysis ready to be delivered
+    trailblazer_api: TrailblazerAPI = create_autospec(TrailblazerAPI)
+    tb_analysis: TrailblazerAnalysis = create_autospec(
+        TrailblazerAnalysis, id=1, delivered=False, case_id="case_id"
+    )
+    trailblazer_api.get_analyses_to_deliver_for_case = Mock(return_value=[tb_analysis])
+
+    # GIVEN a Freshdesk client
+    freshdesk_client: TypedMock[FreshdeskClient] = create_typed_mock(FreshdeskClient)
+
+    # GIVEN a delivery message method
+    delivery_message_mock = mocker.patch.object(deliver_service_module, "get_message")
+
+    # GIVEN a deliver service
+    deliver_service = DeliverService(
+        freshdesk_client=freshdesk_client.as_type,
+        status_db=status_db,
+        trailblazer_api=trailblazer_api,
+    )
+    mark_analyses_spy = mocker.spy(deliver_service.mark_as_delivered_service, "mark_analyses")
+
+    # WHEN delivering the case
+    deliver_service.deliver_case(case_id="case_id", signature="CG")
+
+    # THEN the analysis of the case should be marked as delivered
+    mark_analyses_spy.assert_called_once_with(analyses=[analysis], signature="CG")
+
+    # THEN the delivery message is not generated
+    delivery_message_mock.assert_not_called()
+
+    # THEN the ticket in freshdesk is not closed
+    freshdesk_client.as_mock.get_ticket.assert_not_called()
 
 
 def test_deliver_case_more_than_one_found():
@@ -530,7 +588,10 @@ def test_deliver_all_available_freshdesk_delivery_message_error(mocker: MockerFi
 def test_deliver_all_available_freshdesk_closing_ticket_error(mocker: MockerFixture):
     # GIVEN a store with an analysis to deliver
     status_db: TypedMock[Store] = create_typed_mock(Store)
-    case: Case = create_autospec(Case)
+    case: Case = create_autospec(
+        Case,
+        data_delivery=DataDelivery.FASTQ_ANALYSIS_SCOUT,
+    )
     analysis_to_deliver = create_autospec(
         Analysis,
         case=case,
@@ -592,11 +653,13 @@ def test_deliver_order_success(mocker: MockerFixture):
         Case,
         internal_id="case_1",
         analyses=[analysis_1],
+        data_delivery=DataDelivery.FASTQ_ANALYSIS_SCOUT,
     )
     case_2: Case = create_autospec(
         Case,
         internal_id="case_2",
         analyses=[analysis_2],
+        data_delivery=DataDelivery.FASTQ_ANALYSIS_SCOUT,
     )
     analysis_1.case = case_1
     analysis_2.case = case_2

--- a/tests/services/test_deliver_service.py
+++ b/tests/services/test_deliver_service.py
@@ -588,10 +588,7 @@ def test_deliver_all_available_freshdesk_delivery_message_error(mocker: MockerFi
 def test_deliver_all_available_freshdesk_closing_ticket_error(mocker: MockerFixture):
     # GIVEN a store with an analysis to deliver
     status_db: TypedMock[Store] = create_typed_mock(Store)
-    case: Case = create_autospec(
-        Case,
-        data_delivery=DataDelivery.FASTQ_ANALYSIS_SCOUT,
-    )
+    case: Case = create_autospec(Case, data_delivery=DataDelivery.FASTQ_ANALYSIS_SCOUT)
     analysis_to_deliver = create_autospec(
         Analysis,
         case=case,


### PR DESCRIPTION
## Description

### Added

- Static method to determine if the order is `NO_DELIVERY`
- Check if order is not `NO_DELIVERY` when calling freshdesk to send delivery message and closing ticket

### Changed

- Refactoring to keep symetry in exposed methods



### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
