### PR TITLE
Fix typehint for Order external_samples

### DIFF
--- a/cg/services/orders/validation/models/order.py
+++ b/cg/services/orders/validation/models/order.py
@@ -1,13 +1,18 @@
+from typing import Generic, TypeVar
+
 from pydantic import BaseModel, BeforeValidator, Field, PrivateAttr, model_validator
 from typing_extensions import Annotated
 
 from cg.constants import DataDelivery
 from cg.models.orders.constants import OrderType
+from cg.services.orders.validation.models.sample import Sample
 from cg.services.orders.validation.models.utils import set_null_to_false
 from cg.store.store import Store
 
+SampleType = TypeVar("SampleType", bound=Sample)
 
-class Order(BaseModel):
+
+class Order(BaseModel, Generic[SampleType]):
     customer: str = Field(min_length=1)
     delivery_type: DataDelivery
     order_type: OrderType = Field(alias="project_type")
@@ -16,7 +21,7 @@ class Order(BaseModel):
     _generated_ticket_id: int | None = PrivateAttr(default=None)
     _user_id: int = PrivateAttr(default=None)
 
-    def external_samples(self, status_db: Store):  # TODO: Fix return type
+    def external_samples(self, status_db: Store) -> list[SampleType]:
         raise NotImplementedError
 
     @model_validator(mode="before")

--- a/cg/services/orders/validation/models/order_with_cases.py
+++ b/cg/services/orders/validation/models/order_with_cases.py
@@ -15,7 +15,7 @@ CaseType = TypeVar("CaseType", bound=Case)
 SampleType = TypeVar("SampleType", bound=Sample)
 
 
-class OrderWithCases(Order, Generic[CaseType, SampleType]):
+class OrderWithCases(Order[SampleType], Generic[CaseType, SampleType]):
     cases: list[
         Annotated[
             Annotated[CaseType, Tag("new")] | Annotated[ExistingCase, Tag("existing")],

--- a/cg/services/orders/validation/models/order_with_samples.py
+++ b/cg/services/orders/validation/models/order_with_samples.py
@@ -1,4 +1,4 @@
-from typing import Generic, TypeVar
+from typing import TypeVar
 
 from cg.services.orders.validation.models.order import Order
 from cg.services.orders.validation.models.sample import Sample
@@ -7,7 +7,7 @@ from cg.store.store import Store
 SampleType = TypeVar("SampleType", bound=Sample)
 
 
-class OrderWithSamples(Order, Generic[SampleType]):
+class OrderWithSamples(Order[SampleType]):
     samples: list[SampleType]
 
     def external_samples(self, status_db: Store) -> list[SampleType]:


### PR DESCRIPTION
## Description

Fixes a typehint for the parent Order model's external_samples method.

### Added

-

### Changed

-

### Fixed

- Introduced TypeVar on the parent model to correctly typehint the abstract external_samples method


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
