### PR TITLE
Add validation rule for consistent prep category in Balsamic

### DIFF
--- a/cg/services/orders/validation/order_types/balsamic/validation_rules.py
+++ b/cg/services/orders/validation/order_types/balsamic/validation_rules.py
@@ -7,6 +7,7 @@ from cg.services.orders.validation.rules.case.rules import (
     validate_case_names_not_repeated,
     validate_existing_cases_belong_to_collaboration,
     validate_number_of_normal_samples,
+    validate_samples_in_case_have_same_prep_category,
 )
 from cg.services.orders.validation.rules.case_sample.rules import (
     reset_optional_capture_kits,
@@ -45,6 +46,7 @@ BALSAMIC_CASE_RULES: list[Callable] = [
     validate_case_names_not_repeated,
     validate_existing_cases_belong_to_collaboration,
     validate_number_of_normal_samples,
+    validate_samples_in_case_have_same_prep_category,
 ]
 
 BALSAMIC_CASE_SAMPLE_RULES: list[Callable] = [


### PR DESCRIPTION
## Description
Add the existing case validation rule `validate_samples_in_case_have_same_prep_category` to the balsamic order validation


### How to prepare for test

- [x] Deploy to CGVS-stage

### How to test

- [x] Try to submit a Balsamic order with two samples with applications corresponding to different prep categories

### Expected test outcome

- [x] Check that a banner showing the error appears above the case
<img width="972" height="236" alt="Screenshot 2026-08-12 at 13 11 35" src="https://github.com/user-attachments/assets/b10294c5-32e6-4e75-8e2d-8c6ebe643e88" />


## Review

- [x] Tests executed by SD
- [x] "Merge and deploy" approved by IO
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

Deploy to:

- [x] CGVS-stage
- [x] CGVS-prod
