### PR TITLE
Allow `unknown` workflow in unhandled samples request

### DIFF
--- a/cg/server/dto/samples/requests.py
+++ b/cg/server/dto/samples/requests.py
@@ -1,4 +1,5 @@
 from enum import StrEnum
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -46,4 +47,4 @@ class UnhandledSamplesRequest(BaseModel):
     search: str | None = None
     sort_by: UnhandledSamplesSortBy | None = None
     sort_order: SortDirection | None = None
-    workflow: Workflow | None = None
+    workflow: Workflow | Literal["unknown"] | None = None

--- a/cg/store/crud/read.py
+++ b/cg/store/crud/read.py
@@ -3,7 +3,7 @@
 import datetime as dt
 import logging
 from datetime import datetime
-from typing import Callable, Iterator
+from typing import Callable, Iterator, Literal
 
 import sqlalchemy
 from sqlalchemy.orm import Query
@@ -1931,7 +1931,7 @@ class ReadHandler(BaseHandler):
         search: str | None = None,
         sort_by: UnhandledSamplesSortBy | None = None,
         sort_order: SortDirection | None = None,
-        workflow: Workflow | None = None,
+        workflow: Workflow | Literal["unknown"] | None = None,
     ) -> tuple[list[Sample], int]:
         unhandled_samples: Query = self._get_unhandled_samples(
             lims_status=lims_status,
@@ -1948,7 +1948,7 @@ class ReadHandler(BaseHandler):
         search: str | None = None,
         sort_by: UnhandledSamplesSortBy | None = None,
         sort_order: SortDirection | None = None,
-        workflow: Workflow | None = None,
+        workflow: Workflow | Literal["unknown"] | None = None,
     ) -> Query:
         """
         Return samples with the given lims_status that:
@@ -1991,7 +1991,10 @@ class ReadHandler(BaseHandler):
             )
 
         if workflow:
-            query = query.filter(Sample.workflow_of_case_that_delivers == workflow)
+            if workflow == "unknown":
+                query = query.filter(Sample.workflow_of_case_that_delivers.is_(None))
+            else:
+                query = query.filter(Sample.workflow_of_case_that_delivers == workflow)
 
         return query
 

--- a/tests/server/endpoints/test_samples_endpoint.py
+++ b/tests/server/endpoints/test_samples_endpoint.py
@@ -471,6 +471,34 @@ def test_get_unhandled_samples_filter_on_workflow(client: FlaskClient, mocker: M
     )
 
 
+def test_get_unhandled_samples_filter_on_unknown_workflow(
+    client: FlaskClient, mocker: MockerFixture
+):
+    # GIVEN a store with unhandled samples in top-up
+    status_db: TypedMock[Store] = create_typed_mock(Store)
+    status_db.as_type.get_paginated_unhandled_samples = Mock(return_value=([], 0))
+    mocker.patch.object(samples, "db", status_db.as_type)
+
+    # WHEN querying the unhandled samples endpoint with workflow Raredisease
+    response = client.get(
+        path="/api/v1/unhandled_samples?lims_status=top-up&page=1&page_size=10&workflow=unknown",
+    )
+
+    # THEN the response should be successful
+    assert response.status_code == HTTPStatus.OK
+
+    # THEN function has been called with the correct arguments
+    status_db.as_mock.get_paginated_unhandled_samples.assert_called_once_with(
+        lims_status=LimsStatus.TOP_UP,
+        page=1,
+        page_size=10,
+        search=None,
+        sort_by=None,
+        sort_order=None,
+        workflow="unknown",
+    )
+
+
 def test_get_unhandled_samples_unknown_param(client: FlaskClient, mocker: MockerFixture):
     # GIVEN an unknown param in the request
 

--- a/tests/store/crud/read/test_read_sample.py
+++ b/tests/store/crud/read/test_read_sample.py
@@ -889,6 +889,51 @@ def test_get_unhandled_samples_filters_on_workflow(store: Store, helpers: StoreH
     assert unhandled_samples.all() == [raredisease_sample]
 
 
+def test_get_unhandled_samples_filters_on_unknown_workflow(store: Store, helpers: StoreHelpers):
+    # GIVEN a store with one sample without a delivering case and one with a workflow
+    unknown_workflow_sample = helpers.add_sample(
+        store=store,
+        lims_status=LimsStatus.TOP_UP,
+        internal_id="unknown_workflow_sample",
+        is_cancelled=False,
+        from_sample=None,
+        last_sequenced_at=datetime.now(),
+        delivered_at=None,
+        customer_id="cust1337",
+    )
+    known_workflow_sample = helpers.add_sample(
+        store=store,
+        lims_status=LimsStatus.TOP_UP,
+        internal_id="known_workflow_sample",
+        is_cancelled=False,
+        from_sample=None,
+        last_sequenced_at=datetime.now(),
+        delivered_at=None,
+        customer_id="cust1337",
+    )
+    known_workflow_case = helpers.add_case(
+        store=store,
+        internal_id="known_workflow_case",
+        name="known_workflow_case",
+        data_analysis=Workflow.RAREDISEASE,
+    )
+    helpers.add_relationship(
+        store=store,
+        sample=known_workflow_sample,
+        case=known_workflow_case,
+        should_deliver_sample=True,
+    )
+
+    # WHEN getting unhandled samples filtered by unknown workflow
+    unhandled_samples: Query = store._get_unhandled_samples(
+        lims_status=LimsStatus.TOP_UP,
+        workflow="unknown",
+    )
+
+    # THEN only the sample without a delivering case is returned
+    assert unhandled_samples.all() == [unknown_workflow_sample]
+
+
 def test_get_paginated_unhandled_samples_sort_by_ticket(store: Store, helpers: StoreHelpers):
     # GIVEN two unhandled samples whose delivering cases belong to orders with different tickets
     sample_in_ticket_1 = helpers.add_sample(


### PR DESCRIPTION
## Description

There is no constraint that a sample should have a delivering case. It is therefore practiacal to set workflow equal `unknown` in the request to the end point unhandled samples.
To be merged with: https://github.com/Clinical-Genomics/cigrid-ui/pull/860

### Added

- Ability to make this request `/api/v1/unhandled_samples?lims_status=pending&page=1&page_size=50&search=&workflow=unknown`


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
