### PR TITLE
Feat(Delivery messages) Add signature

### DIFF
--- a/cg/services/deliver_service.py
+++ b/cg/services/deliver_service.py
@@ -162,7 +162,7 @@ class DeliverService:
         self, order: Order, analyses: list[Analysis], cc_emails: list[str]
     ):
         cases: list[Case] = [analysis.case for analysis in analyses]
-        message: str = get_message(cases=cases, store=self.status_db)
+        message: str = get_message(cases=cases, store=self.status_db, include_signature=True)
         self.freshdesk_client.reply_to_ticket(
             ticket_id=order.ticket_id, message=message, cc_emails=cc_emails
         )

--- a/cg/services/delivery_message/messages/microsalt_message.py
+++ b/cg/services/delivery_message/messages/microsalt_message.py
@@ -11,8 +11,7 @@ class MicrosaltMessage(DeliveryMessage):
         delivery_path: str = get_caesar_delivery_path(cases[0])
         return (
             f"Hello,\n\n"
-            f"The analysis is now complete and the fastq files have been uploaded to:\n\n"
+            f"The analysis is now complete. The fastq files, QC report and typing report have been uploaded to:\n\n"
             f"{delivery_path} \n\n"
-            "The QC and Typing reports can be found attached. \n\n"
             f"{REMINDER_TO_DOWNLOAD_MESSAGE}"
         )

--- a/cg/services/delivery_message/messages/utils.py
+++ b/cg/services/delivery_message/messages/utils.py
@@ -2,6 +2,7 @@ from cg.constants import Workflow
 from cg.store.models import Case
 
 REMINDER_TO_DOWNLOAD_MESSAGE = "The files will be kept on the server for 30 days before being automatically removed. Please make sure to download them in time."
+BEST_REGARDS_MESSAGE = "Best regards,\nClinical Genomics"
 
 
 def get_caesar_delivery_path(case: Case) -> str:

--- a/cg/services/delivery_message/utils.py
+++ b/cg/services/delivery_message/utils.py
@@ -28,6 +28,7 @@ from cg.services.delivery_message.messages.rna_delivery_message import (
     RNAUploadMessageStrategy,
 )
 from cg.services.delivery_message.messages.taxprofiler_message import TaxprofilerDeliveryMessage
+from cg.services.delivery_message.messages.utils import BEST_REGARDS_MESSAGE
 from cg.store.models import Case
 from cg.store.store import Store
 
@@ -56,9 +57,12 @@ RNA_STRATEGY_MAP: dict[DataDelivery, type[RNAUploadMessageStrategy]] = {
 }
 
 
-def get_message(cases: list[Case], store: Store) -> str:
+def get_message(cases: list[Case], store: Store, include_signature: bool = False) -> str:
     message_strategy: DeliveryMessage = get_message_strategy(case=cases[0], store=store)
-    return message_strategy.create_message(cases)
+    message: str = message_strategy.create_message(cases)
+    if include_signature:
+        message = f"{message}\n\n{BEST_REGARDS_MESSAGE}"
+    return message
 
 
 def get_message_strategy(case: Case, store: Store) -> DeliveryMessage:

--- a/tests/fixture_plugins/delivery_message_fixtures/message_fixtures.py
+++ b/tests/fixture_plugins/delivery_message_fixtures/message_fixtures.py
@@ -21,9 +21,9 @@ def microsalt_message(customer_id: str, ticket_id: str) -> str:
     """Return the delivery message for a microSALT case."""
     return (
         "Hello,\n\n"
-        "The analysis is now complete and the fastq files have been uploaded to:\n\n"
+        "The analysis is now complete. The fastq files, QC report and typing report have been "
+        "uploaded to:\n\n"
         f"/home/{customer_id}/inbox/{ticket_id} \n\n"
-        "The QC and Typing reports can be found attached. \n\n"
         f"{REMINDER_TO_DOWNLOAD_MESSAGE}"
     )
 

--- a/tests/services/delivery_message/test_delivery_message.py
+++ b/tests/services/delivery_message/test_delivery_message.py
@@ -2,7 +2,9 @@ import pytest
 
 from cg.constants.constants import DataDelivery, Workflow
 from cg.services.delivery_message.delivery_message_service import DeliveryMessageService
-from cg.store.models import Order
+from cg.services.delivery_message.messages.utils import BEST_REGARDS_MESSAGE
+from cg.services.delivery_message.utils import get_message
+from cg.store.models import Case, Order
 from cg.store.store import Store
 from tests.store_helpers import StoreHelpers
 
@@ -36,6 +38,23 @@ def test_get_delivery_message_for_single_case(
     # THEN the message should be as expected
     expected_message: str = request.getfixturevalue(expected_message_fixture)
     assert message == expected_message
+
+
+def test_get_message_with_signature(
+    delivery_message_service: DeliveryMessageService,
+    mip_case_id: str,
+    analysis_scout_message: str,
+) -> None:
+    """Test that the signature is appended only when explicitly requested."""
+    # GIVEN a store with a case
+    store: Store = delivery_message_service.store
+    cases: list[Case] = store.get_cases_by_internal_ids([mip_case_id])
+
+    # WHEN the delivery message is requested with a signature
+    message: str = get_message(cases=cases, store=store, include_signature=True)
+
+    # THEN the message should end with the signature
+    assert message == f"{analysis_scout_message}\n\n{BEST_REGARDS_MESSAGE}"
 
 
 @pytest.mark.parametrize(

--- a/tests/services/test_deliver_service.py
+++ b/tests/services/test_deliver_service.py
@@ -85,7 +85,9 @@ def test_deliver_case_closes_order(mocker: MockerFixture):
     assert not order.is_open
 
     # THEN the delivery message is generated
-    delivery_message_mock.assert_called_once_with(cases=[case], store=status_db)
+    delivery_message_mock.assert_called_once_with(
+        cases=[case], store=status_db, include_signature=True
+    )
 
     # THEN the delivery message is sent
     freshdesk_client.as_mock.reply_to_ticket.assert_called_once_with(
@@ -180,7 +182,9 @@ def test_deliver_case_order_is_not_closed(mocker: MockerFixture):
     assert order.is_open
 
     # THEN the delivery message is generated
-    delivery_message_mock.assert_called_once_with(cases=[case_ready], store=status_db)
+    delivery_message_mock.assert_called_once_with(
+        cases=[case_ready], store=status_db, include_signature=True
+    )
 
     # THEN the delivery message is sent
     freshdesk_client.as_mock.reply_to_ticket.assert_called_once_with(
@@ -412,8 +416,10 @@ def test_deliver_all_available_success(mocker: MockerFixture):
     close_order_call.assert_any_call(order_2)
 
     # THEN the delivery message should have been generated and sent for both orders separately
-    delivery_message_mock.assert_any_call(cases=[case_1], store=status_db)
-    delivery_message_mock.assert_any_call(cases=[case_2, case_3], store=status_db)
+    delivery_message_mock.assert_any_call(cases=[case_1], store=status_db, include_signature=True)
+    delivery_message_mock.assert_any_call(
+        cases=[case_2, case_3], store=status_db, include_signature=True
+    )
     freshdesk_client.as_mock.reply_to_ticket.assert_any_call(
         ticket_id=order_1.ticket_id,
         message="delivery message",
@@ -640,7 +646,9 @@ def test_deliver_all_available_freshdesk_closing_ticket_error(mocker: MockerFixt
     assert not success
 
     # THEN the delivery message is generated
-    delivery_message_mock.assert_called_once_with(cases=[case], store=status_db.as_type)
+    delivery_message_mock.assert_called_once_with(
+        cases=[case], store=status_db.as_type, include_signature=True
+    )
 
     # THEN the delivery message should have been sent
     freshdesk_client.as_mock.reply_to_ticket.assert_called_once_with(
@@ -724,7 +732,9 @@ def test_deliver_order_success(mocker: MockerFixture):
     mark_analyses_call.assert_called_once_with(analyses=[analysis_1, analysis_2], signature="CG")
 
     # THEN the delivery message should have been generated for the correct cases
-    delivery_message_mock.assert_called_once_with(cases=[case_1, case_2], store=status_db.as_type)
+    delivery_message_mock.assert_called_once_with(
+        cases=[case_1, case_2], store=status_db.as_type, include_signature=True
+    )
 
     # THEN the delivery message should have been sent
     freshdesk_client.as_mock.reply_to_ticket.assert_called_once_with(


### PR DESCRIPTION
## Description

This PR removes the phrase regarding attached microSALT reports and adds a signature for messages sent bu the automatic deliveries

### Added

- Signature line for delivery messages sent my delivery automation

### Changed

- Removed the line "The QC and Typing reports can be found attached." from the microSALT delivery messages