### PR TITLE
Admin view - Wider admin view

### DIFF
--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -453,7 +453,6 @@ class CustomerView(BaseView):
         "internal_id",
         "name",
         "data_archive_location",
-        "comment",
         "primary_contact",
         "delivery_contact",
         "label",
@@ -463,6 +462,7 @@ class CustomerView(BaseView):
         "project_account_kth",
         "return_samples",
         "scout_access",
+        "comment",
     ]
     column_filters = ["priority", "scout_access", "data_archive_location", "label"]
     column_formatters = {

--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -133,27 +133,6 @@ def view_pacbio_sample_sequencing_metrics_link(unused1, unused2, model, unused3)
     )
 
 
-def view_application_text_column(unused1, unused2, model, attribute_name):
-    """Column formatter to widen long text columns."""
-    del unused1, unused2
-    text = getattr(model, attribute_name)
-    return (
-        Markup(f"<div style='display: inline-block; min-width: 300px;'>{text}</div>")
-        if text
-        else ""
-    )
-
-
-def view_order_types(unused1, unused2, model, unused3):
-    del unused1, unused2, unused3
-    order_type_list = "<br>".join(model.order_types)
-    return (
-        Markup(f'<div style="display: inline-block; min-width: 200px;">{order_type_list}</div>')
-        if model.order_type_applications
-        else ""
-    )
-
-
 def view_sample_concentration_minimum(unused1, unused2, model, unused3):
     """Column formatter to append unit"""
     del unused1, unused2, unused3
@@ -319,14 +298,10 @@ class ApplicationView(BaseView):
     ]
     column_formatters = {
         "tag": view_application_version_link,
-        "order_types": view_order_types,
         "sample_concentration_minimum": view_sample_concentration_minimum,
         "sample_concentration_maximum": view_sample_concentration_maximum,
         "sample_concentration_minimum_cfdna": view_sample_concentration_minimum_cfdna,
         "sample_concentration_maximum_cfdna": view_sample_concentration_maximum_cfdna,
-        "limitations": view_application_text_column,
-        "comment": view_application_text_column,
-        "details": view_application_text_column,
     }
     column_filters = ["prep_category", "is_accredited", "is_archived", "read_type", "is_external"]
     column_searchable_list = ["tag", "prep_category", "description", "details"]

--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -452,16 +452,16 @@ class CustomerView(BaseView):
     column_list = [
         "internal_id",
         "name",
-        "label",
+        "data_archive_location",
         "primary_contact",
         "delivery_contact",
+        "label",
         "lab_contact",
         "priority",
-        "agreement_registration",
-        "invoice_reference",
+        "project_account_KI",
+        "project_account_kth",
         "return_samples",
         "scout_access",
-        "data_archive_location",
         "comment",
     ]
     column_filters = ["priority", "scout_access", "data_archive_location", "label"]

--- a/cg/server/admin.py
+++ b/cg/server/admin.py
@@ -452,16 +452,16 @@ class CustomerView(BaseView):
     column_list = [
         "internal_id",
         "name",
-        "data_archive_location",
+        "label",
         "primary_contact",
         "delivery_contact",
-        "label",
         "lab_contact",
         "priority",
-        "project_account_KI",
-        "project_account_kth",
+        "agreement_registration",
+        "invoice_reference",
         "return_samples",
         "scout_access",
+        "data_archive_location",
         "comment",
     ]
     column_filters = ["priority", "scout_access", "data_archive_location", "label"]

--- a/cg/server/app.py
+++ b/cg/server/app.py
@@ -67,6 +67,7 @@ def create_app():
 def _load_config(app: Flask):
     app.config.update(app_config.model_dump())
     app.secret_key = app_config.cg_secret_key
+    app.config["FLASK_ADMIN_FLUID_LAYOUT"] = True
 
 
 def _configure_extensions(app: Flask):


### PR DESCRIPTION
## Description

### Added

- Freeze the column header

### Changed

- Tables will now use the full width of the web browser


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t cg -b wider-tables-admin-view -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
