### PR TITLE
Move order to order

### DIFF
--- a/alembic/versions/2026_08_06_5f3c86391226_move_order_to_order_table.py
+++ b/alembic/versions/2026_08_06_5f3c86391226_move_order_to_order_table.py
@@ -1,0 +1,121 @@
+"""Move order to order table
+
+Revision ID: 5f3c86391226
+Revises: d2900fdde3e8
+Create Date: 2026-08-06 11:11:15.435937
+
+"""
+
+from typing import Annotated
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+from sqlalchemy.orm import (
+    DeclarativeBase,
+    Mapped,
+    Session,
+    mapped_column,
+    relationship,
+    selectinload,
+)
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "5f3c86391226"
+down_revision = "d2900fdde3e8"
+branch_labels = None
+depends_on = None
+
+PrimaryKeyInt = Annotated[int, mapped_column(primary_key=True)]
+Str32 = Annotated[str, 32]
+Str64 = Annotated[str, 64]
+
+
+class Base(DeclarativeBase):
+    type_annotation_map = {
+        Str32: sa.String(32),
+        Str64: sa.String(64),
+    }
+
+
+order_case = sa.Table(
+    "order_case",
+    Base.metadata,
+    sa.Column("order_id", sa.ForeignKey("order.id", ondelete="CASCADE"), nullable=False),
+    sa.Column("case_id", sa.ForeignKey("case.id", ondelete="CASCADE"), nullable=False),
+    sa.UniqueConstraint("order_id", "case_id", name="_order_case_uc"),
+)
+
+
+class Order(Base):
+    """Model for storing orders."""
+
+    __tablename__ = "order"
+
+    id: Mapped[PrimaryKeyInt]
+    order: Mapped[str | None]
+    cases: Mapped[list["Case"]] = relationship(secondary=order_case, back_populates="orders")
+    name: Mapped[str | None]
+    ticket_id: Mapped[int]
+
+
+class Case(Base):
+    __tablename__ = "case"
+    id: Mapped[PrimaryKeyInt]
+    links: Mapped[list["CaseSample"]] = relationship(back_populates="case")
+    orders: Mapped[list["Order"]] = relationship(secondary=order_case, back_populates="cases")
+
+    @property
+    def samples(self) -> list["Sample"]:
+        """Return case samples."""
+        return [link.sample for link in self.links]
+
+
+class CaseSample(Base):
+    __tablename__ = "case_sample"
+    id: Mapped[PrimaryKeyInt]
+    case_id: Mapped[str] = mapped_column(
+        sa.ForeignKey("case.id", ondelete="CASCADE"), nullable=False
+    )
+    sample_id: Mapped[int] = mapped_column(
+        sa.ForeignKey("sample.id", ondelete="CASCADE"), nullable=False
+    )
+    case: Mapped[Case] = relationship(back_populates="links")
+    sample: Mapped["Sample"] = relationship(foreign_keys=[sample_id], back_populates="links")
+
+
+class Sample(Base):
+    __tablename__ = "sample"
+    id: Mapped[PrimaryKeyInt]
+    internal_id: Mapped[str]
+    links: Mapped[list[CaseSample]] = relationship(back_populates="sample")
+    order: Mapped[str | None]
+    original_ticket: Mapped[str | None]
+
+
+def upgrade():
+    bind: sa.Connection = op.get_bind()
+    session = Session(bind=bind)
+    op.add_column(
+        table_name="order",
+        column=sa.Column(
+            name="name",
+            type_=mysql.VARCHAR(64),
+        ),
+    )
+    orders = session.query(Order).options(
+        selectinload(Order.cases).selectinload(Case.links).selectinload(CaseSample.sample)
+    )
+
+    for order in orders.all():
+        for case in order.cases:
+            for sample in case.samples:
+                if sample.original_ticket == str(order.ticket_id):
+                    order.name = sample.order
+                    session.add(order)
+                    break
+
+
+def downgrade():
+    pass

--- a/alembic/versions/2026_08_06_5f3c86391226_move_order_to_order_table.py
+++ b/alembic/versions/2026_08_06_5f3c86391226_move_order_to_order_table.py
@@ -123,7 +123,7 @@ def upgrade():
     for order in orders.all():
         for case in order.cases:
             for sample in case.samples:
-                if not sample.order:
+                if order.name or not sample.order:
                     continue
                 elif sample.original_ticket == str(order.ticket_id):
                     order.name = sample.order
@@ -176,13 +176,13 @@ def downgrade():
                 elif sample.original_ticket == str(order.ticket_id):
                     sample.order = order.name
                     session.add(sample)
-                    break
+                    continue
                 # If unable to match on original ticket, check if it is the only order the sample has been in
                 elif len(sample.links) == 1:
                     if len(sample.links[0].case.orders) == 1:
                         sample.order = order.name
                         session.add(sample)
-                        break
+                        continue
         for pool in order.pools:
             if pool.order:
                 continue

--- a/alembic/versions/2026_08_06_5f3c86391226_move_order_to_order_table.py
+++ b/alembic/versions/2026_08_06_5f3c86391226_move_order_to_order_table.py
@@ -176,13 +176,11 @@ def downgrade():
                 elif sample.original_ticket == str(order.ticket_id):
                     sample.order = order.name
                     session.add(sample)
-                    continue
                 # If unable to match on original ticket, check if it is the only order the sample has been in
                 elif len(sample.links) == 1:
                     if len(sample.links[0].case.orders) == 1:
                         sample.order = order.name
                         session.add(sample)
-                        continue
         for pool in order.pools:
             if pool.order:
                 continue

--- a/alembic/versions/2026_08_06_5f3c86391226_move_order_to_order_table.py
+++ b/alembic/versions/2026_08_06_5f3c86391226_move_order_to_order_table.py
@@ -55,7 +55,6 @@ class Order(Base):
     __tablename__ = "order"
 
     id: Mapped[PrimaryKeyInt]
-    order: Mapped[str | None]
     cases: Mapped[list["Case"]] = relationship(secondary=order_case, back_populates="orders")
     name: Mapped[str | None]
     ticket_id: Mapped[int]
@@ -149,6 +148,7 @@ def downgrade():
         table_name="pool",
         column=sa.Column(name="order", type_=mysql.VARCHAR(64, charset="latin1"), nullable=True),
     )
+    op.drop_constraint(constraint_name="_order_name_uc", table_name="pool", type_="unique")
     op.create_unique_constraint(
         constraint_name="order_name_uc", table_name="pool", columns=["order", "name"]
     )
@@ -189,3 +189,4 @@ def downgrade():
         existing_type=mysql.VARCHAR(64, charset="latin1"),
         nullable=False,
     )
+    op.drop_column(table_name="order", column_name="name")

--- a/alembic/versions/2026_08_06_5f3c86391226_move_order_to_order_table.py
+++ b/alembic/versions/2026_08_06_5f3c86391226_move_order_to_order_table.py
@@ -135,6 +135,10 @@ def upgrade():
                         break
     session.commit()
     op.drop_column(table_name="sample", column_name="order")
+    op.drop_constraint(constraint_name="_order_name_uc", table_name="pool", type_="unique")
+    op.create_unique_constraint(
+        constraint_name="_order_name_uc", table_name="pool", columns=["order_id", "name"]
+    )
     op.drop_column(table_name="pool", column_name="order")
 
 

--- a/alembic/versions/2026_08_06_5f3c86391226_move_order_to_order_table.py
+++ b/alembic/versions/2026_08_06_5f3c86391226_move_order_to_order_table.py
@@ -157,7 +157,7 @@ def downgrade():
     )
     op.drop_constraint(constraint_name="_order_name_uc", table_name="pool", type_="unique")
     op.create_unique_constraint(
-        constraint_name="order_name_uc", table_name="pool", columns=["order", "name"]
+        constraint_name="_order_name_uc", table_name="pool", columns=["order", "name"]
     )
     op.add_column(
         table_name="sample",

--- a/alembic/versions/2026_08_06_5f3c86391226_move_order_to_order_table.py
+++ b/alembic/versions/2026_08_06_5f3c86391226_move_order_to_order_table.py
@@ -109,6 +109,9 @@ class Pool(Base):
 def upgrade():
     bind: sa.Connection = op.get_bind()
     session = Session(bind=bind)
+    op.create_index(
+        index_name="pool_order_id_ix", table_name="pool", columns=["order_id"]
+    )  # This was missing
     op.add_column(
         table_name="order",
         column=sa.Column(name="name", type_=mysql.VARCHAR(64), nullable=True, index=True),
@@ -132,6 +135,10 @@ def upgrade():
                         order.name = sample.order
                         session.add(order)
                         break
+        if not order.name:
+            for pool in order.pools:
+                if pool.order:
+                    order.name = pool.order
     session.commit()
     op.drop_column(table_name="sample", column_name="order")
     op.drop_constraint(constraint_name="_order_name_uc", table_name="pool", type_="unique")
@@ -190,3 +197,4 @@ def downgrade():
         nullable=False,
     )
     op.drop_column(table_name="order", column_name="name")
+    op.drop_index(table_name="pool", index_name="pool_order_id_ix")

--- a/alembic/versions/2026_08_06_5f3c86391226_move_order_to_order_table.py
+++ b/alembic/versions/2026_08_06_5f3c86391226_move_order_to_order_table.py
@@ -6,6 +6,7 @@ Create Date: 2026-08-06 11:11:15.435937
 
 """
 
+from datetime import datetime
 from typing import Annotated
 
 import sqlalchemy as sa
@@ -58,6 +59,9 @@ class Order(Base):
     cases: Mapped[list["Case"]] = relationship(secondary=order_case, back_populates="orders")
     name: Mapped[str | None]
     ticket_id: Mapped[int]
+    pools: Mapped[list["Pool"]] = relationship(
+        back_populates="db_order", order_by="Pool.ordered_at"
+    )
 
 
 class Case(Base):
@@ -94,15 +98,21 @@ class Sample(Base):
     original_ticket: Mapped[str | None]
 
 
+class Pool(Base):
+    __tablename__ = "pool"
+    id: Mapped[PrimaryKeyInt]
+    order: Mapped[str]
+    order_id: Mapped[int] = mapped_column(sa.ForeignKey("order.id"))
+    db_order: Mapped[Order] = relationship(back_populates="pools", foreign_keys=[order_id])
+    ordered_at: Mapped[datetime]
+
+
 def upgrade():
     bind: sa.Connection = op.get_bind()
     session = Session(bind=bind)
     op.add_column(
         table_name="order",
-        column=sa.Column(
-            name="name",
-            type_=mysql.VARCHAR(64),
-        ),
+        column=sa.Column(name="name", type_=mysql.VARCHAR(64), nullable=True, index=True),
     )
     orders = session.query(Order).options(
         selectinload(Order.cases).selectinload(Case.links).selectinload(CaseSample.sample)
@@ -111,11 +121,67 @@ def upgrade():
     for order in orders.all():
         for case in order.cases:
             for sample in case.samples:
-                if sample.original_ticket == str(order.ticket_id):
+                if not sample.order:
+                    continue
+                elif sample.original_ticket == str(order.ticket_id):
                     order.name = sample.order
                     session.add(order)
                     break
+                # If unable to match on original ticket, check if it is the only order the sample has been in
+                elif len(sample.links) == 1:
+                    if len(sample.links[0].case.orders) == 1:
+                        order.name = sample.order
+                        session.add(order)
+                        break
+    session.commit()
+    op.drop_column(table_name="sample", column_name="order")
+    op.drop_column(table_name="pool", column_name="order")
 
 
 def downgrade():
-    pass
+    bind: sa.Connection = op.get_bind()
+    session = Session(bind=bind)
+    op.add_column(
+        table_name="pool",
+        column=sa.Column(name="order", type_=mysql.VARCHAR(64, charset="latin1"), nullable=True),
+    )
+    op.create_unique_constraint(
+        constraint_name="order_name_uc", table_name="pool", columns=["order", "name"]
+    )
+    op.add_column(
+        table_name="sample",
+        column=sa.Column(name="order", type_=mysql.VARCHAR(64, charset="latin1"), nullable=True),
+    )
+    orders = session.query(Order).options(
+        selectinload(Order.pools),
+        selectinload(Order.cases).selectinload(Case.links).selectinload(CaseSample.sample),
+    )
+
+    for order in orders.all():
+        for case in order.cases:
+            for sample in case.samples:
+                if sample.order:
+                    continue
+                elif sample.original_ticket == str(order.ticket_id):
+                    sample.order = order.name
+                    session.add(sample)
+                    break
+                # If unable to match on original ticket, check if it is the only order the sample has been in
+                elif len(sample.links) == 1:
+                    if len(sample.links[0].case.orders) == 1:
+                        sample.order = order.name
+                        session.add(sample)
+                        break
+        for pool in order.pools:
+            if pool.order:
+                continue
+            else:
+                pool.order = order.name
+                session.add(pool)
+    session.commit()
+    op.alter_column(
+        table_name="pool",
+        column_name="order",
+        existing_type=mysql.VARCHAR(64, charset="latin1"),
+        nullable=False,
+    )

--- a/cg/cli/add.py
+++ b/cg/cli/add.py
@@ -299,15 +299,16 @@ def add_case(
     if not order:
         LOG.warning(f"No order found with ticket_id {ticket}")
         click.confirm("No order found for the given ticket, proceed?", default=False, abort=True)
+        order_name: str = click.prompt("What should the new order's name be?")
         order = Order(
             customer_id=customer.id,
-            name=f"OrderFor{new_case.internal_id}",
+            name=order_name,
             ticket_id=int(ticket),
         )
         LOG.info(f"Created order with name OrderFor{new_case.internal_id}")
     new_case.orders.append(order)
 
-    new_case.customer: Customer = customer
+    new_case.customer = customer
     status_db.session.add(new_case)
     status_db.session.commit()
     LOG.info(f"{new_case.internal_id}: new case added")

--- a/cg/cli/add.py
+++ b/cg/cli/add.py
@@ -305,7 +305,6 @@ def add_case(
             name=order_name,
             ticket_id=int(ticket),
         )
-        LOG.info(f"Created order with name OrderFor{new_case.internal_id}")
     new_case.orders.append(order)
 
     new_case.customer = customer

--- a/cg/cli/add.py
+++ b/cg/cli/add.py
@@ -156,7 +156,6 @@ def add_user(context: CGConfig, admin: bool, customer_id: str, email: str, name:
 @click.option(
     "-d", "--down-sampled", type=int, help="How many reads is the sample down sampled to?"
 )
-@click.option("-o", "--order", help="Name of the order the sample belongs to")
 @click.option(
     "-s",
     "--sex",
@@ -193,7 +192,6 @@ def add_sample(
     lims_id: str | None,
     lims_status: LimsStatus,
     name: str,
-    order: str | None,
     original_ticket: str,
     priority: Priority,
     sex: Sex,
@@ -201,11 +199,13 @@ def add_sample(
     """Add a sample for CUSTOMER_ID with a NAME (display)."""
     status_db: Store = context.status_db
 
-    customer: Customer = status_db.get_customer_by_internal_id(customer_internal_id=customer_id)
+    customer: Customer | None = status_db.get_customer_by_internal_id(
+        customer_internal_id=customer_id
+    )
     if not customer:
         LOG.error(f"Customer: {customer_id} not found")
         raise click.Abort
-    application: Application = status_db.get_application_by_tag(tag=application_tag)
+    application: Application | None = status_db.get_application_by_tag(tag=application_tag)
     if not application:
         LOG.error(f"Application: {application_tag} not found")
         raise click.Abort
@@ -215,7 +215,6 @@ def add_sample(
         internal_id=lims_id,
         lims_status=lims_status,
         name=name,
-        order=order,
         original_ticket=original_ticket,
         priority=priority,
         sex=sex,
@@ -270,13 +269,15 @@ def add_case(
     """Add a case with the given name and associated with the given customer"""
     status_db: Store = context.status_db
 
-    customer: Customer = status_db.get_customer_by_internal_id(customer_internal_id=customer_id)
+    customer: Customer | None = status_db.get_customer_by_internal_id(
+        customer_internal_id=customer_id
+    )
     if customer is None:
         LOG.error(f"{customer_id}: customer not found")
         raise click.Abort
 
     for panel_abbreviation in panel_abbreviations:
-        panel: Panel = status_db.get_panel_by_abbreviation(abbreviation=panel_abbreviation)
+        panel: Panel | None = status_db.get_panel_by_abbreviation(abbreviation=panel_abbreviation)
 
         if panel is None:
             LOG.error(f"{panel_abbreviation}: panel not found")
@@ -294,14 +295,16 @@ def add_case(
         priority=priority,
         ticket=ticket,
     )
-    order: Order = status_db.get_order_by_ticket_id(int(ticket))
+    order: Order | None = status_db.get_order_by_ticket_id(int(ticket))
     if not order:
         LOG.warning(f"No order found with ticket_id {ticket}")
         click.confirm("No order found for the given ticket, proceed?", default=False, abort=True)
         order = Order(
             customer_id=customer.id,
+            name=f"OrderFor{new_case.internal_id}",
             ticket_id=int(ticket),
         )
+        LOG.info(f"Created order with name OrderFor{new_case.internal_id}")
     new_case.orders.append(order)
 
     new_case.customer: Customer = customer

--- a/cg/models/downsample/downsample_data.py
+++ b/cg/models/downsample/downsample_data.py
@@ -96,8 +96,7 @@ class DownsampleData:
             internal_id=self.downsampled_sample_name,
             last_sequenced_at=self.original_sample.last_sequenced_at,
             lims_status=self.original_sample.lims_status,
-            name=self.downsampled_sample_name,
-            order=self.original_sample.order,
+            name=self.downsampled_sample_name,  # How important is it to have the old order name?
             prepared_at=self.original_sample.prepared_at,
             priority=Priority.standard,
             reads=multiply_by_million(self.number_of_reads),

--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -770,13 +770,13 @@ class PoolView(BaseView):
         "delivered_at",
         "name",
         "no_invoice",
-        "order",
+        "db_order.name",
         "ordered_at",
         "received_at",
         "db_order.ticket_id",
     ]
-    column_labels = {"db_order.ticket_id": "Ticket"}
-    column_searchable_list = ["name", "order", "db_order.ticket_id", "customer.internal_id"]
+    column_labels = {"db_order.ticket_id": "Ticket", "db_order.name": "Order"}
+    column_searchable_list = ["name", "db_order.name", "db_order.ticket_id", "customer.internal_id"]
 
 
 class SampleView(BaseView):

--- a/cg/services/orders/storing/implementations/case_order_service.py
+++ b/cg/services/orders/storing/implementations/case_order_service.py
@@ -130,7 +130,6 @@ class StoreCaseOrderService(StoreOrderService):
         self,
         case: Case,
         customer: Customer,
-        order_name: str,
         ordered: datetime,
         sample: SampleInCase,
         ticket: str,
@@ -229,7 +228,6 @@ class StoreCaseOrderService(StoreOrderService):
                     db_sample: DbSample = self._create_db_sample(
                         case=case,
                         customer=customer,
-                        order_name=order.name,
                         ordered=datetime.now(),
                         sample=sample,
                         ticket=str(order._generated_ticket_id),

--- a/cg/services/orders/storing/implementations/case_order_service.py
+++ b/cg/services/orders/storing/implementations/case_order_service.py
@@ -147,7 +147,6 @@ class StoreCaseOrderService(StoreOrderService):
             internal_id=sample._generated_lims_id,
             lims_status=lims_status,
             no_invoice=application_version.application.is_external,
-            order=order_name,
             ordered=ordered,
             original_ticket=ticket,
             priority=case.priority,
@@ -175,11 +174,10 @@ class StoreCaseOrderService(StoreOrderService):
         return db_case
 
     def _create_db_order(self, order: OrderWithCases) -> DbOrder:
-        customer: Customer = self.status_db.get_customer_by_internal_id(
-            customer_internal_id=order.customer
-        )
+        customer: Customer = self.status_db.get_customer_by_internal_id_strict(order.customer)
         return DbOrder(
             customer=customer,
+            name=order.name,
             order_date=datetime.now(),
             ticket_id=order._generated_ticket_id,
         )

--- a/cg/services/orders/storing/implementations/fastq_order_service.py
+++ b/cg/services/orders/storing/implementations/fastq_order_service.py
@@ -79,7 +79,7 @@ class StoreFastqOrderService(StoreOrderService):
         customer: Customer = self.status_db.get_customer_by_internal_id(
             customer_internal_id=order.customer
         )
-        return self.status_db.add_order(customer=customer, ticket_id=ticket_id)
+        return self.status_db.add_order(customer=customer, name=order.name, ticket_id=ticket_id)
 
     def _create_db_case_for_sample(
         self,
@@ -120,7 +120,6 @@ class StoreFastqOrderService(StoreOrderService):
             lims_status=lims_status,
             name=sample.name,
             no_invoice=application_version.application.is_external,
-            order=order_name,
             ordered=datetime.now(),
             original_ticket=ticket_id,
             priority=sample.priority,

--- a/cg/services/orders/storing/implementations/fastq_order_service.py
+++ b/cg/services/orders/storing/implementations/fastq_order_service.py
@@ -56,7 +56,6 @@ class StoreFastqOrderService(StoreOrderService):
                 )
                 db_sample: Sample = self._create_db_sample(
                     sample=sample,
-                    order_name=order.name,
                     ticket_id=str(db_order.ticket_id),
                     customer=db_order.customer,
                 )
@@ -101,9 +100,7 @@ class StoreFastqOrderService(StoreOrderService):
         case.customer = customer
         return case
 
-    def _create_db_sample(
-        self, sample: FastqSample, order_name: str, customer: Customer, ticket_id: str
-    ) -> Sample:
+    def _create_db_sample(self, sample: FastqSample, customer: Customer, ticket_id: str) -> Sample:
         """Return a Sample database object."""
         application_version: ApplicationVersion = (
             self.status_db.get_current_application_version_by_tag(tag=sample.application)

--- a/cg/services/orders/storing/implementations/metagenome_order_service.py
+++ b/cg/services/orders/storing/implementations/metagenome_order_service.py
@@ -50,7 +50,7 @@ class StoreMetagenomeOrderService(StoreOrderService):
         customer: Customer = self.status_db.get_customer_by_internal_id(order.customer)
         new_samples = []
         db_order: DbOrder = self.status_db.add_order(
-            customer=customer, ticket_id=order._generated_ticket_id
+            customer=customer, name=order.name, ticket_id=order._generated_ticket_id
         )
         with self.status_db.session.no_autoflush:
             for sample in order.samples:
@@ -106,7 +106,6 @@ class StoreMetagenomeOrderService(StoreOrderService):
             lims_status=lims_status,
             name=sample.name,
             no_invoice=application_version.application.is_external,
-            order=order.name,
             ordered=datetime.now(),
             original_ticket=order._generated_ticket_id,
             priority=sample.priority,

--- a/cg/services/orders/storing/implementations/microbial_fastq_order_service.py
+++ b/cg/services/orders/storing/implementations/microbial_fastq_order_service.py
@@ -79,7 +79,7 @@ class StoreMicrobialFastqOrderService(StoreOrderService):
         customer: Customer = self.status_db.get_customer_by_internal_id(
             customer_internal_id=order.customer
         )
-        return self.status_db.add_order(customer=customer, ticket_id=ticket_id)
+        return self.status_db.add_order(customer=customer, name=order.name, ticket_id=ticket_id)
 
     def _create_db_case_for_sample(
         self, sample: MicrobialFastqSample, customer: Customer, order: MicrobialFastqOrder
@@ -119,7 +119,6 @@ class StoreMicrobialFastqOrderService(StoreOrderService):
             lims_status=lims_status,
             name=sample.name,
             no_invoice=application_version.application.is_external,
-            order=order_name,
             ordered=datetime.now(),
             original_ticket=ticket_id,
             priority=sample.priority,

--- a/cg/services/orders/storing/implementations/microbial_fastq_order_service.py
+++ b/cg/services/orders/storing/implementations/microbial_fastq_order_service.py
@@ -56,7 +56,6 @@ class StoreMicrobialFastqOrderService(StoreOrderService):
                 )
                 db_sample: Sample = self._create_db_sample(
                     sample=sample,
-                    order_name=order.name,
                     ticket_id=str(db_order.ticket_id),
                     customer=db_order.customer,
                 )
@@ -100,7 +99,6 @@ class StoreMicrobialFastqOrderService(StoreOrderService):
     def _create_db_sample(
         self,
         sample: MicrobialFastqSample,
-        order_name: str,
         ticket_id: str,
         customer: Customer,
     ) -> Sample:

--- a/cg/services/orders/storing/implementations/microbial_order_service.py
+++ b/cg/services/orders/storing/implementations/microbial_order_service.py
@@ -59,6 +59,7 @@ class StoreMicrobialOrderService(StoreOrderService):
         new_samples = []
         db_order: DbOrder = self.status_db.add_order(
             customer=customer,
+            name=order.name,
             ticket_id=order._generated_ticket_id,
         )
         db_case: DbCase = self._create_case(customer=customer, order=order)
@@ -144,7 +145,6 @@ class StoreMicrobialOrderService(StoreOrderService):
             lims_status=lims_status,
             name=sample.name,
             no_invoice=application_version.application.is_external,
-            order=order_name,
             ordered=datetime.now(),
             organism=organism,
             original_ticket=str(ticket_id),

--- a/cg/services/orders/storing/implementations/microbial_order_service.py
+++ b/cg/services/orders/storing/implementations/microbial_order_service.py
@@ -69,7 +69,6 @@ class StoreMicrobialOrderService(StoreOrderService):
                 organism: Organism = self._ensure_organism(sample)
                 db_sample = self._create_db_sample(
                     customer=customer,
-                    order_name=order.name,
                     organism=organism,
                     sample=sample,
                     ticket_id=order._generated_ticket_id,
@@ -124,7 +123,6 @@ class StoreMicrobialOrderService(StoreOrderService):
     def _create_db_sample(
         self,
         customer: Customer,
-        order_name: str,
         organism: Organism,
         sample: MicrobialSample,
         ticket_id: int,

--- a/cg/services/orders/storing/implementations/pacbio_order_service.py
+++ b/cg/services/orders/storing/implementations/pacbio_order_service.py
@@ -78,10 +78,8 @@ class StorePacBioOrderService(StoreOrderService):
     def _create_db_order(self, order: PacbioOrder) -> Order:
         """Return an Order database object."""
         ticket_id: int = order._generated_ticket_id
-        customer: Customer = self.status_db.get_customer_by_internal_id(
-            customer_internal_id=order.customer
-        )
-        return self.status_db.add_order(customer=customer, ticket_id=ticket_id)
+        customer: Customer = self.status_db.get_customer_by_internal_id_strict(order.customer)
+        return self.status_db.add_order(customer=customer, name=order.name, ticket_id=ticket_id)
 
     def _create_db_case_for_sample(
         self, sample: PacbioSample, customer: Customer, order: PacbioOrder
@@ -116,7 +114,6 @@ class StorePacBioOrderService(StoreOrderService):
             lims_status=lims_status,
             name=sample.name,
             no_invoice=application_version.application.is_external,
-            order=order_name,
             ordered=datetime.now(),
             original_ticket=ticket_id,
             priority=sample.priority,

--- a/cg/services/orders/storing/implementations/pacbio_order_service.py
+++ b/cg/services/orders/storing/implementations/pacbio_order_service.py
@@ -58,7 +58,6 @@ class StorePacBioOrderService(StoreOrderService):
                 )
                 db_sample: Sample = self._create_db_sample(
                     sample=sample,
-                    order_name=order.name,
                     customer=status_db_order.customer,
                     ticket_id=str(status_db_order.ticket_id),
                 )
@@ -96,9 +95,7 @@ class StorePacBioOrderService(StoreOrderService):
         case.customer = customer
         return case
 
-    def _create_db_sample(
-        self, sample: PacbioSample, order_name: str, customer: Customer, ticket_id: str
-    ) -> Sample:
+    def _create_db_sample(self, sample: PacbioSample, customer: Customer, ticket_id: str) -> Sample:
         """Return a Sample database object."""
         application_version: ApplicationVersion = (
             self.status_db.get_current_application_version_by_tag(tag=sample.application)

--- a/cg/services/orders/storing/implementations/pool_order_service.py
+++ b/cg/services/orders/storing/implementations/pool_order_service.py
@@ -61,7 +61,6 @@ class StorePoolOrderService(StoreOrderService):
                 for sample in pool[1]:
                     db_sample: Sample = self._create_db_sample(
                         sample=sample,
-                        order_name=order.name,
                         ticket_id=str(db_order.ticket_id),
                         customer=db_order.customer,
                         application_version=db_pool.application_version,
@@ -152,7 +151,6 @@ class StorePoolOrderService(StoreOrderService):
     def _create_db_sample(
         self,
         sample: IndexedSample,
-        order_name: str,
         ticket_id: str,
         customer: Customer,
         application_version: ApplicationVersion,

--- a/cg/services/orders/storing/implementations/pool_order_service.py
+++ b/cg/services/orders/storing/implementations/pool_order_service.py
@@ -56,7 +56,6 @@ class StorePoolOrderService(StoreOrderService):
                 db_pool: Pool = self._create_db_pool(
                     db_order=db_order,
                     pool=pool,
-                    order_name=order.name,
                     customer=db_order.customer,
                 )
                 for sample in pool[1]:
@@ -110,10 +109,8 @@ class StorePoolOrderService(StoreOrderService):
     def _create_db_order(self, order: OrderWithIndexedSamples) -> Order:
         """Return an Order database object."""
         ticket_id: int = order._generated_ticket_id
-        customer: Customer = self.status_db.get_customer_by_internal_id(
-            customer_internal_id=order.customer
-        )
-        return self.status_db.add_order(customer=customer, ticket_id=ticket_id)
+        customer: Customer = self.status_db.get_customer_by_internal_id_strict(order.customer)
+        return self.status_db.add_order(customer=customer, name=order.name, ticket_id=ticket_id)
 
     def _create_db_case_for_pool(
         self,
@@ -138,7 +135,6 @@ class StorePoolOrderService(StoreOrderService):
         self,
         pool: tuple[str, list[IndexedSample]],
         db_order: Order,
-        order_name: str,
         customer: Customer,
     ) -> Pool:
         """Return a Pool database object."""
@@ -149,7 +145,6 @@ class StorePoolOrderService(StoreOrderService):
             application_version=application_version,
             customer=customer,
             name=pool[0],
-            order=order_name,
             ordered=datetime.now(),
             db_order=db_order,
         )
@@ -176,7 +171,6 @@ class StorePoolOrderService(StoreOrderService):
             lims_status=lims_status,
             name=sample.name,
             no_invoice=True,
-            order=order_name,
             ordered=datetime.now(),
             original_ticket=ticket_id,
             pool=pool,

--- a/cg/services/orders/storing/implementations/taxprofiler_order_service.py
+++ b/cg/services/orders/storing/implementations/taxprofiler_order_service.py
@@ -48,9 +48,9 @@ class StoreTaxprofilerOrderService(StoreOrderService):
     ) -> list[DbSample]:
         """Store samples in the StatusDB database."""
         new_samples = []
-        customer: Customer = self.status_db.get_customer_by_internal_id(order.customer)
+        customer: Customer = self.status_db.get_customer_by_internal_id_strict(order.customer)
         db_order: DbOrder = self.status_db.add_order(
-            customer=customer, ticket_id=order._generated_ticket_id
+            customer=customer, name=order.name, ticket_id=order._generated_ticket_id
         )
         priority: PriorityEnum = order.samples[0].priority
         db_case: DbCase = self._create_db_case(order=order, customer=customer, priority=priority)
@@ -103,7 +103,6 @@ class StoreTaxprofilerOrderService(StoreOrderService):
             lims_status=lims_status,
             name=sample.name,
             no_invoice=application_version.application.is_external,
-            order=order.name,
             ordered=datetime.now(),
             original_ticket=order._generated_ticket_id,
             priority=sample.priority,

--- a/cg/store/crud/create.py
+++ b/cg/store/crud/create.py
@@ -194,7 +194,6 @@ class CreateMixin(ReadHandler):
         downsampled_to: int = None,
         internal_id: str = None,
         last_sequenced_at: datetime = None,
-        order: str = None,
         ordered: datetime = None,
         pool: Pool | None = None,
         prepared_at: datetime = None,
@@ -217,7 +216,6 @@ class CreateMixin(ReadHandler):
             is_tumour=tumour,
             last_sequenced_at=last_sequenced_at,
             name=name,
-            order=order,
             ordered_at=ordered or datetime.now(),
             original_ticket=original_ticket,
             pool=pool,
@@ -323,7 +321,6 @@ class CreateMixin(ReadHandler):
         self,
         customer: Customer,
         name: str,
-        order: str,
         ordered: datetime,
         application_version: ApplicationVersion,
         db_order: Order,
@@ -339,7 +336,6 @@ class CreateMixin(ReadHandler):
         new_record: Pool = Pool(
             name=name,
             ordered_at=ordered or datetime.now(),
-            order=order,
             db_order=db_order,
             received_at=received_at,
             comment=comment,
@@ -399,10 +395,11 @@ class CreateMixin(ReadHandler):
             **kwargs,
         )
 
-    def add_order(self, customer: Customer, ticket_id: int, **kwargs) -> Order:
+    def add_order(self, customer: Customer, name: str, ticket_id: int, **kwargs) -> Order:
         """Build a new Order record."""
         order = Order(
             customer=customer,
+            name=name,
             order_date=datetime.now(),
             ticket_id=ticket_id,
             **kwargs,

--- a/cg/store/crud/read.py
+++ b/cg/store/crud/read.py
@@ -611,11 +611,12 @@ class ReadHandler(BaseHandler):
 
     def get_pools_by_order_enquiry(self, *, order_enquiry: str = None) -> list[Pool]:
         """Return all the pools with an order fitting the enquiry."""
-        return apply_pool_filter(
-            pools=self._get_query(table=Pool),
-            order_enquiry=order_enquiry,
-            filter_functions=[PoolFilter.BY_ORDER_ENQUIRY],
-        ).all()
+        return (
+            self._get_query(table=Pool)
+            .join(Pool.db_order)
+            .filter(Order.name.contains(order_enquiry))
+            .all()
+        )
 
     def get_pool_by_entry_id(self, entry_id: int) -> Pool:
         """Return a pool by entry id."""

--- a/cg/store/filters/status_pool_filters.py
+++ b/cg/store/filters/status_pool_filters.py
@@ -16,11 +16,6 @@ def filter_pools_by_name_enquiry(pools: Query, name_enquiry: str, **kwargs) -> Q
     return pools.filter(Pool.name.contains(name_enquiry))
 
 
-def filter_pools_by_order_enquiry(pools: Query, order_enquiry: str, **kwargs) -> Query:
-    """Return pools by order enquiry."""
-    return pools.filter(Pool.order.contains(order_enquiry))
-
-
 def filter_pools_by_entry_id(pools: Query, entry_id: int, **kwargs) -> Query:
     """Return pools by entry id."""
     return pools.filter(Pool.id == entry_id)
@@ -120,6 +115,5 @@ class PoolFilter(Enum):
     DO_INVOICE: Callable = filter_pools_do_invoice
     BY_CUSTOMER_IDS: Callable = filter_pools_by_customer_ids
     BY_NAME_ENQUIRY: Callable = filter_pools_by_name_enquiry
-    BY_ORDER_ENQUIRY: Callable = filter_pools_by_order_enquiry
     BY_CUSTOMER: Callable = filter_pools_by_customer
     BY_CUSTOMERS: Callable = filter_pools_by_customers

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -726,7 +726,6 @@ class Pool(Base):
     invoice_id: Mapped[int | None] = mapped_column(ForeignKey("invoice.id"))
     name: Mapped[Str32]
     no_invoice: Mapped[bool | None] = mapped_column(default=False)
-    order: Mapped[Str64]
     order_id: Mapped[int] = mapped_column(ForeignKey("order.id"))
     db_order: Mapped["Order"] = orm.relationship(foreign_keys=[order_id])
     ordered_at: Mapped[datetime]
@@ -735,12 +734,18 @@ class Pool(Base):
     invoice: Mapped["Invoice | None"] = orm.relationship(back_populates="pools")
     samples: Mapped[list["Sample"]] = orm.relationship(back_populates="pool")
 
-    def to_dict(self):
-        return to_dict(model_instance=self)
+    @property
+    def order(self):
+        return self.db_order.name
 
     @property
     def ticket(self) -> str | None:
         return str(self.db_order.ticket_id) if self.db_order else None
+
+    def to_dict(self):
+        pool_dict = to_dict(model_instance=self)
+        pool_dict["order"] = self.order
+        return pool_dict
 
 
 class Sample(Base, PriorityMixin):
@@ -772,7 +777,6 @@ class Sample(Base, PriorityMixin):
     loqusdb_id: Mapped[Str64 | None]
     name: Mapped[Str128]
     no_invoice: Mapped[bool] = mapped_column(default=False)
-    order: Mapped[Str64 | None]
     ordered_at: Mapped[datetime]
     organism_id: Mapped[int | None] = mapped_column(ForeignKey("organism.id"))
     organism: Mapped["Organism | None"] = orm.relationship(foreign_keys=[organism_id])
@@ -1012,6 +1016,13 @@ class Sample(Base, PriorityMixin):
             .label("ticket_id_from_original_order")
         )
 
+    @property
+    def order(self):
+        if case := self.case_that_delivers:
+            if order := case.original_order:
+                return order.name
+        return None
+
     def to_dict(self, links: bool = False) -> dict:
         """Represent as dictionary"""
         data = to_dict(model_instance=self)
@@ -1021,6 +1032,7 @@ class Sample(Base, PriorityMixin):
         data["application"] = self.application_version.application.to_dict()
         data["hifi_yield"] = self.hifi_yield
         data["uses_reads"] = True
+        data["order"] = self.order
         if self.device_type == DeviceType.PACBIO:
             data["uses_reads"] = False
         if links:
@@ -1088,6 +1100,7 @@ class Order(Base):
     cases: Mapped[list[Case]] = orm.relationship(secondary=order_case, back_populates="orders")
     customer_id: Mapped[int] = mapped_column(ForeignKey("customer.id"))
     customer: Mapped[Customer] = orm.relationship(foreign_keys=[customer_id])
+    name: Mapped[str]
     order_date: Mapped[datetime] = mapped_column(default=datetime.now)
     ticket_id: Mapped[int] = mapped_column(unique=True, index=True)
     is_open: Mapped[bool] = mapped_column(default=True)

--- a/cg/store/models.py
+++ b/cg/store/models.py
@@ -711,7 +711,7 @@ class Panel(Base):
 
 class Pool(Base):
     __tablename__ = "pool"
-    __table_args__ = (UniqueConstraint("order", "name", name="_order_name_uc"),)
+    __table_args__ = (UniqueConstraint("order_id", "name", name="_order_name_uc"),)
 
     application_version_id: Mapped[int] = mapped_column(ForeignKey("application_version.id"))
     application_version: Mapped["ApplicationVersion"] = orm.relationship(
@@ -1016,12 +1016,28 @@ class Sample(Base, PriorityMixin):
             .label("ticket_id_from_original_order")
         )
 
-    @property
-    def order(self):
+    @hybrid_property
+    def order(self) -> str | None:
         if case := self.case_that_delivers:
             if order := case.original_order:
                 return order.name
         return None
+
+    @order.expression
+    @classmethod
+    def order(cls) -> SQLColumnExpression[int]:
+        return (
+            select(Order.name)
+            .join(Order.cases)
+            .join(Case.links)
+            .where(
+                CaseSample.sample_id == cls.id,
+                CaseSample.should_deliver_sample.is_(True),
+            )
+            .order_by(Order.order_date.asc())
+            .limit(1)
+            .label("order")
+        )
 
     def to_dict(self, links: bool = False) -> dict:
         """Represent as dictionary"""

--- a/tests/cli/add/test_cli_add_family.py
+++ b/tests/cli/add/test_cli_add_family.py
@@ -43,7 +43,7 @@ def test_add_case_required(
             name,
         ],
         obj=base_context,
-        input="y",
+        input="y\nOrderForCase",
     )
 
     # THEN it should be added
@@ -85,7 +85,7 @@ def test_add_case_bad_workflow(
             customer_id,
             name,
         ],
-        input="y",
+        input="y\nOrderForCase",
     )
 
     # THEN it should not be added
@@ -123,7 +123,7 @@ def test_add_case_bad_data_delivery(
             name,
         ],
         obj=base_context,
-        input="y",
+        input="y\nOrderForCase",
     )
 
     # THEN it should not be added
@@ -155,7 +155,7 @@ def test_add_case_bad_customer(cli_runner: CliRunner, base_context: CGConfig, ti
             name,
         ],
         obj=base_context,
-        input="y",
+        input="y\nOrderForCase",
     )
 
     # THEN it should complain about missing customer instead of adding a case
@@ -230,7 +230,7 @@ def test_add_case_priority(
             name,
         ],
         obj=base_context,
-        input="y",
+        input="y\nOrderForCase",
     )
 
     # THEN it should be added

--- a/tests/cli/add/test_cli_add_sample.py
+++ b/tests/cli/add/test_cli_add_sample.py
@@ -154,49 +154,6 @@ def test_add_sample_lims_id(cli_runner: CliRunner, base_context: CGConfig, helpe
     assert sample_query.first().internal_id == lims_id
 
 
-def test_add_sample_order(
-    cli_runner: CliRunner,
-    base_context: CGConfig,
-    disk_store: Store,
-    helpers: StoreHelpers,
-    application_tag: str,
-):
-    """Test adding a sample using an external sample id."""
-    # GIVEN a database with a customer and an application
-    helpers.ensure_application(store=disk_store, tag=application_tag)
-    helpers.ensure_application_version(store=disk_store, application_tag=application_tag)
-    customer: Customer = helpers.ensure_customer(store=disk_store)
-    name = "sample_name"
-    order = "sample_order"
-    original_ticket = "dummy ticket"
-    # WHEN adding a sample
-    result = cli_runner.invoke(
-        add,
-        [
-            "sample",
-            "--sex",
-            Sex.MALE,
-            "--application-tag",
-            application_tag,
-            "--original-ticket",
-            original_ticket,
-            "--lims-status",
-            "re-prep",
-            "--order",
-            order,
-            customer.internal_id,
-            name,
-        ],
-        obj=base_context,
-    )
-
-    # THEN it should be added
-    assert result.exit_code == EXIT_SUCCESS
-    sample_query = disk_store._get_query(table=Sample)
-    assert sample_query.count() == 1
-    assert sample_query.first().order == order
-
-
 def test_add_sample_when_down_sampled(
     cli_runner,
     base_context: CGConfig,

--- a/tests/cli/delete/test_cli_delete_cases.py
+++ b/tests/cli/delete/test_cli_delete_cases.py
@@ -17,7 +17,6 @@ def test_set_cases_by_sample_identifiers(
     # GIVEN a database with a case with a sample
     sample_obj = helpers.add_sample(base_store)
     sample_obj.original_ticket = ticket_id
-    sample_obj.order = "An order"
     case = helpers.add_case(base_store)
     helpers.add_relationship(base_store, sample=sample_obj, case=case)
     identifier_value = getattr(sample_obj, identifier_key)

--- a/tests/cli/set/test_cli_set_cases.py
+++ b/tests/cli/set/test_cli_set_cases.py
@@ -26,7 +26,6 @@ def test_set_cases_by_sample_identifiers(
     base_store: Store = base_context.status_db
     new_sample: Sample = helpers.add_sample(base_store)
     new_sample.original_ticket: str = ticket_id
-    new_sample.order: str = "An order"
     case: Case = helpers.add_case(base_store)
     helpers.add_relationship(base_store, sample=new_sample, case=case)
     identifier_value = getattr(new_sample, identifier_key)

--- a/tests/cli/workflow/fluffy/conftest.py
+++ b/tests/cli/workflow/fluffy/conftest.py
@@ -14,22 +14,22 @@ from cg.store.store import Store
 from tests.store_helpers import StoreHelpers
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def fluffy_case_id_existing(selected_novaseq_6000_post_1_5_kits_case_ids: list[str]) -> str:
     return selected_novaseq_6000_post_1_5_kits_case_ids[0]
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def fluffy_case_id_non_existing():
     return "nakedmolerat"
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def fluffy_sample_lims_id(selected_novaseq_6000_post_1_5_kits_sample_ids):
     return selected_novaseq_6000_post_1_5_kits_sample_ids[0]
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def fluffy_success_output_summary(tmpdir_factory):
     output_dir = tmpdir_factory.mktemp("output")
     file_path = Path(output_dir, "summary.csv")
@@ -37,7 +37,7 @@ def fluffy_success_output_summary(tmpdir_factory):
     return file_path
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def fluffy_success_output_aberrations(tmpdir_factory):
     output_dir = tmpdir_factory.mktemp("output")
     file_path = Path(output_dir, "WCXpredict_aberrations.filt.bed")
@@ -63,7 +63,7 @@ def sample() -> Sample:
     )
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def fluffy_fastq_file_path(config_root_dir):
     path = Path(config_root_dir)
     path.mkdir(parents=True, exist_ok=True)
@@ -72,7 +72,7 @@ def fluffy_fastq_file_path(config_root_dir):
     return fastq_path
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def deliverables_yaml_path():
     return Path("tests/fixtures/apps/fluffy/deliverables.yaml")
 
@@ -108,7 +108,7 @@ def fluffy_hermes_deliverables_response_data(
     )
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def fluffy_fastq_hk_bundle_data(
     fluffy_fastq_file_path: Path,
     fluffy_sample_lims_id: str,
@@ -128,7 +128,7 @@ def fluffy_fastq_hk_bundle_data(
     }
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def fluffy_samplesheet_bundle_data(
     novaseq_6000_post_1_5_kits_correct_sample_sheet_path: Path,
     novaseq_6000_post_1_5_kits_flow_cell_id: str,
@@ -147,7 +147,7 @@ def fluffy_samplesheet_bundle_data(
     }
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def fluffy_store(
     store_with_illumina_sequencing_data: Store,
     fluffy_case_id_existing: str,
@@ -163,7 +163,7 @@ def fluffy_store(
     return store_with_illumina_sequencing_data
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def fluffy_context(
     cg_context: CGConfig,
     helpers: StoreHelpers,

--- a/tests/cli/workflow/fluffy/conftest.py
+++ b/tests/cli/workflow/fluffy/conftest.py
@@ -9,7 +9,7 @@ from cg.constants import SequencingFileTag, Workflow
 from cg.constants.constants import CaseActions
 from cg.meta.workflow.fluffy import FluffyAnalysisAPI
 from cg.models.cg_config import CGConfig
-from cg.store.models import Case, Sample
+from cg.store.models import Case, CaseSample, Customer, Order, Sample
 from cg.store.store import Store
 from tests.store_helpers import StoreHelpers
 
@@ -52,11 +52,14 @@ def bcl_convert_samplesheet_path() -> Path:
 
 @pytest.fixture
 def sample() -> Sample:
+    order = Order(customer=Customer(), name="order-name", ticket_id=123)
+    case = Case(internal_id="case_id", orders=[order])
+    case_sample = CaseSample(case=case, should_deliver_sample=True)
     return Sample(
         name="sample_name",
-        order="sample_project",
         control="positive",
         last_sequenced_at=dt.datetime.now(),
+        links=[case_sample],
     )
 
 

--- a/tests/fixture_plugins/analysis_starter/store_fixtures.py
+++ b/tests/fixture_plugins/analysis_starter/store_fixtures.py
@@ -52,7 +52,7 @@ def microsalt_store(base_store: Store, helpers: StoreHelpers) -> Store:
         status=StatusEnum.unknown,
         should_deliver_sample=True,
     )
-    order: Order = base_store.add_order(customer=customer, ticket_id=1)
+    order: Order = base_store.add_order(customer=customer, name="order_name", ticket_id=1)
     microsalt_case.orders.append(order)
     base_store.add_item_to_store(microsalt_case)
     base_store.add_item_to_store(microsalt_sample)

--- a/tests/meta/archive/conftest.py
+++ b/tests/meta/archive/conftest.py
@@ -272,8 +272,7 @@ def archive_store(
         case=case, sample=new_samples[0], status="unknown", should_deliver_sample=True
     )
     order = Order(
-        customer_id=customer_ddn.id,
-        ticket_id=new_samples[0].original_ticket,
+        customer_id=customer_ddn.id, ticket_id=new_samples[0].original_ticket, name="order_name"
     )
     base_store.session.add(order)
     base_store.session.add(case)

--- a/tests/meta/archive/conftest.py
+++ b/tests/meta/archive/conftest.py
@@ -272,7 +272,9 @@ def archive_store(
         case=case, sample=new_samples[0], status="unknown", should_deliver_sample=True
     )
     order = Order(
-        customer_id=customer_ddn.id, ticket_id=new_samples[0].original_ticket, name="order_name"
+        customer_id=customer_ddn.id,
+        name="order_name",
+        ticket_id=new_samples[0].original_ticket,
     )
     base_store.session.add(order)
     base_store.session.add(case)

--- a/tests/services/orders/store_service/test_fastq_order_service.py
+++ b/tests/services/orders/store_service/test_fastq_order_service.py
@@ -102,7 +102,7 @@ def test_create_db_sample_with_lims_status_and_invoice(
 
     # WHEN creating a db sample with the application
     store_order_service._create_db_sample(
-        sample=fastq_sample, order_name="order", customer=customer, ticket_id="1234567"
+        sample=fastq_sample, customer=customer, ticket_id="1234567"
     )
 
     # THEN the sample should be created with the expected lims status

--- a/tests/services/orders/store_service/test_generic_order_store_service.py
+++ b/tests/services/orders/store_service/test_generic_order_store_service.py
@@ -321,7 +321,6 @@ def test_create_db_sample_with_lims_status_and_invoice(
         case=case,
         sample=rna_fusion_sample,
         customer=customer,
-        order_name="any_old_string",
         ordered=datetime.now(),
         ticket="1234567",
     )

--- a/tests/services/orders/store_service/test_generic_order_store_service.py
+++ b/tests/services/orders/store_service/test_generic_order_store_service.py
@@ -193,8 +193,9 @@ def test_store_tomte_order(
     assert new_link
 
 
-def test_store_rnafusion_sample_is_set_to_tumour(store: Store, mocker: MockerFixture):
+def test_store_rnafusion_sample_is_set_to_tumour():
     # GIVEN an RNAFusion order with a new sample in it
+    store: Store = create_autospec(Store)
     rna_fusion_sample = RNAFusionSample(
         application="rnafusiontag",
         container=ContainerEnum.tube,
@@ -214,16 +215,8 @@ def test_store_rnafusion_sample_is_set_to_tumour(store: Store, mocker: MockerFix
 
     # GIVEN that persisting to StatusDB and LIMS is successful
     application_version = ApplicationVersion(application=Application())
-    mocker.patch.object(
-        store, "get_current_application_version_by_tag", return_value=application_version
-    )
-    mocker.patch.object(
-        store, "get_customer_by_internal_id_strict", return_value=create_autospec(Customer)
-    )
-    mocker.patch.object(store, "get_lims_workflow_id_by_application_tag")
-    mocker.patch.object(store, "add_multiple_items_to_store")
-    mocker.patch.object(store, "add_item_to_store")
-    mocker.patch.object(store, "commit_to_store")
+    store.get_current_application_version_by_tag = Mock(return_value=application_version)
+    store.get_customer_by_internal_id_strict = Mock(return_value=create_autospec(Customer))
     lims_service: OrderLimsService = create_autospec(
         OrderLimsService, lims_api=create_autospec(LimsAPI)
     )

--- a/tests/services/orders/store_service/test_generic_order_store_service.py
+++ b/tests/services/orders/store_service/test_generic_order_store_service.py
@@ -217,7 +217,12 @@ def test_store_rnafusion_sample_is_set_to_tumour(store: Store, mocker: MockerFix
     mocker.patch.object(
         store, "get_current_application_version_by_tag", return_value=application_version
     )
+    mocker.patch.object(
+        store, "get_customer_by_internal_id_strict", return_value=create_autospec(Customer)
+    )
     mocker.patch.object(store, "get_lims_workflow_id_by_application_tag")
+    mocker.patch.object(store, "add_multiple_items_to_store")
+    mocker.patch.object(store, "add_item_to_store")
     mocker.patch.object(store, "commit_to_store")
     lims_service: OrderLimsService = create_autospec(
         OrderLimsService, lims_api=create_autospec(LimsAPI)

--- a/tests/services/orders/store_service/test_microbial_fastq_order_store_service.py
+++ b/tests/services/orders/store_service/test_microbial_fastq_order_store_service.py
@@ -88,7 +88,7 @@ def test_create_db_sample_with_lims_status_and_invoice(
 
     # WHEN creating a db sample with the application
     store_order_service._create_db_sample(
-        sample=micro_fastq_sample, order_name="order", customer=customer, ticket_id="1234567"
+        sample=micro_fastq_sample, customer=customer, ticket_id="1234567"
     )
 
     # THEN the sample should be created with LimsStatus DONE if the application was external

--- a/tests/services/orders/store_service/test_microbial_store_order_service.py
+++ b/tests/services/orders/store_service/test_microbial_store_order_service.py
@@ -158,7 +158,6 @@ def test_create_db_sample_with_lims_status_and_invoice(
     # WHEN creating a db sample with the application
     store_order_service._create_db_sample(
         customer=customer,
-        order_name="order",
         organism=create_autospec(Organism),
         sample=fastq_sample,
         ticket_id=1234567,

--- a/tests/services/orders/store_service/test_pacbio_order_service.py
+++ b/tests/services/orders/store_service/test_pacbio_order_service.py
@@ -88,7 +88,7 @@ def test_create_db_sample_with_lims_status_and_invoice(
 
     # WHEN creating a db sample with the application
     store_order_service._create_db_sample(
-        sample=fastq_sample, order_name="order", customer=customer, ticket_id="1234567"
+        sample=fastq_sample, customer=customer, ticket_id="1234567"
     )
 
     # THEN the sample should be created with LimsStatus DONE if the application is external

--- a/tests/services/orders/store_service/test_pool_order_store_service.py
+++ b/tests/services/orders/store_service/test_pool_order_store_service.py
@@ -127,7 +127,6 @@ def test_create_db_sample_with_lims_status_and_invoice(
     store_order_service._create_db_sample(
         application_version=application_version,
         customer=customer,
-        order_name="order",
         pool=create_autospec(Pool),
         sample=fastq_sample,
         ticket_id="1234567",

--- a/tests/store/conftest.py
+++ b/tests/store/conftest.py
@@ -124,7 +124,6 @@ def store_with_a_sample_that_has_many_attributes_and_one_without(
         capture_kit=StoreConstants.CAPTURE_KIT_SAMPLE_WITH_ATTRIBUTES.value,
         comment=StoreConstants.COMMENT_SAMPLE_WITH_ATTRIBUTES.value,
         from_sample=StoreConstants.FROM_SAMPLE_SAMPLE_WITH_ATTRIBUTES.value,
-        order=StoreConstants.ORDER_SAMPLE_WITH_ATTRIBUTES.value,
         priority=StoreConstants.PRIORITY_SAMPLE_WITH_ATTRIBUTES.value,
         reference_genome=StoreConstants.REFERENCE_GENOME_SAMPLE_WITH_ATTRIBUTES.value,
         sex=StoreConstants.SEX_SAMPLE_WITH_ATTRIBUTES.value,
@@ -163,7 +162,6 @@ def store_with_a_pool_with_and_without_attributes(
         invoice_id=StoreConstants.INVOICE_ID_POOL_WITH_ATTRIBUTES.value,
         no_invoice=False,
         name=StoreConstants.NAME_POOL_WITH_ATTRIBUTES.value,
-        order=StoreConstants.ORDER_POOL_WITH_ATTRIBUTES.value,
     )
 
     helpers.ensure_pool(
@@ -384,11 +382,10 @@ def rml_pool_store(
         },
     )
     store.session.add(app_version)
-    test_order = store.add_order(customer=new_customer, ticket_id=int(ticket_id))
+    test_order = store.add_order(customer=new_customer, name="order_name", ticket_id=int(ticket_id))
     new_pool = store.add_pool(
         customer=new_customer,
         name="Test",
-        order="Test",
         ordered=dt.datetime.now(),
         application_version=app_version,
         db_order=test_order,

--- a/tests/store/crud/add/test_store_add_base.py
+++ b/tests/store/crud/add/test_store_add_base.py
@@ -128,13 +128,12 @@ def test_add_pool(rml_pool_store: Store):
         .filter(ApplicationVersion.application_id == application.id)
         .first()
     )
-    db_order: Order = rml_pool_store.get_order_by_ticket_id(123456)
+    db_order: Order = rml_pool_store.get_order_by_ticket_id_strict(123456)
 
     # WHEN adding a new pool
     new_pool = rml_pool_store.add_pool(
         customer=customer,
         name="pool2",
-        order="123456",
         ordered=dt.now(),
         application_version=app_version,
         db_order=db_order,

--- a/tests/store/crud/conftest.py
+++ b/tests/store/crud/conftest.py
@@ -471,7 +471,6 @@ def store_with_multiple_pools_for_customer(
             store=store,
             customer_id=customer_id,
             name="_".join(["pool", str(number)]),
-            order="_".join(["pool", "order", str(number)]),
         )
     yield store
 

--- a/tests/store/crud/read/test_read.py
+++ b/tests/store/crud/read/test_read.py
@@ -1045,19 +1045,17 @@ def test_get_pools_to_render_with(
     assert len(pools) == 2
 
 
-def test_get_pools_to_render_with_customer(
-    store_with_multiple_pools_for_customer: Store,
-):
+def test_get_pools_to_render_with_customer(store: Store, helpers: StoreHelpers):
     """Test that pools can be fetched from the store by customer id."""
-    # GIVEN a database with two pools
+    # GIVEN a database with two pools tied to different customers
+    pool_1: Pool = helpers.ensure_pool(store=store, customer_id="cust_to_fetch", name="pool_1")
+    helpers.ensure_pool(store=store, customer_id="cust_to_not_fetch", name="pool_2")
 
-    # WHEN getting pools by customer id
-    pools: list[Pool] = store_with_multiple_pools_for_customer.get_pools_to_render(
-        customers=store_with_multiple_pools_for_customer.get_customers()
-    )
+    # WHEN getting pools using the customer id of the first pool
+    pools: list[Pool] = store.get_pools_to_render(customers=[pool_1.customer])
 
-    # THEN two pools should be returned
-    assert len(pools) == 2
+    # THEN only the first pool should be returned
+    assert pools == [pool_1]
 
 
 def test_get_pools_to_render_with_customer_and_name_enquiry(
@@ -1079,19 +1077,22 @@ def test_get_pools_to_render_with_customer_and_name_enquiry(
 def test_get_pools_to_render_with_customer_and_order_enquiry(store: Store, helpers: StoreHelpers):
     """Test that pools can be fetched from the store by customer id."""
     # GIVEN a database with two pools belonging to different orders
-    customer = helpers.ensure_customer(store=store)
-    order_1 = store.add_order(customer=customer, name="order_1", ticket_id=1)
-    order_2 = store.add_order(customer=customer, name="order_2", ticket_id=2)
-    store.add_multiple_items_to_store([order_1, order_2])
+    customer_1 = helpers.ensure_customer(
+        store=store, customer_id="customer_id_1", customer_name="customer name 1"
+    )
+    customer_2 = helpers.ensure_customer(
+        store=store, customer_id="customer_id_2", customer_name="customer name 2"
+    )
+    order_1 = store.add_order(customer=customer_1, name="order_1", ticket_id=1)
+    order_2 = store.add_order(customer=customer_2, name="order_2", ticket_id=2)
+    store.add_multiple_items_to_store([customer_1, customer_2, order_1, order_2])
     store.commit_to_store()
 
     pool_1 = helpers.ensure_pool(store=store, ticket=1)
     helpers.ensure_pool(store=store, ticket=2)
 
-    # WHEN fetching pools by customer id and order enquiry
-    pools: list[Pool] = store.get_pools_to_render(
-        customers=store.get_customers(), enquiry="order_1"
-    )
+    # WHEN fetching pools by order enquiry
+    pools: list[Pool] = store.get_pools_to_render(enquiry="order_1")
 
     # THEN only the first pool should be returned
     assert pools == [pool_1]

--- a/tests/store/crud/read/test_read.py
+++ b/tests/store/crud/read/test_read.py
@@ -1014,19 +1014,23 @@ def test_get_pools_by_name_enquiry(store_with_multiple_pools_for_customer: Store
     assert len(pools) == 1
 
 
-def test_get_pools_by_order_enquiry(
-    store_with_multiple_pools_for_customer: Store, pool_order_1: str
-):
+def test_get_pools_by_order_enquiry(store: Store, helpers: StoreHelpers):
     """Test that pools can be fetched from the store by customer id."""
     # GIVEN a database with two pools
+    customer = helpers.ensure_customer(store=store)
+    order_1 = store.add_order(customer=customer, name="order_1", ticket_id=1)
+    order_2 = store.add_order(customer=customer, name="order_2", ticket_id=2)
+    store.add_multiple_items_to_store([order_1, order_2])
+    store.commit_to_store()
+
+    pool_1 = helpers.ensure_pool(store=store, ticket=1)
+    helpers.ensure_pool(store=store, ticket=2)
 
     # WHEN getting pools by customer id
-    pools: list[Pool] = store_with_multiple_pools_for_customer.get_pools_by_order_enquiry(
-        order_enquiry=pool_order_1
-    )
+    pools: list[Pool] = store.get_pools_by_order_enquiry(order_enquiry="order_1")
 
-    # THEN one pool should be returned
-    assert len(pools) == 1
+    # THEN only pool 1 should be returned
+    assert pools == [pool_1]
 
 
 def test_get_pools_to_render_with(
@@ -1072,20 +1076,25 @@ def test_get_pools_to_render_with_customer_and_name_enquiry(
     assert len(pools) == 1
 
 
-def test_get_pools_to_render_with_customer_and_order_enquiry(
-    store_with_multiple_pools_for_customer: Store,
-    pool_order_1: str,
-):
+def test_get_pools_to_render_with_customer_and_order_enquiry(store: Store, helpers: StoreHelpers):
     """Test that pools can be fetched from the store by customer id."""
-    # GIVEN a database with two pools
+    # GIVEN a database with two pools belonging to different orders
+    customer = helpers.ensure_customer(store=store)
+    order_1 = store.add_order(customer=customer, name="order_1", ticket_id=1)
+    order_2 = store.add_order(customer=customer, name="order_2", ticket_id=2)
+    store.add_multiple_items_to_store([order_1, order_2])
+    store.commit_to_store()
+
+    pool_1 = helpers.ensure_pool(store=store, ticket=1)
+    helpers.ensure_pool(store=store, ticket=2)
 
     # WHEN fetching pools by customer id and order enquiry
-    pools: list[Pool] = store_with_multiple_pools_for_customer.get_pools_to_render(
-        customers=store_with_multiple_pools_for_customer.get_customers(), enquiry=pool_order_1
+    pools: list[Pool] = store.get_pools_to_render(
+        customers=store.get_customers(), enquiry="order_1"
     )
 
-    # THEN one pools should be returned
-    assert len(pools) == 1
+    # THEN only the first pool should be returned
+    assert pools == [pool_1]
 
 
 def test_get_case_by_name_and_customer_case_found(store_with_multiple_cases_and_samples: Store):

--- a/tests/store/crud/read/test_read_order.py
+++ b/tests/store/crud/read/test_read_order.py
@@ -9,12 +9,14 @@ from tests.store_helpers import StoreHelpers
 def test_get_order_by_ticket_id_strict_success(store: Store, helpers: StoreHelpers):
     # GIVEN a store with two orders with different ticket IDs
     order_1: Order = store.add_order(
-        ticket_id=123,
         customer=helpers.ensure_customer(store),
+        name="order_1",
+        ticket_id=123,
     )
     order_2: Order = store.add_order(
-        ticket_id=456,
         customer=helpers.ensure_customer(store),
+        name="order_2",
+        ticket_id=456,
     )
     store.add_multiple_items_to_store([order_1, order_2])
 

--- a/tests/store/crud/read/test_read_sample.py
+++ b/tests/store/crud/read/test_read_sample.py
@@ -17,7 +17,7 @@ from cg.server.dto.samples.requests import (
     SortDirection,
     UnhandledSamplesSortBy,
 )
-from cg.store.models import Case, Customer, Invoice, OrderTypeApplication, Sample
+from cg.store.models import Case, CaseSample, Customer, Invoice, OrderTypeApplication, Sample
 from cg.store.store import Store
 from tests.store_helpers import StoreHelpers
 
@@ -564,10 +564,17 @@ def test_get_samples_by_customer_id_and_pattern_name(store: Store, helpers: Stor
     sample_to_query_via_internal_id: Sample = helpers.add_sample(
         customer_id="cust000", internal_id="internal_id_to_search_for", store=store
     )
-    sample_to_query_via_order: Sample = helpers.add_sample(
-        customer_id="cust000", order="order_to_search_for", store=store
-    )
+    sample_to_query_via_order: Sample = helpers.add_sample(customer_id="cust000", store=store)
     customer: Customer = sample_to_query_via_name.customer
+    order = store.add_order(customer=customer, name="order_to_search_for", ticket_id=123)
+    store.add_item_to_store(order)
+    store.commit_to_store()
+    case = helpers.ensure_case(store=store, order=order)
+    case_sample: CaseSample = store.relate_sample(
+        case=case, sample=sample_to_query_via_order, status="affected", should_deliver_sample=True
+    )
+    store.add_item_to_store(case_sample)
+    store.commit_to_store()
 
     # WHEN getting samples via customers and pattern
     samples_matching_name, _ = store.get_samples_by_customers_and_pattern(

--- a/tests/store/filters/test_status_order_filters.py
+++ b/tests/store/filters/test_status_order_filters.py
@@ -1,6 +1,5 @@
 from sqlalchemy.orm import Query
 
-from cg.constants import Workflow
 from cg.store.filters.status_order_filters import filter_orders_by_ticket_id
 from cg.store.models import Order
 from cg.store.store import Store
@@ -12,6 +11,7 @@ def test_filter_orders_by_ticket_no_matching_ticket(base_store: Store, non_exist
     order = Order(
         id=1,
         customer_id=1,
+        name="order",
         ticket_id=1,
     )
     base_store.session.add(order)
@@ -31,6 +31,7 @@ def test_filter_orders_by_ticket_id_matching_ticket(base_store: Store, ticket_id
     order = Order(
         id=1,
         customer_id=1,
+        name="order",
         ticket_id=int(ticket_id),
     )
     base_store.session.add(order)

--- a/tests/store/filters/test_status_pool_filters.py
+++ b/tests/store/filters/test_status_pool_filters.py
@@ -4,7 +4,6 @@ from cg.store.filters.status_pool_filters import (
     filter_pools_by_customer_ids,
     filter_pools_by_invoice_id,
     filter_pools_by_name_enquiry,
-    filter_pools_by_order_enquiry,
     filter_pools_do_invoice,
     filter_pools_is_delivered,
     filter_pools_is_not_delivered,
@@ -213,33 +212,6 @@ def test_filter_pools_by_name_enquiry(
     pools: Query = filter_pools_by_name_enquiry(
         pools=store_with_a_pool_with_and_without_attributes._get_query(table=Pool),
         name_enquiry=StoreConstants.NAME_POOL_WITH_ATTRIBUTES.value,
-    )
-
-    # THEN a Query is returned
-    assert isinstance(pools, Query)
-
-    # THEN pools should contain the test pool
-    assert pools.all()
-
-    # THEN only one pool should be returned
-    assert len(pools.all()) == 1
-
-    # THEN the pool should have the expected name
-    assert pools.all()[0].name == name
-
-
-def test_filter_pools_by_order_enquiry(
-    store_with_a_pool_with_and_without_attributes: Store,
-    name=StoreConstants.NAME_POOL_WITH_ATTRIBUTES.value,
-):
-    """Test that a pool is returned when there is a pool with a specific order enquiry."""
-
-    # GIVEN a store with two pools of which one has an order enquiry
-
-    # WHEN getting pools with order enquiry
-    pools: Query = filter_pools_by_order_enquiry(
-        pools=store_with_a_pool_with_and_without_attributes._get_query(table=Pool),
-        order_enquiry=StoreConstants.ORDER_POOL_WITH_ATTRIBUTES.value,
     )
 
     # THEN a Query is returned

--- a/tests/store_helpers.py
+++ b/tests/store_helpers.py
@@ -1053,7 +1053,7 @@ class StoreHelpers:
         )
         db_order: Order | None = store.get_order_by_ticket_id(ticket)
         if ticket and not db_order:
-            db_order = store.add_order(customer=customer, name="order_name", ticket_id=int(ticket))
+            db_order = store.add_order(customer=customer, name="order_name", ticket_id=ticket)
 
         pool = store.add_pool(
             name=name,

--- a/tests/store_helpers.py
+++ b/tests/store_helpers.py
@@ -548,11 +548,10 @@ class StoreHelpers:
         customer_id: int,
         ticket_id: int,
         order_date: datetime = datetime(year=2023, month=12, day=24),
+        name: str = "order_name",
     ) -> Order:
         order = Order(
-            customer_id=customer_id,
-            ticket_id=ticket_id,
-            order_date=order_date,
+            customer_id=customer_id, ticket_id=ticket_id, order_date=order_date, name=name
         )
         store.session.add(order)
         store.session.commit()
@@ -604,8 +603,7 @@ class StoreHelpers:
         """Load a case with samples and link relations from a dictionary."""
         customer_obj = StoreHelpers.ensure_customer(store)
         order = store.get_order_by_ticket_id(ticket_id=int(case_info["tickets"])) or Order(
-            ticket_id=int(case_info["tickets"]),
-            customer_id=customer_obj.id,
+            ticket_id=int(case_info["tickets"]), customer_id=customer_obj.id, name="order_name"
         )
         case = Case(
             name=case_info["name"],
@@ -1028,7 +1026,6 @@ class StoreHelpers:
         store: Store,
         customer_id: str = "cust000",
         name: str = "test_pool",
-        order: str = "test_order",
         application_tag: str = "dummy_tag",
         application_type: str = "tgs",
         is_external: bool = False,
@@ -1037,11 +1034,13 @@ class StoreHelpers:
         received_at: datetime = None,
         no_invoice: bool = None,
         invoice_id: int = None,
-        ticket: str = "123456",
+        ticket: int = 123456,
     ) -> Pool:
         """Utility function to add a pool that can be used in tests."""
         customer_id = customer_id or "cust000"
-        customer: Customer = store.get_customer_by_internal_id(customer_internal_id=customer_id)
+        customer: Customer | None = store.get_customer_by_internal_id(
+            customer_internal_id=customer_id
+        )
         if not customer:
             customer = StoreHelpers.ensure_customer(store, customer_id=customer_id)
 
@@ -1054,14 +1053,13 @@ class StoreHelpers:
         )
         db_order: Order | None = store.get_order_by_ticket_id(ticket)
         if ticket and not db_order:
-            db_order = store.add_order(customer=customer, ticket_id=int(ticket))
+            db_order = store.add_order(customer=customer, name="order_name", ticket_id=int(ticket))
 
         pool = store.add_pool(
             name=name,
             ordered=datetime.now(),
             application_version=application_version,
             customer=customer,
-            order=order,
             delivered_at=delivered_at,
             received_at=received_at,
             no_invoice=no_invoice,


### PR DESCRIPTION
## Description

Closes #5179

### Added

- New column name on the Order table
- Index on the order_id column in the Pool table.

### Changed

- Column order is dropped from the pool table. The value is accessed via the relationship to the order table in a new property with the same name
- Column order is dropped from the sample table. The value is accessed via the relationships to the order table in a new property with the same name

### Fixed

- Back population of the name column is performed using the values in the sample and pool tables, before the columns are dropped in the sample and pool tables.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b move-order-to-order -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
