### PR TITLE
Add emails to cc when replying and closing tickets

### DIFF
--- a/cg/clients/freshdesk/freshdesk_client.py
+++ b/cg/clients/freshdesk/freshdesk_client.py
@@ -73,9 +73,9 @@ class FreshdeskClient:
         except HTTPError as error:
             raise FreshdeskGetTicketError from error
 
-    def update_ticket(self, ticket_id: int, status: int, cc_emails: list[str]) -> TicketResponse:
+    def update_ticket(self, ticket_id: int, status: int) -> TicketResponse:
         url = f"{self.base_url}{EndPoints.TICKETS}/{ticket_id}"
-        json = {"status": status, "cc_emails": cc_emails}
+        json = {"status": status}
         LOG.debug(f"URL={url}; JSON={json}")
         try:
             response = self.session.put(url=url, json=json)

--- a/cg/clients/freshdesk/freshdesk_client.py
+++ b/cg/clients/freshdesk/freshdesk_client.py
@@ -73,9 +73,9 @@ class FreshdeskClient:
         except HTTPError as error:
             raise FreshdeskGetTicketError from error
 
-    def update_ticket(self, ticket_id: int, status: int) -> TicketResponse:
+    def update_ticket(self, ticket_id: int, status: int, cc_emails: list[str]) -> TicketResponse:
         url = f"{self.base_url}{EndPoints.TICKETS}/{ticket_id}"
-        json = {"status": status}
+        json = {"status": status, "cc_emails": cc_emails}
         LOG.debug(f"URL={url}; JSON={json}")
         try:
             response = self.session.put(url=url, json=json)
@@ -84,11 +84,11 @@ class FreshdeskClient:
         except HTTPError as error:
             raise FreshdeskUpdateTicketError from error
 
-    def reply_to_ticket(self, ticket_id: int, message: str) -> None:
+    def reply_to_ticket(self, ticket_id: int, message: str, cc_emails: list[str]) -> None:
         """Send a reply to an existing ticket in Freshdesk."""
         url = f"{self.base_url}{EndPoints.TICKETS}/{ticket_id}/reply"
         html_body = escape(message).replace("\n", "<br>")
-        json = {"body": html_body}
+        json = {"body": html_body, "cc_emails": cc_emails}
         LOG.debug(f"URL={url}; JSON={json}")
         try:
             response = self.session.post(url=url, json=json)

--- a/cg/clients/freshdesk/models.py
+++ b/cg/clients/freshdesk/models.py
@@ -42,6 +42,7 @@ class TicketCreate(BaseModel):
 class TicketResponse(BaseModel):
     """Response from Freshdesk"""
 
+    cc_emails: list[str]
     id: int
     description: str
     subject: str

--- a/cg/services/deliver_service.py
+++ b/cg/services/deliver_service.py
@@ -72,16 +72,7 @@ class DeliverService:
             self.mark_as_delivered_service.mark_analyses(analyses=analyses, signature=signature)
             self.mark_as_delivered_service.close_order_in_status_db_if_closable(order)
             if not self._is_order_no_delivery(order):
-                freshdesk_ticket: TicketResponse = self.freshdesk_client.get_ticket(order.ticket_id)
-                self._freshdesk_send_delivery_message(
-                    order=order, analyses=analyses, cc_emails=freshdesk_ticket.cc_emails
-                )
-                if not order.is_open and freshdesk_ticket.status == Status.OPEN:
-                    self.freshdesk_client.update_ticket(
-                        ticket_id=order.ticket_id,
-                        status=Status.CLOSED,
-                        cc_emails=freshdesk_ticket.cc_emails,
-                    )
+                self._interact_with_freshdesk(analyses, order)
         except TrailblazerAnalysisDeliveryError as error:
             self.status_db.rollback()
             LOG.error(f"Failed to mark analyses as delivered in Trailblazer for order {order.id}")
@@ -149,6 +140,17 @@ class DeliverService:
     @staticmethod
     def _is_order_no_delivery(order: Order) -> bool:
         return order.cases[0].data_delivery == DataDelivery.NO_DELIVERY
+
+    def _interact_with_freshdesk(self, analyses: list[Analysis], order: Order):
+        freshdesk_ticket: TicketResponse = self.freshdesk_client.get_ticket(order.ticket_id)
+        self._freshdesk_send_delivery_message(
+            order=order, analyses=analyses, cc_emails=freshdesk_ticket.cc_emails
+        )
+        if not order.is_open and freshdesk_ticket.status == Status.OPEN:
+            self.freshdesk_client.update_ticket(
+                ticket_id=order.ticket_id,
+                status=Status.CLOSED,
+            )
 
     def _freshdesk_send_delivery_message(
         self, order: Order, analyses: list[Analysis], cc_emails: list[str]

--- a/cg/services/deliver_service.py
+++ b/cg/services/deliver_service.py
@@ -4,6 +4,7 @@ from cg.apps.tb.api import TrailblazerAPI
 from cg.apps.tb.models import TrailblazerAnalysis
 from cg.clients.freshdesk.constants import Status
 from cg.clients.freshdesk.freshdesk_client import FreshdeskClient
+from cg.clients.freshdesk.models import TicketResponse
 from cg.constants import DataDelivery, Workflow
 from cg.exc import (
     FreshdeskDeliveryMessageError,
@@ -71,8 +72,16 @@ class DeliverService:
             self.mark_as_delivered_service.mark_analyses(analyses=analyses, signature=signature)
             self.mark_as_delivered_service.close_order_in_status_db_if_closable(order)
             if not self._is_order_no_delivery(order):
-                self._freshdesk_send_delivery_message(order=order, analyses=analyses)
-                self._freshdesk_close_ticket_if_open(order=order)
+                freshdesk_ticket: TicketResponse = self.freshdesk_client.get_ticket(order.ticket_id)
+                self._freshdesk_send_delivery_message(
+                    order=order, analyses=analyses, cc_emails=freshdesk_ticket.cc_emails
+                )
+                if not order.is_open and freshdesk_ticket.status == Status.OPEN:
+                    self.freshdesk_client.update_ticket(
+                        ticket_id=order.ticket_id,
+                        status=Status.CLOSED,
+                        cc_emails=freshdesk_ticket.cc_emails,
+                    )
         except TrailblazerAnalysisDeliveryError as error:
             self.status_db.rollback()
             LOG.error(f"Failed to mark analyses as delivered in Trailblazer for order {order.id}")
@@ -141,14 +150,11 @@ class DeliverService:
     def _is_order_no_delivery(order: Order) -> bool:
         return order.cases[0].data_delivery == DataDelivery.NO_DELIVERY
 
-    def _freshdesk_send_delivery_message(self, order: Order, analyses: list[Analysis]):
+    def _freshdesk_send_delivery_message(
+        self, order: Order, analyses: list[Analysis], cc_emails: list[str]
+    ):
         cases: list[Case] = [analysis.case for analysis in analyses]
         message: str = get_message(cases=cases, store=self.status_db)
-        self.freshdesk_client.reply_to_ticket(ticket_id=order.ticket_id, message=message)
-
-    def _freshdesk_close_ticket_if_open(self, order: Order):
-        if not order.is_open:
-            if self.freshdesk_client.get_ticket(order.ticket_id).status == Status.OPEN:
-                self.freshdesk_client.update_ticket(ticket_id=order.ticket_id, status=Status.CLOSED)
-        else:
-            return
+        self.freshdesk_client.reply_to_ticket(
+            ticket_id=order.ticket_id, message=message, cc_emails=cc_emails
+        )

--- a/cg/services/deliver_service.py
+++ b/cg/services/deliver_service.py
@@ -72,7 +72,7 @@ class DeliverService:
             self.mark_as_delivered_service.mark_analyses(analyses=analyses, signature=signature)
             self.mark_as_delivered_service.close_order_in_status_db_if_closable(order)
             if not self._is_order_no_delivery(order):
-                self._interact_with_freshdesk(analyses, order)
+                self._interact_with_freshdesk(analyses=analyses, order=order)
         except TrailblazerAnalysisDeliveryError as error:
             self.status_db.rollback()
             LOG.error(f"Failed to mark analyses as delivered in Trailblazer for order {order.id}")

--- a/tests/clients/freshdesk/test_freshdesk_client.py
+++ b/tests/clients/freshdesk/test_freshdesk_client.py
@@ -110,9 +110,7 @@ def test_update_ticket_success(ticket_raw_response: dict, mocker: MockerFixture)
     mocker.patch.object(client.session, "put", return_value=response)
 
     # WHEN updating the ticket with a status
-    ticket_response = client.update_ticket(
-        ticket_id=20, status=Status.CLOSED, cc_emails=["email@to.cc"]
-    )
+    ticket_response = client.update_ticket(ticket_id=20, status=Status.CLOSED)
 
     # THEN the response should be as expected
     expected_ticket_response = TicketResponse(
@@ -140,7 +138,7 @@ def test_update_ticket_failure(mocker: MockerFixture):
     # WHEN updating the ticket with a status
     # THEN a FreshdeskUpdateTicketError should be raised
     with pytest.raises(FreshdeskUpdateTicketError):
-        client.update_ticket(ticket_id=20, status=Status.CLOSED, cc_emails=["email@to.cc"])
+        client.update_ticket(ticket_id=20, status=Status.CLOSED)
 
 
 def test_reply_to_ticket_success(mocker: MockerFixture):

--- a/tests/clients/freshdesk/test_freshdesk_client.py
+++ b/tests/clients/freshdesk/test_freshdesk_client.py
@@ -70,6 +70,7 @@ def test_get_ticket_success(ticket_raw_response: dict, mocker: MockerFixture):
     # THEN the response should be as expected
     expected_ticket_response = TicketResponse(
         id=20,
+        cc_emails=["user@cc.com"],
         description="<div>Not given.</div>",
         subject="",
         priority=Priority.LOW,
@@ -109,11 +110,14 @@ def test_update_ticket_success(ticket_raw_response: dict, mocker: MockerFixture)
     mocker.patch.object(client.session, "put", return_value=response)
 
     # WHEN updating the ticket with a status
-    ticket_response = client.update_ticket(ticket_id=20, status=Status.CLOSED)
+    ticket_response = client.update_ticket(
+        ticket_id=20, status=Status.CLOSED, cc_emails=["email@to.cc"]
+    )
 
     # THEN the response should be as expected
     expected_ticket_response = TicketResponse(
         id=20,
+        cc_emails=["user@cc.com"],
         description="<div>Not given.</div>",
         subject="",
         priority=Priority.LOW,
@@ -136,7 +140,7 @@ def test_update_ticket_failure(mocker: MockerFixture):
     # WHEN updating the ticket with a status
     # THEN a FreshdeskUpdateTicketError should be raised
     with pytest.raises(FreshdeskUpdateTicketError):
-        client.update_ticket(ticket_id=20, status=Status.CLOSED)
+        client.update_ticket(ticket_id=20, status=Status.CLOSED, cc_emails=["email@to.cc"])
 
 
 def test_reply_to_ticket_success(mocker: MockerFixture):
@@ -149,12 +153,12 @@ def test_reply_to_ticket_success(mocker: MockerFixture):
     mocked_post = mocker.patch.object(client.session, "post", return_value=mocked_response)
 
     # WHEN replying to a ticket with a message
-    client.reply_to_ticket(ticket_id=123, message="Reply to ticket")
+    client.reply_to_ticket(ticket_id=123, message="Reply to ticket", cc_emails=["email@to.cc"])
 
     # THEN a reply was sent to the ticket
     mocked_post.assert_called_once_with(
         url="https://example.freshdesk.com/api/v2/tickets/123/reply",
-        json={"body": "Reply to ticket"},
+        json={"body": "Reply to ticket", "cc_emails": ["email@to.cc"]},
     )
 
 
@@ -170,4 +174,4 @@ def test_reply_to_ticket_failure(mocker: MockerFixture):
     # WHEN replying to the ticket with a message
     # THEN a FreshdeskDeliveryMessageError should be raised
     with pytest.raises(FreshdeskDeliveryMessageError):
-        client.reply_to_ticket(ticket_id=20, message="")
+        client.reply_to_ticket(ticket_id=20, message="", cc_emails=[])

--- a/tests/services/orders/submitter/test_order_submitter.py
+++ b/tests/services/orders/submitter/test_order_submitter.py
@@ -1,5 +1,5 @@
 import datetime as dt
-from unittest.mock import PropertyMock, create_autospec, patch
+from unittest.mock import Mock, PropertyMock, create_autospec, patch
 
 import pytest
 from genologics.entities import Sample as LimsSample
@@ -56,10 +56,11 @@ def monkeypatch_process_lims(monkeypatch: pytest.MonkeyPatch, order: Order) -> N
     )
 
 
-def mock_freshdesk_ticket_creation(mock_create_ticket: callable, ticket_id: str):
+def mock_freshdesk_ticket_creation(mock_create_ticket: Mock, ticket_id: str):
     """Helper function to mock Freshdesk ticket creation."""
     mock_create_ticket.return_value = TicketResponse(
         id=int(ticket_id),
+        cc_emails=["email@to.cc"],
         description="This is a test description.",
         subject="Support needed..",
         status=2,
@@ -67,7 +68,7 @@ def mock_freshdesk_ticket_creation(mock_create_ticket: callable, ticket_id: str)
     )
 
 
-def mock_freshdesk_reply_to_ticket(mock_reply_to_ticket: callable):
+def mock_freshdesk_reply_to_ticket(mock_reply_to_ticket: Mock):
     """Helper function to mock Freshdesk reply to ticket."""
     mock_reply_to_ticket.return_value = None
 

--- a/tests/services/test_deliver_service.py
+++ b/tests/services/test_deliver_service.py
@@ -12,7 +12,7 @@ from cg.clients.freshdesk.models import TicketResponse
 from cg.constants.constants import DataDelivery, Workflow
 from cg.exc import (
     FreshdeskDeliveryMessageError,
-    FreshdeskGetTicketError,
+    FreshdeskUpdateTicketError,
     MultipleAnalysesToDeliverError,
     OrderNotFoundError,
     TrailblazerAnalysisDeliveryError,
@@ -59,7 +59,7 @@ def test_deliver_case_closes_order(mocker: MockerFixture):
     # GIVEN a Freshdesk client
     freshdesk_client: TypedMock[FreshdeskClient] = create_typed_mock(FreshdeskClient)
     freshdesk_client.as_type.get_ticket = Mock(
-        return_value=create_autospec(TicketResponse, status=2)
+        return_value=create_autospec(TicketResponse, status=2, cc_emails=["email@to.cc"])
     )
 
     # GIVEN a delivery message method
@@ -89,12 +89,12 @@ def test_deliver_case_closes_order(mocker: MockerFixture):
 
     # THEN the delivery message is sent
     freshdesk_client.as_mock.reply_to_ticket.assert_called_once_with(
-        ticket_id=123, message="delivery message"
+        ticket_id=123, message="delivery message", cc_emails=["email@to.cc"]
     )
 
     # THEN we should have closed the ticket in Freshdesk
     freshdesk_client.as_mock.update_ticket.assert_called_once_with(
-        ticket_id=order.ticket_id, status=5
+        ticket_id=order.ticket_id, status=5, cc_emails=["email@to.cc"]
     )
 
 
@@ -151,7 +151,7 @@ def test_deliver_case_order_is_not_closed(mocker: MockerFixture):
     # GIVEN a Freshdesk client
     freshdesk_client: TypedMock[FreshdeskClient] = create_typed_mock(FreshdeskClient)
     freshdesk_client.as_type.get_ticket = Mock(
-        return_value=create_autospec(TicketResponse, status=2)
+        return_value=create_autospec(TicketResponse, cc_emails=["email@to.cc"], status=2)
     )
 
     # GIVEN a delivery message method
@@ -184,7 +184,7 @@ def test_deliver_case_order_is_not_closed(mocker: MockerFixture):
 
     # THEN the delivery message is sent
     freshdesk_client.as_mock.reply_to_ticket.assert_called_once_with(
-        ticket_id=123, message="delivery message"
+        ticket_id=123, message="delivery message", cc_emails=["email@to.cc"]
     )
 
     # THEN the ticket is not closed in freshdesk
@@ -370,7 +370,7 @@ def test_deliver_all_available_success(mocker: MockerFixture):
     # GIVEN a Freshdesk Client
     freshdesk_client: TypedMock[FreshdeskClient] = create_typed_mock(FreshdeskClient)
     freshdesk_client.as_type.get_ticket = lambda ticket_id: create_autospec(
-        TicketResponse, id=ticket_id, status=2
+        TicketResponse, id=ticket_id, status=2, cc_emails=["email@to.cc"]
     )
 
     # GIVEN a delivery message method
@@ -417,15 +417,23 @@ def test_deliver_all_available_success(mocker: MockerFixture):
     delivery_message_mock.assert_any_call(cases=[case_1], store=status_db)
     delivery_message_mock.assert_any_call(cases=[case_2, case_3], store=status_db)
     freshdesk_client.as_mock.reply_to_ticket.assert_any_call(
-        ticket_id=order_1.ticket_id, message="delivery message"
+        ticket_id=order_1.ticket_id,
+        message="delivery message",
+        cc_emails=["email@to.cc"],
     )
     freshdesk_client.as_mock.reply_to_ticket.assert_any_call(
-        ticket_id=order_2.ticket_id, message="delivery message"
+        ticket_id=order_2.ticket_id,
+        message="delivery message",
+        cc_emails=["email@to.cc"],
     )
 
     # THEN both tickets were closed in freshdesk
-    freshdesk_client.as_mock.update_ticket.assert_any_call(ticket_id=order_1.ticket_id, status=5)
-    freshdesk_client.as_mock.update_ticket.assert_any_call(ticket_id=order_2.ticket_id, status=5)
+    freshdesk_client.as_mock.update_ticket.assert_any_call(
+        ticket_id=order_1.ticket_id, status=5, cc_emails=["email@to.cc"]
+    )
+    freshdesk_client.as_mock.update_ticket.assert_any_call(
+        ticket_id=order_2.ticket_id, status=5, cc_emails=["email@to.cc"]
+    )
 
 
 def test_deliver_all_available_no_analyses_to_deliver(mocker: MockerFixture):
@@ -607,6 +615,16 @@ def test_deliver_all_available_freshdesk_closing_ticket_error(mocker: MockerFixt
 
     # GIVEN a Freshdesk client
     freshdesk_client: TypedMock[FreshdeskClient] = create_typed_mock(FreshdeskClient)
+    freshdesk_client.as_type.get_ticket = Mock(
+        return_value=TicketResponse(
+            id=1,
+            cc_emails=["email@to.cc"],
+            description="A ticket",
+            subject="A subject",
+            status=Status.OPEN,
+            priority=1,
+        )
+    )
 
     # GIVEN a Delivery Service
     deliver_service = DeliverService(
@@ -620,8 +638,8 @@ def test_deliver_all_available_freshdesk_closing_ticket_error(mocker: MockerFixt
         deliver_service_module, "get_message", return_value="delivery message"
     )
 
-    # GIVEN that the Freshdesk client raises a FreshdeskGetTicketError
-    freshdesk_client.as_type.get_ticket = Mock(side_effect=FreshdeskGetTicketError)
+    # GIVEN that the Freshdesk client raises a FreshdeskUpdateTicketError
+    freshdesk_client.as_type.update_ticket = Mock(side_effect=FreshdeskUpdateTicketError)
 
     # WHEN delivering all analyses
     success: bool = deliver_service.deliver_all_available()
@@ -634,7 +652,9 @@ def test_deliver_all_available_freshdesk_closing_ticket_error(mocker: MockerFixt
 
     # THEN the delivery message should have been sent
     freshdesk_client.as_mock.reply_to_ticket.assert_called_once_with(
-        ticket_id=1, message="delivery message"
+        ticket_id=1,
+        message="delivery message",
+        cc_emails=["email@to.cc"],
     )
 
     # THEN the order should have been reopened if ever closed
@@ -686,7 +706,7 @@ def test_deliver_order_success(mocker: MockerFixture):
     # GIVEN a Freshdesk client
     freshdesk_client: TypedMock[FreshdeskClient] = create_typed_mock(FreshdeskClient)
     freshdesk_client.as_type.get_ticket = Mock(
-        return_value=create_autospec(TicketResponse, status=2)
+        return_value=create_autospec(TicketResponse, cc_emails=["email@to.cc"], status=2)
     )
     freshdesk_client.as_type.update_ticket = Mock(return_value=None)
 
@@ -716,7 +736,7 @@ def test_deliver_order_success(mocker: MockerFixture):
 
     # THEN the delivery message should have been sent
     freshdesk_client.as_mock.reply_to_ticket.assert_called_once_with(
-        ticket_id=123, message="delivery message"
+        ticket_id=123, message="delivery message", cc_emails=["email@to.cc"]
     )
 
     # THEN the order should have been closed
@@ -727,7 +747,7 @@ def test_deliver_order_success(mocker: MockerFixture):
 
     # THEN the Freshdesk ticket should have been closed
     freshdesk_client.as_mock.update_ticket.assert_called_once_with(
-        ticket_id=123, status=Status.CLOSED
+        ticket_id=123, status=Status.CLOSED, cc_emails=["email@to.cc"]
     )
 
 

--- a/tests/services/test_deliver_service.py
+++ b/tests/services/test_deliver_service.py
@@ -94,7 +94,7 @@ def test_deliver_case_closes_order(mocker: MockerFixture):
 
     # THEN we should have closed the ticket in Freshdesk
     freshdesk_client.as_mock.update_ticket.assert_called_once_with(
-        ticket_id=order.ticket_id, status=5, cc_emails=["email@to.cc"]
+        ticket_id=order.ticket_id, status=5
     )
 
 
@@ -428,12 +428,8 @@ def test_deliver_all_available_success(mocker: MockerFixture):
     )
 
     # THEN both tickets were closed in freshdesk
-    freshdesk_client.as_mock.update_ticket.assert_any_call(
-        ticket_id=order_1.ticket_id, status=5, cc_emails=["email@to.cc"]
-    )
-    freshdesk_client.as_mock.update_ticket.assert_any_call(
-        ticket_id=order_2.ticket_id, status=5, cc_emails=["email@to.cc"]
-    )
+    freshdesk_client.as_mock.update_ticket.assert_any_call(ticket_id=order_1.ticket_id, status=5)
+    freshdesk_client.as_mock.update_ticket.assert_any_call(ticket_id=order_2.ticket_id, status=5)
 
 
 def test_deliver_all_available_no_analyses_to_deliver(mocker: MockerFixture):
@@ -747,7 +743,7 @@ def test_deliver_order_success(mocker: MockerFixture):
 
     # THEN the Freshdesk ticket should have been closed
     freshdesk_client.as_mock.update_ticket.assert_called_once_with(
-        ticket_id=123, status=Status.CLOSED, cc_emails=["email@to.cc"]
+        ticket_id=123, status=Status.CLOSED
     )
 
 


### PR DESCRIPTION
## Description

When delivering analyses, we need to cc all the people involved in the ticket. This PR adds these emails to cc when sending out the reply and when closing the ticket.

### Added

-

### Changed

- cc_emails are added when replying to a ticket.
- cc_emails are added when closing a ticket.

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b cc-emails-freshdesk -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
