### PR TITLE
fix panel bed overriding in Balsamic

### DIFF
--- a/cg/services/analysis_starter/configurator/file_creators/balsamic_config.py
+++ b/cg/services/analysis_starter/configurator/file_creators/balsamic_config.py
@@ -10,13 +10,14 @@ from cg.constants import SexOptions
 from cg.constants.constants import BedVersionGenomeVersion, GenomeVersion
 from cg.constants.process import EXIT_SUCCESS
 from cg.constants.sequencing import SeqLibraryPrepCategory
+from cg.exc import MultipleCaptureKitsError
 from cg.models.cg_config import BalsamicConfig
 from cg.services.analysis_starter.configurator.models.balsamic import (
     BalsamicConfigInput,
     BalsamicConfigInputPanel,
     BalsamicConfigInputWGS,
 )
-from cg.store.models import BedVersion, Case, Sample
+from cg.store.models import BedVersion, Case
 from cg.store.store import Store
 
 LOG = logging.getLogger(__name__)
@@ -208,7 +209,7 @@ class BalsamicConfigFileCreator:
                     return sample.internal_id
 
     @staticmethod
-    def _get_tumor_or_single_sample_id(case) -> str:
+    def _get_tumor_or_single_sample_id(case: Case) -> str:
         """
         Return the internal id of the tumour sample if the case is a paired analysis,
         otherwise return the internal id of the single sample.
@@ -224,10 +225,17 @@ class BalsamicConfigFileCreator:
         return len(case.samples) == 2
 
     def _get_bed_version(self, case: Case, override_panel_bed: str | None) -> BedVersion:
-        first_sample: Sample = case.samples[0]
-        short_name: str = override_panel_bed or self.lims_api.get_capture_kit_strict(
-            first_sample.internal_id
-        )
+        if override_panel_bed:
+            short_name: str = override_panel_bed
+        else:
+            capture_kits: set[str] = {
+                self.lims_api.get_capture_kit_strict(sample.internal_id) for sample in case.samples
+            }
+            if len(capture_kits) > 1:
+                raise MultipleCaptureKitsError(
+                    f"Multiple capture kits found for {case.internal_id}: {capture_kits}"
+                )
+            short_name: str = capture_kits.pop()
         return self.status_db.get_bed_version_by_short_name_and_genome_version_strict(
             short_name=short_name, genome_version=BedVersionGenomeVersion.HG19
         )

--- a/cg/services/analysis_starter/configurator/implementations/balsamic_configurator.py
+++ b/cg/services/analysis_starter/configurator/implementations/balsamic_configurator.py
@@ -2,7 +2,7 @@ import logging
 from pathlib import Path
 
 from cg.apps.lims.api import LimsAPI
-from cg.exc import CaseNotConfiguredError, MultipleCaptureKitsError
+from cg.exc import CaseNotConfiguredError
 from cg.meta.workflow.fastq import BalsamicFastqHandler
 from cg.models.cg_config import BalsamicConfig
 from cg.services.analysis_starter.configurator.configurator import Configurator
@@ -10,7 +10,6 @@ from cg.services.analysis_starter.configurator.file_creators.balsamic_config imp
     BalsamicConfigFileCreator,
 )
 from cg.services.analysis_starter.configurator.models.balsamic import BalsamicCaseConfig
-from cg.store.models import Case
 from cg.store.store import Store
 
 LOG = logging.getLogger(__name__)
@@ -41,8 +40,6 @@ class BalsamicConfigurator(Configurator):
 
     def configure(self, case_id: str, **flags) -> BalsamicCaseConfig:
         LOG.info(f"Configuring case {case_id}")
-        if flags.get("panel_bed") is None:
-            self._ensure_consistent_capture_kits(case_id)
         self.fastq_handler.link_fastq_files(case_id)
         fastq_path: Path = self.fastq_handler.get_fastq_dir(case_id)
         self.config_file_creator.create(case_id=case_id, fastq_path=fastq_path, **flags)
@@ -67,16 +64,6 @@ class BalsamicConfigurator(Configurator):
 
     def _get_sample_config_path(self, case_id: str) -> Path:
         return Path(self.root_dir, case_id, f"{case_id}.json")
-
-    def _ensure_consistent_capture_kits(self, case_id):
-        case: Case = self.store.get_case_by_internal_id_strict(case_id)
-        capture_kits: set[str | None] = {
-            self.lims_api.capture_kit(sample.internal_id) for sample in case.samples
-        }
-        if len(capture_kits) > 1:
-            raise MultipleCaptureKitsError(
-                f"Multiple capture kits found for {case_id}: {capture_kits}"
-            )
 
     def _ensure_required_config_files_exist(self, config: BalsamicCaseConfig) -> None:
         if not config.sample_config.exists():

--- a/cg/services/analysis_starter/configurator/implementations/balsamic_configurator.py
+++ b/cg/services/analysis_starter/configurator/implementations/balsamic_configurator.py
@@ -41,7 +41,8 @@ class BalsamicConfigurator(Configurator):
 
     def configure(self, case_id: str, **flags) -> BalsamicCaseConfig:
         LOG.info(f"Configuring case {case_id}")
-        self._ensure_consistent_capture_kits(case_id)
+        if flags.get("panel_bed") is None:
+            self._ensure_consistent_capture_kits(case_id)
         self.fastq_handler.link_fastq_files(case_id)
         fastq_path: Path = self.fastq_handler.get_fastq_dir(case_id)
         self.config_file_creator.create(case_id=case_id, fastq_path=fastq_path, **flags)

--- a/tests/services/analysis_starter/file_creators/balsamic_config_file_creator/test_balsamic_config_file_creator.py
+++ b/tests/services/analysis_starter/file_creators/balsamic_config_file_creator/test_balsamic_config_file_creator.py
@@ -333,10 +333,9 @@ def test_create_mixed_capture_kits(
 
     # WHEN creating the config file
     # THEN an error should be raised due to the mixed capture kits
+    fastq_path = Path(f"{cg_balsamic_config.root}/case_1/fastq")
     with pytest.raises(MultipleCaptureKitsError):
-        config_file_creator.create(
-            case_id="case_1", fastq_path=Path(f"{cg_balsamic_config.root}/case_1/fastq")
-        )
+        config_file_creator.create(case_id="case_1", fastq_path=fastq_path)
 
 
 @pytest.mark.parametrize("workflow", [Workflow.BALSAMIC, Workflow.BALSAMIC_UMI])

--- a/tests/services/analysis_starter/file_creators/balsamic_config_file_creator/test_balsamic_config_file_creator.py
+++ b/tests/services/analysis_starter/file_creators/balsamic_config_file_creator/test_balsamic_config_file_creator.py
@@ -12,7 +12,7 @@ from cg.constants.constants import BedVersionGenomeVersion, Workflow
 from cg.constants.observations import BalsamicObservationPanel
 from cg.constants.process import EXIT_SUCCESS
 from cg.constants.sequencing import SeqLibraryPrepCategory
-from cg.exc import CaseNotFoundError, LimsDataError
+from cg.exc import CaseNotFoundError, LimsDataError, MultipleCaptureKitsError
 from cg.models.cg_config import BalsamicConfig
 from cg.services.analysis_starter.configurator.file_creators.balsamic_config import (
     BalsamicConfigFileCreator,
@@ -20,6 +20,7 @@ from cg.services.analysis_starter.configurator.file_creators.balsamic_config imp
 )
 from cg.store.models import BedVersion, Case, Sample
 from cg.store.store import Store
+from tests.typed_mock import TypedMock, create_typed_mock
 
 
 @pytest.mark.parametrize("workflow", [Workflow.BALSAMIC, Workflow.BALSAMIC_UMI])
@@ -254,9 +255,12 @@ def test_create_override_panel_bed(
         return_value=create_autospec(BedVersion, filename="bed_version.bed")
     )
 
+    # GIVEN a LIMS API
+    lims_mock: TypedMock[LimsAPI] = create_typed_mock(LimsAPI)
+
     # GIVEN a BalsamicConfigFileCreator
     config_file_creator = BalsamicConfigFileCreator(
-        status_db=store, lims_api=Mock(), cg_balsamic_config=cg_balsamic_config
+        status_db=store, lims_api=lims_mock.as_type, cg_balsamic_config=cg_balsamic_config
     )
 
     # GIVEN that the subprocess exits successfully
@@ -285,6 +289,54 @@ def test_create_override_panel_bed(
         short_name="override_panel_bed",
         genome_version=BedVersionGenomeVersion.HG19,
     )
+
+    # THEN Lims was not called
+    lims_mock.as_mock.get_capture_kit_strict.assert_not_called()
+
+
+@pytest.mark.parametrize("workflow", [Workflow.BALSAMIC, Workflow.BALSAMIC_UMI])
+def test_create_mixed_capture_kits(
+    cg_balsamic_config: BalsamicConfig,
+    expected_tgs_tumour_only_command: str,
+    workflow: Workflow,
+):
+    # GIVEN a store with a TGS paired case
+    tumour_sample: Sample = create_autospec(
+        Sample,
+        internal_id="sample_tumour",
+        is_tumour=True,
+        prep_category=SeqLibraryPrepCategory.TARGETED_GENOME_SEQUENCING,
+        sex=SexOptions.MALE,
+    )
+    normal_sample: Sample = create_autospec(
+        Sample,
+        internal_id="sample_normal",
+        is_tumour=False,
+        prep_category=SeqLibraryPrepCategory.TARGETED_GENOME_SEQUENCING,
+        sex=SexOptions.MALE,
+    )
+    tgs_paired_case: Case = create_autospec(
+        Case, data_analysis=workflow, internal_id="case_1", samples=[tumour_sample, normal_sample]
+    )
+    tgs_paired_case.name = "cust_case_name"
+    store: Store = create_autospec(Store)
+    store.get_case_by_internal_id_strict = Mock(return_value=tgs_paired_case)
+
+    # GIVEN a LimsAPI which returns two different capture kits for the two samples
+    lims_api: TypedMock[LimsAPI] = create_typed_mock(LimsAPI)
+    lims_api.as_type.get_capture_kit_strict = Mock(side_effect=["capture_kit_1", "capture_kit_2"])
+
+    # GIVEN a BalsamicConfigFileCreator
+    config_file_creator = BalsamicConfigFileCreator(
+        status_db=store, lims_api=lims_api.as_type, cg_balsamic_config=cg_balsamic_config
+    )
+
+    # WHEN creating the config file
+    # THEN an error should be raised due to the mixed capture kits
+    with pytest.raises(MultipleCaptureKitsError):
+        config_file_creator.create(
+            case_id="case_1", fastq_path=Path(f"{cg_balsamic_config.root}/case_1/fastq")
+        )
 
 
 @pytest.mark.parametrize("workflow", [Workflow.BALSAMIC, Workflow.BALSAMIC_UMI])

--- a/tests/services/analysis_starter/test_balsamic_configurator.py
+++ b/tests/services/analysis_starter/test_balsamic_configurator.py
@@ -301,33 +301,30 @@ def test_configure_override_panel_skips_lims_check(
     cg_balsamic_config: BalsamicConfig, mocker: MockerFixture
 ):
     """Test that when overriding the panel bed, the check for multiple panels is skipped."""
-    # GIVEN a store with a case
+    # GIVEN a store with a Balsamic case
     store: Store = create_autospec(Store)
     store.get_case_workflow = Mock(return_value=Workflow.BALSAMIC)
     store.get_case_by_internal_id_strict = Mock(
-        return_value=create_autospec(
-            Case,
-            # samples=[create_autospec(Sample), create_autospec(Sample)],
-            slurm_priority=SlurmQos.NORMAL,
-        )
+        return_value=create_autospec(Case, slurm_priority=SlurmQos.NORMAL)
     )
 
     # GIVEN a fastq handler
-    fastq_handler: BalsamicFastqHandler = create_autospec(BalsamicFastqHandler)
-    fastq_handler.get_fastq_dir = Mock(return_value=Path("some/path"))
+    fastq_handler: TypedMock[BalsamicFastqHandler] = create_typed_mock(BalsamicFastqHandler)
+    fastq_handler.as_type.get_fastq_dir = Mock(return_value=Path("some/path"))
 
     # GIVEN a BalsamicConfigFileCreator
-    config_file_creator: BalsamicConfigFileCreator = create_autospec(BalsamicConfigFileCreator)
+    config_file_creator: TypedMock[BalsamicConfigFileCreator] = create_typed_mock(
+        BalsamicConfigFileCreator
+    )
 
     # GIVEN a LimsAPI
     lims_api: TypedMock[LimsAPI] = create_typed_mock(LimsAPI)
-    # lims_api.as_type.capture_kit = Mock()
 
     # GIVEN a Balsamic configurator
     balsamic_configurator = BalsamicConfigurator(
         config=cg_balsamic_config,
-        config_file_creator=config_file_creator,
-        fastq_handler=fastq_handler,
+        config_file_creator=config_file_creator.as_type,
+        fastq_handler=fastq_handler.as_type,
         lims_api=lims_api.as_type,
         store=store,
     )
@@ -339,13 +336,13 @@ def test_configure_override_panel_skips_lims_check(
     balsamic_configurator.configure(case_id="case_id")
 
     # THEN the fastq handler is called
-    fastq_handler.link_fastq_files.assert_called_once_with(case_id="case_id")
-    fastq_handler.get_fastq_dir.assert_called_once_with("case_id")
+    fastq_handler.as_mock.link_fastq_files.assert_called_once_with(case_id="case_id")
+    fastq_handler.as_mock.get_fastq_dir.assert_called_once_with("case_id")
 
     # THEN the config file creator is called
-    config_file_creator.create.assert_called_once_with(
+    config_file_creator.as_mock.create.assert_called_once_with(
         case_id="case_id", fastq_path=Path("some/path")
     )
 
     # THEN the Lims check is not performed
-    lims_api.as_type.capture_kit.assert_not_called()
+    lims_api.as_mock.capture_kit.assert_not_called()

--- a/tests/services/analysis_starter/test_balsamic_configurator.py
+++ b/tests/services/analysis_starter/test_balsamic_configurator.py
@@ -8,7 +8,7 @@ from pytest_mock import MockerFixture
 from cg.apps.lims import LimsAPI
 from cg.constants import Workflow
 from cg.constants.priority import SlurmQos
-from cg.exc import CaseNotConfiguredError, MultipleCaptureKitsError
+from cg.exc import CaseNotConfiguredError
 from cg.meta.workflow.fastq import BalsamicFastqHandler
 from cg.models.cg_config import BalsamicConfig
 from cg.services.analysis_starter.configurator.file_creators.balsamic_config import (
@@ -20,7 +20,6 @@ from cg.services.analysis_starter.configurator.implementations.balsamic_configur
 from cg.services.analysis_starter.configurator.models.balsamic import BalsamicCaseConfig
 from cg.store.models import Case, Sample
 from cg.store.store import Store
-from tests.typed_mock import TypedMock, create_typed_mock
 
 PANEL_ONLY_FIELDS = ["soft_filter_normal", "panel_bed", "pon_cnn", "exome"]
 WGS_ONLY_FIELDS = ["genome_interval", "gens_coverage_pon"]
@@ -259,90 +258,3 @@ def test_configure_with_flags(
         workflow=workflow,
         workflow_profile=workflow_profile,
     )
-
-
-def test_configure_mixed_capture_kits(cg_balsamic_config: BalsamicConfig):
-    # GIVEN a fastq handler
-    fastq_handler: BalsamicFastqHandler = create_autospec(BalsamicFastqHandler)
-    fastq_handler.get_fastq_dir = Mock(return_value=Path("some/path"))
-
-    # GIVEN a BalsamicConfigFileCreator
-    config_file_creator: BalsamicConfigFileCreator = create_autospec(BalsamicConfigFileCreator)
-
-    # GIVEN a store containing a case with two samples
-    store: Store = create_autospec(Store)
-    store.get_case_by_internal_id_strict = Mock(
-        return_value=create_autospec(
-            Case,
-            samples=[create_autospec(Sample), create_autospec(Sample)],
-            slurm_priority=SlurmQos.NORMAL,
-        )
-    )
-
-    # GIVEN a LimsAPI which returns two different capture kits for the two samples
-    lims_api: TypedMock[LimsAPI] = create_typed_mock(LimsAPI)
-    lims_api.as_type.capture_kit = Mock(side_effect=["capture_kit_1", "capture_kit_2"])
-
-    # GIVEN a Balsamic configurator
-    balsamic_configurator = BalsamicConfigurator(
-        config=cg_balsamic_config,
-        config_file_creator=config_file_creator,
-        fastq_handler=fastq_handler,
-        lims_api=lims_api.as_type,
-        store=store,
-    )
-    # WHEN calling configure
-    # THEN an error should be raised due to the mixed capture kits
-    with pytest.raises(MultipleCaptureKitsError):
-        balsamic_configurator.configure(case_id="case_id")
-
-
-def test_configure_override_panel_skips_lims_check(
-    cg_balsamic_config: BalsamicConfig, mocker: MockerFixture
-):
-    """Test that when overriding the panel bed, the check for multiple panels is skipped."""
-    # GIVEN a store with a Balsamic case
-    store: Store = create_autospec(Store)
-    store.get_case_workflow = Mock(return_value=Workflow.BALSAMIC)
-    store.get_case_by_internal_id_strict = Mock(
-        return_value=create_autospec(Case, slurm_priority=SlurmQos.NORMAL)
-    )
-
-    # GIVEN a fastq handler
-    fastq_handler: TypedMock[BalsamicFastqHandler] = create_typed_mock(BalsamicFastqHandler)
-    fastq_handler.as_type.get_fastq_dir = Mock(return_value=Path("some/path"))
-
-    # GIVEN a BalsamicConfigFileCreator
-    config_file_creator: TypedMock[BalsamicConfigFileCreator] = create_typed_mock(
-        BalsamicConfigFileCreator
-    )
-
-    # GIVEN a LimsAPI
-    lims_api: TypedMock[LimsAPI] = create_typed_mock(LimsAPI)
-
-    # GIVEN a Balsamic configurator
-    balsamic_configurator = BalsamicConfigurator(
-        config=cg_balsamic_config,
-        config_file_creator=config_file_creator.as_type,
-        fastq_handler=fastq_handler.as_type,
-        lims_api=lims_api.as_type,
-        store=store,
-    )
-
-    # GIVEN that all relevant paths exist
-    mocker.patch.object(Path, "exists", return_value=True)
-
-    # WHEN calling configure
-    balsamic_configurator.configure(case_id="case_id")
-
-    # THEN the fastq handler is called
-    fastq_handler.as_mock.link_fastq_files.assert_called_once_with(case_id="case_id")
-    fastq_handler.as_mock.get_fastq_dir.assert_called_once_with("case_id")
-
-    # THEN the config file creator is called
-    config_file_creator.as_mock.create.assert_called_once_with(
-        case_id="case_id", fastq_path=Path("some/path")
-    )
-
-    # THEN the Lims check is not performed
-    lims_api.as_mock.capture_kit.assert_not_called()

--- a/tests/services/analysis_starter/test_balsamic_configurator.py
+++ b/tests/services/analysis_starter/test_balsamic_configurator.py
@@ -295,3 +295,57 @@ def test_configure_mixed_capture_kits(cg_balsamic_config: BalsamicConfig):
     # THEN an error should be raised due to the mixed capture kits
     with pytest.raises(MultipleCaptureKitsError):
         balsamic_configurator.configure(case_id="case_id")
+
+
+def test_configure_override_panel_skips_lims_check(
+    cg_balsamic_config: BalsamicConfig, mocker: MockerFixture
+):
+    """Test that when overriding the panel bed, the check for multiple panels is skipped."""
+    # GIVEN a store with a case
+    store: Store = create_autospec(Store)
+    store.get_case_workflow = Mock(return_value=Workflow.BALSAMIC)
+    store.get_case_by_internal_id_strict = Mock(
+        return_value=create_autospec(
+            Case,
+            # samples=[create_autospec(Sample), create_autospec(Sample)],
+            slurm_priority=SlurmQos.NORMAL,
+        )
+    )
+
+    # GIVEN a fastq handler
+    fastq_handler: BalsamicFastqHandler = create_autospec(BalsamicFastqHandler)
+    fastq_handler.get_fastq_dir = Mock(return_value=Path("some/path"))
+
+    # GIVEN a BalsamicConfigFileCreator
+    config_file_creator: BalsamicConfigFileCreator = create_autospec(BalsamicConfigFileCreator)
+
+    # GIVEN a LimsAPI
+    lims_api: TypedMock[LimsAPI] = create_typed_mock(LimsAPI)
+    # lims_api.as_type.capture_kit = Mock()
+
+    # GIVEN a Balsamic configurator
+    balsamic_configurator = BalsamicConfigurator(
+        config=cg_balsamic_config,
+        config_file_creator=config_file_creator,
+        fastq_handler=fastq_handler,
+        lims_api=lims_api.as_type,
+        store=store,
+    )
+
+    # GIVEN that all relevant paths exist
+    mocker.patch.object(Path, "exists", return_value=True)
+
+    # WHEN calling configure
+    balsamic_configurator.configure(case_id="case_id")
+
+    # THEN the fastq handler is called
+    fastq_handler.link_fastq_files.assert_called_once_with(case_id="case_id")
+    fastq_handler.get_fastq_dir.assert_called_once_with("case_id")
+
+    # THEN the config file creator is called
+    config_file_creator.create.assert_called_once_with(
+        case_id="case_id", fastq_path=Path("some/path")
+    )
+
+    # THEN the Lims check is not performed
+    lims_api.as_type.capture_kit.assert_not_called()


### PR DESCRIPTION
## Description
When running Balsamic `config-case`, make the consistent capture kits check only applicable when the user does not provide any panel bed manually

### Added

- New tests

### Changed
- The check for multiple capture kits is done in the BalsamicConfigFileCreator (not in the BalsamicConfigurator) only for non-wgs cases where no manual panel bed has been provided

### Fixed

- Check that panel-bed is not provided before checking in Lims that all sample capture kits are the same within the case 


### How to prepare for test

- [x] Ssh to relevant server (depending on type of change)
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b fix-panel-bed-balsamic -a
    ```

### How to test

- [x] Do `cg -l DEBUG workflow balsamic config-case <case-id> --panel-bed NJU`

### Expected test outcome

- [x] Check that the provided panel bed is used in the config and that no call to LIMS was done

## Review

- [x] Tests executed by SD
- [x] "Merge and deploy" approved by VJ
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [x] Deployed to stage:
```shell
Logging deploy ...
Getting deployer... done.
Getting last commit message and SHA... done.
Getting version of deploy scripts... done.
Log deploy... done.
cg, version 87.9.2
[js.diazboada@hasta:unitedbeagle] [S_base] $ up
```
- [x] Deployed to production:
```shell
Getting deployer... done.
Getting last commit message and SHA... done.
Getting version of deploy scripts... done.
Log deploy... done.
cg, version 87.9.2
[js.diazboada@hasta:unitedbeagle] [P_base] $
```
