### PR TITLE
Exclude workflows in request to TB

### DIFF
--- a/cg/apps/tb/api.py
+++ b/cg/apps/tb/api.py
@@ -275,11 +275,19 @@ class TrailblazerAPI:
         validated_response = AnalysesResponse.model_validate(raw_response)
         return validated_response.analyses
 
-    def get_all_analyses_to_deliver(self) -> list[TrailblazerAnalysis]:
-        exclude_workflows = f"excludeWorkflow[]={Workflow.RSYNC.upper()}&excludeWorkflow[]={Workflow.DEMULTIPLEX.upper()}"
-        endpoint = f"analyses?status[]={AnalysisStatus.COMPLETED}&delivered=false&holdDelivery=false&{exclude_workflows}"
+    def get_all_analyses_to_deliver(
+        self, exclude_workflows: list[Workflow] | None = None
+    ) -> list[TrailblazerAnalysis]:
+        exclude: str = self._get_exclude_workflow_request_string(exclude_workflows)
+        endpoint = f"analyses?status[]={AnalysisStatus.COMPLETED}&delivered=false&holdDelivery=false{exclude}"
         raw_response = self.query_trailblazer(
             command=endpoint, request_body={}, method=APIMethods.GET
         )
         validated_response = AnalysesResponse.model_validate(raw_response)
         return validated_response.analyses
+
+    @staticmethod
+    def _get_exclude_workflow_request_string(workflows: list[Workflow] | None) -> str:
+        if not workflows:
+            return ""
+        return "".join(f"&excludeWorkflow[]={workflow.upper()}" for workflow in workflows)

--- a/cg/apps/tb/api.py
+++ b/cg/apps/tb/api.py
@@ -268,8 +268,7 @@ class TrailblazerAPI:
             raise AnalysisNotCompletedError(f"The latest analysis for {case_id} has not completed.")
 
     def get_analyses_to_deliver_for_case(self, case_id: str) -> list[TrailblazerAnalysis]:
-        exclude_workflows = f"excludeWorkflow={Workflow.RSYNC.upper()}&excludeWorkflow={Workflow.DEMULTIPLEX.upper()}"
-        endpoint = f"analyses?case_id={case_id}&status[]={AnalysisStatus.COMPLETED}&delivered=false&holdDelivery=false&{exclude_workflows}"
+        endpoint = f"analyses?case_id={case_id}&status[]={AnalysisStatus.COMPLETED}&delivered=false&holdDelivery=false"
         raw_response = self.query_trailblazer(
             command=endpoint, request_body={}, method=APIMethods.GET
         )
@@ -277,9 +276,8 @@ class TrailblazerAPI:
         return validated_response.analyses
 
     def get_all_analyses_to_deliver(self) -> list[TrailblazerAnalysis]:
-        endpoint = (
-            f"analyses?status[]={AnalysisStatus.COMPLETED}&delivered=false&holdDelivery=false"
-        )
+        exclude_workflows = f"excludeWorkflow={Workflow.RSYNC.upper()}&excludeWorkflow={Workflow.DEMULTIPLEX.upper()}"
+        endpoint = f"analyses?status[]={AnalysisStatus.COMPLETED}&delivered=false&holdDelivery=false&{exclude_workflows}"
         raw_response = self.query_trailblazer(
             command=endpoint, request_body={}, method=APIMethods.GET
         )

--- a/cg/apps/tb/api.py
+++ b/cg/apps/tb/api.py
@@ -278,8 +278,8 @@ class TrailblazerAPI:
     def get_all_analyses_to_deliver(
         self, exclude_workflows: list[Workflow] | None = None
     ) -> list[TrailblazerAnalysis]:
-        exclude: str = self._get_exclude_workflow_request_string(exclude_workflows)
-        endpoint = f"analyses?status[]={AnalysisStatus.COMPLETED}&delivered=false&holdDelivery=false{exclude}"
+        exclude_workflows_params: str = self._get_exclude_workflow_request_string(exclude_workflows)
+        endpoint = f"analyses?status[]={AnalysisStatus.COMPLETED}&delivered=false&holdDelivery=false{exclude_workflows_params}"
         raw_response = self.query_trailblazer(
             command=endpoint, request_body={}, method=APIMethods.GET
         )

--- a/cg/apps/tb/api.py
+++ b/cg/apps/tb/api.py
@@ -276,7 +276,7 @@ class TrailblazerAPI:
         return validated_response.analyses
 
     def get_all_analyses_to_deliver(self) -> list[TrailblazerAnalysis]:
-        exclude_workflows = f"excludeWorkflow={Workflow.RSYNC.upper()}&excludeWorkflow={Workflow.DEMULTIPLEX.upper()}"
+        exclude_workflows = f"excludeWorkflow[]={Workflow.RSYNC.upper()}&excludeWorkflow[]={Workflow.DEMULTIPLEX.upper()}"
         endpoint = f"analyses?status[]={AnalysisStatus.COMPLETED}&delivered=false&holdDelivery=false&{exclude_workflows}"
         raw_response = self.query_trailblazer(
             command=endpoint, request_body={}, method=APIMethods.GET

--- a/cg/apps/tb/api.py
+++ b/cg/apps/tb/api.py
@@ -268,7 +268,8 @@ class TrailblazerAPI:
             raise AnalysisNotCompletedError(f"The latest analysis for {case_id} has not completed.")
 
     def get_analyses_to_deliver_for_case(self, case_id: str) -> list[TrailblazerAnalysis]:
-        endpoint = f"analyses?case_id={case_id}&status[]={AnalysisStatus.COMPLETED}&delivered=false&holdDelivery=false"
+        exclude_workflows = f"excludeWorkflow={Workflow.RSYNC.upper()}&excludeWorkflow={Workflow.DEMULTIPLEX.upper()}"
+        endpoint = f"analyses?case_id={case_id}&status[]={AnalysisStatus.COMPLETED}&delivered=false&holdDelivery=false&{exclude_workflows}"
         raw_response = self.query_trailblazer(
             command=endpoint, request_body={}, method=APIMethods.GET
         )

--- a/cg/apps/tb/api.py
+++ b/cg/apps/tb/api.py
@@ -278,8 +278,8 @@ class TrailblazerAPI:
     def get_all_analyses_to_deliver(
         self, exclude_workflows: list[Workflow] | None = None
     ) -> list[TrailblazerAnalysis]:
-        exclude_workflows_params: str = self._get_exclude_workflow_request_string(exclude_workflows)
-        endpoint = f"analyses?status[]={AnalysisStatus.COMPLETED}&delivered=false&holdDelivery=false{exclude_workflows_params}"
+        exclude_workflows_query: str = self._generate_exclude_workflow_query(exclude_workflows)
+        endpoint = f"analyses?status[]={AnalysisStatus.COMPLETED}&delivered=false&holdDelivery=false{exclude_workflows_query}"
         raw_response = self.query_trailblazer(
             command=endpoint, request_body={}, method=APIMethods.GET
         )
@@ -287,7 +287,7 @@ class TrailblazerAPI:
         return validated_response.analyses
 
     @staticmethod
-    def _get_exclude_workflow_request_string(workflows: list[Workflow] | None) -> str:
+    def _generate_exclude_workflow_query(workflows: list[Workflow] | None) -> str:
         if not workflows:
             return ""
         return "".join(f"&excludeWorkflow[]={workflow.upper()}" for workflow in workflows)

--- a/cg/services/deliver_service.py
+++ b/cg/services/deliver_service.py
@@ -133,8 +133,7 @@ class DeliverService:
             )
         )
         uploaded_analyses_to_deliver: list[Analysis] = self.status_db.get_uploaded_analyses(
-            trailblazer_ids=[analysis.id for analysis in undelivered_trailblazer_analyses],
-            exclude_workflows=[Workflow.MICROSALT, Workflow.TAXPROFILER],
+            trailblazer_ids=[analysis.id for analysis in undelivered_trailblazer_analyses]
         )
         order_analyses = {}
         for analysis in uploaded_analyses_to_deliver:

--- a/cg/services/deliver_service.py
+++ b/cg/services/deliver_service.py
@@ -123,7 +123,14 @@ class DeliverService:
         Trailblazer. We are currently excluding microSALT and Taxprofiler from automatic delivery.
         """
         undelivered_trailblazer_analyses: list[TrailblazerAnalysis] = (
-            self.trailblazer_api.get_all_analyses_to_deliver()
+            self.trailblazer_api.get_all_analyses_to_deliver(
+                exclude_workflows=[
+                    Workflow.MICROSALT,
+                    Workflow.TAXPROFILER,
+                    Workflow.DEMULTIPLEX,
+                    Workflow.RSYNC,
+                ]
+            )
         )
         uploaded_analyses_to_deliver: list[Analysis] = self.status_db.get_uploaded_analyses(
             trailblazer_ids=[analysis.id for analysis in undelivered_trailblazer_analyses],

--- a/cg/store/crud/read.py
+++ b/cg/store/crud/read.py
@@ -2050,15 +2050,12 @@ class ReadHandler(BaseHandler):
 
         return query
 
-    def get_uploaded_analyses(
-        self, trailblazer_ids: list[int], exclude_workflows: list[Workflow] = []
-    ) -> list[Analysis]:
+    def get_uploaded_analyses(self, trailblazer_ids: list[int]) -> list[Analysis]:
         return (
             self._get_query(table=Analysis)
             .filter(
                 Analysis.trailblazer_id.in_(trailblazer_ids),
                 Analysis.uploaded_at.is_not(None),
-                Analysis.workflow.notin_(exclude_workflows),
             )
             .all()
         )

--- a/tests/apps/tb/test_api.py
+++ b/tests/apps/tb/test_api.py
@@ -554,6 +554,44 @@ def test_get_all_completed_undelivered_analyses_improper_response(
         tb_api.get_all_analyses_to_deliver()
 
 
+def test_get_all_completed_undelivered_analyses_exclude_workflow(
+    response_with_two_analyses: str,
+    valid_google_credentials: IDTokenCredentials,
+    valid_trailblazer_config: dict,
+    mocker: MockerFixture,
+):
+    # GIVEN a TrailblazerAPI
+    tb_api = TrailblazerAPI(valid_trailblazer_config)
+
+    # GIVEN that Trailblazer returns two analyses, one of which is an RSYNC analysis
+    get_request = mocker.patch.object(
+        requests,
+        "get",
+        return_value=create_autospec(
+            requests.Response,
+            status_code=200,
+            ok=True,
+            text=response_with_two_analyses,
+        ),
+    )
+
+    # WHEN getting all analyses to deliver
+    analyses = tb_api.get_all_analyses_to_deliver(
+        exclude_workflows=[Workflow.RSYNC, Workflow.MIP_DNA]
+    )
+
+    # THEN a list of two analyses is returned
+    assert len(analyses) == 2
+
+    # THEN the correct url is called
+    get_request.assert_called_once_with(
+        headers={"Authorization": "Bearer some_token"},
+        json={},
+        url=f"{tb_api.host}/analyses?status[]=completed&delivered=false&holdDelivery=false&workflowExclude[]=RSYNC&workflowExclude[]=MIP-DNA",
+        verify=True,
+    )
+
+
 def test_get_delivered_analyses_for_order_success(
     valid_google_credentials: IDTokenCredentials,
     valid_trailblazer_config: dict,

--- a/tests/apps/tb/test_api.py
+++ b/tests/apps/tb/test_api.py
@@ -587,7 +587,7 @@ def test_get_all_completed_undelivered_analyses_exclude_workflow(
     get_request.assert_called_once_with(
         headers={"Authorization": "Bearer some_token"},
         json={},
-        url=f"{tb_api.host}/analyses?status[]=completed&delivered=false&holdDelivery=false&workflowExclude[]=RSYNC&workflowExclude[]=MIP-DNA",
+        url=f"{tb_api.host}/analyses?status[]=completed&delivered=false&holdDelivery=false&excludeWorkflow[]=RSYNC&excludeWorkflow[]=MIP-DNA",
         verify=True,
     )
 

--- a/tests/services/test_deliver_service.py
+++ b/tests/services/test_deliver_service.py
@@ -401,9 +401,7 @@ def test_deliver_all_available_success(mocker: MockerFixture):
     trailblazer_api.as_mock.get_all_analyses_to_deliver.assert_called_once()
 
     # THEN uploaded analyses should have been fetched from StatusDB
-    status_db.get_uploaded_analyses.assert_called_once_with(
-        trailblazer_ids=ANY, exclude_workflows=[Workflow.MICROSALT, Workflow.TAXPROFILER]
-    )
+    status_db.get_uploaded_analyses.assert_called_once_with(trailblazer_ids=ANY)
 
     # THEN the analyses of both orders should have been marked as delivered separately
     mark_analyses_call.assert_any_call(analyses=[analysis_1], signature=None)
@@ -461,9 +459,7 @@ def test_deliver_all_available_no_analyses_to_deliver(mocker: MockerFixture):
     trailblazer_api.as_mock.get_all_analyses_to_deliver.assert_called_once()
 
     # THEN uploaded analyses should have been fetched from StatusDB
-    status_db.get_uploaded_analyses.assert_called_once_with(
-        trailblazer_ids=ANY, exclude_workflows=[Workflow.MICROSALT, Workflow.TAXPROFILER]
-    )
+    status_db.get_uploaded_analyses.assert_called_once_with(trailblazer_ids=ANY)
 
     # THEN no call should have been made
     mark_analyses_call.assert_not_called()

--- a/tests/store/crud/read/test_read_analysis.py
+++ b/tests/store/crud/read/test_read_analysis.py
@@ -746,40 +746,6 @@ def test_get_uploaded_analyses(store: Store):
     assert uploaded_analyses == [uploaded_analysis]
 
 
-def test_get_uploaded_analyses_exclude_workflow(store: Store):
-    # GIVEN a store with three analyses, one with a workflow we want to exclude
-    desired_analysis = store.add_analysis(
-        case_id=1,
-        workflow=Workflow.NALLO,
-        trailblazer_id=1,
-        uploaded=datetime.now(),
-    )
-    not_desired_analysis = store.add_analysis(
-        case_id=2,
-        workflow=Workflow.MICROSALT,
-        trailblazer_id=2,
-        uploaded=datetime.now(),
-    )
-    not_desired_analysis_two = store.add_analysis(
-        case_id=3,
-        workflow=Workflow.TAXPROFILER,
-        trailblazer_id=3,
-        uploaded=datetime.now(),
-    )
-
-    store.add_multiple_items_to_store(
-        [desired_analysis, not_desired_analysis, not_desired_analysis_two]
-    )
-
-    # WHEN getting the uploaded analyses excluding microSALT
-    uploaded_analyses: list[Analysis] = store.get_uploaded_analyses(
-        trailblazer_ids=[1, 2, 3], exclude_workflows=[Workflow.MICROSALT, Workflow.TAXPROFILER]
-    )
-
-    # THEN only the requested uploaded analysis is returned
-    assert uploaded_analyses == [desired_analysis]
-
-
 def test_get_uploaded_analyses_no_analyses_in_store(store: Store):
     # GIVEN an empty store
 


### PR DESCRIPTION
## Description

TB allows for exclusion in the get request towards the analysis endpoint. We want to exclude some workflows from the delivery automation. 

### Added

- excludeWorkflow in the request sent to TB

### Changed

- Filter in request to TB and not in StatusDB

### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b exclude-workflows-in-request -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
