### PR TITLE
Clarify event publisher function names

### DIFF
--- a/cg/services/deliver_files/rsync/service.py
+++ b/cg/services/deliver_files/rsync/service.py
@@ -31,7 +31,7 @@ from cg.services.deliver_files.rsync.sbatch_commands import (
     ERROR_RSYNC_FUNCTION,
     RSYNC_COMMAND,
 )
-from cg.services.events.event_publisher import publish_command
+from cg.services.events.event_publisher import get_publish_command
 from cg.services.events.upload_handler import ANALYSIS_UPLOADED_SUBJECT
 from cg.store.models import Case
 from cg.store.store import Store
@@ -316,7 +316,7 @@ class DeliveryRsyncService:
             "cg.analysis_id": analysis_id,
             "uploaded_at": "$(date +%Y-%m-%dT%H:%M:%SZ)",
         }
-        command += "\n" + publish_command(
+        command += "\n" + get_publish_command(
             nats_config=self.nats_config,
             subject=f"{self.nats_config.stream}.{ANALYSIS_UPLOADED_SUBJECT}",
             data=data,

--- a/cg/services/events/event_handlers/external_sample_transferred_handler.py
+++ b/cg/services/events/event_handlers/external_sample_transferred_handler.py
@@ -45,7 +45,7 @@ def handle(config: CGConfig, event_payload: dict) -> None:
 
     _add_sample_files_to_housekeeper(housekeeper_api=config.housekeeper_api, event=event)
     config.status_db.commit_to_store()
-    event_publisher.publish(
+    event_publisher.publish_event(
         nats_config=config.nats,
         event_name=EXTERNAL_SAMPLE_STORED_SUBJECT,
         event_payload={SAMPLE_INTERNAL_ID_FIELD: event.sample_internal_id},

--- a/cg/services/events/event_publisher.py
+++ b/cg/services/events/event_publisher.py
@@ -27,7 +27,7 @@ def get_publish_command(nats_config, subject: str, data: dict) -> str:
     return command
 
 
-def publish(nats_config, event_name: str, event_payload: dict) -> None:
+def publish_event(nats_config, event_name: str, event_payload: dict) -> None:
     """Publish an event to NATS JetStream from synchronous code."""
     asyncio.run(_publish_async(nats_config=nats_config, event_name=event_name, data=event_payload))
 

--- a/cg/services/events/event_publisher.py
+++ b/cg/services/events/event_publisher.py
@@ -12,7 +12,7 @@ from nats.js import JetStreamContext
 LOG = logging.getLogger(__name__)
 
 
-def publish_command(nats_config, subject: str, data: dict) -> str:
+def get_publish_command(nats_config, subject: str, data: dict) -> str:
     json_str: str = json.dumps(data).replace('"', '\\"')
     command: str = (
         f"{nats_config.nats_binary_path} pub "

--- a/cg/services/orders/submitter/service.py
+++ b/cg/services/orders/submitter/service.py
@@ -69,7 +69,7 @@ class OrderSubmitter:
             customer_internal_id=customer_internal_id, sample_names=sample_names
         )
         event_name = "external.samples_ordered"
-        event_publisher.publish(
+        event_publisher.publish_event(
             nats_config=self.nats_config,
             event_name=event_name,
             event_payload=payload,

--- a/cg/services/transfer_to_cluster_service.py
+++ b/cg/services/transfer_to_cluster_service.py
@@ -67,7 +67,7 @@ def _get_sbatch_command(cg_config: CGConfig, sample: Sample) -> str:
             destination_path=destination_path,
         )
         + "\n"
-        + event_publisher.publish_command(
+        + event_publisher.get_publish_command(
             nats_config=cg_config.nats,
             subject=f"{cg_config.nats.stream}.{EXTERNAL_SAMPLE_TRANSFERRED_SUBJECT}",
             data=event_payload,

--- a/tests/services/events/event_handlers/test_external_sample_transferred_handler.py
+++ b/tests/services/events/event_handlers/test_external_sample_transferred_handler.py
@@ -40,7 +40,7 @@ def test_handle_success(mocker: MockerFixture):
 
     # GIVEN a publisher for completion events
     publish_mock = mocker.patch.object(
-        external_sample_transferred_handler.event_publisher, "publish"
+        external_sample_transferred_handler.event_publisher, "publish_event"
     )
 
     # GIVEN a valid event payload

--- a/tests/services/events/test_event_publisher.py
+++ b/tests/services/events/test_event_publisher.py
@@ -32,7 +32,7 @@ def test_publish_command(nats_config: NatsConfig):
     event_payload = {"analysis": "analysis_1", "uploaded_at": "$(date +%Y-%m-%dT%H:%M:%SZ)"}
 
     # WHEN the publish_command function is called with the NatsConfig, subject, and data
-    command = event_publisher.publish_command(
+    command = event_publisher.get_publish_command(
         nats_config=nats_config, subject=subject, data=event_payload
     )
 

--- a/tests/services/events/test_event_publisher.py
+++ b/tests/services/events/test_event_publisher.py
@@ -50,7 +50,7 @@ def test_publish_command(nats_config: NatsConfig):
     assert command == expected
 
 
-def test_publish(nats_config: NatsConfig, mocker: MockerFixture):
+def test_publish_event(nats_config: NatsConfig, mocker: MockerFixture):
     # GIVEN a NatsConfig, a subject and payload
     event_name = "upload.completed"
     event_payload = {"analysis": "analysis_1"}
@@ -70,7 +70,7 @@ def test_publish(nats_config: NatsConfig, mocker: MockerFixture):
     mocker.patch.object(event_publisher, "_tls_context", return_value=tls_context)
 
     # WHEN publishing synchronously
-    event_publisher.publish(
+    event_publisher.publish_event(
         nats_config=nats_config, event_name=event_name, event_payload=event_payload
     )
 

--- a/tests/services/orders/submitter/test_order_submitter.py
+++ b/tests/services/orders/submitter/test_order_submitter.py
@@ -269,7 +269,7 @@ def test_submit_order(
         assert not store_to_submit_and_validate_orders._get_query(table=Sample).first()
 
         # GIVEN an event publisher
-        event_publisher_spy = mocker.spy(event_publisher, "publish")
+        event_publisher_spy = mocker.spy(event_publisher, "publish_event")
 
         # WHEN submitting the order
         result = order_submitter.submit(order_type=order_type, raw_order=raw_order, user=user)
@@ -329,7 +329,7 @@ def test_submit_order_with_external_samples(
     )
 
     # GIVEN an event publisher
-    mock_publish_external_order = mocker.patch.object(event_publisher, "publish")
+    mock_publish_external_order = mocker.patch.object(event_publisher, "publish_event")
 
     # WHEN submitting the order
     order_submitter.submit(


### PR DESCRIPTION
**Description:**

Renames the publish functions to make their purpose clearer:

-  `publish_command` → `get_publish_command`
-  `publish` → `publish_event`
-  Updates callers, tests, and mocks. No behavior changes.
-  Validation: all tests pass.


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
