### PR TITLE
Freshdesk logging

### DIFF
--- a/cg/clients/freshdesk/freshdesk_client.py
+++ b/cg/clients/freshdesk/freshdesk_client.py
@@ -74,10 +74,10 @@ class FreshdeskClient:
 
     def update_ticket(self, ticket_id: int, status: int) -> TicketResponse:
         url = f"{self.base_url}{EndPoints.TICKETS}/{ticket_id}"
-        data = {"status": status}
-        LOG.debug(f"URL={url}; JSON={data}")
+        json = {"status": status}
+        LOG.debug(f"URL={url}; JSON={json}")
         try:
-            response = self.session.put(url=url, data=data)
+            response = self.session.put(url=url, json=json)
             response.raise_for_status()
             return TicketResponse.model_validate(response.json()["ticket"])
         except HTTPError as error:
@@ -86,10 +86,10 @@ class FreshdeskClient:
     def reply_to_ticket(self, ticket_id: int, message: str) -> None:
         """Send a reply to an existing ticket in Freshdesk."""
         url = f"{self.base_url}{EndPoints.TICKETS}/{ticket_id}/reply"
-        data = {"body": message}
-        LOG.debug(f"URL={url}; JSON={data}")
+        json = {"body": message}
+        LOG.debug(f"URL={url}; JSON={json}")
         try:
-            response = self.session.post(url=url, data=data)
+            response = self.session.post(url=url, json=json)
             response.raise_for_status()
         except HTTPError as error:
             raise FreshdeskDeliveryMessageError from error

--- a/cg/clients/freshdesk/freshdesk_client.py
+++ b/cg/clients/freshdesk/freshdesk_client.py
@@ -1,7 +1,8 @@
+import logging
 from http import HTTPStatus
 from pathlib import Path
 
-from requests import HTTPError, Response, Session
+from requests import HTTPError, Session
 from requests.adapters import HTTPAdapter
 from urllib3 import Retry
 
@@ -13,6 +14,8 @@ from cg.exc import (
     FreshdeskGetTicketError,
     FreshdeskUpdateTicketError,
 )
+
+LOG = logging.getLogger(__name__)
 
 
 class FreshdeskClient:
@@ -60,19 +63,21 @@ class FreshdeskClient:
         session.mount("https://", adapter)
 
     def get_ticket(self, ticket_id: int) -> TicketResponse:
+        url = f"{self.base_url}{EndPoints.TICKETS}/{ticket_id}"
+        LOG.debug(f"URL={url}")
         try:
-            response = self.session.get(url=f"{self.base_url}{EndPoints.TICKETS}/{ticket_id}")
+            response = self.session.get(url=url)
             response.raise_for_status()
             return TicketResponse.model_validate(response.json()["ticket"])
         except HTTPError as error:
             raise FreshdeskGetTicketError from error
 
     def update_ticket(self, ticket_id: int, status: int) -> TicketResponse:
+        url = f"{self.base_url}{EndPoints.TICKETS}/{ticket_id}"
         data = {"status": status}
+        LOG.debug(f"URL={url}; JSON={data}")
         try:
-            response = self.session.put(
-                url=f"{self.base_url}{EndPoints.TICKETS}/{ticket_id}", data=data
-            )
+            response = self.session.put(url=url, data=data)
             response.raise_for_status()
             return TicketResponse.model_validate(response.json()["ticket"])
         except HTTPError as error:
@@ -81,8 +86,10 @@ class FreshdeskClient:
     def reply_to_ticket(self, ticket_id: int, message: str) -> None:
         """Send a reply to an existing ticket in Freshdesk."""
         url = f"{self.base_url}{EndPoints.TICKETS}/{ticket_id}/reply"
+        data = {"body": message}
+        LOG.debug(f"URL={url}; JSON={data}")
         try:
-            response = self.session.post(url=url, data={"body": message})
+            response = self.session.post(url=url, data=data)
             response.raise_for_status()
         except HTTPError as error:
             raise FreshdeskDeliveryMessageError from error

--- a/tests/clients/freshdesk/test_freshdesk_client.py
+++ b/tests/clients/freshdesk/test_freshdesk_client.py
@@ -156,7 +156,7 @@ def test_reply_to_ticket_success(mocker: MockerFixture):
     # THEN a reply was sent to the ticket
     mocked_post.assert_called_once_with(
         url="https://example.freshdesk.com/api/v2/tickets/123/reply",
-        data={"body": "Reply to ticket"},
+        json={"body": "Reply to ticket"},
     )
 
 


### PR DESCRIPTION
## Description

Adds debug logging of the requests sent to Freshdesk and also changed from data to json when sending the requests to get the correct content type.

### Added

- Logging in the Freshdesk client

### Changed

-

### Fixed

- Body is specified as json to get the correct Content-Type.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b add-freshdesk-logging -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
