### PR TITLE
Exclude taxprofiler from automatic delivery

### DIFF
--- a/cg/services/deliver_service.py
+++ b/cg/services/deliver_service.py
@@ -120,14 +120,14 @@ class DeliverService:
         """
         Returns a dictionary with orders as keys and lists of analyses as values. Only includes
         analyses that are marked as uploaded in StatusDB and not yet marked as delivered in
-        Trailblazer. We are currently excluding microSALT from automatic delivery.
+        Trailblazer. We are currently excluding microSALT and Taxprofiler from automatic delivery.
         """
         undelivered_trailblazer_analyses: list[TrailblazerAnalysis] = (
             self.trailblazer_api.get_all_analyses_to_deliver()
         )
         uploaded_analyses_to_deliver: list[Analysis] = self.status_db.get_uploaded_analyses(
             trailblazer_ids=[analysis.id for analysis in undelivered_trailblazer_analyses],
-            exclude_workflows=[Workflow.MICROSALT],
+            exclude_workflows=[Workflow.MICROSALT, Workflow.TAXPROFILER],
         )
         order_analyses = {}
         for analysis in uploaded_analyses_to_deliver:

--- a/tests/services/test_deliver_service.py
+++ b/tests/services/test_deliver_service.py
@@ -402,7 +402,7 @@ def test_deliver_all_available_success(mocker: MockerFixture):
 
     # THEN uploaded analyses should have been fetched from StatusDB
     status_db.get_uploaded_analyses.assert_called_once_with(
-        trailblazer_ids=ANY, exclude_workflows=[Workflow.MICROSALT]
+        trailblazer_ids=ANY, exclude_workflows=[Workflow.MICROSALT, Workflow.TAXPROFILER]
     )
 
     # THEN the analyses of both orders should have been marked as delivered separately
@@ -462,7 +462,7 @@ def test_deliver_all_available_no_analyses_to_deliver(mocker: MockerFixture):
 
     # THEN uploaded analyses should have been fetched from StatusDB
     status_db.get_uploaded_analyses.assert_called_once_with(
-        trailblazer_ids=ANY, exclude_workflows=[Workflow.MICROSALT]
+        trailblazer_ids=ANY, exclude_workflows=[Workflow.MICROSALT, Workflow.TAXPROFILER]
     )
 
     # THEN no call should have been made

--- a/tests/store/crud/read/test_read_analysis.py
+++ b/tests/store/crud/read/test_read_analysis.py
@@ -760,12 +760,20 @@ def test_get_uploaded_analyses_exclude_workflow(store: Store):
         trailblazer_id=2,
         uploaded=datetime.now(),
     )
+    not_desired_analysis_two = store.add_analysis(
+        case_id=3,
+        workflow=Workflow.TAXPROFILER,
+        trailblazer_id=3,
+        uploaded=datetime.now(),
+    )
 
-    store.add_multiple_items_to_store([desired_analysis, not_desired_analysis])
+    store.add_multiple_items_to_store(
+        [desired_analysis, not_desired_analysis, not_desired_analysis_two]
+    )
 
     # WHEN getting the uploaded analyses excluding microSALT
     uploaded_analyses: list[Analysis] = store.get_uploaded_analyses(
-        trailblazer_ids=[1, 2], exclude_workflows=[Workflow.MICROSALT]
+        trailblazer_ids=[1, 2, 3], exclude_workflows=[Workflow.MICROSALT, Workflow.TAXPROFILER]
     )
 
     # THEN only the requested uploaded analysis is returned

--- a/tests/store/crud/read/test_read_analysis.py
+++ b/tests/store/crud/read/test_read_analysis.py
@@ -747,7 +747,7 @@ def test_get_uploaded_analyses(store: Store):
 
 
 def test_get_uploaded_analyses_exclude_workflow(store: Store):
-    # GIVEN a store with two analyses, one with a workflow we want to exclude
+    # GIVEN a store with three analyses, one with a workflow we want to exclude
     desired_analysis = store.add_analysis(
         case_id=1,
         workflow=Workflow.NALLO,


### PR DESCRIPTION
## Description

Taxprofiler does not have a QC check. There for the production have a hard time known when to set case to top-up.

### Added

- Taxprofiler to the list of workflows excluded from automatic delivery.



### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
