### PR TITLE
Link rank models to case dir for nallo and raredisease

### DIFF
--- a/cg/services/analysis_starter/configurator/extensions/nallo.py
+++ b/cg/services/analysis_starter/configurator/extensions/nallo.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 from cg.constants.scout import ScoutExportFileName
@@ -11,6 +12,7 @@ from cg.services.analysis_starter.configurator.file_creators.gene_panel import G
 class NalloExtension(PipelineExtension):
     def __init__(self, gene_panel_file_creator: GenePanelFileCreator, nallo_config: NalloConfig):
         self.gene_panel_file_creator = gene_panel_file_creator
+        self.config = nallo_config
 
     def configure(self, case_id: str, case_run_directory: Path) -> None:
         self.gene_panel_file_creator.create(
@@ -18,12 +20,19 @@ class NalloExtension(PipelineExtension):
             file_path=self._get_gene_panel_file_path(case_run_directory),
             double_hashtag_filtering=True,
         )
-        # TODO: copy rank model files to case directory
+        self._copy_rank_model_files(case_run_directory)
 
     def do_required_files_exist(self, case_run_directory: Path) -> bool:
         gene_panel_file_path: Path = self._get_gene_panel_file_path(case_run_directory)
         # TODO: Add existence checks for case directory rank model files
         return gene_panel_file_path.is_file()
+
+    def _copy_rank_model_files(self, case_run_directory: Path) -> None:
+        """Copy rank model files to the case run directory."""
+        snv_rank_model_file = Path(self.config.rank_model_snv)
+        sv_rank_model = Path(self.config.rank_model_sv)
+        os.link(snv_rank_model_file, case_run_directory / snv_rank_model_file.name)
+        os.link(sv_rank_model, case_run_directory / sv_rank_model.name)
 
     @staticmethod
     def _get_gene_panel_file_path(case_run_directory: Path) -> Path:

--- a/cg/services/analysis_starter/configurator/extensions/nallo.py
+++ b/cg/services/analysis_starter/configurator/extensions/nallo.py
@@ -1,4 +1,4 @@
-import os
+import shutil
 from pathlib import Path
 
 from cg.constants.scout import ScoutExportFileName
@@ -37,11 +37,11 @@ class NalloExtension(PipelineExtension):
 
     def _copy_rank_model_files(self, case_run_directory: Path) -> None:
         """Copy rank model files to the case run directory."""
-        os.link(
+        shutil.copy2(
             self.source_snv_rank_model_path,
             case_run_directory / self.source_snv_rank_model_path.name,
         )
-        os.link(
+        shutil.copy2(
             self.source_sv_rank_model_path, case_run_directory / self.source_sv_rank_model_path.name
         )
 

--- a/cg/services/analysis_starter/configurator/extensions/nallo.py
+++ b/cg/services/analysis_starter/configurator/extensions/nallo.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from cg.constants.scout import ScoutExportFileName
+from cg.models.cg_config import NalloConfig
 from cg.services.analysis_starter.configurator.extensions.pipeline_extension import (
     PipelineExtension,
 )
@@ -8,8 +9,7 @@ from cg.services.analysis_starter.configurator.file_creators.gene_panel import G
 
 
 class NalloExtension(PipelineExtension):
-    # TODO: Add pipeline config to constructor
-    def __init__(self, gene_panel_file_creator: GenePanelFileCreator):
+    def __init__(self, gene_panel_file_creator: GenePanelFileCreator, nallo_config: NalloConfig):
         self.gene_panel_file_creator = gene_panel_file_creator
 
     def configure(self, case_id: str, case_run_directory: Path) -> None:

--- a/cg/services/analysis_starter/configurator/extensions/nallo.py
+++ b/cg/services/analysis_starter/configurator/extensions/nallo.py
@@ -12,28 +12,39 @@ from cg.services.analysis_starter.configurator.file_creators.gene_panel import G
 class NalloExtension(PipelineExtension):
     def __init__(self, gene_panel_file_creator: GenePanelFileCreator, nallo_config: NalloConfig):
         self.gene_panel_file_creator = gene_panel_file_creator
-        self.config = nallo_config
+        self.source_snv_rank_model_path = Path(nallo_config.rank_model_snv)
+        self.source_sv_rank_model_path = Path(nallo_config.rank_model_sv)
 
     def configure(self, case_id: str, case_run_directory: Path) -> None:
         self.gene_panel_file_creator.create(
             case_id=case_id,
-            file_path=self._get_gene_panel_file_path(case_run_directory),
+            file_path=_get_gene_panel_file_path(case_run_directory),
             double_hashtag_filtering=True,
         )
         self._copy_rank_model_files(case_run_directory)
 
     def do_required_files_exist(self, case_run_directory: Path) -> bool:
-        gene_panel_file_path: Path = self._get_gene_panel_file_path(case_run_directory)
-        # TODO: Add existence checks for case directory rank model files
-        return gene_panel_file_path.is_file()
+        gene_panel_file_path: Path = _get_gene_panel_file_path(case_run_directory)
+        case_snv_rank_model_file = Path(case_run_directory, self.source_snv_rank_model_path.name)
+        case_sv_rank_model_file = Path(case_run_directory, self.source_sv_rank_model_path.name)
+        return all(
+            [
+                gene_panel_file_path.is_file(),
+                case_sv_rank_model_file.is_file(),
+                case_snv_rank_model_file.is_file(),
+            ]
+        )
 
     def _copy_rank_model_files(self, case_run_directory: Path) -> None:
         """Copy rank model files to the case run directory."""
-        snv_rank_model_file = Path(self.config.rank_model_snv)
-        sv_rank_model = Path(self.config.rank_model_sv)
-        os.link(snv_rank_model_file, case_run_directory / snv_rank_model_file.name)
-        os.link(sv_rank_model, case_run_directory / sv_rank_model.name)
+        os.link(
+            self.source_snv_rank_model_path,
+            case_run_directory / self.source_snv_rank_model_path.name,
+        )
+        os.link(
+            self.source_sv_rank_model_path, case_run_directory / self.source_sv_rank_model_path.name
+        )
 
-    @staticmethod
-    def _get_gene_panel_file_path(case_run_directory: Path) -> Path:
-        return case_run_directory.joinpath(ScoutExportFileName.PANELS_TSV)
+
+def _get_gene_panel_file_path(case_run_directory: Path) -> Path:
+    return case_run_directory.joinpath(ScoutExportFileName.PANELS_TSV)

--- a/cg/services/analysis_starter/configurator/extensions/nallo.py
+++ b/cg/services/analysis_starter/configurator/extensions/nallo.py
@@ -1,3 +1,4 @@
+import logging
 import shutil
 from pathlib import Path
 
@@ -7,6 +8,8 @@ from cg.services.analysis_starter.configurator.extensions.pipeline_extension imp
     PipelineExtension,
 )
 from cg.services.analysis_starter.configurator.file_creators.gene_panel import GenePanelFileCreator
+
+LOG = logging.getLogger(__name__)
 
 
 class NalloExtension(PipelineExtension):
@@ -41,8 +44,16 @@ class NalloExtension(PipelineExtension):
             self.source_snv_rank_model_path,
             case_run_directory / self.source_snv_rank_model_path.name,
         )
+        LOG.debug(
+            f"Copied {self.source_snv_rank_model_path.name} to case directory "
+            f"for case {case_run_directory.name}"
+        )
         shutil.copy2(
             self.source_sv_rank_model_path, case_run_directory / self.source_sv_rank_model_path.name
+        )
+        LOG.debug(
+            f"Copied {self.source_sv_rank_model_path.name} to case directory "
+            f"for case {case_run_directory.name}"
         )
 
 

--- a/cg/services/analysis_starter/configurator/extensions/nallo.py
+++ b/cg/services/analysis_starter/configurator/extensions/nallo.py
@@ -8,6 +8,7 @@ from cg.services.analysis_starter.configurator.file_creators.gene_panel import G
 
 
 class NalloExtension(PipelineExtension):
+    # TODO: Add pipeline config to constructor
     def __init__(self, gene_panel_file_creator: GenePanelFileCreator):
         self.gene_panel_file_creator = gene_panel_file_creator
 
@@ -17,9 +18,11 @@ class NalloExtension(PipelineExtension):
             file_path=self._get_gene_panel_file_path(case_run_directory),
             double_hashtag_filtering=True,
         )
+        # TODO: copy rank model files to case directory
 
     def do_required_files_exist(self, case_run_directory: Path) -> bool:
         gene_panel_file_path: Path = self._get_gene_panel_file_path(case_run_directory)
+        # TODO: Add existence checks for case directory rank model files
         return gene_panel_file_path.is_file()
 
     @staticmethod

--- a/cg/services/analysis_starter/configurator/extensions/raredisease.py
+++ b/cg/services/analysis_starter/configurator/extensions/raredisease.py
@@ -1,3 +1,4 @@
+import logging
 import shutil
 from pathlib import Path
 
@@ -10,6 +11,8 @@ from cg.services.analysis_starter.configurator.file_creators.gene_panel import G
 from cg.services.analysis_starter.configurator.file_creators.managed_variants import (
     ManagedVariantsFileCreator,
 )
+
+LOG = logging.getLogger(__name__)
 
 
 class RarediseaseExtension(PipelineExtension):
@@ -56,8 +59,16 @@ class RarediseaseExtension(PipelineExtension):
             self.source_snv_rank_model_path,
             case_run_directory / self.source_snv_rank_model_path.name,
         )
+        LOG.debug(
+            f"Copied {self.source_snv_rank_model_path.name} to case directory "
+            f"for case {case_run_directory.name}"
+        )
         shutil.copy2(
             self.source_sv_rank_model_path, case_run_directory / self.source_sv_rank_model_path.name
+        )
+        LOG.debug(
+            f"Copied {self.source_sv_rank_model_path.name} to case directory "
+            f"for case {case_run_directory.name}"
         )
 
 

--- a/cg/services/analysis_starter/configurator/extensions/raredisease.py
+++ b/cg/services/analysis_starter/configurator/extensions/raredisease.py
@@ -1,4 +1,4 @@
-import os
+import shutil
 from pathlib import Path
 
 from cg.constants.scout import ScoutExportFileName
@@ -52,11 +52,11 @@ class RarediseaseExtension(PipelineExtension):
 
     def _copy_rank_model_files(self, case_run_directory: Path) -> None:
         """Copy rank model files to the case run directory."""
-        os.link(
+        shutil.copy2(
             self.source_snv_rank_model_path,
             case_run_directory / self.source_snv_rank_model_path.name,
         )
-        os.link(
+        shutil.copy2(
             self.source_sv_rank_model_path, case_run_directory / self.source_sv_rank_model_path.name
         )
 

--- a/cg/services/analysis_starter/configurator/extensions/raredisease.py
+++ b/cg/services/analysis_starter/configurator/extensions/raredisease.py
@@ -20,6 +20,7 @@ class RarediseaseExtension(PipelineExtension):
         self,
         gene_panel_file_creator: GenePanelFileCreator,
         managed_variants_file_creator: ManagedVariantsFileCreator,
+        # TODO: Add pipeline config to constructor
     ):
         self.gene_panel_file_creator = gene_panel_file_creator
         self.managed_variants_file_creator = managed_variants_file_creator
@@ -32,8 +33,10 @@ class RarediseaseExtension(PipelineExtension):
         self.managed_variants_file_creator.create(
             case_id=case_id, file_path=_get_managed_variants(case_run_directory)
         )
+        # TODO: copy rank model files to case directory
 
     def do_required_files_exist(self, case_run_directory: Path) -> bool:
+        # TODO: Add existence checks for case directory rank model files
         return isfile(_get_gene_panel_file_path(case_run_directory)) and isfile(
             _get_managed_variants(case_run_directory)
         )

--- a/cg/services/analysis_starter/configurator/extensions/raredisease.py
+++ b/cg/services/analysis_starter/configurator/extensions/raredisease.py
@@ -1,3 +1,4 @@
+import os
 from os.path import isfile
 from pathlib import Path
 
@@ -25,6 +26,7 @@ class RarediseaseExtension(PipelineExtension):
     ):
         self.gene_panel_file_creator = gene_panel_file_creator
         self.managed_variants_file_creator = managed_variants_file_creator
+        self.config = raredisease_config
 
     def configure(self, case_id: str, case_run_directory: Path) -> None:
         """Perform pipeline specific actions."""
@@ -34,13 +36,20 @@ class RarediseaseExtension(PipelineExtension):
         self.managed_variants_file_creator.create(
             case_id=case_id, file_path=_get_managed_variants(case_run_directory)
         )
-        # TODO: copy rank model files to case directory
+        self._copy_rank_model_files(case_run_directory)
 
     def do_required_files_exist(self, case_run_directory: Path) -> bool:
         # TODO: Add existence checks for case directory rank model files
         return isfile(_get_gene_panel_file_path(case_run_directory)) and isfile(
             _get_managed_variants(case_run_directory)
         )
+
+    def _copy_rank_model_files(self, case_run_directory: Path) -> None:
+        """Copy rank model files to the case run directory."""
+        snv_rank_model_file = Path(self.config.rank_model_snv)
+        sv_rank_model = Path(self.config.rank_model_sv)
+        os.link(snv_rank_model_file, case_run_directory / snv_rank_model_file.name)
+        os.link(sv_rank_model, case_run_directory / sv_rank_model.name)
 
 
 def _get_gene_panel_file_path(case_run_directory: Path) -> Path:

--- a/cg/services/analysis_starter/configurator/extensions/raredisease.py
+++ b/cg/services/analysis_starter/configurator/extensions/raredisease.py
@@ -1,6 +1,7 @@
 from os.path import isfile
 from pathlib import Path
 
+from cg.models.cg_config import RarediseaseConfig
 from cg.services.analysis_starter.configurator.extensions.pipeline_extension import (
     PipelineExtension,
 )
@@ -20,7 +21,7 @@ class RarediseaseExtension(PipelineExtension):
         self,
         gene_panel_file_creator: GenePanelFileCreator,
         managed_variants_file_creator: ManagedVariantsFileCreator,
-        # TODO: Add pipeline config to constructor
+        raredisease_config: RarediseaseConfig,
     ):
         self.gene_panel_file_creator = gene_panel_file_creator
         self.managed_variants_file_creator = managed_variants_file_creator

--- a/cg/services/analysis_starter/configurator/extensions/raredisease.py
+++ b/cg/services/analysis_starter/configurator/extensions/raredisease.py
@@ -1,7 +1,7 @@
 import os
-from os.path import isfile
 from pathlib import Path
 
+from cg.constants.scout import ScoutExportFileName
 from cg.models.cg_config import RarediseaseConfig
 from cg.services.analysis_starter.configurator.extensions.pipeline_extension import (
     PipelineExtension,
@@ -10,9 +10,6 @@ from cg.services.analysis_starter.configurator.file_creators.gene_panel import G
 from cg.services.analysis_starter.configurator.file_creators.managed_variants import (
     ManagedVariantsFileCreator,
 )
-
-GENE_PANEL_FILE_NAME = "gene_panels.bed"
-MANAGED_VARIANTS_FILE_NAME = "managed_variants.vcf"
 
 
 class RarediseaseExtension(PipelineExtension):
@@ -26,7 +23,8 @@ class RarediseaseExtension(PipelineExtension):
     ):
         self.gene_panel_file_creator = gene_panel_file_creator
         self.managed_variants_file_creator = managed_variants_file_creator
-        self.config = raredisease_config
+        self.source_snv_rank_model_path = Path(raredisease_config.rank_model_snv)
+        self.source_sv_rank_model_path = Path(raredisease_config.rank_model_sv)
 
     def configure(self, case_id: str, case_run_directory: Path) -> None:
         """Perform pipeline specific actions."""
@@ -39,22 +37,33 @@ class RarediseaseExtension(PipelineExtension):
         self._copy_rank_model_files(case_run_directory)
 
     def do_required_files_exist(self, case_run_directory: Path) -> bool:
-        # TODO: Add existence checks for case directory rank model files
-        return isfile(_get_gene_panel_file_path(case_run_directory)) and isfile(
-            _get_managed_variants(case_run_directory)
+        gene_panel_file: Path = _get_gene_panel_file_path(case_run_directory)
+        managed_variants_file: Path = _get_managed_variants(case_run_directory)
+        case_snv_rank_model_file = Path(case_run_directory, self.source_snv_rank_model_path.name)
+        case_sv_rank_model_file = Path(case_run_directory, self.source_sv_rank_model_path.name)
+        return all(
+            [
+                gene_panel_file.is_file(),
+                managed_variants_file.is_file(),
+                case_snv_rank_model_file.is_file(),
+                case_sv_rank_model_file.is_file(),
+            ]
         )
 
     def _copy_rank_model_files(self, case_run_directory: Path) -> None:
         """Copy rank model files to the case run directory."""
-        snv_rank_model_file = Path(self.config.rank_model_snv)
-        sv_rank_model = Path(self.config.rank_model_sv)
-        os.link(snv_rank_model_file, case_run_directory / snv_rank_model_file.name)
-        os.link(sv_rank_model, case_run_directory / sv_rank_model.name)
+        os.link(
+            self.source_snv_rank_model_path,
+            case_run_directory / self.source_snv_rank_model_path.name,
+        )
+        os.link(
+            self.source_sv_rank_model_path, case_run_directory / self.source_sv_rank_model_path.name
+        )
 
 
 def _get_gene_panel_file_path(case_run_directory: Path) -> Path:
-    return case_run_directory.joinpath(GENE_PANEL_FILE_NAME)
+    return case_run_directory.joinpath(ScoutExportFileName.PANELS)
 
 
 def _get_managed_variants(case_run_directory: Path):
-    return case_run_directory.joinpath(MANAGED_VARIANTS_FILE_NAME)
+    return case_run_directory.joinpath(ScoutExportFileName.MANAGED_VARIANTS)

--- a/cg/services/analysis_starter/factories/configurator_factory.py
+++ b/cg/services/analysis_starter/factories/configurator_factory.py
@@ -187,12 +187,14 @@ class ConfiguratorFactory:
 
     def _get_pipeline_extension(self, workflow: Workflow) -> PipelineExtension:
         match workflow:
-            # TODO: Add pipeline config to extension constructors
             case Workflow.NALLO:
                 gene_panel_creator: GenePanelFileCreator = self._get_gene_panel_file_creator(
                     workflow
                 )
-                return NalloExtension(gene_panel_file_creator=gene_panel_creator)
+                return NalloExtension(
+                    gene_panel_file_creator=gene_panel_creator,
+                    nallo_config=self.cg_config.nallo,  # type: ignore
+                )
             case Workflow.RAREDISEASE:
                 gene_panel_creator: GenePanelFileCreator = self._get_gene_panel_file_creator(
                     workflow
@@ -203,6 +205,7 @@ class ConfiguratorFactory:
                 return RarediseaseExtension(
                     gene_panel_file_creator=gene_panel_creator,
                     managed_variants_file_creator=managed_variants_creator,
+                    raredisease_config=self.cg_config.raredisease,  # type: ignore
                 )
             case Workflow.TOMTE:
                 gene_panel_creator: GenePanelFileCreator = self._get_gene_panel_file_creator(

--- a/cg/services/analysis_starter/factories/configurator_factory.py
+++ b/cg/services/analysis_starter/factories/configurator_factory.py
@@ -187,6 +187,7 @@ class ConfiguratorFactory:
 
     def _get_pipeline_extension(self, workflow: Workflow) -> PipelineExtension:
         match workflow:
+            # TODO: Add pipeline config to extension constructors
             case Workflow.NALLO:
                 gene_panel_creator: GenePanelFileCreator = self._get_gene_panel_file_creator(
                     workflow

--- a/tests/integration/workflows/test_nallo.py
+++ b/tests/integration/workflows/test_nallo.py
@@ -151,6 +151,8 @@ def test_start_available_nallo(
     )
     create_empty_file(Path(test_root_dir, "nallo_config.config"))
     create_empty_file(Path(test_root_dir, "nallo_resources.config"))
+    create_empty_file(Path(test_root_dir, "ghxx_nallo_rank_model_snvs.ini"))
+    create_empty_file(Path(test_root_dir, "ghxx_nallo_rank_model_svs.ini"))
 
     # GIVEN an order associated with the case
     order: Order = helpers.add_order(
@@ -243,3 +245,7 @@ def test_start_available_nallo(
     assert (
         Path(case_directory, "gene_panels.tsv").open().read() == scout_export_panel_stdout.decode()
     )
+
+    # THEN the rank model files have been copied into the case directory
+    assert Path(case_directory, "ghxx_nallo_rank_model_snvs.ini").is_file()
+    assert Path(case_directory, "ghxx_nallo_rank_model_svs.ini").is_file()

--- a/tests/services/analysis_starter/nextflow_extension/test_nallo_extension.py
+++ b/tests/services/analysis_starter/nextflow_extension/test_nallo_extension.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from unittest.mock import Mock, create_autospec
 
+import pytest
 from pytest_mock import MockerFixture
 
 from cg.constants.scout import ScoutExportFileName
@@ -10,10 +11,17 @@ from cg.services.analysis_starter.configurator.extensions.nallo import NalloExte
 from cg.services.analysis_starter.configurator.file_creators.gene_panel import GenePanelFileCreator
 from tests.typed_mock import TypedMock, create_typed_mock
 
-# TODO: create fixture for nallo config
+
+@pytest.fixture
+def nallo_config() -> NalloConfig:
+    return create_autospec(
+        NalloConfig,
+        rank_model_snv="path/to/snv_rank_model.ini",
+        rank_model_sv="path/to/sv_rank_model.ini",
+    )
 
 
-def test_configure(mocker: MockerFixture):
+def test_configure(nallo_config: NalloConfig, mocker: MockerFixture):
     # GIVEN a gene panel file creator
     gene_panel_file_creator: TypedMock[GenePanelFileCreator] = create_typed_mock(
         GenePanelFileCreator
@@ -22,11 +30,7 @@ def test_configure(mocker: MockerFixture):
     # GIVEN a Nallo extension
     nallo_extension = NalloExtension(
         gene_panel_file_creator=gene_panel_file_creator.as_type,
-        nallo_config=create_autospec(
-            NalloConfig,
-            rank_model_snv="path/to/snv_rank_model.ini",
-            rank_model_sv="path/to/sv_rank_model.ini",
-        ),
+        nallo_config=nallo_config,
     )
 
     # GIVEN a case run directory
@@ -52,7 +56,7 @@ def test_configure(mocker: MockerFixture):
     )
 
 
-def test_do_required_files_exist_true(tmp_path: Path):
+def test_do_required_files_exist_true(nallo_config: NalloConfig, tmp_path: Path):
     # GIVEN that there is a gene panel tsv, a snv and sv rank model files
     gene_panels_file = tmp_path / ScoutExportFileName.PANELS_TSV
     gene_panels_file.touch()
@@ -62,14 +66,7 @@ def test_do_required_files_exist_true(tmp_path: Path):
     sv_rank_model_file.touch()
 
     # GIVEN a Nallo extension
-    nallo_extension = NalloExtension(
-        gene_panel_file_creator=Mock(),
-        nallo_config=create_autospec(
-            NalloConfig,
-            rank_model_snv="path/to/snv_rank_model.ini",
-            rank_model_sv="path/to/sv_rank_model.ini",
-        ),
-    )
+    nallo_extension = NalloExtension(gene_panel_file_creator=Mock(), nallo_config=nallo_config)
 
     # WHEN checking that the required files exist
     does_exist: bool = nallo_extension.do_required_files_exist(case_run_directory=tmp_path)
@@ -78,20 +75,13 @@ def test_do_required_files_exist_true(tmp_path: Path):
     assert does_exist
 
 
-def test_do_required_files_exist_false(tmp_path: Path):
+def test_do_required_files_exist_false(nallo_config: NalloConfig, tmp_path: Path):
     # GIVEN that there is no gene panel tsv file
     scout_file = tmp_path / ScoutExportFileName.PANELS_TSV
     assert not scout_file.exists()
 
     # GIVEN a Nallo extension
-    nallo_extension = NalloExtension(
-        gene_panel_file_creator=Mock(),
-        nallo_config=create_autospec(
-            NalloConfig,
-            rank_model_snv="path/to/snv_rank_model.ini",
-            rank_model_sv="path/to/sv_rank_model.ini",
-        ),
-    )
+    nallo_extension = NalloExtension(gene_panel_file_creator=Mock(), nallo_config=nallo_config)
 
     # WHEN checking that the required files exist
     does_exist: bool = nallo_extension.do_required_files_exist(case_run_directory=tmp_path)

--- a/tests/services/analysis_starter/nextflow_extension/test_nallo_extension.py
+++ b/tests/services/analysis_starter/nextflow_extension/test_nallo_extension.py
@@ -37,7 +37,7 @@ def test_configure(nallo_config: NalloConfig, mocker: MockerFixture):
     case_run_directory = Path("case", "run", "directory")
 
     # WHEN configuring a case
-    link_mock = mocker.patch.object(nallo.os, "link")
+    copy_mock = mocker.patch.object(nallo.shutil, "copy2")
     nallo_extension.configure(case_id="nallo_case", case_run_directory=case_run_directory)
 
     # THEN a gene panel file should have been created
@@ -48,10 +48,10 @@ def test_configure(nallo_config: NalloConfig, mocker: MockerFixture):
     )
 
     # THEN the rank model files were copied to the case directory
-    link_mock.assert_any_call(
+    copy_mock.assert_any_call(
         Path("path/to/snv_rank_model.ini"), case_run_directory / "snv_rank_model.ini"
     )
-    link_mock.assert_any_call(
+    copy_mock.assert_any_call(
         Path("path/to/sv_rank_model.ini"), case_run_directory / "sv_rank_model.ini"
     )
 

--- a/tests/services/analysis_starter/nextflow_extension/test_nallo_extension.py
+++ b/tests/services/analysis_starter/nextflow_extension/test_nallo_extension.py
@@ -75,16 +75,44 @@ def test_do_required_files_exist_true(nallo_config: NalloConfig, tmp_path: Path)
     assert does_exist
 
 
-def test_do_required_files_exist_false(nallo_config: NalloConfig, tmp_path: Path):
+@pytest.mark.parametrize(
+    "file_existence_array",
+    [
+        [False, True, True],
+        [True, False, True],
+        [True, True, False],
+    ],
+    ids=[
+        "missing gene panel scenario",
+        "missing snv rank model scenario",
+        "missing sv rank model  scenario",
+    ],
+)
+def test_do_required_files_exist_false(
+    file_existence_array: list[bool], nallo_config: NalloConfig, tmp_path: Path
+):
     # GIVEN that there is no gene panel tsv file
     scout_file = tmp_path / ScoutExportFileName.PANELS_TSV
     assert not scout_file.exists()
 
+    # GIVEN a case run directory
+    case_run_directory = tmp_path
+
+    # GIVEN that one required file does not exist
+    file_map: dict[Path, bool] = {
+        Path(case_run_directory, ScoutExportFileName.PANELS): file_existence_array[0],
+        Path(case_run_directory, "snv_rank_model.ini"): file_existence_array[1],
+        Path(case_run_directory, "sv_rank_model.ini"): file_existence_array[2],
+    }
+    for file, should_exist in file_map.items():
+        if should_exist:
+            file.touch()
+
     # GIVEN a Nallo extension
     nallo_extension = NalloExtension(gene_panel_file_creator=Mock(), nallo_config=nallo_config)
 
-    # WHEN checking that the required files exist
-    does_exist: bool = nallo_extension.do_required_files_exist(case_run_directory=tmp_path)
+    # WHEN calling do_required_files_exist
+    does_exist: bool = nallo_extension.do_required_files_exist(case_run_directory)
 
-    # THEN the required file should not exist
+    # THEN one of the files is marked as missing
     assert not does_exist

--- a/tests/services/analysis_starter/nextflow_extension/test_nallo_extension.py
+++ b/tests/services/analysis_starter/nextflow_extension/test_nallo_extension.py
@@ -91,10 +91,6 @@ def test_do_required_files_exist_true(nallo_config: NalloConfig, tmp_path: Path)
 def test_do_required_files_exist_false(
     file_existence_array: list[bool], nallo_config: NalloConfig, tmp_path: Path
 ):
-    # GIVEN that there is no gene panel tsv file
-    scout_file = tmp_path / ScoutExportFileName.PANELS_TSV
-    assert not scout_file.exists()
-
     # GIVEN a case run directory
     case_run_directory = tmp_path
 

--- a/tests/services/analysis_starter/nextflow_extension/test_nallo_extension.py
+++ b/tests/services/analysis_starter/nextflow_extension/test_nallo_extension.py
@@ -1,14 +1,17 @@
 from pathlib import Path
 from unittest.mock import Mock, create_autospec
 
+from pytest_mock import MockerFixture
+
 from cg.constants.scout import ScoutExportFileName
 from cg.models.cg_config import NalloConfig
+from cg.services.analysis_starter.configurator.extensions import nallo
 from cg.services.analysis_starter.configurator.extensions.nallo import NalloExtension
 from cg.services.analysis_starter.configurator.file_creators.gene_panel import GenePanelFileCreator
 from tests.typed_mock import TypedMock, create_typed_mock
 
 
-def test_configure():
+def test_configure(mocker: MockerFixture):
     # GIVEN a gene panel file creator
     gene_panel_file_creator: TypedMock[GenePanelFileCreator] = create_typed_mock(
         GenePanelFileCreator
@@ -17,13 +20,18 @@ def test_configure():
     # GIVEN a Nallo extension
     nallo_extension = NalloExtension(
         gene_panel_file_creator=gene_panel_file_creator.as_type,
-        nallo_config=create_autospec(NalloConfig),
+        nallo_config=create_autospec(
+            NalloConfig,
+            rank_model_snv="path/to/snv_rank_model.ini",
+            rank_model_sv="path/to/sv_rank_model.ini",
+        ),
     )
 
     # GIVEN a case run directory
     case_run_directory = Path("case", "run", "directory")
 
     # WHEN configuring a case
+    link_mock = mocker.patch.object(nallo.os, "link")
     nallo_extension.configure(case_id="nallo_case", case_run_directory=case_run_directory)
 
     # THEN a gene panel file should have been created
@@ -31,6 +39,14 @@ def test_configure():
         case_id="nallo_case",
         file_path=case_run_directory / ScoutExportFileName.PANELS_TSV,
         double_hashtag_filtering=True,
+    )
+
+    # THEN the rank model files were copied to the case directory
+    link_mock.assert_any_call(
+        Path("path/to/snv_rank_model.ini"), case_run_directory / "snv_rank_model.ini"
+    )
+    link_mock.assert_any_call(
+        Path("path/to/sv_rank_model.ini"), case_run_directory / "sv_rank_model.ini"
     )
 
 

--- a/tests/services/analysis_starter/nextflow_extension/test_nallo_extension.py
+++ b/tests/services/analysis_starter/nextflow_extension/test_nallo_extension.py
@@ -1,7 +1,8 @@
 from pathlib import Path
-from unittest.mock import Mock
+from unittest.mock import Mock, create_autospec
 
 from cg.constants.scout import ScoutExportFileName
+from cg.models.cg_config import NalloConfig
 from cg.services.analysis_starter.configurator.extensions.nallo import NalloExtension
 from cg.services.analysis_starter.configurator.file_creators.gene_panel import GenePanelFileCreator
 from tests.typed_mock import TypedMock, create_typed_mock
@@ -14,7 +15,10 @@ def test_configure():
     )
 
     # GIVEN a Nallo extension
-    nallo_extension = NalloExtension(gene_panel_file_creator=gene_panel_file_creator.as_type)
+    nallo_extension = NalloExtension(
+        gene_panel_file_creator=gene_panel_file_creator.as_type,
+        nallo_config=create_autospec(NalloConfig),
+    )
 
     # GIVEN a case run directory
     case_run_directory = Path("case", "run", "directory")
@@ -36,7 +40,9 @@ def test_do_required_files_exist_true(tmp_path: Path):
     scout_file.touch()
 
     # GIVEN a Nallo extension
-    nallo_extension = NalloExtension(gene_panel_file_creator=Mock())
+    nallo_extension = NalloExtension(
+        gene_panel_file_creator=Mock(), nallo_config=create_autospec(NalloConfig)
+    )
 
     # WHEN checking that the required files exist
     does_exist: bool = nallo_extension.do_required_files_exist(case_run_directory=tmp_path)
@@ -51,7 +57,9 @@ def test_do_required_files_exist_false(tmp_path: Path):
     assert not scout_file.exists()
 
     # GIVEN a Nallo extension
-    nallo_extension = NalloExtension(gene_panel_file_creator=Mock())
+    nallo_extension = NalloExtension(
+        gene_panel_file_creator=Mock(), nallo_config=create_autospec(NalloConfig)
+    )
 
     # WHEN checking that the required files exist
     does_exist: bool = nallo_extension.do_required_files_exist(case_run_directory=tmp_path)

--- a/tests/services/analysis_starter/nextflow_extension/test_nallo_extension.py
+++ b/tests/services/analysis_starter/nextflow_extension/test_nallo_extension.py
@@ -10,6 +10,8 @@ from cg.services.analysis_starter.configurator.extensions.nallo import NalloExte
 from cg.services.analysis_starter.configurator.file_creators.gene_panel import GenePanelFileCreator
 from tests.typed_mock import TypedMock, create_typed_mock
 
+# TODO: create fixture for nallo config
+
 
 def test_configure(mocker: MockerFixture):
     # GIVEN a gene panel file creator
@@ -51,13 +53,22 @@ def test_configure(mocker: MockerFixture):
 
 
 def test_do_required_files_exist_true(tmp_path: Path):
-    # GIVEN that there is a gene panel tsv file
-    scout_file = tmp_path / ScoutExportFileName.PANELS_TSV
-    scout_file.touch()
+    # GIVEN that there is a gene panel tsv, a snv and sv rank model files
+    gene_panels_file = tmp_path / ScoutExportFileName.PANELS_TSV
+    gene_panels_file.touch()
+    snv_rank_model_file = tmp_path / "snv_rank_model.ini"
+    snv_rank_model_file.touch()
+    sv_rank_model_file = tmp_path / "sv_rank_model.ini"
+    sv_rank_model_file.touch()
 
     # GIVEN a Nallo extension
     nallo_extension = NalloExtension(
-        gene_panel_file_creator=Mock(), nallo_config=create_autospec(NalloConfig)
+        gene_panel_file_creator=Mock(),
+        nallo_config=create_autospec(
+            NalloConfig,
+            rank_model_snv="path/to/snv_rank_model.ini",
+            rank_model_sv="path/to/sv_rank_model.ini",
+        ),
     )
 
     # WHEN checking that the required files exist
@@ -74,7 +85,12 @@ def test_do_required_files_exist_false(tmp_path: Path):
 
     # GIVEN a Nallo extension
     nallo_extension = NalloExtension(
-        gene_panel_file_creator=Mock(), nallo_config=create_autospec(NalloConfig)
+        gene_panel_file_creator=Mock(),
+        nallo_config=create_autospec(
+            NalloConfig,
+            rank_model_snv="path/to/snv_rank_model.ini",
+            rank_model_sv="path/to/sv_rank_model.ini",
+        ),
     )
 
     # WHEN checking that the required files exist

--- a/tests/services/analysis_starter/nextflow_extension/test_nallo_extension.py
+++ b/tests/services/analysis_starter/nextflow_extension/test_nallo_extension.py
@@ -71,7 +71,7 @@ def test_do_required_files_exist_true(nallo_config: NalloConfig, tmp_path: Path)
     # WHEN checking that the required files exist
     does_exist: bool = nallo_extension.do_required_files_exist(case_run_directory=tmp_path)
 
-    # THEN the required file should exist
+    # THEN the required files should exist
     assert does_exist
 
 

--- a/tests/services/analysis_starter/nextflow_extension/test_raredisease_extension.py
+++ b/tests/services/analysis_starter/nextflow_extension/test_raredisease_extension.py
@@ -13,19 +13,22 @@ from cg.services.analysis_starter.configurator.file_creators.managed_variants im
     ManagedVariantsFileCreator,
 )
 
-# TODO: Add fixture for rd config
+
+@pytest.fixture
+def raredisease_config() -> RarediseaseConfig:
+    return create_autospec(
+        RarediseaseConfig,
+        rank_model_snv="path/to/snv_rank_model.ini",
+        rank_model_sv="path/to/sv_rank_model.ini",
+    )
 
 
-def test_configure_success(mocker: MockerFixture):
+def test_configure_success(raredisease_config: RarediseaseConfig, mocker: MockerFixture):
     # GIVEN a raredisease pipeline extension
     raredisease_extension = RarediseaseExtension(
         gene_panel_file_creator=create_autospec(GenePanelFileCreator),
         managed_variants_file_creator=create_autospec(ManagedVariantsFileCreator),
-        raredisease_config=create_autospec(
-            RarediseaseConfig,
-            rank_model_snv="path/to/snv_rank_model.ini",
-            rank_model_sv="path/to/sv_rank_model.ini",
-        ),
+        raredisease_config=raredisease_config,
     )
 
     # GIVEN a case run directory
@@ -52,7 +55,7 @@ def test_configure_success(mocker: MockerFixture):
     )
 
 
-def test_do_required_files_exist_true(tmp_path: Path):
+def test_do_required_files_exist_true(raredisease_config: RarediseaseConfig, tmp_path: Path):
     # GIVEN that there is a gene panels, managed variants, snv and sv rank model files
     gene_panels_file = tmp_path / ScoutExportFileName.PANELS
     gene_panels_file.touch()
@@ -67,11 +70,7 @@ def test_do_required_files_exist_true(tmp_path: Path):
     raredisease_extension = RarediseaseExtension(
         gene_panel_file_creator=Mock(),
         managed_variants_file_creator=Mock(),
-        raredisease_config=create_autospec(
-            RarediseaseConfig,
-            rank_model_snv="path/to/snv_rank_model.ini",
-            rank_model_sv="path/to/sv_rank_model.ini",
-        ),
+        raredisease_config=raredisease_config,
     )
 
     # WHEN checking that the required files exist
@@ -98,6 +97,7 @@ def test_do_required_files_exist_true(tmp_path: Path):
 )
 def test_do_required_files_exist(
     file_existence_array: list[bool],
+    raredisease_config: RarediseaseConfig,
     tmp_path: Path,
 ):
     # GIVEN a case run directory
@@ -118,11 +118,7 @@ def test_do_required_files_exist(
     raredisease_extension = RarediseaseExtension(
         gene_panel_file_creator=create_autospec(GenePanelFileCreator),
         managed_variants_file_creator=create_autospec(ManagedVariantsFileCreator),
-        raredisease_config=create_autospec(
-            RarediseaseConfig,
-            rank_model_snv="path/to/snv_rank_model.ini",
-            rank_model_sv="path/to/sv_rank_model.ini",
-        ),
+        raredisease_config=raredisease_config,
     )
 
     # WHEN calling do_required_files_exist

--- a/tests/services/analysis_starter/nextflow_extension/test_raredisease_extension.py
+++ b/tests/services/analysis_starter/nextflow_extension/test_raredisease_extension.py
@@ -35,7 +35,7 @@ def test_configure_success(raredisease_config: RarediseaseConfig, mocker: Mocker
     case_run_directory = Path("/path/to/dir")
 
     # WHEN calling configure
-    link_mock = mocker.patch.object(raredisease.os, "link")
+    copy_mock = mocker.patch.object(raredisease.shutil, "copy2")
     raredisease_extension.configure(case_id="case_id", case_run_directory=case_run_directory)
 
     # THEN the file creators should have been called
@@ -47,10 +47,10 @@ def test_configure_success(raredisease_config: RarediseaseConfig, mocker: Mocker
     )
 
     # THEN the rank model files were copied to the case directory
-    link_mock.assert_any_call(
+    copy_mock.assert_any_call(
         Path("path/to/snv_rank_model.ini"), case_run_directory / "snv_rank_model.ini"
     )
-    link_mock.assert_any_call(
+    copy_mock.assert_any_call(
         Path("path/to/sv_rank_model.ini"), case_run_directory / "sv_rank_model.ini"
     )
 
@@ -110,8 +110,8 @@ def test_do_required_files_exist(
     }
 
     # GIVEN that one required file does not exist
-    for file, exists in file_map.items():
-        if exists:
+    for file, should_exist in file_map.items():
+        if should_exist:
             file.touch()
 
     # GIVEN a raredisease extension

--- a/tests/services/analysis_starter/nextflow_extension/test_raredisease_extension.py
+++ b/tests/services/analysis_starter/nextflow_extension/test_raredisease_extension.py
@@ -76,7 +76,7 @@ def test_do_required_files_exist_true(raredisease_config: RarediseaseConfig, tmp
     # WHEN checking that the required files exist
     does_exist: bool = raredisease_extension.do_required_files_exist(case_run_directory=tmp_path)
 
-    # THEN the required file should exist
+    # THEN the required files should exist
     assert does_exist
 
 

--- a/tests/services/analysis_starter/nextflow_extension/test_raredisease_extension.py
+++ b/tests/services/analysis_starter/nextflow_extension/test_raredisease_extension.py
@@ -17,22 +17,39 @@ from cg.services.analysis_starter.configurator.file_creators.managed_variants im
 )
 
 
-def test_configure_success():
+def test_configure_success(mocker: MockerFixture):
     # GIVEN a raredisease pipeline extension
     raredisease_extension = RarediseaseExtension(
         gene_panel_file_creator=create_autospec(GenePanelFileCreator),
         managed_variants_file_creator=create_autospec(ManagedVariantsFileCreator),
-        raredisease_config=create_autospec(RarediseaseConfig),
+        raredisease_config=create_autospec(
+            RarediseaseConfig,
+            rank_model_snv="path/to/snv_rank_model.ini",
+            rank_model_sv="path/to/sv_rank_model.ini",
+        ),
     )
+
+    # GIVEN a case run directory
+    case_run_directory = Path("/path/to/dir")
+
     # WHEN calling configure
-    raredisease_extension.configure(case_id="case_id", case_run_directory=Path("/path/to/dir"))
+    link_mock = mocker.patch.object(raredisease.os, "link")
+    raredisease_extension.configure(case_id="case_id", case_run_directory=case_run_directory)
 
     # THEN the file creators should have been called
     raredisease_extension.gene_panel_file_creator.create.assert_called_once_with(
-        case_id="case_id", file_path=Path("/path/to/dir/", GENE_PANEL_FILE_NAME)
+        case_id="case_id", file_path=case_run_directory / GENE_PANEL_FILE_NAME
     )
     raredisease_extension.managed_variants_file_creator.create.assert_called_once_with(
-        case_id="case_id", file_path=Path("/path/to/dir/", MANAGED_VARIANTS_FILE_NAME)
+        case_id="case_id", file_path=case_run_directory / MANAGED_VARIANTS_FILE_NAME
+    )
+
+    # THEN the rank model files were copied to the case directory
+    link_mock.assert_any_call(
+        Path("path/to/snv_rank_model.ini"), case_run_directory / "snv_rank_model.ini"
+    )
+    link_mock.assert_any_call(
+        Path("path/to/sv_rank_model.ini"), case_run_directory / "sv_rank_model.ini"
     )
 
 

--- a/tests/services/analysis_starter/nextflow_extension/test_raredisease_extension.py
+++ b/tests/services/analysis_starter/nextflow_extension/test_raredisease_extension.py
@@ -1,20 +1,19 @@
 from pathlib import Path
-from unittest.mock import create_autospec
+from unittest.mock import Mock, create_autospec
 
 import pytest
 from pytest_mock import MockerFixture
 
+from cg.constants.scout import ScoutExportFileName
 from cg.models.cg_config import RarediseaseConfig
 from cg.services.analysis_starter.configurator.extensions import raredisease
-from cg.services.analysis_starter.configurator.extensions.raredisease import (
-    GENE_PANEL_FILE_NAME,
-    MANAGED_VARIANTS_FILE_NAME,
-    RarediseaseExtension,
-)
+from cg.services.analysis_starter.configurator.extensions.raredisease import RarediseaseExtension
 from cg.services.analysis_starter.configurator.file_creators.gene_panel import GenePanelFileCreator
 from cg.services.analysis_starter.configurator.file_creators.managed_variants import (
     ManagedVariantsFileCreator,
 )
+
+# TODO: Add fixture for rd config
 
 
 def test_configure_success(mocker: MockerFixture):
@@ -38,10 +37,10 @@ def test_configure_success(mocker: MockerFixture):
 
     # THEN the file creators should have been called
     raredisease_extension.gene_panel_file_creator.create.assert_called_once_with(
-        case_id="case_id", file_path=case_run_directory / GENE_PANEL_FILE_NAME
+        case_id="case_id", file_path=case_run_directory / ScoutExportFileName.PANELS
     )
     raredisease_extension.managed_variants_file_creator.create.assert_called_once_with(
-        case_id="case_id", file_path=case_run_directory / MANAGED_VARIANTS_FILE_NAME
+        case_id="case_id", file_path=case_run_directory / ScoutExportFileName.MANAGED_VARIANTS
     )
 
     # THEN the rank model files were copied to the case directory
@@ -53,47 +52,81 @@ def test_configure_success(mocker: MockerFixture):
     )
 
 
+def test_do_required_files_exist_true(tmp_path: Path):
+    # GIVEN that there is a gene panels, managed variants, snv and sv rank model files
+    gene_panels_file = tmp_path / ScoutExportFileName.PANELS
+    gene_panels_file.touch()
+    managed_variants_file = tmp_path / ScoutExportFileName.MANAGED_VARIANTS
+    managed_variants_file.touch()
+    snv_rank_model_file = tmp_path / "snv_rank_model.ini"
+    snv_rank_model_file.touch()
+    sv_rank_model_file = tmp_path / "sv_rank_model.ini"
+    sv_rank_model_file.touch()
+
+    # GIVEN a Nallo extension
+    raredisease_extension = RarediseaseExtension(
+        gene_panel_file_creator=Mock(),
+        managed_variants_file_creator=Mock(),
+        raredisease_config=create_autospec(
+            RarediseaseConfig,
+            rank_model_snv="path/to/snv_rank_model.ini",
+            rank_model_sv="path/to/sv_rank_model.ini",
+        ),
+    )
+
+    # WHEN checking that the required files exist
+    does_exist: bool = raredisease_extension.do_required_files_exist(case_run_directory=tmp_path)
+
+    # THEN the required file should exist
+    assert does_exist
+
+
 @pytest.mark.parametrize(
-    "does_gene_panel_exist, does_managed_variants_exist, expected_value",
+    "file_existence_array",
     [
-        (False, False, False),
-        (False, True, False),
-        (True, False, False),
-        (True, True, True),
+        [False, True, True, True],
+        [True, False, True, True],
+        [True, True, False, True],
+        [True, True, True, False],
     ],
     ids=[
-        "neither file exists",
-        "only managed variants file exists",
-        "only gene panel file exists",
-        "both files exist",
+        "missing gene panel scenario",
+        "missing managed variants scenario",
+        "missing snv rank model scenario",
+        "missing sv rank model  scenario",
     ],
 )
 def test_do_required_files_exist(
-    does_gene_panel_exist: bool,
-    does_managed_variants_exist: bool,
-    expected_value: bool,
-    mocker: MockerFixture,
+    file_existence_array: list[bool],
+    tmp_path: Path,
 ):
     # GIVEN a case run directory
-    case_run_directory = Path("root")
+    case_run_directory = tmp_path
     file_map: dict[Path, bool] = {
-        Path(case_run_directory, GENE_PANEL_FILE_NAME): does_gene_panel_exist,
-        Path(case_run_directory, MANAGED_VARIANTS_FILE_NAME): does_managed_variants_exist,
+        Path(case_run_directory, ScoutExportFileName.PANELS): file_existence_array[0],
+        Path(case_run_directory, ScoutExportFileName.MANAGED_VARIANTS): file_existence_array[1],
+        Path(case_run_directory, "snv_rank_model.ini"): file_existence_array[2],
+        Path(case_run_directory, "sv_rank_model.ini"): file_existence_array[3],
     }
 
-    # GIVEN that one required file exists and one does not
-    isfile_mock = mocker.patch.object(raredisease, "isfile")
-    isfile_mock.side_effect = lambda path: file_map.get(path, False)
+    # GIVEN that one required file does not exist
+    for file, exists in file_map.items():
+        if exists:
+            file.touch()
 
     # GIVEN a raredisease extension
     raredisease_extension = RarediseaseExtension(
         gene_panel_file_creator=create_autospec(GenePanelFileCreator),
         managed_variants_file_creator=create_autospec(ManagedVariantsFileCreator),
-        raredisease_config=create_autospec(RarediseaseConfig),
+        raredisease_config=create_autospec(
+            RarediseaseConfig,
+            rank_model_snv="path/to/snv_rank_model.ini",
+            rank_model_sv="path/to/sv_rank_model.ini",
+        ),
     )
 
     # WHEN calling do_required_files_exist
     do_files_exist: bool = raredisease_extension.do_required_files_exist(case_run_directory)
 
-    # THEN the return values should be as expected
-    assert do_files_exist == expected_value
+    # THEN one of the files is marked as missing
+    assert not do_files_exist

--- a/tests/services/analysis_starter/nextflow_extension/test_raredisease_extension.py
+++ b/tests/services/analysis_starter/nextflow_extension/test_raredisease_extension.py
@@ -4,6 +4,7 @@ from unittest.mock import create_autospec
 import pytest
 from pytest_mock import MockerFixture
 
+from cg.models.cg_config import RarediseaseConfig
 from cg.services.analysis_starter.configurator.extensions import raredisease
 from cg.services.analysis_starter.configurator.extensions.raredisease import (
     GENE_PANEL_FILE_NAME,
@@ -21,6 +22,7 @@ def test_configure_success():
     raredisease_extension = RarediseaseExtension(
         gene_panel_file_creator=create_autospec(GenePanelFileCreator),
         managed_variants_file_creator=create_autospec(ManagedVariantsFileCreator),
+        raredisease_config=create_autospec(RarediseaseConfig),
     )
     # WHEN calling configure
     raredisease_extension.configure(case_id="case_id", case_run_directory=Path("/path/to/dir"))
@@ -70,6 +72,7 @@ def test_do_required_files_exist(
     raredisease_extension = RarediseaseExtension(
         gene_panel_file_creator=create_autospec(GenePanelFileCreator),
         managed_variants_file_creator=create_autospec(ManagedVariantsFileCreator),
+        raredisease_config=create_autospec(RarediseaseConfig),
     )
 
     # WHEN calling do_required_files_exist

--- a/tests/services/analysis_starter/nextflow_extension/test_raredisease_extension.py
+++ b/tests/services/analysis_starter/nextflow_extension/test_raredisease_extension.py
@@ -102,14 +102,14 @@ def test_do_required_files_exist(
 ):
     # GIVEN a case run directory
     case_run_directory = tmp_path
+
+    # GIVEN that one required file does not exist
     file_map: dict[Path, bool] = {
         Path(case_run_directory, ScoutExportFileName.PANELS): file_existence_array[0],
         Path(case_run_directory, ScoutExportFileName.MANAGED_VARIANTS): file_existence_array[1],
         Path(case_run_directory, "snv_rank_model.ini"): file_existence_array[2],
         Path(case_run_directory, "sv_rank_model.ini"): file_existence_array[3],
     }
-
-    # GIVEN that one required file does not exist
     for file, should_exist in file_map.items():
         if should_exist:
             file.touch()


### PR DESCRIPTION
## Description
Copy the SNV andSV rank model files from the directory in servers to the case directory when running `config-case` for nallo and raredisease.

### Changed

- Add a step to copy rank model files in the configure method of the PipelineExtension class for Nallo and raredisease
- Add new files to existence checks for config-case for Nallo and raredisease
- Unified extensions of nallo and raredisease

### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b link-rank-models-to-case-dir -a
    ```

### How to test

- [x] Run `cg -l DEBUG workflow nallo/raredisease config-case <case-id>`

### Expected test outcome

- [x] Check that both snv and sv rank model files are copied to the case directory

## Review

- [x] Tests executed by SD
- [x] "Merge and deploy" approved by VJ
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [x] Deployed to stage:
```shell
Logging deploy ...
Getting deployer... done.
Getting last commit message and SHA... done.
Getting version of deploy scripts... done.
Log deploy... done.
cg, version 87.9.0
[js.diazboada@hasta:~] [S_base] $ up
```
- [x] Deployed to production:
```shell
Logging deploy ...
Getting deployer... done.
Getting last commit message and SHA... done.
Getting version of deploy scripts... done.
Log deploy... done.
cg, version 87.9.0
[js.diazboada@hasta:~] [P_base] $
```