### PR TITLE
Change QC threshold operator for Nallo median coverage from "gt" to "ge"

### DIFF
--- a/cg/constants/nf_analysis.py
+++ b/cg/constants/nf_analysis.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 NALLO_GENERAL_METRIC_CONDITIONS: dict[str, dict[str, Any]] = {
-    "median_coverage": {"norm": "gt", "threshold": 20},
+    "median_coverage": {"norm": "ge", "threshold": 20},
 }
 
 NALLO_PARENT_PEDDY_METRIC_CONDITION: dict[str, dict[str, Any]] = {

--- a/tests/meta/workflow/conftest.py
+++ b/tests/meta/workflow/conftest.py
@@ -426,7 +426,7 @@ def nallo_metrics_deliverables(
                 "value": 2.0,
             },
             {
-                "condition": {"norm": "gt", "threshold": 20.0},
+                "condition": {"norm": "ge", "threshold": 20.0},
                 "header": None,
                 "id": "ADM1",
                 "input": "multiqc_data.json",


### PR DESCRIPTION
## Description

### Added

-

### Changed

- Change QC threshold for Nallo median coverage from "gt" to "ge"

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
