### PR TITLE
add event publishing through nats-py

### DIFF
--- a/cg/services/events/event_handlers/external_sample_transferred_handler.py
+++ b/cg/services/events/event_handlers/external_sample_transferred_handler.py
@@ -57,5 +57,5 @@ def handle(config: CGConfig, event_payload: dict) -> None:
     event_publisher.publish(
         nats_config=config.nats,
         subject=f"{config.nats.stream}.{EXTERNAL_SAMPLE_STORED_SUBJECT}",
-        data={"statusdb.sample_internal_id": event.sample_internal_id},
+        event_payload={"statusdb.sample_internal_id": event.sample_internal_id},
     )

--- a/cg/services/events/event_handlers/external_sample_transferred_handler.py
+++ b/cg/services/events/event_handlers/external_sample_transferred_handler.py
@@ -7,9 +7,11 @@ from pydantic import BaseModel, Field
 
 from cg.exc import CgError
 from cg.models.cg_config import CGConfig
+from cg.services.events import event_publisher
 from cg.store.models import Sample
 
 LOG = logging.getLogger(__name__)
+EXTERNAL_SAMPLE_STORED_SUBJECT = "external_sample.storage_completed"
 
 
 class ExternalSampleTransferredEvent(BaseModel):
@@ -52,5 +54,8 @@ def handle(config: CGConfig, event_payload: dict) -> None:
         files.append(file)
     config.housekeeper_api.finalize_file_transactions(files=files, version=version)
     config.status_db.commit_to_store()
-
-    # TODO: Publish event that storing is complete
+    event_publisher.publish(
+        nats_config=config.nats,
+        subject=f"{config.nats.stream}.{EXTERNAL_SAMPLE_STORED_SUBJECT}",
+        data={"statusdb.sample_internal_id": event.sample_internal_id},
+    )

--- a/cg/services/events/event_publisher.py
+++ b/cg/services/events/event_publisher.py
@@ -1,4 +1,12 @@
+import asyncio
 import json
+import ssl
+from pathlib import Path
+from ssl import Purpose, SSLContext, TLSVersion
+
+import nats
+from nats.aio.client import Client
+from nats.js import JetStreamContext
 
 
 def publish_command(nats_config, subject: str, data: dict) -> str:
@@ -14,3 +22,33 @@ def publish_command(nats_config, subject: str, data: dict) -> str:
         f'{subject} "{json_str}"'  # double quotes around json to allow bash expansion
     )
     return command
+
+
+def publish(nats_config, subject: str, data: dict) -> None:
+    """Publish an event to NATS JetStream from synchronous code."""
+    asyncio.run(publish_async(nats_config=nats_config, subject=subject, data=data))
+
+
+async def publish_async(nats_config, subject: str, data: dict) -> None:
+    nc: Client = await nats.connect(
+        servers=nats_config.server,
+        tls=_tls_context(nats_config=nats_config),
+        token=Path(nats_config.token_path).read_text().strip(),
+    )
+    try:
+        js: JetStreamContext = nc.jetstream()
+        payload: bytes = json.dumps(data).encode()
+        await js.publish(subject=subject, payload=payload)
+    finally:
+        await nc.drain()
+
+
+def _tls_context(nats_config) -> SSLContext:
+    ctx: SSLContext = ssl.create_default_context(Purpose.SERVER_AUTH)
+    ctx.minimum_version = TLSVersion.TLSv1_2
+    ctx.load_verify_locations(nats_config.ca_cert_path)
+    ctx.load_cert_chain(
+        certfile=nats_config.client_cert_path,
+        keyfile=nats_config.client_key_path,
+    )
+    return ctx

--- a/cg/services/events/event_publisher.py
+++ b/cg/services/events/event_publisher.py
@@ -24,9 +24,9 @@ def publish_command(nats_config, subject: str, data: dict) -> str:
     return command
 
 
-def publish(nats_config, subject: str, data: dict) -> None:
+def publish(nats_config, subject: str, event_payload: dict) -> None:
     """Publish an event to NATS JetStream from synchronous code."""
-    asyncio.run(publish_async(nats_config=nats_config, subject=subject, data=data))
+    asyncio.run(publish_async(nats_config=nats_config, subject=subject, data=event_payload))
 
 
 async def publish_async(nats_config, subject: str, data: dict) -> None:

--- a/cg/services/events/event_publisher.py
+++ b/cg/services/events/event_publisher.py
@@ -26,10 +26,10 @@ def publish_command(nats_config, subject: str, data: dict) -> str:
 
 def publish(nats_config, subject: str, event_payload: dict) -> None:
     """Publish an event to NATS JetStream from synchronous code."""
-    asyncio.run(publish_async(nats_config=nats_config, subject=subject, data=event_payload))
+    asyncio.run(_publish_async(nats_config=nats_config, subject=subject, data=event_payload))
 
 
-async def publish_async(nats_config, subject: str, data: dict) -> None:
+async def _publish_async(nats_config, subject: str, data: dict) -> None:
     nc: Client = await nats.connect(
         servers=nats_config.server,
         tls=_tls_context(nats_config=nats_config),

--- a/tests/services/events/event_handlers/test_external_sample_transferred_handler.py
+++ b/tests/services/events/event_handlers/test_external_sample_transferred_handler.py
@@ -27,7 +27,7 @@ def test_handle_success(mocker: MockerFixture):
     housekeeper_api.as_type.add_new_bundle_and_version = Mock(return_value=bundle)
 
     # GIVEN a NATS configuration
-    nats_config: NatsConfig = create_autospec(NatsConfig, stream="cg_tests")
+    nats_config: NatsConfig = create_autospec(NatsConfig, stream="cg-test")
 
     # GIVEN a CG config
     config: CGConfig = create_autospec(
@@ -77,6 +77,6 @@ def test_handle_success(mocker: MockerFixture):
     # THEN an event was published saying the sample was stored
     publish_mock.assert_called_once_with(
         nats_config=nats_config,
-        subject="cg_tests.external_sample.storage_completed",
+        subject="cg-test.external_sample.storage_completed",
         event_payload={"statusdb.sample_internal_id": "ACC123"},
     )

--- a/tests/services/events/event_handlers/test_external_sample_transferred_handler.py
+++ b/tests/services/events/event_handlers/test_external_sample_transferred_handler.py
@@ -26,9 +26,20 @@ def test_handle_success(mocker: MockerFixture):
     bundle = create_autospec(Bundle, versions=[version])
     housekeeper_api.as_type.add_new_bundle_and_version = Mock(return_value=bundle)
 
+    # GIVEN NATS configuration
+    nats_config = Mock(stream="CG")
+
     # GIVEN a CG config
     config: CGConfig = create_autospec(
-        CGConfig, status_db=status_db.as_type, housekeeper_api=housekeeper_api.as_type
+        CGConfig,
+        status_db=status_db.as_type,
+        housekeeper_api=housekeeper_api.as_type,
+        nats=nats_config,
+    )
+
+    # GIVEN a publisher for completion events
+    publish_mock = mocker.patch.object(
+        external_sample_transferred_handler.event_publisher, "publish"
     )
 
     # GIVEN a valid event payload
@@ -64,3 +75,8 @@ def test_handle_success(mocker: MockerFixture):
     assert len(function_calls) == 2
 
     # THEN an event was published saying the sample was stored
+    publish_mock.assert_called_once_with(
+        nats_config=nats_config,
+        subject="CG.external_sample.storage_completed",
+        data={"statusdb.sample_internal_id": "ACC123"},
+    )

--- a/tests/services/events/event_handlers/test_external_sample_transferred_handler.py
+++ b/tests/services/events/event_handlers/test_external_sample_transferred_handler.py
@@ -6,7 +6,7 @@ from housekeeper.store.models import Bundle, Version
 from pytest_mock import MockerFixture
 
 from cg.apps.housekeeper.hk import HousekeeperAPI
-from cg.models.cg_config import CGConfig
+from cg.models.cg_config import CGConfig, NatsConfig
 from cg.services.events.event_handlers import external_sample_transferred_handler
 from cg.store.models import Sample
 from cg.store.store import Store
@@ -26,8 +26,8 @@ def test_handle_success(mocker: MockerFixture):
     bundle = create_autospec(Bundle, versions=[version])
     housekeeper_api.as_type.add_new_bundle_and_version = Mock(return_value=bundle)
 
-    # GIVEN NATS configuration
-    nats_config = Mock(stream="CG")
+    # GIVEN a NATS configuration
+    nats_config: NatsConfig = create_autospec(NatsConfig, stream="cg_tests")
 
     # GIVEN a CG config
     config: CGConfig = create_autospec(
@@ -77,6 +77,6 @@ def test_handle_success(mocker: MockerFixture):
     # THEN an event was published saying the sample was stored
     publish_mock.assert_called_once_with(
         nats_config=nats_config,
-        subject="CG.external_sample.storage_completed",
+        subject="cg_tests.external_sample.storage_completed",
         event_payload={"statusdb.sample_internal_id": "ACC123"},
     )

--- a/tests/services/events/event_handlers/test_external_sample_transferred_handler.py
+++ b/tests/services/events/event_handlers/test_external_sample_transferred_handler.py
@@ -78,5 +78,5 @@ def test_handle_success(mocker: MockerFixture):
     publish_mock.assert_called_once_with(
         nats_config=nats_config,
         subject="CG.external_sample.storage_completed",
-        data={"statusdb.sample_internal_id": "ACC123"},
+        event_payload={"statusdb.sample_internal_id": "ACC123"},
     )

--- a/tests/services/events/test_event_publisher.py
+++ b/tests/services/events/test_event_publisher.py
@@ -1,7 +1,15 @@
+import asyncio
+import json
 from pathlib import Path
+from unittest.mock import AsyncMock, Mock
+
+import nats
+from nats.aio.client import Client
+from nats.js import JetStreamContext as JSC
 
 from cg.models.cg_config import NatsConfig
 from cg.services.events import event_publisher
+from tests.typed_mock import TypedMock, create_typed_mock
 
 
 def test_publish_command():
@@ -33,3 +41,85 @@ def test_publish_command():
         r'cg.upload.completed "{\"analysis\": \"analysis_1\", \"uploaded_at\": \"$(date +%Y-%m-%dT%H:%M:%SZ)\"}"'
     )
     assert command == expected
+
+
+def test_publish(mocker):
+    # GIVEN a NatsConfig, a subject and payload
+    nats_config = NatsConfig(
+        server="nats://server",
+        stream="cg-test",
+        nats_binary_path=Path("nats_binary"),
+        ca_cert_path=Path("ca_cert"),
+        client_cert_path=Path("client_cert"),
+        client_key_path=Path("client_key"),
+        token_path=Path("/token/path"),
+    )
+    subject = "cg.upload.completed"
+    data = {"analysis": "analysis_1"}
+
+    # GIVEN a mocked nats client and jetstream context
+    jetstream_context: TypedMock[JSC] = create_typed_mock(JSC)
+    jetstream_context.as_mock.publish = AsyncMock()
+
+    nats_client: TypedMock[Client] = create_typed_mock(Client)
+    nats_client.as_mock.jetstream.return_value = jetstream_context.as_type
+    nats_client.as_mock.drain = AsyncMock()
+
+    connect_mock = mocker.patch.object(nats, "connect", AsyncMock(return_value=nats_client.as_type))
+    mocker.patch.object(event_publisher.Path, "read_text", return_value="nats-token")
+    tls_context = Mock()
+    mocker.patch.object(event_publisher, "_tls_context", return_value=tls_context)
+
+    # WHEN publishing synchronously
+    event_publisher.publish(nats_config=nats_config, subject=subject, data=data)
+
+    # THEN the event is sent via JetStream
+    connect_mock.assert_awaited_once_with(
+        servers="nats://server", tls=tls_context, token="nats-token"
+    )
+    jetstream_context.as_mock.publish.assert_awaited_once_with(
+        subject=subject,
+        payload=json.dumps(data).encode(),
+    )
+    nats_client.as_mock.drain.assert_awaited_once()
+
+
+def test_publish_async(mocker):
+    # GIVEN a NatsConfig, a subject and payload
+    nats_config = NatsConfig(
+        server="nats://server",
+        stream="cg-test",
+        nats_binary_path=Path("nats_binary"),
+        ca_cert_path=Path("ca_cert"),
+        client_cert_path=Path("client_cert"),
+        client_key_path=Path("client_key"),
+        token_path=Path("/token/path"),
+    )
+    subject = "cg.upload.completed"
+    data = {"analysis": "analysis_1"}
+
+    # GIVEN a mocked nats client and jetstream context
+    jetstream_context: TypedMock[JSC] = create_typed_mock(JSC)
+    jetstream_context.as_mock.publish = AsyncMock()
+
+    nats_client: TypedMock[Client] = create_typed_mock(Client)
+    nats_client.as_mock.jetstream.return_value = jetstream_context.as_type
+    nats_client.as_mock.drain = AsyncMock()
+
+    connect_mock = mocker.patch.object(nats, "connect", AsyncMock(return_value=nats_client.as_type))
+    mocker.patch.object(event_publisher.Path, "read_text", return_value="nats-token")
+    tls_context = Mock()
+    mocker.patch.object(event_publisher, "_tls_context", return_value=tls_context)
+
+    # WHEN publishing asynchronously
+    asyncio.run(event_publisher.publish_async(nats_config=nats_config, subject=subject, data=data))
+
+    # THEN the event is sent via JetStream
+    connect_mock.assert_awaited_once_with(
+        servers="nats://server", tls=tls_context, token="nats-token"
+    )
+    jetstream_context.as_mock.publish.assert_awaited_once_with(
+        subject=subject,
+        payload=json.dumps(data).encode(),
+    )
+    nats_client.as_mock.drain.assert_awaited_once()

--- a/tests/services/events/test_event_publisher.py
+++ b/tests/services/events/test_event_publisher.py
@@ -1,20 +1,21 @@
-import asyncio
 import json
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock
 
 import nats
+import pytest
 from nats.aio.client import Client
-from nats.js import JetStreamContext as JSC
+from nats.js import JetStreamContext
+from pytest_mock import MockerFixture
 
 from cg.models.cg_config import NatsConfig
 from cg.services.events import event_publisher
 from tests.typed_mock import TypedMock, create_typed_mock
 
 
-def test_publish_command():
-    # GIVEN a NatsConfig with publisher authentication details, a subject, and data
-    nats_config = NatsConfig(
+@pytest.fixture
+def nats_config() -> NatsConfig:
+    return NatsConfig(
         server="nats://server",
         stream="cg-test",
         nats_binary_path=Path("nats_binary"),
@@ -23,11 +24,17 @@ def test_publish_command():
         client_key_path=Path("client_key"),
         token_path=Path("/token/path"),
     )
+
+
+def test_publish_command(nats_config: NatsConfig):
+    # GIVEN a NatsConfig with publisher authentication details, a subject, and an event payload
     subject = "cg.upload.completed"
-    data = {"analysis": "analysis_1", "uploaded_at": "$(date +%Y-%m-%dT%H:%M:%SZ)"}
+    event_payload = {"analysis": "analysis_1", "uploaded_at": "$(date +%Y-%m-%dT%H:%M:%SZ)"}
 
     # WHEN the publish_command function is called with the NatsConfig, subject, and data
-    command = event_publisher.publish_command(nats_config=nats_config, subject=subject, data=data)
+    command = event_publisher.publish_command(
+        nats_config=nats_config, subject=subject, data=event_payload
+    )
 
     # THEN the generated command string matches the expected format
     expected = (
@@ -43,35 +50,27 @@ def test_publish_command():
     assert command == expected
 
 
-def test_publish(mocker):
+def test_publish(nats_config: NatsConfig, mocker: MockerFixture):
     # GIVEN a NatsConfig, a subject and payload
-    nats_config = NatsConfig(
-        server="nats://server",
-        stream="cg-test",
-        nats_binary_path=Path("nats_binary"),
-        ca_cert_path=Path("ca_cert"),
-        client_cert_path=Path("client_cert"),
-        client_key_path=Path("client_key"),
-        token_path=Path("/token/path"),
-    )
     subject = "cg.upload.completed"
-    data = {"analysis": "analysis_1"}
+    event_payload = {"analysis": "analysis_1"}
 
     # GIVEN a mocked nats client and jetstream context
-    jetstream_context: TypedMock[JSC] = create_typed_mock(JSC)
+    jetstream_context: TypedMock[JetStreamContext] = create_typed_mock(JetStreamContext)
     jetstream_context.as_mock.publish = AsyncMock()
 
     nats_client: TypedMock[Client] = create_typed_mock(Client)
-    nats_client.as_mock.jetstream.return_value = jetstream_context.as_type
+    nats_client.as_mock.jetstream = Mock(return_value=jetstream_context.as_type)
     nats_client.as_mock.drain = AsyncMock()
 
+    # GIVEN that we can connect to the NATS server using the correct token and authentication
     connect_mock = mocker.patch.object(nats, "connect", AsyncMock(return_value=nats_client.as_type))
     mocker.patch.object(event_publisher.Path, "read_text", return_value="nats-token")
     tls_context = Mock()
     mocker.patch.object(event_publisher, "_tls_context", return_value=tls_context)
 
     # WHEN publishing synchronously
-    event_publisher.publish(nats_config=nats_config, subject=subject, event_payload=data)
+    event_publisher.publish(nats_config=nats_config, subject=subject, event_payload=event_payload)
 
     # THEN the event is sent via JetStream
     connect_mock.assert_awaited_once_with(
@@ -79,47 +78,6 @@ def test_publish(mocker):
     )
     jetstream_context.as_mock.publish.assert_awaited_once_with(
         subject=subject,
-        payload=json.dumps(data).encode(),
-    )
-    nats_client.as_mock.drain.assert_awaited_once()
-
-
-def test_publish_async(mocker):
-    # GIVEN a NatsConfig, a subject and payload
-    nats_config = NatsConfig(
-        server="nats://server",
-        stream="cg-test",
-        nats_binary_path=Path("nats_binary"),
-        ca_cert_path=Path("ca_cert"),
-        client_cert_path=Path("client_cert"),
-        client_key_path=Path("client_key"),
-        token_path=Path("/token/path"),
-    )
-    subject = "cg.upload.completed"
-    data = {"analysis": "analysis_1"}
-
-    # GIVEN a mocked nats client and jetstream context
-    jetstream_context: TypedMock[JSC] = create_typed_mock(JSC)
-    jetstream_context.as_mock.publish = AsyncMock()
-
-    nats_client: TypedMock[Client] = create_typed_mock(Client)
-    nats_client.as_mock.jetstream.return_value = jetstream_context.as_type
-    nats_client.as_mock.drain = AsyncMock()
-
-    connect_mock = mocker.patch.object(nats, "connect", AsyncMock(return_value=nats_client.as_type))
-    mocker.patch.object(event_publisher.Path, "read_text", return_value="nats-token")
-    tls_context = Mock()
-    mocker.patch.object(event_publisher, "_tls_context", return_value=tls_context)
-
-    # WHEN publishing asynchronously
-    asyncio.run(event_publisher.publish_async(nats_config=nats_config, subject=subject, data=data))
-
-    # THEN the event is sent via JetStream
-    connect_mock.assert_awaited_once_with(
-        servers="nats://server", tls=tls_context, token="nats-token"
-    )
-    jetstream_context.as_mock.publish.assert_awaited_once_with(
-        subject=subject,
-        payload=json.dumps(data).encode(),
+        payload=json.dumps(event_payload).encode(),
     )
     nats_client.as_mock.drain.assert_awaited_once()

--- a/tests/services/events/test_event_publisher.py
+++ b/tests/services/events/test_event_publisher.py
@@ -71,7 +71,7 @@ def test_publish(mocker):
     mocker.patch.object(event_publisher, "_tls_context", return_value=tls_context)
 
     # WHEN publishing synchronously
-    event_publisher.publish(nats_config=nats_config, subject=subject, data=data)
+    event_publisher.publish(nats_config=nats_config, subject=subject, event_payload=data)
 
     # THEN the event is sent via JetStream
     connect_mock.assert_awaited_once_with(


### PR DESCRIPTION
## Description

### Added

-

### Changed

-

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
