### PR TITLE
Rollback database changes in upload handler

### DIFF
--- a/cg/services/events/upload_handler.py
+++ b/cg/services/events/upload_handler.py
@@ -27,6 +27,7 @@ def completed(status_db: Store, trailblazer_api: TrailblazerAPI):
             LOG.error(f"Failed to update analysis uploaded_at for analysis with id {analysis_id}")
             LOG.error(f"Failed to handle message {message}.")
             LOG.exception(error)
+            status_db.rollback()
             raise error
 
     return handler

--- a/tests/services/events/test_upload_handler.py
+++ b/tests/services/events/test_upload_handler.py
@@ -49,7 +49,10 @@ def test_completed_missing_analysis():
     store.update_analysis_uploaded_at = Mock(side_effect=Exception)
 
     # WHEN a completed message is received
-    # THEN it lets the exception propagate
+    # THEN the exception is propagated
     completed_handler = completed(status_db=store, trailblazer_api=create_autospec(TrailblazerAPI))
     with pytest.raises(Exception):
         completed_handler(message)
+
+    # THEN any database changes are rolled back
+    store.rollback.assert_called_once()


### PR DESCRIPTION
### Fixed

- Rollback any pending database operations when an error was raised so that the database session is cleared up for the next event.
