### PR TITLE
Remove ticket from response

### DIFF
--- a/cg/clients/freshdesk/freshdesk_client.py
+++ b/cg/clients/freshdesk/freshdesk_client.py
@@ -69,7 +69,7 @@ class FreshdeskClient:
         try:
             response = self.session.get(url=url)
             response.raise_for_status()
-            return TicketResponse.model_validate(response.json()["ticket"])
+            return TicketResponse.model_validate(response.json())
         except HTTPError as error:
             raise FreshdeskGetTicketError from error
 

--- a/cg/clients/freshdesk/freshdesk_client.py
+++ b/cg/clients/freshdesk/freshdesk_client.py
@@ -80,7 +80,7 @@ class FreshdeskClient:
         try:
             response = self.session.put(url=url, json=json)
             response.raise_for_status()
-            return TicketResponse.model_validate(response.json()["ticket"])
+            return TicketResponse.model_validate(response.json())
         except HTTPError as error:
             raise FreshdeskUpdateTicketError from error
 

--- a/tests/clients/freshdesk/test_freshdesk_client.py
+++ b/tests/clients/freshdesk/test_freshdesk_client.py
@@ -104,9 +104,8 @@ def test_update_ticket_success(ticket_raw_response: dict, mocker: MockerFixture)
     # GIVEN a successful HTTP response
     response = Response()
     response.status_code = HTTPStatus.OK
-    update_response = {"ticket": ticket_raw_response}
-    update_response["ticket"]["status"] = 5
-    response._content = str.encode(json.dumps(update_response))
+    ticket_raw_response["status"] = 5
+    response._content = str.encode(json.dumps(ticket_raw_response))
     mocker.patch.object(client.session, "put", return_value=response)
 
     # WHEN updating the ticket with a status

--- a/tests/clients/freshdesk/test_freshdesk_client.py
+++ b/tests/clients/freshdesk/test_freshdesk_client.py
@@ -18,41 +18,39 @@ from cg.exc import (
 @pytest.fixture
 def ticket_raw_response() -> dict:
     return {
-        "ticket": {
-            "cc_emails": ["user@cc.com"],
-            "fwd_emails": [],
-            "reply_cc_emails": ["user@cc.com"],
-            "email_config_id": None,
-            "fr_escalated": False,
-            "group_id": None,
-            "priority": Priority.LOW,
-            "requester_id": 1,
-            "responder_id": None,
-            "source": 2,
-            "source_info": 1,
-            "spam": False,
-            "status": Status.OPEN,
-            "subject": "",
-            "company_id": 1,
-            "id": 20,
-            "type": None,
-            "to_emails": None,
-            "product_id": None,
-            "created_at": "2015-08-24T11:56:51Z",
-            "updated_at": "2015-08-24T11:59:05Z",
-            "due_by": "2015-08-27T11:30:00Z",
-            "fr_due_by": "2015-08-25T11:30:00Z",
-            "is_escalated": False,
-            "association_type": None,
-            "description_text": "Not given.",
-            "structured_description": {
-                "description_contents": [{"type": "text", "data": {"content": "Not given."}}]
-            },
-            "description": "<div>Not given.</div>",
-            "custom_fields": {"category": "Primary"},
-            "tags": [],
-            "attachments": [],
-        }
+        "cc_emails": ["user@cc.com"],
+        "fwd_emails": [],
+        "reply_cc_emails": ["user@cc.com"],
+        "email_config_id": None,
+        "fr_escalated": False,
+        "group_id": None,
+        "priority": Priority.LOW,
+        "requester_id": 1,
+        "responder_id": None,
+        "source": 2,
+        "source_info": 1,
+        "spam": False,
+        "status": Status.OPEN,
+        "subject": "",
+        "company_id": 1,
+        "id": 20,
+        "type": None,
+        "to_emails": None,
+        "product_id": None,
+        "created_at": "2015-08-24T11:56:51Z",
+        "updated_at": "2015-08-24T11:59:05Z",
+        "due_by": "2015-08-27T11:30:00Z",
+        "fr_due_by": "2015-08-25T11:30:00Z",
+        "is_escalated": False,
+        "association_type": None,
+        "description_text": "Not given.",
+        "structured_description": {
+            "description_contents": [{"type": "text", "data": {"content": "Not given."}}]
+        },
+        "description": "<div>Not given.</div>",
+        "custom_fields": {"category": "Primary"},
+        "tags": [],
+        "attachments": [],
     }
 
 
@@ -106,8 +104,9 @@ def test_update_ticket_success(ticket_raw_response: dict, mocker: MockerFixture)
     # GIVEN a successful HTTP response
     response = Response()
     response.status_code = HTTPStatus.OK
-    ticket_raw_response["ticket"]["status"] = 5
-    response._content = str.encode(json.dumps(ticket_raw_response))
+    update_response = {"ticket": ticket_raw_response}
+    update_response["ticket"]["status"] = 5
+    response._content = str.encode(json.dumps(update_response))
     mocker.patch.object(client.session, "put", return_value=response)
 
     # WHEN updating the ticket with a status


### PR DESCRIPTION
## Description

The view ticket endpoint only includes the "ticket" layer if additional params are specified. In our use case the response is flat.

### Added

-

### Changed

-

### Fixed

- The response when viewing a freshdesk ticket is flat.
- The response when updating a freshdesk ticket is flat.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
