### PR TITLE
Raise exception when scout export for gene panels has a successful exit code but no output

### DIFF
--- a/cg/apps/scout/scoutapi.py
+++ b/cg/apps/scout/scoutapi.py
@@ -8,7 +8,7 @@ from cg.apps.scout.scout_export import ScoutExportCase, Variant
 from cg.constants.constants import FileFormat
 from cg.constants.gene_panel import GENOME_BUILD_37
 from cg.constants.scout import ScoutCustomCaseReportTags
-from cg.exc import ScoutUploadError
+from cg.exc import ScoutExportError, ScoutUploadError
 from cg.io.controller import ReadFile, ReadStream
 from cg.models.scout.scout_load_config import ScoutLoadConfig
 from cg.services.slurm_upload_service.slurm_upload_service import SlurmUploadService
@@ -65,7 +65,8 @@ class ScoutAPI:
         try:
             self.process.run_command(export_panels_command, dry_run=dry_run)
             if not self.process.stdout:
-                return []
+                LOG.error(self.process.stderr)
+                raise ScoutExportError("Empty export output from scout")
         except CalledProcessError:
             LOG.info("Could not find panels")
             return []

--- a/cg/exc.py
+++ b/cg/exc.py
@@ -230,6 +230,10 @@ class ScoutUploadError(CgError):
     """Raised when uploading to Scout fails."""
 
 
+class ScoutExportError(CgError):
+    """Raised when exporting from Scout fails."""
+
+
 class StatinaAPIHTTPError(CgError):
     """Raised when Statina REST API response code is not 200."""
 

--- a/tests/apps/scout/test_scoutapi.py
+++ b/tests/apps/scout/test_scoutapi.py
@@ -1,0 +1,48 @@
+from unittest.mock import Mock, create_autospec
+
+import pytest
+from pytest_mock import MockerFixture
+
+from cg.apps.scout import scoutapi
+from cg.apps.scout.scoutapi import ScoutAPI
+from cg.exc import ScoutExportError
+from cg.models.cg_config import CommonAppConfig
+from cg.services.slurm_upload_service.slurm_upload_service import SlurmUploadService
+from cg.utils.commands import Process
+
+
+def test_export_panels_with_panel_output(mocker: MockerFixture):
+    # GIVEN scout returns panel output
+    process = create_autospec(
+        Process,
+        stdout="exported_1 exported_2",
+    )
+    process.stdout_lines = Mock(return_value=["exported_1", "exported_2"])
+    mocker.patch.object(scoutapi, "Process", return_value=process)
+
+    scout_api = ScoutAPI(
+        scout_config=CommonAppConfig(binary_path="scout/binary", config_path="scout/config"),
+        slurm_upload_service=create_autospec(SlurmUploadService),
+    )
+
+    # WHEN exporting panels
+    result = scout_api.export_panels(panels=["some_panel", "another_panel"])
+
+    # THEN the exported panel names are returned
+    assert result == ["exported_1", "exported_2"]
+
+
+def test_export_panels_with_empty_output(mocker: MockerFixture):
+    # GIVEN scout returns no output
+    process = create_autospec(Process, stdout=None)
+    mocker.patch.object(scoutapi, "Process", return_value=process)
+
+    scout_api = ScoutAPI(
+        scout_config=CommonAppConfig(binary_path="scout/binary", config_path="scout/config"),
+        slurm_upload_service=create_autospec(SlurmUploadService),
+    )
+
+    # WHEN exporting panels
+    # THEN a ScoutExportError is raised
+    with pytest.raises(ScoutExportError):
+        scout_api.export_panels(panels=["some_panel", "another_panel"])


### PR DESCRIPTION
### Changed

- Treat an empty gene panels export from scout as an error
