### PR TITLE
Add case_ids parameter to set cases

### DIFF
--- a/cg/cli/delete/cases.py
+++ b/cg/cli/delete/cases.py
@@ -12,13 +12,13 @@ CONFIRM = "Continue?"
 LOG = logging.getLogger(__name__)
 
 
-def _get_samples_by_identifiers(identifiers: click.Tuple([str, str]), store: Store) -> [Sample]:
+def _get_samples_by_identifiers(identifiers: list[tuple[str, str]], store: Store) -> list[Sample]:
     """Get samples matched by given set of identifiers"""
     identifier_args = dict(identifiers)
-    return store.get_samples_by_any_id(**identifier_args)
+    return store.get_samples_by_any_id(identifier_args).all()
 
 
-def _get_cases(identifiers: click.Tuple([str, str]), store: Store) -> [Case]:
+def _get_cases(identifiers: list[tuple[str, str]], store: Store) -> set[Case]:
     """Get cases that have samples that match identifiers if given"""
     samples_by_id = _get_samples_by_identifiers(identifiers, store)
     _cases = set()
@@ -44,7 +44,7 @@ def _get_cases(identifiers: click.Tuple([str, str]), store: Store) -> [Case]:
 def delete_cases(
     context: click.Context,
     dry_run: bool,
-    identifiers: click.Tuple([str, str]),
+    identifiers: list[tuple[str, str]],
 ):
     """Delete many cases of samples at the same time"""
     store = context.obj.status_db

--- a/cg/cli/set/base.py
+++ b/cg/cli/set/base.py
@@ -73,8 +73,8 @@ def set_cmd():
 @click.pass_context
 def samples(
     context: click.Context,
-    identifiers: click.Tuple([str, str]),
-    kwargs: click.Tuple([str, str]),
+    identifiers: list[tuple[str, str]],
+    kwargs: list[tuple[str, str]],
     skip_lims: bool,
     skip_confirmation: bool,
     case_id: str,
@@ -105,7 +105,7 @@ def samples(
         )
 
 
-def _get_samples(case_id: str, identifiers: click.Tuple([str, str]), store: Store) -> list[Sample]:
+def _get_samples(case_id: str, identifiers: list[tuple[str, str]], store: Store) -> list[Sample]:
     """Get samples that match both case_id and identifiers if given."""
     samples_by_case_id = None
     samples_by_id = None
@@ -117,20 +117,20 @@ def _get_samples(case_id: str, identifiers: click.Tuple([str, str]), store: Stor
         samples_by_id: list[Sample] = _get_samples_by_identifiers(identifiers, store)
 
     if case_id and identifiers:
-        sample_objs = set(set(samples_by_case_id) & set(samples_by_id))
+        sample_objs = list(set(samples_by_case_id) & set(samples_by_id))
     else:
         sample_objs = samples_by_case_id or samples_by_id
 
     return sample_objs
 
 
-def _get_samples_by_identifiers(identifiers: click.Tuple([str, str]), store: Store) -> list[Sample]:
+def _get_samples_by_identifiers(identifiers: list[tuple[str, str]], store: Store) -> list[Sample]:
     """Get samples matched by given set of identifiers."""
     identifier_args = {
         identifier_name: identifier_value for identifier_name, identifier_value in identifiers
     }
 
-    return list(store.get_samples_by_any_id(**identifier_args))
+    return list(store.get_samples_by_any_id(identifier_args))
 
 
 def is_locked_attribute_on_sample(key: str, skip_attributes: list[str]) -> bool:

--- a/cg/cli/set/cases.py
+++ b/cg/cli/set/cases.py
@@ -14,32 +14,46 @@ CONFIRM = "Continue?"
 LOG = logging.getLogger(__name__)
 
 
-def _get_samples_by_identifiers(identifiers: click.Tuple([str, str]), store: Store) -> list[Sample]:
+def _get_samples_by_identifiers(
+    sample_identifiers: list[tuple[str, str]], store: Store
+) -> list[Sample]:
     """Get samples matched by given set of identifiers"""
-    identifier_args = dict(identifiers)
-    return list(store.get_samples_by_any_id(**identifier_args))
+    identifier_args = dict(sample_identifiers)
+    return list(store.get_samples_by_any_id(identifier_args))
 
 
-def _get_cases(identifiers: click.Tuple([str, str]), store: Store) -> list[Case]:
+def _get_cases(
+    case_ids: tuple[str], sample_identifiers: list[tuple[str, str]], store: Store
+) -> set[Case]:
     """Get cases that have samples that match identifiers if given"""
-    samples_by_id: list[Sample] = _get_samples_by_identifiers(identifiers, store)
+    samples_by_id: list[Sample] = _get_samples_by_identifiers(
+        sample_identifiers=sample_identifiers, store=store
+    )
     cases: set[Case] = set()
     for sample in samples_by_id:
         for link in sample.links:
             cases.add(link.case)
-
-    return list(cases)
+    cases = cases.union(set(store.get_cases_by_internal_ids(list(case_ids))))
+    return cases
 
 
 @click.command("cases")
 @click.option(
     "--sample-identifier",
-    "identifiers",
+    "sample_identifiers",
     nargs=2,
     type=click.Tuple([str, str]),
     multiple=True,
+    required=False,
     help="Give an identifier on sample and the value to use it with, e.g. --sample-identifier "
     "name Prov52",
+)
+@click.option(
+    "--case-id",
+    "case_ids",
+    multiple=True,
+    required=False,
+    help="Give a list of case internal ids on which to perform the action, e.g. --case-id case_1 --case-id case_2",
 )
 @click.option("-a", "--action", type=click.Choice(CaseActions.actions()), help="update case action")
 @click.option("-c", "--customer-id", type=click.STRING, help="update customer")
@@ -50,15 +64,22 @@ def _get_cases(identifiers: click.Tuple([str, str]), store: Store) -> list[Case]
 @click.pass_context
 def set_cases(
     context: click.Context,
+    case_ids: tuple[str] | None,
+    sample_identifiers: list[tuple[str, str]] | None,
     action: str | None,
     priority: Priority | None,
     panel_abbreviations: tuple[str] | None,
     customer_id: str | None,
-    identifiers: click.Tuple([str, str]),
 ):
     """Set values on many families at the same time"""
+    if not case_ids and not sample_identifiers:
+        LOG.error("You must provide either case ids or sample identifiers")
+        raise click.Abort
+
     store: Store = context.obj.status_db
-    cases_to_alter: list[Case] = _get_cases(identifiers, store)
+    cases_to_alter: set[Case] = _get_cases(
+        case_ids=case_ids, sample_identifiers=sample_identifiers, store=store
+    )
 
     if not cases_to_alter:
         LOG.error("No cases to alter!")

--- a/cg/cli/set/cases.py
+++ b/cg/cli/set/cases.py
@@ -26,13 +26,14 @@ def _get_cases(
     case_ids: tuple[str], sample_identifiers: list[tuple[str, str]], store: Store
 ) -> set[Case]:
     """Get cases that have samples that match identifiers if given"""
-    samples_by_id: list[Sample] = _get_samples_by_identifiers(
-        sample_identifiers=sample_identifiers, store=store
-    )
     cases: set[Case] = set()
-    for sample in samples_by_id:
-        for link in sample.links:
-            cases.add(link.case)
+    if sample_identifiers:
+        samples_by_id: list[Sample] = _get_samples_by_identifiers(
+            sample_identifiers=sample_identifiers, store=store
+        )
+        for sample in samples_by_id:
+            for link in sample.links:
+                cases.add(link.case)
     cases = cases.union(set(store.get_cases_by_internal_ids(list(case_ids))))
     return cases
 

--- a/cg/store/crud/read.py
+++ b/cg/store/crud/read.py
@@ -739,7 +739,7 @@ class ReadHandler(BaseHandler):
             customer_internal_id=customer_internal_id, subject_id=subject_id
         ).all()
 
-    def get_samples_by_any_id(self, **identifiers: dict) -> Query:
+    def get_samples_by_any_id(self, identifiers: dict) -> Query:
         """Return a sample query filtered by the given names and values of Sample attributes."""
         samples: Query = self._get_query(table=Sample).order_by(Sample.internal_id.desc())
         for identifier_name, identifier_value in identifiers.items():

--- a/tests/cli/set/test_cli_set_cases.py
+++ b/tests/cli/set/test_cli_set_cases.py
@@ -11,6 +11,7 @@ from cg.models.cg_config import CGConfig
 from cg.store.models import Case, Sample
 from cg.store.store import Store
 from tests.store_helpers import StoreHelpers
+from tests.typed_mock import TypedMock, create_typed_mock
 
 
 @pytest.mark.parametrize("identifier_key", ["original_ticket", "order"])
@@ -32,7 +33,7 @@ def test_set_cases_by_sample_identifiers(
 
     caplog.set_level(logging.INFO)
 
-    # WHEN calling set families with valid sample identifiers
+    # WHEN calling set cases with valid sample identifiers
     cli_runner.invoke(
         set_cases,
         ["--sample-identifier", identifier_key, identifier_value],
@@ -42,3 +43,19 @@ def test_set_cases_by_sample_identifiers(
     # THEN it should name the case to be changed
     assert case.internal_id in caplog.text
     assert case.name in caplog.text
+
+
+def test_set_cases_by_case_ids(cli_runner: CliRunner, base_context: CGConfig):
+    # GIVEN a store
+    status_db: TypedMock[Store] = create_typed_mock(Store)
+    base_context.status_db_ = status_db.as_type
+
+    # WHEN calling set_cases and providing a list of case_ids that are to be set with action 'hold'
+    cli_runner.invoke(
+        set_cases,
+        ["--case-id", "case_1", "--case-id", "case_2", "-a", "hold"],
+        obj=base_context,
+    )
+
+    # THEN the store should have been called with the provided case_ids
+    status_db.as_mock.get_cases_by_internal_ids.assert_called_once_with(["case_1", "case_2"])

--- a/tests/store/crud/read/test_read_sample.py
+++ b/tests/store/crud/read/test_read_sample.py
@@ -226,7 +226,7 @@ def test_get_samples_by_any_id_not_an_attribute_fails(
     # WHEN trying to filter using an attribute not of Sample
     with pytest.raises(AttributeError) as exc_info:
         store_with_a_sample_that_has_many_attributes_and_one_without.get_samples_by_any_id(
-            **identifiers
+            identifiers
         )
 
     # THEN the error message should contain the non-existent-attribute
@@ -256,7 +256,7 @@ def test_get_samples_by_any_id_exclusive_filtering_gives_empty_query(
     }
     filtered_query: Query = (
         store_with_a_sample_that_has_many_attributes_and_one_without.get_samples_by_any_id(
-            **identifiers
+            identifiers
         )
     )
 


### PR DESCRIPTION
## Description

Closes #5071, although I took the liberty to name the parameter case_id as I thought it would be more intuitive for the user.

### Added

- Option case_id to the CLI command set cases which can be provided multiple times.

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b case-identifier -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
