### PR TITLE
Add CNV upload to RD WES loqus upload

### DIFF
--- a/cg/meta/observations/raredisease_observations_api.py
+++ b/cg/meta/observations/raredisease_observations_api.py
@@ -114,18 +114,13 @@ class RarediseaseObservationsAPI(ObservationsAPI):
         self, hk_version: Version, case_id: str
     ) -> RarediseaseObservationsInputFiles:
         """Return observations files given a Housekeeper version for RAREDISEASE."""
-        input_files: dict[str, File] = {
+        input_files: dict[str, File | None] = {
             "snv_vcf_path": self.housekeeper_api.files(
                 version=hk_version.id, tags=[RarediseaseObservationsAnalysisTag.SNV_VCF]
             ).first(),
-            "sv_vcf_path": (
-                self.housekeeper_api.files(
-                    version=hk_version.id, tags=[RarediseaseObservationsAnalysisTag.SV_VCF]
-                ).first()
-                if self.analysis_api.get_data_analysis_type(case_id)
-                == SeqLibraryPrepCategory.WHOLE_GENOME_SEQUENCING
-                else None
-            ),
+            "sv_vcf_path": self.housekeeper_api.files(
+                version=hk_version.id, tags=[RarediseaseObservationsAnalysisTag.SV_VCF]
+            ).first(),
             "profile_vcf_path": self.housekeeper_api.files(
                 version=hk_version.id, tags=[RarediseaseObservationsAnalysisTag.SNV_VCF]
             ).first(),

--- a/cg/meta/observations/raredisease_observations_api.py
+++ b/cg/meta/observations/raredisease_observations_api.py
@@ -128,7 +128,9 @@ class RarediseaseObservationsAPI(ObservationsAPI):
                 version=hk_version.id, tags=[RarediseaseObservationsAnalysisTag.FAMILY_PED]
             ).first(),
         }
-        return RarediseaseObservationsInputFiles(**get_full_path_dictionary(input_files))
+        file_paths: dict[str, str] = get_full_path_dictionary(input_files)
+        LOG.debug(f"Observations input files for case {case_id}: {file_paths}")
+        return RarediseaseObservationsInputFiles(**file_paths)
 
     def delete_case(self, case_id: str) -> None:
         """Delete RAREDISEASE case observations from Loqusdb."""


### PR DESCRIPTION
## Description
Remove restriction on uploading SV_VCF files to LoqusDB for Raredisease WES cases


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b add-cnv-to-wes-rd-loqus -a
    ```

### How to test

- [ ] Do `cg -l DEBUG upload observations <case-id>` with a raredisease WES case

### Expected test outcome

- [ ] Check that the SV_VCF file is uploaded

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
