### PR TITLE
Set external samples as no_invoice

### DIFF
--- a/cg/services/orders/storing/implementations/case_order_service.py
+++ b/cg/services/orders/storing/implementations/case_order_service.py
@@ -146,6 +146,7 @@ class StoreCaseOrderService(StoreOrderService):
             application_version=application_version,
             internal_id=sample._generated_lims_id,
             lims_status=lims_status,
+            no_invoice=application_version.application.is_external,
             order=order_name,
             ordered=ordered,
             original_ticket=ticket,

--- a/cg/services/orders/storing/implementations/fastq_order_service.py
+++ b/cg/services/orders/storing/implementations/fastq_order_service.py
@@ -119,6 +119,7 @@ class StoreFastqOrderService(StoreOrderService):
             internal_id=sample._generated_lims_id,
             lims_status=lims_status,
             name=sample.name,
+            no_invoice=application_version.application.is_external,
             order=order_name,
             ordered=datetime.now(),
             original_ticket=ticket_id,

--- a/cg/services/orders/storing/implementations/metagenome_order_service.py
+++ b/cg/services/orders/storing/implementations/metagenome_order_service.py
@@ -105,6 +105,7 @@ class StoreMetagenomeOrderService(StoreOrderService):
             internal_id=sample._generated_lims_id,
             lims_status=lims_status,
             name=sample.name,
+            no_invoice=application_version.application.is_external,
             order=order.name,
             ordered=datetime.now(),
             original_ticket=order._generated_ticket_id,

--- a/cg/services/orders/storing/implementations/microbial_fastq_order_service.py
+++ b/cg/services/orders/storing/implementations/microbial_fastq_order_service.py
@@ -118,6 +118,7 @@ class StoreMicrobialFastqOrderService(StoreOrderService):
             internal_id=sample._generated_lims_id,
             lims_status=lims_status,
             name=sample.name,
+            no_invoice=application_version.application.is_external,
             order=order_name,
             ordered=datetime.now(),
             original_ticket=ticket_id,

--- a/cg/services/orders/storing/implementations/microbial_order_service.py
+++ b/cg/services/orders/storing/implementations/microbial_order_service.py
@@ -143,6 +143,7 @@ class StoreMicrobialOrderService(StoreOrderService):
             internal_id=sample._generated_lims_id,
             lims_status=lims_status,
             name=sample.name,
+            no_invoice=application_version.application.is_external,
             order=order_name,
             ordered=datetime.now(),
             organism=organism,

--- a/cg/services/orders/storing/implementations/pacbio_order_service.py
+++ b/cg/services/orders/storing/implementations/pacbio_order_service.py
@@ -115,6 +115,7 @@ class StorePacBioOrderService(StoreOrderService):
             internal_id=sample._generated_lims_id,
             lims_status=lims_status,
             name=sample.name,
+            no_invoice=application_version.application.is_external,
             order=order_name,
             ordered=datetime.now(),
             original_ticket=ticket_id,

--- a/cg/services/orders/storing/implementations/taxprofiler_order_service.py
+++ b/cg/services/orders/storing/implementations/taxprofiler_order_service.py
@@ -102,6 +102,7 @@ class StoreTaxprofilerOrderService(StoreOrderService):
             internal_id=sample._generated_lims_id,
             lims_status=lims_status,
             name=sample.name,
+            no_invoice=application_version.application.is_external,
             order=order.name,
             ordered=datetime.now(),
             original_ticket=order._generated_ticket_id,

--- a/tests/services/orders/store_service/test_fastq_order_service.py
+++ b/tests/services/orders/store_service/test_fastq_order_service.py
@@ -69,8 +69,10 @@ def test_store_order_data_in_status_db(
 @pytest.mark.parametrize(
     "is_external, expected_lims_status", [(True, LimsStatus.DONE), (False, LimsStatus.PENDING)]
 )
-def test_create_db_sample_with_lims_status(is_external: bool, expected_lims_status: LimsStatus):
-    # GIVEN a store containing an external application
+def test_create_db_sample_with_lims_status_and_invoice(
+    is_external: bool, expected_lims_status: LimsStatus
+):
+    # GIVEN a store containing an application
     application: Application = create_autospec(Application, is_external=is_external)
     application_version: ApplicationVersion = create_autospec(
         ApplicationVersion, application=application
@@ -103,5 +105,8 @@ def test_create_db_sample_with_lims_status(is_external: bool, expected_lims_stat
         sample=fastq_sample, order_name="order", customer=customer, ticket_id="1234567"
     )
 
-    # THEN the sample should be created with LimsStatus DONE
+    # THEN the sample should be created with the expected lims status
     assert status_db.as_mock.add_sample.call_args[1]["lims_status"] == expected_lims_status
+
+    # THEN the sample should have been set to no_invoice if the application was external
+    assert status_db.as_mock.add_sample.call_args[1]["no_invoice"] == is_external

--- a/tests/services/orders/store_service/test_generic_order_store_service.py
+++ b/tests/services/orders/store_service/test_generic_order_store_service.py
@@ -279,8 +279,10 @@ def test_existing_samples_should_not_be_delivered_again(mocker: MockerFixture):
 @pytest.mark.parametrize(
     "is_external, expected_lims_status", [(True, LimsStatus.DONE), (False, LimsStatus.PENDING)]
 )
-def test_create_db_sample_with_lims_status(is_external: bool, expected_lims_status: LimsStatus):
-    # GIVEN a store containing an external application
+def test_create_db_sample_with_lims_status_and_invoice(
+    is_external: bool, expected_lims_status: LimsStatus
+):
+    # GIVEN a store containing an application
     application: Application = create_autospec(Application, is_external=is_external)
     application_version: ApplicationVersion = create_autospec(
         ApplicationVersion, application=application
@@ -301,7 +303,7 @@ def test_create_db_sample_with_lims_status(is_external: bool, expected_lims_stat
         subject_id="father",
     )
 
-    # GIVEN order case
+    # GIVEN a case
     case = create_autospec(RNAFusionCase, priority=Priority.standard)
 
     # GIVEN a store case order service
@@ -309,7 +311,7 @@ def test_create_db_sample_with_lims_status(is_external: bool, expected_lims_stat
         status_db=status_db.as_type, lims_service=create_autospec(OrderLimsService)
     )
 
-    # WHEN creating a database sample with an external application
+    # WHEN creating a database sample
     store_order_service._create_db_sample(
         case=case,
         sample=rna_fusion_sample,
@@ -319,5 +321,8 @@ def test_create_db_sample_with_lims_status(is_external: bool, expected_lims_stat
         ticket="1234567",
     )
 
-    # THEN the lims status of the sample is done
+    # THEN the lims status of the sample should be done if it is an external application
     assert status_db.as_mock.add_sample.call_args[1]["lims_status"] == expected_lims_status
+
+    # THEN the sample should be set to no_invoice if it is an external application
+    assert status_db.as_mock.add_sample.call_args[1]["no_invoice"] == is_external

--- a/tests/services/orders/store_service/test_metagenome_store_service.py
+++ b/tests/services/orders/store_service/test_metagenome_store_service.py
@@ -63,8 +63,10 @@ def test_store_metagenome_order_data_in_status_db(
 @pytest.mark.parametrize(
     "is_external, expected_lims_status", [(True, LimsStatus.DONE), (False, LimsStatus.PENDING)]
 )
-def test_create_db_sample_with_lims_status(is_external: bool, expected_lims_status: LimsStatus):
-    # GIVEN a store containing an external application
+def test_create_db_sample_with_lims_status_and_invoice(
+    is_external: bool, expected_lims_status: LimsStatus
+):
+    # GIVEN a store containing an application
     application: Application = create_autospec(Application, is_external=is_external)
     application_version: ApplicationVersion = create_autospec(
         ApplicationVersion, application=application
@@ -103,5 +105,8 @@ def test_create_db_sample_with_lims_status(is_external: bool, expected_lims_stat
         customer=customer,
     )
 
-    # THEN the sample should be created with LimsStatus DONE
+    # THEN the sample should be created with LimsStatus DONE if the application was external
     assert status_db.as_mock.add_sample.call_args[1]["lims_status"] == expected_lims_status
+
+    # THEN the sample should have been set to no_invoice if the application was external
+    assert status_db.as_mock.add_sample.call_args[1]["no_invoice"] == is_external

--- a/tests/services/orders/store_service/test_microbial_fastq_order_store_service.py
+++ b/tests/services/orders/store_service/test_microbial_fastq_order_store_service.py
@@ -57,8 +57,10 @@ def test_store_samples(
 @pytest.mark.parametrize(
     "is_external, expected_lims_status", [(True, LimsStatus.DONE), (False, LimsStatus.PENDING)]
 )
-def test_create_db_sample_with_lims_status(is_external: bool, expected_lims_status: LimsStatus):
-    # GIVEN a store containing an external application
+def test_create_db_sample_with_lims_status_and_invoice(
+    is_external: bool, expected_lims_status: LimsStatus
+):
+    # GIVEN a store containing an application
     application: Application = create_autospec(Application, is_external=is_external)
     application_version: ApplicationVersion = create_autospec(
         ApplicationVersion, application=application
@@ -89,5 +91,8 @@ def test_create_db_sample_with_lims_status(is_external: bool, expected_lims_stat
         sample=micro_fastq_sample, order_name="order", customer=customer, ticket_id="1234567"
     )
 
-    # THEN the sample should be created with LimsStatus DONE
+    # THEN the sample should be created with LimsStatus DONE if the application was external
     assert status_db.as_mock.add_sample.call_args[1]["lims_status"] == expected_lims_status
+
+    # THEN the sample should have been set to no_invoice if the application was external
+    assert status_db.as_mock.add_sample.call_args[1]["no_invoice"] == is_external

--- a/tests/services/orders/store_service/test_microbial_store_order_service.py
+++ b/tests/services/orders/store_service/test_microbial_store_order_service.py
@@ -125,8 +125,10 @@ def test_store_mutant_order_data_control_has_stored_value(
 @pytest.mark.parametrize(
     "is_external, expected_lims_status", [(True, LimsStatus.DONE), (False, LimsStatus.PENDING)]
 )
-def test_create_db_sample_with_lims_status(is_external: bool, expected_lims_status: LimsStatus):
-    # GIVEN a store containing an external application
+def test_create_db_sample_with_lims_status_and_invoice(
+    is_external: bool, expected_lims_status: LimsStatus
+):
+    # GIVEN a store containing an application
     application: Application = create_autospec(Application, is_external=is_external)
     application_version: ApplicationVersion = create_autospec(
         ApplicationVersion, application=application
@@ -162,5 +164,8 @@ def test_create_db_sample_with_lims_status(is_external: bool, expected_lims_stat
         ticket_id=1234567,
     )
 
-    # THEN the sample should be created with LimsStatus DONE
+    # THEN the sample should be created with LimsStatus DONE if the application is external
     assert status_db.as_mock.add_sample.call_args[1]["lims_status"] == expected_lims_status
+
+    # THEN the sample should have been set to no_invoice if the application was external
+    assert status_db.as_mock.add_sample.call_args[1]["no_invoice"] == is_external

--- a/tests/services/orders/store_service/test_pacbio_order_service.py
+++ b/tests/services/orders/store_service/test_pacbio_order_service.py
@@ -57,8 +57,10 @@ def test_store_pacbio_order_data_in_status_db(
 @pytest.mark.parametrize(
     "is_external, expected_lims_status", [(True, LimsStatus.DONE), (False, LimsStatus.PENDING)]
 )
-def test_create_db_sample_with_lims_status(is_external: bool, expected_lims_status: LimsStatus):
-    # GIVEN a store containing an external application
+def test_create_db_sample_with_lims_status_and_invoice(
+    is_external: bool, expected_lims_status: LimsStatus
+):
+    # GIVEN a store containing an application
     application: Application = create_autospec(Application, is_external=is_external)
     application_version: ApplicationVersion = create_autospec(
         ApplicationVersion, application=application
@@ -89,5 +91,8 @@ def test_create_db_sample_with_lims_status(is_external: bool, expected_lims_stat
         sample=fastq_sample, order_name="order", customer=customer, ticket_id="1234567"
     )
 
-    # THEN the sample should be created with LimsStatus DONE
+    # THEN the sample should be created with LimsStatus DONE if the application is external
     assert status_db.as_mock.add_sample.call_args[1]["lims_status"] == expected_lims_status
+
+    # THEN the sample should have been set to no_invoice if the application was external
+    assert status_db.as_mock.add_sample.call_args[1]["no_invoice"] == is_external

--- a/tests/services/orders/store_service/test_pool_order_store_service.py
+++ b/tests/services/orders/store_service/test_pool_order_store_service.py
@@ -93,8 +93,10 @@ def test_store_pool_order_data_in_status_db(
 @pytest.mark.parametrize(
     "is_external, expected_lims_status", [(True, LimsStatus.DONE), (False, LimsStatus.PENDING)]
 )
-def test_create_db_sample_with_lims_status(is_external: bool, expected_lims_status: LimsStatus):
-    # GIVEN a store containing an external application
+def test_create_db_sample_with_lims_status_and_invoice(
+    is_external: bool, expected_lims_status: LimsStatus
+):
+    # GIVEN a store containing an application
     application: Application = create_autospec(Application, is_external=is_external)
     application_version: ApplicationVersion = create_autospec(
         ApplicationVersion, application=application
@@ -128,5 +130,5 @@ def test_create_db_sample_with_lims_status(is_external: bool, expected_lims_stat
         ticket_id="1234567",
     )
 
-    # THEN the sample should be created with LimsStatus DONE
+    # THEN the sample should be created with LimsStatus DONE if the application is external
     assert status_db.as_mock.add_sample.call_args[1]["lims_status"] == expected_lims_status

--- a/tests/services/orders/store_service/test_taxprofiler_store_service.py
+++ b/tests/services/orders/store_service/test_taxprofiler_store_service.py
@@ -55,8 +55,10 @@ def test_store_taxprofiler_order_data_in_status_db(
 @pytest.mark.parametrize(
     "is_external, expected_lims_status", [(True, LimsStatus.DONE), (False, LimsStatus.PENDING)]
 )
-def test_create_db_sample_with_lims_status(is_external: bool, expected_lims_status: LimsStatus):
-    # GIVEN a store containing an external application
+def test_create_db_sample_with_lims_status_and_invoice(
+    is_external: bool, expected_lims_status: LimsStatus
+):
+    # GIVEN a store containing an application
     application: Application = create_autospec(Application, is_external=is_external)
     application_version: ApplicationVersion = create_autospec(
         ApplicationVersion, application=application
@@ -93,5 +95,8 @@ def test_create_db_sample_with_lims_status(is_external: bool, expected_lims_stat
         sample=fastq_sample, order=taxprofiler_order, customer=customer
     )
 
-    # THEN the sample should be created with LimsStatus DONE
+    # THEN the sample should be created with LimsStatus DONE if the application is external
     assert status_db.as_mock.add_sample.call_args[1]["lims_status"] == expected_lims_status
+
+    # THEN the sample should have been set to no_invoice if the application was external
+    assert status_db.as_mock.add_sample.call_args[1]["no_invoice"] == is_external


### PR DESCRIPTION
## Description

Closes #5150. The pool order service has seen no change as those samples are already not invoiced.

### Added

-

### Changed

- Samples are set as no_invoice if their application is external

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
