### PR TITLE
Set control value for Microbial Fastq orders

### DIFF
--- a/cg/services/orders/storing/implementations/microbial_fastq_order_service.py
+++ b/cg/services/orders/storing/implementations/microbial_fastq_order_service.py
@@ -114,6 +114,7 @@ class StoreMicrobialFastqOrderService(StoreOrderService):
         return self.status_db.add_sample(
             application_version=application_version,
             comment=sample.comment,
+            control=sample.control,
             customer=customer,
             internal_id=sample._generated_lims_id,
             lims_status=lims_status,

--- a/tests/fixtures/cgweb_orders/microbial_fastq.json
+++ b/tests/fixtures/cgweb_orders/microbial_fastq.json
@@ -11,6 +11,7 @@
             "comment": "sample comment",
             "container": "Tube",
             "container_name": "prov1",
+            "control": "positive",
             "data_analysis": "raw-data",
             "data_delivery": "fastq",
             "elution_buffer": "Nuclease-free water",

--- a/tests/services/orders/store_service/test_microbial_fastq_order_store_service.py
+++ b/tests/services/orders/store_service/test_microbial_fastq_order_store_service.py
@@ -53,6 +53,7 @@ def test_store_samples(
         assert len(sample.links) == 1
         assert sample.links[0].should_deliver_sample
 
+        # THEN the samples should have gotten the correct control values set
         order_sample = [
             order_sample
             for order_sample in microbial_fastq_order.samples

--- a/tests/services/orders/store_service/test_microbial_fastq_order_store_service.py
+++ b/tests/services/orders/store_service/test_microbial_fastq_order_store_service.py
@@ -33,7 +33,7 @@ def test_store_samples(
     assert store._get_query(table=Case).count() == 0
 
     # WHEN storing the order
-    new_samples = store_microbial_fastq_order_service.store_order_data_in_status_db(
+    new_samples: list[Sample] = store_microbial_fastq_order_service.store_order_data_in_status_db(
         order=microbial_fastq_order
     )
 
@@ -48,10 +48,20 @@ def test_store_samples(
     assert case_link.case.data_analysis
     assert case_link.case.data_delivery == DataDelivery.FASTQ
 
-    # THEN there should be one relationship per sample which delivers it
     for sample in new_samples:
+        # THEN there should be one relationship per sample which delivers it
         assert len(sample.links) == 1
         assert sample.links[0].should_deliver_sample
+
+        order_sample = [
+            order_sample
+            for order_sample in microbial_fastq_order.samples
+            if order_sample.name == sample.name
+        ][0]
+        if sample.control:
+            assert order_sample.control == sample.control
+        else:
+            assert order_sample.control == ""
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

We have a bug in production where the microbial fastq orders do not get their control values set in StatusDB. This PR addresses that for new samples.

### Added

-

### Changed

-

### Fixed

- Microbial Fastq samples get their control values persisted to StatusDB


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
