### PR TITLE
Start external sample analyses when all samples are stored

### DIFF
--- a/cg/services/events/event_dispatching.py
+++ b/cg/services/events/event_dispatching.py
@@ -2,13 +2,17 @@ import logging
 from typing import Callable
 
 from cg.models.cg_config import CGConfig
-from cg.services.events.event_handlers import external_sample_uploaded_handler
+from cg.services.events.event_handlers import (
+    external_sample_stored_handler,
+    external_sample_uploaded_handler,
+)
 
 LOG = logging.getLogger(__name__)
 
 
 EVENT_HANDLERS: dict[str, Callable] = {
-    "external.customer_uploaded_sample": external_sample_uploaded_handler.handle
+    "external.customer_uploaded_sample": external_sample_uploaded_handler.handle,
+    "external.sample_stored": external_sample_stored_handler.handle,
 }
 
 

--- a/cg/services/events/event_handlers/external_sample_stored_handler.py
+++ b/cg/services/events/event_handlers/external_sample_stored_handler.py
@@ -1,6 +1,10 @@
+from typing import cast
+
 from pydantic import BaseModel, Field
 
 from cg.models.cg_config import CGConfig
+from cg.services.analysis_starter.analysis_starter import AnalysisStarter
+from cg.services.analysis_starter.factories.starter_factory import AnalysisStarterFactory
 from cg.store.models import Case, Sample
 from cg.store.store import Store
 
@@ -28,8 +32,16 @@ def handle(config: CGConfig, event_payload: dict) -> None:
 
     # TODO: Check if all external samples in the case are stored
     sample: Sample = status_db.get_sample_by_internal_id_strict(event.sample_internal_id)
-    case: Case | None = sample.case_that_delivers
+    case: Case = cast(Case, sample.case_that_delivers)
+    if all(sample.is_external and sample.case_that_delivers == case for sample in case.samples):
+        # TODO: Check the samples had stored
+        analysis_starter_factory = AnalysisStarterFactory(config)
+        analysis_starter: AnalysisStarter = analysis_starter_factory.get_analysis_starter_for_case(
+            case.internal_id
+        )
+        analysis_starter.start(case.internal_id)
     # From case get samples
+
     # For every sample check if external and if so if it has hk bundle
 
     # TODO: Start the case if previous check return true else return

--- a/cg/services/events/event_handlers/external_sample_stored_handler.py
+++ b/cg/services/events/event_handlers/external_sample_stored_handler.py
@@ -1,11 +1,31 @@
-from cg.models.cg_config import CGConfig
+from pydantic import BaseModel, Field
 
-# TODO: Model event payload
+from cg.models.cg_config import CGConfig
+from cg.store.models import Case, Sample
+from cg.store.store import Store
+
+
+class ExternalSampleStoredEvent(BaseModel):
+    sample_internal_id: str = Field(alias="status_db.sample_internal_id")
+
+
+# TODO
+"""
+- IF a case can't start because it's waiting for external sample, acknowledge
+- IF a case can't start because it's waiting for internal sample, set status to analyze
+"""
 
 
 def handle(config: CGConfig, event_payload: dict) -> None:
-    # TODO: Validate event payload
+    event = ExternalSampleStoredEvent.model_validate(event_payload)
+    status_db: Store = config.status_db
+
     # TODO: Check if all external samples in the case are stored
+    sample: Sample = status_db.get_sample_by_internal_id_strict(event.sample_internal_id)
+    case: Case | None = sample.case_that_delivers
+    # From case get samples
+    # For every sample check if external and if so if it has hk bundle
+
     # TODO: Start the case if previous check return true else return
     # TODO: If case fails to start raise error else just return
     pass

--- a/cg/services/events/event_handlers/external_sample_stored_handler.py
+++ b/cg/services/events/event_handlers/external_sample_stored_handler.py
@@ -48,25 +48,20 @@ def _are_all_samples_new_external_and_stored(case: Case, housekeeper_api: Housek
     for sample in case.samples:
         if not sample.is_external:
             not_external.append(sample.internal_id)
+        # Ensure sample was originally ordered in this case
         if not sample.case_that_delivers == case:
             not_new.append(sample.internal_id)
+        # Ensure it has been stored
         if not housekeeper_api.bundle(sample.internal_id):
             not_stored.append(sample.internal_id)
     if any([not_external, not_new, not_stored]):
-        LOG.info(
-            f"Could not start analysis because of the following samples:\n"
-            + f"Not external: {not_external}\n"
-            if not_external
-            else (
-                "" + f"Not new: {not_new}\n"
-                if not_new
-                else "" + f"Not stored: {not_stored}" if not_stored else ""
-            )
-        )
-
-    """return all(
-        sample.is_external
-        and sample.case_that_delivers == case  # Ensures sample was originally ordered in this case
-        and housekeeper_api.bundle(sample.internal_id)  # Ensures it has been stored
-        for sample in case.samples
-    )"""
+        message = [
+            f"Could not start case {case.internal_id} because of the following samples:\n",
+            f"Not external: {not_external}\n" if not_external else "",
+            f"Not new: {not_new}\n" if not_new else "",
+            f"Not stored: {not_stored}" if not_stored else "",
+        ]
+        LOG.info("".join(message))
+        return False
+    else:
+        return True

--- a/cg/services/events/event_handlers/external_sample_stored_handler.py
+++ b/cg/services/events/event_handlers/external_sample_stored_handler.py
@@ -1,8 +1,7 @@
-from typing import cast
-
 from pydantic import BaseModel, Field
 
 from cg.apps.housekeeper.hk import HousekeeperAPI
+from cg.exc import CaseNotFoundError
 from cg.models.cg_config import CGConfig
 from cg.services.analysis_starter.analysis_starter import AnalysisStarter
 from cg.services.analysis_starter.factories.starter_factory import AnalysisStarterFactory
@@ -29,7 +28,9 @@ def handle(config: CGConfig, event_payload: dict) -> None:
     housekeeper_api: HousekeeperAPI = config.housekeeper_api
 
     sample: Sample = status_db.get_sample_by_internal_id_strict(event.sample_internal_id)
-    case: Case = cast(Case, sample.case_that_delivers)
+    case: Case | None = sample.case_that_delivers
+    if not case:
+        raise CaseNotFoundError(f"No case found to deliver sample {sample.internal_id}")
     if _are_all_samples_external_and_stored(case=case, housekeeper_api=housekeeper_api):
         analysis_starter_factory = AnalysisStarterFactory(config)
         analysis_starter: AnalysisStarter = analysis_starter_factory.get_analysis_starter_for_case(

--- a/cg/services/events/event_handlers/external_sample_stored_handler.py
+++ b/cg/services/events/event_handlers/external_sample_stored_handler.py
@@ -1,0 +1,11 @@
+from cg.models.cg_config import CGConfig
+
+# TODO: Model event payload
+
+
+def handle(config: CGConfig, event_payload: dict) -> None:
+    # TODO: Validate event payload
+    # TODO: Check if all external samples in the case are stored
+    # TODO: Start the case if previous check return true else return
+    # TODO: If case fails to start raise error else just return
+    pass

--- a/cg/services/events/event_handlers/external_sample_stored_handler.py
+++ b/cg/services/events/event_handlers/external_sample_stored_handler.py
@@ -1,3 +1,5 @@
+import logging
+
 from pydantic import BaseModel, Field
 
 from cg.apps.housekeeper.hk import HousekeeperAPI
@@ -7,6 +9,8 @@ from cg.services.analysis_starter.analysis_starter import AnalysisStarter
 from cg.services.analysis_starter.factories.starter_factory import AnalysisStarterFactory
 from cg.store.models import Case, Sample
 from cg.store.store import Store
+
+LOG = logging.getLogger(__name__)
 
 
 class ExternalSampleStoredEvent(BaseModel):
@@ -23,11 +27,14 @@ def handle(config: CGConfig, event_payload: dict) -> None:
     if not case:
         raise CaseNotFoundError(f"No case found to deliver sample {sample.internal_id}")
     if _are_all_samples_new_external_and_stored(case=case, housekeeper_api=housekeeper_api):
+        LOG.info(f"Case {case.internal_id} is ready to be started.")
         analysis_starter_factory = AnalysisStarterFactory(config)
         analysis_starter: AnalysisStarter = analysis_starter_factory.get_analysis_starter_for_case(
             case.internal_id
         )
         analysis_starter.start(case.internal_id)
+    else:
+        LOG.info(f"Case {case.internal_id} is not ready to be started.")
 
 
 def _are_all_samples_new_external_and_stored(case: Case, housekeeper_api: HousekeeperAPI) -> bool:
@@ -35,9 +42,31 @@ def _are_all_samples_new_external_and_stored(case: Case, housekeeper_api: Housek
     Return True if all of the samples of the case are external, stored in Housekeeper
     and are originally ordered with the case.
     """
-    return all(
+    not_external: list[str] = []
+    not_new: list[str] = []
+    not_stored: list[str] = []
+    for sample in case.samples:
+        if not sample.is_external:
+            not_external.append(sample.internal_id)
+        if not sample.case_that_delivers == case:
+            not_new.append(sample.internal_id)
+        if not housekeeper_api.bundle(sample.internal_id):
+            not_stored.append(sample.internal_id)
+    if any([not_external, not_new, not_stored]):
+        LOG.info(
+            f"Could not start analysis because of the following samples:\n"
+            + f"Not external: {not_external}\n"
+            if not_external
+            else (
+                "" + f"Not new: {not_new}\n"
+                if not_new
+                else "" + f"Not stored: {not_stored}" if not_stored else ""
+            )
+        )
+
+    """return all(
         sample.is_external
         and sample.case_that_delivers == case  # Ensures sample was originally ordered in this case
         and housekeeper_api.bundle(sample.internal_id)  # Ensures it has been stored
         for sample in case.samples
-    )
+    )"""

--- a/cg/services/events/event_handlers/external_sample_stored_handler.py
+++ b/cg/services/events/event_handlers/external_sample_stored_handler.py
@@ -14,19 +14,6 @@ class ExternalSampleStoredEvent(BaseModel):
     sample_internal_id: str = Field(alias="status_db.sample_internal_id")
 
 
-# TODO
-"""
-- IF a case can't start because it's waiting for external sample, acknowledge
-- IF a case can't start because it's waiting for internal sample, set status to analyze
-"""
-
-
-"""
-If purely external and everything -> start (do we need to set case to hold if purely external?)
-Else: AK
-"""
-
-
 def _are_all_samples_external_and_stored(case: Case, housekeeper_api: HousekeeperAPI) -> bool:
     return all(
         sample.is_external
@@ -44,16 +31,8 @@ def handle(config: CGConfig, event_payload: dict) -> None:
     sample: Sample = status_db.get_sample_by_internal_id_strict(event.sample_internal_id)
     case: Case = cast(Case, sample.case_that_delivers)
     if _are_all_samples_external_and_stored(case=case, housekeeper_api=housekeeper_api):
-        # TODO: Check the samples had stored
         analysis_starter_factory = AnalysisStarterFactory(config)
         analysis_starter: AnalysisStarter = analysis_starter_factory.get_analysis_starter_for_case(
             case.internal_id
         )
         analysis_starter.start(case.internal_id)
-    # From case get samples
-
-    # For every sample check if external and if so if it has hk bundle
-
-    # TODO: Start the case if previous check return true else return
-    # TODO: If case fails to start raise error else just return
-    pass

--- a/cg/services/events/event_handlers/external_sample_stored_handler.py
+++ b/cg/services/events/event_handlers/external_sample_stored_handler.py
@@ -13,15 +13,6 @@ class ExternalSampleStoredEvent(BaseModel):
     sample_internal_id: str = Field(alias="status_db.sample_internal_id")
 
 
-def _are_all_samples_external_and_stored(case: Case, housekeeper_api: HousekeeperAPI) -> bool:
-    return all(
-        sample.is_external
-        and sample.case_that_delivers == case  # Ensures sample was originally ordered in this case
-        and housekeeper_api.bundle(sample.internal_id)  # Ensures it has been stored
-        for sample in case.samples
-    )
-
-
 def handle(config: CGConfig, event_payload: dict) -> None:
     event = ExternalSampleStoredEvent.model_validate(event_payload)
     status_db: Store = config.status_db
@@ -31,9 +22,22 @@ def handle(config: CGConfig, event_payload: dict) -> None:
     case: Case | None = sample.case_that_delivers
     if not case:
         raise CaseNotFoundError(f"No case found to deliver sample {sample.internal_id}")
-    if _are_all_samples_external_and_stored(case=case, housekeeper_api=housekeeper_api):
+    if _are_all_samples_new_external_and_stored(case=case, housekeeper_api=housekeeper_api):
         analysis_starter_factory = AnalysisStarterFactory(config)
         analysis_starter: AnalysisStarter = analysis_starter_factory.get_analysis_starter_for_case(
             case.internal_id
         )
         analysis_starter.start(case.internal_id)
+
+
+def _are_all_samples_new_external_and_stored(case: Case, housekeeper_api: HousekeeperAPI) -> bool:
+    """
+    Return True if all of the samples of the case are external, stored in Housekeeper
+    and are originally ordered with the case.
+    """
+    return all(
+        sample.is_external
+        and sample.case_that_delivers == case  # Ensures sample was originally ordered in this case
+        and housekeeper_api.bundle(sample.internal_id)  # Ensures it has been stored
+        for sample in case.samples
+    )

--- a/cg/services/events/event_handlers/external_sample_stored_handler.py
+++ b/cg/services/events/event_handlers/external_sample_stored_handler.py
@@ -2,6 +2,7 @@ from typing import cast
 
 from pydantic import BaseModel, Field
 
+from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.models.cg_config import CGConfig
 from cg.services.analysis_starter.analysis_starter import AnalysisStarter
 from cg.services.analysis_starter.factories.starter_factory import AnalysisStarterFactory
@@ -26,13 +27,23 @@ Else: AK
 """
 
 
+def _are_all_samples_external_and_stored(case: Case, housekeeper_api: HousekeeperAPI) -> bool:
+    return all(
+        sample.is_external
+        and sample.case_that_delivers == case  # Ensures sample was originally ordered in this case
+        and housekeeper_api.bundle(sample.internal_id)  # Ensures it has been stored
+        for sample in case.samples
+    )
+
+
 def handle(config: CGConfig, event_payload: dict) -> None:
     event = ExternalSampleStoredEvent.model_validate(event_payload)
     status_db: Store = config.status_db
+    housekeeper_api: HousekeeperAPI = config.housekeeper_api
 
     sample: Sample = status_db.get_sample_by_internal_id_strict(event.sample_internal_id)
     case: Case = cast(Case, sample.case_that_delivers)
-    if all(sample.is_external and sample.case_that_delivers == case for sample in case.samples):
+    if _are_all_samples_external_and_stored(case=case, housekeeper_api=housekeeper_api):
         # TODO: Check the samples had stored
         analysis_starter_factory = AnalysisStarterFactory(config)
         analysis_starter: AnalysisStarter = analysis_starter_factory.get_analysis_starter_for_case(

--- a/cg/services/events/event_handlers/external_sample_stored_handler.py
+++ b/cg/services/events/event_handlers/external_sample_stored_handler.py
@@ -16,6 +16,12 @@ class ExternalSampleStoredEvent(BaseModel):
 """
 
 
+"""
+If purely external and everything -> start (do we need to set case to hold if purely external?)
+Else: AK
+"""
+
+
 def handle(config: CGConfig, event_payload: dict) -> None:
     event = ExternalSampleStoredEvent.model_validate(event_payload)
     status_db: Store = config.status_db

--- a/cg/services/events/event_handlers/external_sample_stored_handler.py
+++ b/cg/services/events/event_handlers/external_sample_stored_handler.py
@@ -30,7 +30,6 @@ def handle(config: CGConfig, event_payload: dict) -> None:
     event = ExternalSampleStoredEvent.model_validate(event_payload)
     status_db: Store = config.status_db
 
-    # TODO: Check if all external samples in the case are stored
     sample: Sample = status_db.get_sample_by_internal_id_strict(event.sample_internal_id)
     case: Case = cast(Case, sample.case_that_delivers)
     if all(sample.is_external and sample.case_that_delivers == case for sample in case.samples):

--- a/cg/services/events/event_handlers/external_sample_stored_handler.py
+++ b/cg/services/events/event_handlers/external_sample_stored_handler.py
@@ -39,8 +39,6 @@ def handle(config: CGConfig, event_payload: dict) -> None:
             case.internal_id
         )
         analysis_starter.start(case.internal_id)
-    else:
-        LOG.info(f"Case {case.internal_id} is not ready to be started.")
 
 
 def _are_all_samples_new_external_and_stored(case: Case, housekeeper_api: HousekeeperAPI) -> bool:

--- a/cg/services/events/event_handlers/external_sample_stored_handler.py
+++ b/cg/services/events/event_handlers/external_sample_stored_handler.py
@@ -18,6 +18,12 @@ class ExternalSampleStoredEvent(BaseModel):
 
 
 def handle(config: CGConfig, event_payload: dict) -> None:
+    """
+    Start the analysis of a sample's case if all of its samples are external and stored in
+    Housekeeper.
+    Raises:
+        CaseNotFoundError: If the sample provided in the payload doesn't belong to any new case.
+    """
     event = ExternalSampleStoredEvent.model_validate(event_payload)
     status_db: Store = config.status_db
     housekeeper_api: HousekeeperAPI = config.housekeeper_api

--- a/cg/services/events/event_handlers/external_sample_stored_handler.py
+++ b/cg/services/events/event_handlers/external_sample_stored_handler.py
@@ -49,7 +49,7 @@ def _are_all_samples_new_external_and_stored(case: Case, housekeeper_api: Housek
         if not sample.is_external:
             not_external.append(sample.internal_id)
         # Ensure sample was originally ordered in this case
-        if not sample.case_that_delivers == case:
+        if sample.case_that_delivers != case:
             not_new.append(sample.internal_id)
         # Ensure it has been stored
         if not housekeeper_api.bundle(sample.internal_id):

--- a/tests/services/events/event_handlers/test_external_sample_stored_handler.py
+++ b/tests/services/events/event_handlers/test_external_sample_stored_handler.py
@@ -75,7 +75,7 @@ def test_handle_fails_with_no_case(mocker: MockerFixture):
     cg_config: CGConfig = create_autospec(CGConfig, status_db=status_db)
 
     # WHEN handling the event
-    # THEN the appropraite error is raised
+    # THEN the appropriate error is raised
     with pytest.raises(CaseNotFoundError):
         external_sample_stored_handler.handle(config=cg_config, event_payload=event_payload)
 
@@ -84,7 +84,7 @@ def test_handle_ignores_case_with_internal_samples(mocker: MockerFixture):
     # GIVEN a valid event payload
     event_payload: dict = {"status_db.sample_internal_id": "ACC123"}
 
-    # GIVEN that the sample belongs to a case with both external and non-external samples
+    # GIVEN that the sample belongs to a case with both external and internal samples
     status_db: Store = create_autospec(Store)
     case: Case = create_autospec(Case)
     external_sample: Sample = create_autospec(

--- a/tests/services/events/event_handlers/test_external_sample_stored_handler.py
+++ b/tests/services/events/event_handlers/test_external_sample_stored_handler.py
@@ -1,29 +1,48 @@
-from unittest.mock import create_autospec
+from unittest.mock import Mock, call, create_autospec
+
+from pytest_mock import MockerFixture
 
 from cg.apps.housekeeper.hk import HousekeeperAPI
+from cg.models.cg_config import CGConfig
+from cg.services.analysis_starter.analysis_starter import AnalysisStarter
+from cg.services.events.event_handlers import external_sample_stored_handler
 from cg.store.models import Case, Sample
 from cg.store.store import Store
+from housekeeper.store.models import Bundle
+
+from tests.typed_mock import TypedMock, create_typed_mock
 
 
-def test_handle_starts_case():
+def test_handle_starts_case(mocker: MockerFixture):
     # GIVEN a valid event payload
     event_payload: dict = {"status_db.sample_internal_id": "ACC123"}
 
     # GIVEN that the sample belongs to a purely external case
     status_db: Store = create_autospec(Store)
     case: Case = create_autospec(Case)
-    sample: Sample = create_autospec(Sample, case_that_delivers=case, is_external=True)
-    case.samples = [sample]
+    stored_sample: Sample = create_autospec(
+        Sample, case_that_delivers=case, internal_id="ACC123", is_external=True
+    )
+    other_sample: Sample = create_autospec(Sample, case_that_delivers=case, internal_id="ACC234" is_external=True)
+    case.samples = [stored_sample, other_sample]  # type: ignore
 
     # GIVEN that all samples in the case are stored
-    hk_api: HousekeeperAPI = create_autospec(HousekeeperAPI)
+    housekeeper_api: TypedMock[HousekeeperAPI] = create_typed_mock(HousekeeperAPI)
+    housekeeper_api.as_type.bundle = Mock(return_value=create_autospec(Bundle))
 
-    # GIVEN that starting the case goes well
+    # GIVEN a CG config
+    cg_config: CGConfig = create_autospec(CGConfig, housekeeper_api=housekeeper_api, status_db=status_db)
+
+    mock_start = mocker.patch.object(AnalysisStarter, "start")
 
     # WHEN handling the event
+    external_sample_stored_handler.handle(config=cg_config, event_payload=event_payload)
 
     # THEN we should have checked that all samples were indeed stored
+    stored_sample_call = call(name="ACC123")
+    other_sample_call = call(name="ACC234")
+    assert stored_sample_call in housekeeper_api.as_mock.bundle.call_args_list
+    assert other_sample_call in housekeeper_api.as_mock.bundle.call_args_list
 
     # THEN the case was started
-
-    pass
+    mock_start.assert_called_once()

--- a/tests/services/events/event_handlers/test_external_sample_stored_handler.py
+++ b/tests/services/events/event_handlers/test_external_sample_stored_handler.py
@@ -1,11 +1,19 @@
 from unittest.mock import create_autospec
 
 from cg.apps.housekeeper.hk import HousekeeperAPI
+from cg.store.models import Case, Sample
+from cg.store.store import Store
 
 
 def test_handle_starts_case():
     # GIVEN a valid event payload
     event_payload: dict = {"status_db.sample_internal_id": "ACC123"}
+
+    # GIVEN that the sample belongs to a purely external case
+    status_db: Store = create_autospec(Store)
+    case: Case = create_autospec(Case)
+    sample: Sample = create_autospec(Sample, case_that_delivers=case, is_external=True)
+    case.samples = [sample]
 
     # GIVEN that all samples in the case are stored
     hk_api: HousekeeperAPI = create_autospec(HousekeeperAPI)

--- a/tests/services/events/event_handlers/test_external_sample_stored_handler.py
+++ b/tests/services/events/event_handlers/test_external_sample_stored_handler.py
@@ -80,7 +80,7 @@ def test_handle_fails_with_no_case(mocker: MockerFixture):
         external_sample_stored_handler.handle(config=cg_config, event_payload=event_payload)
 
 
-def test_handle_not_fully_external_case(mocker: MockerFixture):
+def test_handle_ignores_case_with_internal_samples(mocker: MockerFixture):
     # GIVEN a valid event payload
     event_payload: dict = {"status_db.sample_internal_id": "ACC123"}
 
@@ -119,7 +119,7 @@ def test_handle_not_fully_external_case(mocker: MockerFixture):
     analysis_starter.as_mock.start.assert_not_called()
 
 
-def test_handle_not_all_samples_stored(mocker: MockerFixture):
+def test_handle_ignores_case_with_unstored_samples(mocker: MockerFixture):
     # GIVEN a valid event payload
     event_payload: dict = {"status_db.sample_internal_id": "ACC123"}
 
@@ -162,4 +162,41 @@ def test_handle_not_all_samples_stored(mocker: MockerFixture):
     analysis_starter.as_mock.start.assert_not_called()
 
 
-# TODO: Not all samples deliverable for case
+def test_handle_ignores_case_with_undeliverable_samples(mocker: MockerFixture):
+    # GIVEN a valid event payload
+    event_payload: dict = {"status_db.sample_internal_id": "ACC123"}
+
+    # GIVEN that the sample belongs to a case that does not deliver all of its samples
+    status_db: Store = create_autospec(Store)
+    case1: Case = create_autospec(Case, internal_id="case1")
+    case2: Case = create_autospec(Case, internal_id="case2")
+    sample1: Sample = create_autospec(
+        Sample, case_that_delivers=case1, internal_id="ACC123", is_external=True
+    )
+    sample2: Sample = create_autospec(
+        Sample, case_that_delivers=case2, internal_id="ACC234", is_external=True
+    )
+    case1.samples = [sample1, sample2]  # type: ignore
+    status_db.get_sample_by_internal_id_strict = Mock(return_value=sample1)
+
+    # GIVEN that all samples in the case are stored
+    housekeeper_api: TypedMock[HousekeeperAPI] = create_typed_mock(HousekeeperAPI)
+    housekeeper_api.as_type.bundle = Mock(return_value=create_autospec(Bundle))
+
+    # GIVEN a CG config
+    cg_config: CGConfig = create_autospec(
+        CGConfig, housekeeper_api=housekeeper_api.as_type, status_db=status_db
+    )
+
+    analysis_starter: TypedMock[AnalysisStarter] = create_typed_mock(AnalysisStarter)
+    mocker.patch.object(
+        AnalysisStarterFactory,
+        "get_analysis_starter_for_case",
+        return_value=analysis_starter.as_type,
+    )
+
+    # WHEN handling the event
+    external_sample_stored_handler.handle(config=cg_config, event_payload=event_payload)
+
+    # THEN the analysis was not started
+    analysis_starter.as_mock.start.assert_not_called()

--- a/tests/services/events/event_handlers/test_external_sample_stored_handler.py
+++ b/tests/services/events/event_handlers/test_external_sample_stored_handler.py
@@ -1,9 +1,11 @@
 from unittest.mock import Mock, call, create_autospec
 
 from housekeeper.store.models import Bundle
+import pytest
 from pytest_mock import MockerFixture
 
 from cg.apps.housekeeper.hk import HousekeeperAPI
+from cg.exc import CaseNotFoundError
 from cg.models.cg_config import CGConfig
 from cg.services.analysis_starter.analysis_starter import AnalysisStarter
 from cg.services.analysis_starter.factories.starter_factory import AnalysisStarterFactory
@@ -58,7 +60,25 @@ def test_handle_starts_case(mocker: MockerFixture):
     analysis_starter.as_mock.start.assert_called_once_with(case.internal_id)
 
 
-# TODO: Test for sample with no case that deliver
+def test_handle_fails_with_no_case(mocker: MockerFixture):
+    # GIVEN a valid event payload
+    event_payload: dict = {"status_db.sample_internal_id": "ACC123"}
+
+    # GIVEN that the sample does not have a linked case that should deliver it
+    status_db: Store = create_autospec(Store)
+    sample: Sample = create_autospec(
+        Sample, case_that_delivers=None, internal_id="ACC123", is_external=True
+    )
+    status_db.get_sample_by_internal_id_strict = Mock(return_value=sample)
+
+    # GIVEN a CG config
+    cg_config: CGConfig = create_autospec(CGConfig, status_db=status_db)
+
+    # WHEN handling the event
+    # THEN the appropraite error is raised
+    with pytest.raises(CaseNotFoundError):
+        external_sample_stored_handler.handle(config=cg_config, event_payload=event_payload)
+
 
 # TODO: Not all samples external
 

--- a/tests/services/events/event_handlers/test_external_sample_stored_handler.py
+++ b/tests/services/events/event_handlers/test_external_sample_stored_handler.py
@@ -27,6 +27,7 @@ def test_handle_starts_case(mocker: MockerFixture):
         Sample, case_that_delivers=case, internal_id="ACC234", is_external=True
     )
     case.samples = [stored_sample, other_sample]  # type: ignore
+    status_db.get_sample_by_internal_id_strict = Mock(return_value=stored_sample)
 
     # GIVEN that all samples in the case are stored
     housekeeper_api: TypedMock[HousekeeperAPI] = create_typed_mock(HousekeeperAPI)
@@ -34,7 +35,7 @@ def test_handle_starts_case(mocker: MockerFixture):
 
     # GIVEN a CG config
     cg_config: CGConfig = create_autospec(
-        CGConfig, housekeeper_api=housekeeper_api, status_db=status_db
+        CGConfig, housekeeper_api=housekeeper_api.as_type, status_db=status_db
     )
 
     analysis_starter: TypedMock[AnalysisStarter] = create_typed_mock(AnalysisStarter)
@@ -48,8 +49,8 @@ def test_handle_starts_case(mocker: MockerFixture):
     external_sample_stored_handler.handle(config=cg_config, event_payload=event_payload)
 
     # THEN we should have checked that all samples were indeed stored
-    stored_sample_call = call(name="ACC123")
-    other_sample_call = call(name="ACC234")
+    stored_sample_call = call("ACC123")
+    other_sample_call = call("ACC234")
     assert stored_sample_call in housekeeper_api.as_mock.bundle.call_args_list
     assert other_sample_call in housekeeper_api.as_mock.bundle.call_args_list
 

--- a/tests/services/events/event_handlers/test_external_sample_stored_handler.py
+++ b/tests/services/events/event_handlers/test_external_sample_stored_handler.py
@@ -1,15 +1,15 @@
 from unittest.mock import Mock, call, create_autospec
 
+from housekeeper.store.models import Bundle
 from pytest_mock import MockerFixture
 
 from cg.apps.housekeeper.hk import HousekeeperAPI
 from cg.models.cg_config import CGConfig
 from cg.services.analysis_starter.analysis_starter import AnalysisStarter
+from cg.services.analysis_starter.factories.starter_factory import AnalysisStarterFactory
 from cg.services.events.event_handlers import external_sample_stored_handler
 from cg.store.models import Case, Sample
 from cg.store.store import Store
-from housekeeper.store.models import Bundle
-
 from tests.typed_mock import TypedMock, create_typed_mock
 
 
@@ -23,7 +23,9 @@ def test_handle_starts_case(mocker: MockerFixture):
     stored_sample: Sample = create_autospec(
         Sample, case_that_delivers=case, internal_id="ACC123", is_external=True
     )
-    other_sample: Sample = create_autospec(Sample, case_that_delivers=case, internal_id="ACC234" is_external=True)
+    other_sample: Sample = create_autospec(
+        Sample, case_that_delivers=case, internal_id="ACC234", is_external=True
+    )
     case.samples = [stored_sample, other_sample]  # type: ignore
 
     # GIVEN that all samples in the case are stored
@@ -31,9 +33,16 @@ def test_handle_starts_case(mocker: MockerFixture):
     housekeeper_api.as_type.bundle = Mock(return_value=create_autospec(Bundle))
 
     # GIVEN a CG config
-    cg_config: CGConfig = create_autospec(CGConfig, housekeeper_api=housekeeper_api, status_db=status_db)
+    cg_config: CGConfig = create_autospec(
+        CGConfig, housekeeper_api=housekeeper_api, status_db=status_db
+    )
 
-    mock_start = mocker.patch.object(AnalysisStarter, "start")
+    analysis_starter: TypedMock[AnalysisStarter] = create_typed_mock(AnalysisStarter)
+    mocker.patch.object(
+        AnalysisStarterFactory,
+        "get_analysis_starter_for_case",
+        return_value=analysis_starter.as_type,
+    )
 
     # WHEN handling the event
     external_sample_stored_handler.handle(config=cg_config, event_payload=event_payload)
@@ -45,4 +54,4 @@ def test_handle_starts_case(mocker: MockerFixture):
     assert other_sample_call in housekeeper_api.as_mock.bundle.call_args_list
 
     # THEN the case was started
-    mock_start.assert_called_once()
+    analysis_starter.as_mock.start.assert_called_once_with(case.internal_id)

--- a/tests/services/events/event_handlers/test_external_sample_stored_handler.py
+++ b/tests/services/events/event_handlers/test_external_sample_stored_handler.py
@@ -80,7 +80,7 @@ def test_handle_fails_with_no_case(mocker: MockerFixture):
         external_sample_stored_handler.handle(config=cg_config, event_payload=event_payload)
 
 
-def test_handle_ignores_not_fully_external_case(mocker: MockerFixture):
+def test_handle_not_fully_external_case(mocker: MockerFixture):
     # GIVEN a valid event payload
     event_payload: dict = {"status_db.sample_internal_id": "ACC123"}
 
@@ -119,6 +119,47 @@ def test_handle_ignores_not_fully_external_case(mocker: MockerFixture):
     analysis_starter.as_mock.start.assert_not_called()
 
 
-# TODO: Not all samples stored
+def test_handle_not_all_samples_stored(mocker: MockerFixture):
+    # GIVEN a valid event payload
+    event_payload: dict = {"status_db.sample_internal_id": "ACC123"}
+
+    # GIVEN that the sample belongs to a purely external case
+    status_db: Store = create_autospec(Store)
+    case: Case = create_autospec(Case)
+    stored_sample: Sample = create_autospec(
+        Sample, case_that_delivers=case, internal_id="ACC123", is_external=True
+    )
+    not_stored_sample: Sample = create_autospec(
+        Sample, case_that_delivers=case, internal_id="ACC234", is_external=True
+    )
+    case.samples = [stored_sample, not_stored_sample]  # type: ignore
+    status_db.get_sample_by_internal_id_strict = Mock(return_value=stored_sample)
+
+    # GIVEN that NOT all samples in the case are stored
+    housekeeper_api: TypedMock[HousekeeperAPI] = create_typed_mock(HousekeeperAPI)
+    housekeeper_api.as_type.bundle = Mock(
+        side_effect=lambda sample_id: (
+            create_autospec(Bundle) if sample_id == stored_sample.internal_id else None
+        )
+    )
+
+    # GIVEN a CG config
+    cg_config: CGConfig = create_autospec(
+        CGConfig, housekeeper_api=housekeeper_api.as_type, status_db=status_db
+    )
+
+    analysis_starter: TypedMock[AnalysisStarter] = create_typed_mock(AnalysisStarter)
+    mocker.patch.object(
+        AnalysisStarterFactory,
+        "get_analysis_starter_for_case",
+        return_value=analysis_starter.as_type,
+    )
+
+    # WHEN handling the event
+    external_sample_stored_handler.handle(config=cg_config, event_payload=event_payload)
+
+    # THEN the analysis was not started
+    analysis_starter.as_mock.start.assert_not_called()
+
 
 # TODO: Not all samples deliverable for case

--- a/tests/services/events/event_handlers/test_external_sample_stored_handler.py
+++ b/tests/services/events/event_handlers/test_external_sample_stored_handler.py
@@ -80,7 +80,44 @@ def test_handle_fails_with_no_case(mocker: MockerFixture):
         external_sample_stored_handler.handle(config=cg_config, event_payload=event_payload)
 
 
-# TODO: Not all samples external
+def test_handle_ignores_not_fully_external_case(mocker: MockerFixture):
+    # GIVEN a valid event payload
+    event_payload: dict = {"status_db.sample_internal_id": "ACC123"}
+
+    # GIVEN that the sample belongs to a case with both external and non-external samples
+    status_db: Store = create_autospec(Store)
+    case: Case = create_autospec(Case)
+    external_sample: Sample = create_autospec(
+        Sample, case_that_delivers=case, internal_id="ACC123", is_external=True
+    )
+    internal_sample: Sample = create_autospec(
+        Sample, case_that_delivers=case, internal_id="ACC234", is_external=False
+    )
+    case.samples = [external_sample, internal_sample]  # type: ignore
+    status_db.get_sample_by_internal_id_strict = Mock(return_value=external_sample)
+
+    # GIVEN that all samples in the case are stored
+    housekeeper_api: TypedMock[HousekeeperAPI] = create_typed_mock(HousekeeperAPI)
+    housekeeper_api.as_type.bundle = Mock(return_value=create_autospec(Bundle))
+
+    # GIVEN a CG config
+    cg_config: CGConfig = create_autospec(
+        CGConfig, housekeeper_api=housekeeper_api.as_type, status_db=status_db
+    )
+
+    analysis_starter: TypedMock[AnalysisStarter] = create_typed_mock(AnalysisStarter)
+    mocker.patch.object(
+        AnalysisStarterFactory,
+        "get_analysis_starter_for_case",
+        return_value=analysis_starter.as_type,
+    )
+
+    # WHEN handling the event
+    external_sample_stored_handler.handle(config=cg_config, event_payload=event_payload)
+
+    # THEN the analysis was not started
+    analysis_starter.as_mock.start.assert_not_called()
+
 
 # TODO: Not all samples stored
 

--- a/tests/services/events/event_handlers/test_external_sample_stored_handler.py
+++ b/tests/services/events/event_handlers/test_external_sample_stored_handler.py
@@ -1,0 +1,21 @@
+from unittest.mock import create_autospec
+
+from cg.apps.housekeeper.hk import HousekeeperAPI
+
+
+def test_handle_starts_case():
+    # GIVEN a valid event payload
+    event_payload: dict = {"status_db.sample_internal_id": "ACC123"}
+
+    # GIVEN that all samples in the case are stored
+    hk_api: HousekeeperAPI = create_autospec(HousekeeperAPI)
+
+    # GIVEN that starting the case goes well
+
+    # WHEN handling the event
+
+    # THEN we should have checked that all samples were indeed stored
+
+    # THEN the case was started
+
+    pass

--- a/tests/services/events/event_handlers/test_external_sample_stored_handler.py
+++ b/tests/services/events/event_handlers/test_external_sample_stored_handler.py
@@ -56,3 +56,12 @@ def test_handle_starts_case(mocker: MockerFixture):
 
     # THEN the case was started
     analysis_starter.as_mock.start.assert_called_once_with(case.internal_id)
+
+
+# TODO: Test for sample with no case that deliver
+
+# TODO: Not all samples external
+
+# TODO: Not all samples stored
+
+# TODO: Not all samples deliverable for case

--- a/tests/services/events/event_handlers/test_external_sample_stored_handler.py
+++ b/tests/services/events/event_handlers/test_external_sample_stored_handler.py
@@ -1,7 +1,7 @@
 from unittest.mock import Mock, call, create_autospec
 
-from housekeeper.store.models import Bundle
 import pytest
+from housekeeper.store.models import Bundle
 from pytest_mock import MockerFixture
 
 from cg.apps.housekeeper.hk import HousekeeperAPI
@@ -16,7 +16,7 @@ from tests.typed_mock import TypedMock, create_typed_mock
 
 
 def test_handle_starts_case(mocker: MockerFixture):
-    # GIVEN a valid event payload
+    # GIVEN a valid event payload with a sample id
     event_payload: dict = {"status_db.sample_internal_id": "ACC123"}
 
     # GIVEN that the sample belongs to a purely external case
@@ -25,13 +25,15 @@ def test_handle_starts_case(mocker: MockerFixture):
     stored_sample: Sample = create_autospec(
         Sample, case_that_delivers=case, internal_id="ACC123", is_external=True
     )
+    status_db.get_sample_by_internal_id_strict = Mock(return_value=stored_sample)
+
+    # GIVEN that the case has another sample that has been also stored
     other_sample: Sample = create_autospec(
         Sample, case_that_delivers=case, internal_id="ACC234", is_external=True
     )
     case.samples = [stored_sample, other_sample]  # type: ignore
-    status_db.get_sample_by_internal_id_strict = Mock(return_value=stored_sample)
 
-    # GIVEN that all samples in the case are stored
+    # GIVEN a Housekeeper API
     housekeeper_api: TypedMock[HousekeeperAPI] = create_typed_mock(HousekeeperAPI)
     housekeeper_api.as_type.bundle = Mock(return_value=create_autospec(Bundle))
 
@@ -40,6 +42,7 @@ def test_handle_starts_case(mocker: MockerFixture):
         CGConfig, housekeeper_api=housekeeper_api.as_type, status_db=status_db
     )
 
+    # GIVEN an analysis starter
     analysis_starter: TypedMock[AnalysisStarter] = create_typed_mock(AnalysisStarter)
     mocker.patch.object(
         AnalysisStarterFactory,
@@ -60,8 +63,8 @@ def test_handle_starts_case(mocker: MockerFixture):
     analysis_starter.as_mock.start.assert_called_once_with(case.internal_id)
 
 
-def test_handle_fails_with_no_case(mocker: MockerFixture):
-    # GIVEN a valid event payload
+def test_handle_fails_with_no_case():
+    # GIVEN a valid event payload with a sample id
     event_payload: dict = {"status_db.sample_internal_id": "ACC123"}
 
     # GIVEN that the sample does not have a linked case that should deliver it
@@ -76,27 +79,29 @@ def test_handle_fails_with_no_case(mocker: MockerFixture):
 
     # WHEN handling the event
     # THEN the appropriate error is raised
-    with pytest.raises(CaseNotFoundError):
+    with pytest.raises(CaseNotFoundError, match="No case found to deliver sample ACC123"):
         external_sample_stored_handler.handle(config=cg_config, event_payload=event_payload)
 
 
 def test_handle_ignores_case_with_internal_samples(mocker: MockerFixture):
-    # GIVEN a valid event payload
+    # GIVEN a valid event payload with a sample id
     event_payload: dict = {"status_db.sample_internal_id": "ACC123"}
 
-    # GIVEN that the sample belongs to a case with both external and internal samples
+    # GIVEN that the sample belongs to a case that delivers the sample
     status_db: Store = create_autospec(Store)
     case: Case = create_autospec(Case)
     external_sample: Sample = create_autospec(
         Sample, case_that_delivers=case, internal_id="ACC123", is_external=True
     )
+
+    # GIVEN that the case has another sample that is not external
+    status_db.get_sample_by_internal_id_strict = Mock(return_value=external_sample)
     internal_sample: Sample = create_autospec(
         Sample, case_that_delivers=case, internal_id="ACC234", is_external=False
     )
     case.samples = [external_sample, internal_sample]  # type: ignore
-    status_db.get_sample_by_internal_id_strict = Mock(return_value=external_sample)
 
-    # GIVEN that all samples in the case are stored
+    # GIVEN a Housekeeper API
     housekeeper_api: TypedMock[HousekeeperAPI] = create_typed_mock(HousekeeperAPI)
     housekeeper_api.as_type.bundle = Mock(return_value=create_autospec(Bundle))
 
@@ -105,6 +110,7 @@ def test_handle_ignores_case_with_internal_samples(mocker: MockerFixture):
         CGConfig, housekeeper_api=housekeeper_api.as_type, status_db=status_db
     )
 
+    # GIVEN an analysis starter
     analysis_starter: TypedMock[AnalysisStarter] = create_typed_mock(AnalysisStarter)
     mocker.patch.object(
         AnalysisStarterFactory,
@@ -120,7 +126,7 @@ def test_handle_ignores_case_with_internal_samples(mocker: MockerFixture):
 
 
 def test_handle_ignores_case_with_unstored_samples(mocker: MockerFixture):
-    # GIVEN a valid event payload
+    # GIVEN a valid event payload with a sample id
     event_payload: dict = {"status_db.sample_internal_id": "ACC123"}
 
     # GIVEN that the sample belongs to a purely external case
@@ -129,13 +135,15 @@ def test_handle_ignores_case_with_unstored_samples(mocker: MockerFixture):
     stored_sample: Sample = create_autospec(
         Sample, case_that_delivers=case, internal_id="ACC123", is_external=True
     )
+    status_db.get_sample_by_internal_id_strict = Mock(return_value=stored_sample)
+
+    # GIVEN that the case has another sample that has not been stored
     not_stored_sample: Sample = create_autospec(
         Sample, case_that_delivers=case, internal_id="ACC234", is_external=True
     )
     case.samples = [stored_sample, not_stored_sample]  # type: ignore
-    status_db.get_sample_by_internal_id_strict = Mock(return_value=stored_sample)
 
-    # GIVEN that NOT all samples in the case are stored
+    # GIVEN a Housekeeper bundle
     housekeeper_api: TypedMock[HousekeeperAPI] = create_typed_mock(HousekeeperAPI)
     housekeeper_api.as_type.bundle = Mock(
         side_effect=lambda sample_id: (
@@ -148,6 +156,7 @@ def test_handle_ignores_case_with_unstored_samples(mocker: MockerFixture):
         CGConfig, housekeeper_api=housekeeper_api.as_type, status_db=status_db
     )
 
+    # GIVEN an analysis starter
     analysis_starter: TypedMock[AnalysisStarter] = create_typed_mock(AnalysisStarter)
     mocker.patch.object(
         AnalysisStarterFactory,
@@ -163,23 +172,25 @@ def test_handle_ignores_case_with_unstored_samples(mocker: MockerFixture):
 
 
 def test_handle_ignores_case_with_undeliverable_samples(mocker: MockerFixture):
-    # GIVEN a valid event payload
+    # GIVEN a valid event payload with a sample id
     event_payload: dict = {"status_db.sample_internal_id": "ACC123"}
 
     # GIVEN that the sample belongs to a case that does not deliver all of its samples
     status_db: Store = create_autospec(Store)
-    case1: Case = create_autospec(Case, internal_id="case1")
-    case2: Case = create_autospec(Case, internal_id="case2")
-    sample1: Sample = create_autospec(
-        Sample, case_that_delivers=case1, internal_id="ACC123", is_external=True
+    case: Case = create_autospec(Case, internal_id="case1")
+    sample_from_case_that_delivers: Sample = create_autospec(
+        Sample, case_that_delivers=case, internal_id="ACC123", is_external=True
     )
-    sample2: Sample = create_autospec(
-        Sample, case_that_delivers=case2, internal_id="ACC234", is_external=True
+    status_db.get_sample_by_internal_id_strict = Mock(return_value=sample_from_case_that_delivers)
+    sample_from_another_case: Sample = create_autospec(
+        Sample,
+        case_that_delivers=create_autospec(Case, internal_id="case2"),
+        internal_id="ACC234",
+        is_external=True,
     )
-    case1.samples = [sample1, sample2]  # type: ignore
-    status_db.get_sample_by_internal_id_strict = Mock(return_value=sample1)
+    case.samples = [sample_from_case_that_delivers, sample_from_another_case]  # type: ignore
 
-    # GIVEN that all samples in the case are stored
+    # GIVEN a Housekeeper API
     housekeeper_api: TypedMock[HousekeeperAPI] = create_typed_mock(HousekeeperAPI)
     housekeeper_api.as_type.bundle = Mock(return_value=create_autospec(Bundle))
 
@@ -188,6 +199,7 @@ def test_handle_ignores_case_with_undeliverable_samples(mocker: MockerFixture):
         CGConfig, housekeeper_api=housekeeper_api.as_type, status_db=status_db
     )
 
+    # GIVEN an analysis starter
     analysis_starter: TypedMock[AnalysisStarter] = create_typed_mock(AnalysisStarter)
     mocker.patch.object(
         AnalysisStarterFactory,


### PR DESCRIPTION
## Description
Implement a handler to start analyses involving external samples when all case samples have been ingested.

### Added

- external_sample_stored_handler that starts analyses for external samples
- tests

## Review

- [x] Tests executed by the mob
- [x] "Merge and deploy" approved by SD
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Deployed to stage:
```shell
Logging deploy ...
Getting deployer... done.
Getting last commit message and SHA... done.
Getting version of deploy scripts... done.
Log deploy... done.
cg, version 88.7.4
[js.diazboada@hasta:~] [S_base] $ up
```
- [ ] Deployed to production:
```shell
Logging deploy ...
Getting deployer... done.
Getting last commit message and SHA... done.
Getting version of deploy scripts... done.
Log deploy... done.
cg, version 88.7.4
[js.diazboada@hasta:~] [P_base] $
```
