### PR TITLE
Remove misleading upload completion message

### DIFF
--- a/cg/cli/upload/base.py
+++ b/cg/cli/upload/base.py
@@ -105,7 +105,6 @@ def upload(context: click.Context, case_id: str | None, restart: bool):
 
         context.obj.meta_apis["upload_api"] = upload_api
         upload_api.upload(ctx=context, case=case, restart=restart)
-        click.echo(click.style(f"{case_id} analysis has been successfully uploaded", fg="green"))
     else:
         suggest_cases_to_upload(status_db=upload_api.status_db)
         raise click.Abort()

--- a/tests/cli/upload/test_cli_upload.py
+++ b/tests/cli/upload/test_cli_upload.py
@@ -96,4 +96,5 @@ def test_upload_raw_data_case(cli_runner: CliRunner, mocker: MockerFixture):
 
     # THEN the upload succeeds and RawDataUploadAPI.upload is called
     assert result.exit_code == EXIT_SUCCESS
+    assert f"{case.internal_id} analysis has been successfully uploaded" not in result.output
     raw_data_upload_api.as_mock.upload.assert_called_once_with(ctx=ANY, case=case, restart=False)


### PR DESCRIPTION
## Summary
- Remove the final “analysis has been successfully uploaded” message from `cg upload`.
- Add test coverage confirming successful command execution no longer prints that message.

The upload command submits background SLURM jobs, which may still be pending when the command exits. Removing the completion message ensures stdout accurately reflects the upload state and does not imply that processing has already finished.

Closes https://github.com/Clinical-Genomics/cg/issues/5169

This PR was generated by a supervised coding agent (BountyHunter v0.1) and reviewed by a human before submission.