### PR TITLE
feat: Add support for Nallo protected tags in housekeeper

### DIFF
--- a/cg/constants/housekeeper_tags.py
+++ b/cg/constants/housekeeper_tags.py
@@ -215,6 +215,9 @@ WORKFLOW_PROTECTED_TAGS = {
         ["gisaid-log"],
         ["gisaid-csv"],
     ],
+    Workflow.NALLO: [
+        [HermesFileTag.LONG_TERM_STORAGE],
+    ],
     Workflow.RAREDISEASE: [
         [HermesFileTag.LONG_TERM_STORAGE],
     ],

--- a/cg/meta/clean/api.py
+++ b/cg/meta/clean/api.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Iterator
 
-from housekeeper.store.models import File, Version
+from housekeeper.store.models import File
 
 from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.constants.constants import Workflow

--- a/tests/cli/clean/test_hk_case_bundle_files.py
+++ b/tests/cli/clean/test_hk_case_bundle_files.py
@@ -1,6 +1,7 @@
 import datetime as dt
 import logging
 
+import pytest
 from click.testing import CliRunner
 
 from cg.cli.clean import hk_case_bundle_files
@@ -103,6 +104,7 @@ def test_clean_hk_case_files_single_analysis(
     assert "found on disk" in caplog.text
 
 
+@pytest.mark.parametrize("workflow", [Workflow.MIP_DNA, Workflow.NALLO, Workflow.RAREDISEASE])
 def test_clean_hk_case_files_analysis_with_protected_tag(
     caplog,
     cg_context: CGConfig,
@@ -110,13 +112,13 @@ def test_clean_hk_case_files_analysis_with_protected_tag(
     helpers: StoreHelpers,
     hk_bundle_data: dict,
     timestamp: dt.datetime,
+    workflow: Workflow,
 ):
     # GIVEN we have some analyses to clean
     context: CGConfig = cg_context
     store: Store = context.status_db
     days_ago: int = 1
     date_days_ago: dt.datetime = get_date_days_ago(days_ago)
-    workflow: Workflow = Workflow.MIP_DNA
 
     analysis: Analysis = helpers.add_analysis(
         store=store,
@@ -148,3 +150,6 @@ def test_clean_hk_case_files_analysis_with_protected_tag(
     assert "Version with id" in caplog.text
     assert "has the tags" in caplog.text
     assert "has the protected tag(s)" in caplog.text
+
+    # THEN protected tags should be present
+    assert f"No protected tags defined for {workflow}" not in caplog.text


### PR DESCRIPTION
## Description
Add "long-term-storage" as a protected tag for Nallo, to avoid Nallo bundles being cleaned after a year

### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
