### PR TITLE
Verify that the workflow profile is correct

### DIFF
--- a/cg/cli/workflow/balsamic/base.py
+++ b/cg/cli/workflow/balsamic/base.py
@@ -1,6 +1,7 @@
 """CLI support to create config and/or start BALSAMIC."""
 
 import logging
+from pathlib import Path
 from typing import cast
 
 import rich_click as click
@@ -157,7 +158,7 @@ def config_case(cg_config: CGConfig, case_id: str, panel_bed: str | None):
 @OPTION_WORKFLOW_PROFILE
 @ARGUMENT_CASE_ID
 @click.pass_obj
-def run(cg_config: CGConfig, case_id: str, workflow_profile: click.Path | None):
+def run(cg_config: CGConfig, case_id: str, workflow_profile: Path | None):
     """
     Run a preconfigured Balsamic case.
 
@@ -179,7 +180,7 @@ def start(
     cg_config: CGConfig,
     case_id: str,
     panel_bed: str | None,
-    workflow_profile: click.Path | None,
+    workflow_profile: Path | None,
 ):
     """
     Starts a Balsamic cases.

--- a/cg/cli/workflow/balsamic/options.py
+++ b/cg/cli/workflow/balsamic/options.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import rich_click as click
 
 OPTION_PANEL_BED = click.option(
@@ -8,7 +10,7 @@ OPTION_PANEL_BED = click.option(
 )
 OPTION_WORKFLOW_PROFILE = click.option(
     "--workflow-profile",
-    type=click.Path(exists=True),
+    type=click.Path(exists=True, path_type=Path),
     required=False,
     help="Path to directory containing config.yaml.",
 )

--- a/cg/services/analysis_starter/configurator/implementations/balsamic_configurator.py
+++ b/cg/services/analysis_starter/configurator/implementations/balsamic_configurator.py
@@ -66,7 +66,12 @@ class BalsamicConfigurator(Configurator):
         return Path(self.root_dir, case_id, f"{case_id}.json")
 
     def _ensure_required_config_files_exist(self, config: BalsamicCaseConfig) -> None:
-        if not config.sample_config.exists():
+        if (
+            not config.sample_config.exists()
+            or not Path(config.workflow_profile, "config.yaml").exists()
+        ):
             raise CaseNotConfiguredError(
-                f"Please ensure that the config file {config.sample_config} exists."
+                f"Please ensure that the config file {config.sample_config} exists and that the "
+                f"workflow profile {config.workflow_profile} points to a directory containing a "
+                f"config.yaml file."
             )

--- a/tests/integration/workflows/test_balsamic.py
+++ b/tests/integration/workflows/test_balsamic.py
@@ -440,6 +440,7 @@ def _create_files_for_flags(test_root_dir: Path):
     create_empty_file(Path(test_root_dir, "loqusdb", "clinical_sv.vcf.gz"))
     create_empty_file(Path(test_root_dir, "swegen", "swegen_snv.vcf.gz"))
     create_empty_file(Path(test_root_dir, "swegen", "swegen_sv.vcf.gz"))
+    create_empty_file(Path(test_root_dir, "balsamic", "config.yaml"))
 
 
 def _create_tga_config_file(test_root_dir: Path, case: Case) -> Path:

--- a/tests/services/analysis_starter/test_balsamic_configurator.py
+++ b/tests/services/analysis_starter/test_balsamic_configurator.py
@@ -46,6 +46,10 @@ def test_get_config(
     Path(balsamic_configurator.root_dir, case_id).mkdir()
     Path(balsamic_configurator.root_dir, case_id, f"{case_id}.json").touch()
 
+    # GIVEN that the workflow profile contains a config.yaml
+    Path(balsamic_configurator.workflow_profile).mkdir()
+    Path(balsamic_configurator.workflow_profile, "config.yaml").touch()
+
     # GIVEN that the database returns a case with the provided case_id
     case_to_configure: Case = create_autospec(
         Case, internal_id=case_id, slurm_priority=SlurmQos.NORMAL
@@ -87,6 +91,10 @@ def test_get_config_with_flag(
     balsamic_configurator.root_dir = tmp_path
     Path(balsamic_configurator.root_dir, case_id).mkdir()
     Path(balsamic_configurator.root_dir, case_id, f"{case_id}.json").touch()
+
+    # GIVEN that the workflow profile contains a config.yaml
+    Path(balsamic_configurator.workflow_profile).mkdir()
+    Path(balsamic_configurator.workflow_profile, "config.yaml").touch()
 
     # GIVEN that the database returns a case with the provided case_id
     case_to_configure: Case = create_autospec(
@@ -140,6 +148,34 @@ def test_get_config_missing_config_file(
     # THEN it should raise a CaseNotConfiguredError
     with pytest.raises(CaseNotConfiguredError):
         balsamic_configurator.get_config(case_id=case_id)
+
+
+def test_get_config_faulty_workflow_profile(
+    balsamic_configurator: BalsamicConfigurator, case_id: str, tmp_path: Path
+):
+    """Tests that the get_config method raises an error if the workflow_profile flag does not point
+    to a directory containing a config.yaml file."""
+
+    # GIVEN a Balsamic configurator with an existing config file
+    balsamic_configurator.root_dir = tmp_path
+    Path(balsamic_configurator.root_dir, case_id).mkdir()
+    Path(balsamic_configurator.root_dir, case_id, f"{case_id}.json").touch()
+
+    # GIVEN that the database returns a case with the provided case_id
+    case_to_configure: Case = create_autospec(
+        Case, internal_id=case_id, slurm_priority=SlurmQos.NORMAL
+    )
+    balsamic_configurator.store.get_case_by_internal_id_strict = Mock(
+        return_value=case_to_configure
+    )
+    balsamic_configurator.store.get_case_workflow = Mock(return_value=Workflow.BALSAMIC)
+
+    # WHEN getting the config using a workflow_profile which does not contain a config.yaml
+    # THEN it should raise a CaseNotConfiguredError
+    with pytest.raises(CaseNotConfiguredError):
+        balsamic_configurator.get_config(
+            case_id=case_id, workflow_profile=Path("path/that/leads/nowhere")
+        )
 
 
 @pytest.mark.parametrize("workflow", [Workflow.BALSAMIC, Workflow.BALSAMIC_UMI])


### PR DESCRIPTION
## Description

Closes #5209. 

### Added

-

### Changed

-

### Fixed

- A workflow profile which does not point to a directory containing a config.yaml file results in a CaseNotConfiguredError.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b verify-workflow-profile-path -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
